### PR TITLE
fix: harden box registry and runtime flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,14 @@ brew install a3s-lab/tap/a3s-box
 
 # From source
 git clone https://github.com/A3S-Lab/Box.git
-cd Box/src
-cargo build --release
+cd Box
+just release
 ```
+
+For development builds that you plan to run locally, build the static Linux
+guest init as well: `just build-guest debug`. `a3s-box` refreshes this binary
+into each guest rootfs as PID 1; without it, cached images may keep an older
+guest init and miss newer runtime behavior such as staged environment variables.
 
 On macOS, use Apple Silicon. On Linux, use a host with KVM/libkrun support. On Windows, enable Windows Hypervisor Platform for the native WHPX backend:
 
@@ -174,9 +179,12 @@ Important supported options:
 - `--name`, `--label`, `--restart no|always|on-failure[:N]|unless-stopped`;
 - `--cpus`, `--memory`, `--timeout`, `--pids-limit`, `--cpuset-cpus`, `--ulimit`, CPU quota/shares, memory reservation/swap;
 - `-e/--env`, `--env-file`, `--entrypoint`, `-u/--user`, `-w/--workdir`, `--hostname`, `--add-host`;
+- `--package-cache pnpm` to mount a persistent pnpm store for repeated throwaway Node boxes;
 - `--health-cmd`, `--health-interval`, `--health-timeout`, `--health-retries`, `--health-start-period`, `--no-healthcheck`;
 - `--stop-signal`, `--stop-timeout`, `--persistent`, `--log-driver json-file|none`;
 - `--cap-add`, `--cap-drop`, `--security-opt seccomp=default|seccomp=unconfined|no-new-privileges`, `--privileged`.
+
+`a3s-box wait` prints a low-frequency stderr keepalive while it is blocking so long CI or SSH sessions do not look idle; use `--no-heartbeat` or `--heartbeat-interval <seconds>` to tune it.
 
 Unsupported or guarded options fail early instead of being silently stored: host devices, GPUs, AppArmor labels, SELinux labels, custom seccomp profiles, unsupported users, invalid workdirs, unsupported port syntax, and unsupported network policies.
 
@@ -228,6 +236,7 @@ and everything after it. The cache lives at `~/.a3s/buildcache` and is size-capp
 ```bash
 a3s-box volume create data
 a3s-box run -d --name app -v data:/data alpine:latest -- sleep 3600
+a3s-box run --rm --package-cache pnpm node:22-alpine -- sh -lc 'corepack enable && pnpm install --frozen-lockfile'
 a3s-box cp ./file.txt app:/data/file.txt
 a3s-box diff app
 a3s-box export app -o rootfs.tar
@@ -236,6 +245,8 @@ a3s-box snapshot create app checkpoint-1
 a3s-box snapshot restore checkpoint-1 --name restored-app
 a3s-box snapshot prune --keep 5          # bound disk: keep the 5 newest
 ```
+
+`--package-cache pnpm` creates/reuses the named volume `a3s-cache-pnpm` and sets `npm_config_store_dir=/a3s-cache/pnpm/store`, so dependency downloads survive across `--rm` boxes without making the whole rootfs persistent. Auto-removed boxes also archive their last logs under `~/.a3s/removed-logs/`, and `a3s-box logs <name-or-id>` can read that archive after the box directory is gone.
 
 The `snapshot` command produces configuration/filesystem-oriented Box snapshots, not a live RAM checkpoint. The live RAM Copy-on-Write facility is a separate, lower-level mechanism described in [Warm pool and snapshot-fork](#warm-pool-and-snapshot-fork).
 
@@ -471,7 +482,7 @@ curl -fsSL https://raw.githubusercontent.com/A3S-Lab/Box/main/deploy/scripts/ins
 
 # or from a checkout:
 sudo deploy/scripts/install-runtimeclass.sh                  # default version
-sudo deploy/scripts/install-runtimeclass.sh --version v3.0.0 # pin a version
+sudo deploy/scripts/install-runtimeclass.sh --version v3.0.1 # pin a version
 ```
 
 Then label the node from a machine with `kubectl`:

--- a/deploy/scripts/install-runtimeclass.sh
+++ b/deploy/scripts/install-runtimeclass.sh
@@ -16,7 +16,7 @@
 # Usage:
 #   install-runtimeclass.sh [--version vX.Y.Z] [--repo OWNER/REPO] [--from-dir DIR]
 #
-#   --version   release tag to install                 (default: v3.0.0)
+#   --version   release tag to install                 (default: v3.0.1)
 #   --repo      GitHub repo to download artifacts from (default: A3S-Lab/Box)
 #   --from-dir  install from a local directory instead of downloading; the dir must
 #               contain a3s-box-<version>-linux-<arch>.tar.gz and a containerd shim
@@ -25,7 +25,7 @@
 # Idempotent: safe to re-run (re-installs binaries, rewrites the containerd drop-in).
 set -euo pipefail
 
-VERSION="v3.0.0"
+VERSION="v3.0.1"
 REPO="A3S-Lab/Box"
 FROM_DIR=""
 WARMUP_IMAGE="busybox:latest"   # first box on a fresh node builds a one-time cache

--- a/justfile
+++ b/justfile
@@ -19,6 +19,7 @@ build:
 # Build release
 release:
     cd src && cargo build --workspace --release
+    just build-guest release
     just sign-shim release
 
 # Sign the shim binary with Hypervisor.framework entitlement (macOS)
@@ -31,15 +32,45 @@ sign-shim profile="debug":
 sign-shim profile="debug":
     @echo "✓ No signing needed on Linux"
 
-# Build guest binaries (cross-compile for Linux aarch64 musl)
-build-guest profile="release":
-    cd src && cargo build -p a3s-box-guest-init --target aarch64-unknown-linux-musl --{{profile}}
-    @if [ "{{profile}}" = "release" ]; then \
-        aarch64-linux-musl-strip src/target/aarch64-unknown-linux-musl/release/a3s-box-guest-init; \
-        aarch64-linux-musl-strip src/target/aarch64-unknown-linux-musl/release/a3s-box-nsexec; \
+# Build the static Linux guest-init used as PID 1 inside boxes.
+build-guest profile="release" target="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target="{{target}}"
+    if [ -z "$target" ]; then
+        case "$(uname -m)" in
+            arm64|aarch64) target="aarch64-unknown-linux-musl" ;;
+            x86_64|amd64) target="x86_64-unknown-linux-musl" ;;
+            *)
+                echo "Unsupported guest-init host architecture: $(uname -m)" >&2
+                echo "Pass an explicit target, e.g. just build-guest release x86_64-unknown-linux-musl" >&2
+                exit 1
+                ;;
+        esac
     fi
-    @echo "Guest binaries built at src/target/aarch64-unknown-linux-musl/{{profile}}/"
-    @ls -lh src/target/aarch64-unknown-linux-musl/{{profile}}/a3s-box-guest-init src/target/aarch64-unknown-linux-musl/{{profile}}/a3s-box-nsexec 2>/dev/null || true
+
+    case "{{profile}}" in
+        release) profile_flag="--release"; profile_dir="release" ;;
+        debug) profile_flag=""; profile_dir="debug" ;;
+        *) profile_flag="--profile {{profile}}"; profile_dir="{{profile}}" ;;
+    esac
+
+    cd src
+    cargo build -p a3s-box-guest-init --target "$target" $profile_flag
+
+    if [ "{{profile}}" = "release" ]; then
+        case "$target" in
+            aarch64-unknown-linux-musl) strip_tool="aarch64-linux-musl-strip" ;;
+            x86_64-unknown-linux-musl) strip_tool="x86_64-linux-musl-strip" ;;
+            *) strip_tool="" ;;
+        esac
+        if [ -n "$strip_tool" ] && command -v "$strip_tool" >/dev/null 2>&1; then
+            "$strip_tool" "target/$target/$profile_dir/a3s-box-guest-init"
+        fi
+    fi
+
+    echo "Guest init built at src/target/$target/$profile_dir/a3s-box-guest-init"
+    ls -lh "target/$target/$profile_dir/a3s-box-guest-init"
 
 # ============================================================================
 # Test (unified command with progress display)
@@ -806,4 +837,3 @@ version:
     echo "  a3s-box-core:    $(grep '^version' src/core/Cargo.toml | head -1 | sed 's/.*\"\(.*\)\".*/\1/')"
     echo "  a3s-box-runtime: $(grep '^version' src/runtime/Cargo.toml | head -1 | sed 's/.*\"\(.*\)\".*/\1/')"
     echo ""
-

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "a3s-box-cli"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-core"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "a3s-common",
  "async-trait",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cri"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-guest-init"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "a3s-box-core",
  "a3s-common",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-lambda"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-netproxy"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "a3s-box-core",
  "libc",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-runtime"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -163,6 +163,7 @@ dependencies = [
  "rand",
  "rcgen",
  "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "ring",
  "rustls",
  "rustls-pki-types",
@@ -185,11 +186,11 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-sdk"
-version = "3.0.0"
+version = "3.0.1"
 
 [[package]]
 name = "a3s-box-shim"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -223,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-libkrun-sys"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "libc",
  "num_cpus",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 h2 = { path = "third_party/h2" }
 
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/src/cli/src/cleanup.rs
+++ b/src/cli/src/cleanup.rs
@@ -132,6 +132,16 @@ pub fn cleanup_external_socket_dir(box_dir: &Path, exec_socket_path: &Path) {
 
 /// Remove all host-side resources owned by a box record.
 pub fn cleanup_removed_box(record: &BoxRecord) {
+    if record.auto_remove {
+        if let Err(err) = crate::log_archive::archive_removed_logs(record) {
+            tracing::debug!(
+                box_id = %record.id,
+                error = %err,
+                "Failed to archive auto-removed box logs"
+            );
+        }
+    }
+
     cleanup_record_resources(record);
     cleanup_anonymous_volumes(&record.anonymous_volumes);
     remove_host_cgroup(&record.id);

--- a/src/cli/src/commands/logs.rs
+++ b/src/cli/src/commands/logs.rs
@@ -48,32 +48,48 @@ struct LogSource {
 
 pub async fn execute(args: LogsArgs) -> Result<(), Box<dyn std::error::Error>> {
     let state = StateFile::load_default()?;
-    let record = resolve::resolve(&state, &args.r#box)?;
-    let box_id = record.id.clone();
-
-    // If logging is disabled, tell the user
-    if record.log_config.driver == LogDriver::None {
-        return Err(format!(
-            "Logging is disabled for box {} (log-driver=none)",
-            record.name
-        )
-        .into());
-    }
-
     let since = args.since.as_deref().map(parse_time_filter).transpose()?;
     let until = args.until.as_deref().map(parse_time_filter).transpose()?;
 
-    let Some(log_source) = resolve_log_source(record) else {
-        if args.follow && record.status == "running" {
-            match wait_for_log_source(&box_id).await? {
-                Some(source) => return stream_logs(&box_id, source, args, since, until).await,
-                None => return Ok(()),
-            }
-        }
-        return Ok(());
-    };
+    match resolve::resolve(&state, &args.r#box) {
+        Ok(record) => {
+            let box_id = record.id.clone();
 
-    stream_logs(&box_id, log_source, args, since, until).await
+            // If logging is disabled, tell the user
+            if record.log_config.driver == LogDriver::None {
+                return Err(format!(
+                    "Logging is disabled for box {} (log-driver=none)",
+                    record.name
+                )
+                .into());
+            }
+
+            let Some(log_source) = resolve_log_source(record) else {
+                if args.follow && record.status == "running" {
+                    match wait_for_log_source(&box_id).await? {
+                        Some(source) => {
+                            return stream_logs(&box_id, source, args, since, until).await;
+                        }
+                        None => return Ok(()),
+                    }
+                }
+                return Ok(());
+            };
+
+            stream_logs(&box_id, log_source, args, since, until).await
+        }
+        Err(resolve_error) => {
+            let Some(archive) = crate::log_archive::resolve_archive(&args.r#box)? else {
+                return Err(resolve_error.into());
+            };
+            let Some(log_source) = resolve_archived_log_source(&archive) else {
+                return Ok(());
+            };
+            let mut args = args;
+            args.follow = false;
+            stream_logs(&archive.id, log_source, args, since, until).await
+        }
+    }
 }
 
 async fn stream_logs(
@@ -304,6 +320,29 @@ fn resolve_log_source(record: &BoxRecord) -> Option<LogSource> {
     None
 }
 
+fn resolve_archived_log_source(
+    archive: &crate::log_archive::RemovedLogArchive,
+) -> Option<LogSource> {
+    let log_dir = archive.log_dir();
+    let json_log = a3s_box_runtime::log::json_log_path(&log_dir);
+    if json_log.exists() {
+        return Some(LogSource {
+            path: json_log,
+            structured: true,
+        });
+    }
+
+    let console_log = archive.console_log();
+    if console_log.exists() {
+        return Some(LogSource {
+            path: console_log,
+            structured: false,
+        });
+    }
+
+    None
+}
+
 async fn wait_for_log_source(
     box_id: &str,
 ) -> Result<Option<LogSource>, Box<dyn std::error::Error>> {
@@ -449,6 +488,36 @@ fn extract_line_timestamp(line: &str) -> Option<DateTime<Utc>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &Path) -> Self {
+            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            let lock = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self {
+                _lock: lock,
+                key,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     #[cfg(unix)]
@@ -620,5 +689,30 @@ mod tests {
         record.console_log = record.box_dir.join("logs").join("console.log");
 
         assert!(resolve_log_source(&record).is_none());
+    }
+
+    #[test]
+    fn test_resolve_archived_log_source_prefers_structured_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set("A3S_HOME", tmp.path());
+        let archive = crate::log_archive::RemovedLogArchive {
+            id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            short_id: "550e8400e29b".to_string(),
+            name: "web".to_string(),
+            image: "alpine:latest".to_string(),
+            removed_at: Utc::now(),
+            created_at: Utc::now(),
+            started_at: None,
+            exit_code: Some(1),
+            log_config: a3s_box_core::log::LogConfig::default(),
+        };
+        std::fs::create_dir_all(archive.log_dir()).unwrap();
+        let json_log = a3s_box_runtime::log::json_log_path(&archive.log_dir());
+        std::fs::write(&json_log, "{}\n").unwrap();
+        std::fs::write(archive.console_log(), "console\n").unwrap();
+
+        let source = resolve_archived_log_source(&archive).unwrap();
+        assert!(source.structured);
+        assert_eq!(source.path, json_log);
     }
 }

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -7,13 +7,22 @@ use a3s_box_core::config::{BoxConfig, ResourceConfig, SidecarConfig, TeeConfig};
 use a3s_box_core::event::EventEmitter;
 use a3s_box_core::vmm::{parse_signal_name, DEFAULT_SHUTDOWN_TIMEOUT_MS};
 use a3s_box_runtime::VmManager;
-use clap::Args;
+use clap::{Args, ValueEnum};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use super::common::{self, CommonBoxArgs};
 use crate::output::parse_memory;
 use crate::state::{generate_name, BoxRecord, StateFile};
+
+const PNPM_CACHE_VOLUME_SPEC: &str = "a3s-cache-pnpm:/a3s-cache/pnpm";
+const PNPM_STORE_ENV: &str = "npm_config_store_dir";
+const PNPM_STORE_DIR: &str = "/a3s-cache/pnpm/store";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum PackageCache {
+    Pnpm,
+}
 
 #[derive(Args)]
 pub struct RunArgs {
@@ -35,6 +44,10 @@ pub struct RunArgs {
     /// Automatically remove the box when it stops
     #[arg(long)]
     pub rm: bool,
+
+    /// Mount a persistent package-manager cache (currently: pnpm)
+    #[arg(long = "package-cache", value_enum)]
+    pub package_cache: Vec<PackageCache>,
 
     /// Command to run (override entrypoint)
     #[arg(last = true)]
@@ -78,6 +91,7 @@ struct RunContext {
     box_id: String,
     box_dir: PathBuf,
     name: String,
+    record: BoxRecord,
     exec_socket_path: PathBuf,
     #[cfg_attr(windows, allow(dead_code))]
     pty_socket_path: PathBuf,
@@ -148,7 +162,7 @@ async fn setup_and_boot(args: &RunArgs) -> Result<RunContext, Box<dyn std::error
     };
 
     let name = args.common.name.clone().unwrap_or_else(generate_name);
-    let env = common::build_env_map(&args.common)?;
+    let mut env = common::build_env_map(&args.common)?;
     let port_map = common::normalize_port_maps(&args.common.publish)
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
     let labels = common::parse_env_vars(&args.common.labels)
@@ -158,7 +172,9 @@ async fn setup_and_boot(args: &RunArgs) -> Result<RunContext, Box<dyn std::error
         .entrypoint
         .as_ref()
         .map(|ep| ep.split_whitespace().map(String::from).collect::<Vec<_>>());
-    let (resolved_volumes, volume_names) = resolve_volumes(&args.common.volumes)?;
+    let mut volume_specs = args.common.volumes.clone();
+    apply_package_caches(&args.package_cache, &mut volume_specs, &mut env);
+    let (resolved_volumes, volume_names) = resolve_volumes(&volume_specs)?;
 
     // Parse --shm-size once; reuse for both tmpfs entry and the box record.
     let shm_size = match &args.common.shm_size {
@@ -405,6 +421,7 @@ async fn setup_and_boot(args: &RunArgs) -> Result<RunContext, Box<dyn std::error
         box_id,
         box_dir,
         name,
+        record,
         exec_socket_path,
         pty_socket_path,
         volume_names,
@@ -704,6 +721,9 @@ async fn run_foreground(
         .await;
     log_handle.abort();
 
+    let exit_code = foreground_exit_code(stop_reason, ctx.vm.exit_code());
+    archive_auto_removed_logs(&ctx, args.rm, exit_code, stop_reason.stopped_by_user());
+
     // Best-effort teardown: a stop failure (wedged VM, transient store error)
     // must not orphan the box's other resources, so every step runs regardless
     // of whether an earlier one failed.
@@ -717,7 +737,6 @@ async fn run_foreground(
     {
         tracing::warn!(box_id = %ctx.box_id, %error, "Failed to destroy VM on stop; continuing teardown");
     }
-    let exit_code = foreground_exit_code(stop_reason, ctx.vm.exit_code());
     teardown_box_resources(
         &ctx,
         args.common.network.as_deref(),
@@ -852,6 +871,27 @@ fn resolve_volumes(
     Ok((resolved, names))
 }
 
+fn apply_package_caches(
+    caches: &[PackageCache],
+    volume_specs: &mut Vec<String>,
+    env: &mut std::collections::HashMap<String, String>,
+) {
+    for cache in caches {
+        match cache {
+            PackageCache::Pnpm => {
+                if !volume_specs
+                    .iter()
+                    .any(|spec| spec == PNPM_CACHE_VOLUME_SPEC)
+                {
+                    volume_specs.push(PNPM_CACHE_VOLUME_SPEC.to_string());
+                }
+                env.entry(PNPM_STORE_ENV.to_string())
+                    .or_insert_with(|| PNPM_STORE_DIR.to_string());
+            }
+        }
+    }
+}
+
 /// Disconnect from network if connected.
 fn disconnect_network(
     box_id: &str,
@@ -882,6 +922,7 @@ async fn cleanup_box(
     if let Some(ref handle) = ctx.health_checker {
         handle.abort();
     }
+    archive_auto_removed_logs(ctx, auto_remove, exit_code, false);
     if let Err(error) = ctx
         .vm
         .destroy_with_options(ctx.stop_signal, ctx.stop_timeout_ms)
@@ -915,7 +956,7 @@ fn teardown_box_resources(
 
     if auto_remove {
         crate::cleanup::cleanup_anonymous_volumes(&ctx.anonymous_volumes);
-        if let Err(error) = StateFile::remove_record(&ctx.box_id) {
+        if let Err(error) = remove_auto_removed_record(&ctx.box_id, exit_code, stopped_by_user) {
             tracing::warn!(box_id = %ctx.box_id, %error, "Failed to remove box record during teardown");
         }
         let _ = std::fs::remove_dir_all(&ctx.box_dir);
@@ -925,6 +966,49 @@ fn teardown_box_resources(
     }) {
         tracing::warn!(box_id = %ctx.box_id, %error, "Failed to mark box stopped during teardown");
     }
+}
+
+fn archive_auto_removed_logs(
+    ctx: &RunContext,
+    auto_remove: bool,
+    exit_code: Option<i32>,
+    stopped_by_user: bool,
+) {
+    if !auto_remove {
+        return;
+    }
+
+    let archive_record = stopped_record_for_archive(&ctx.record, exit_code, stopped_by_user);
+    if let Err(error) = crate::log_archive::archive_removed_logs(&archive_record) {
+        tracing::debug!(
+            box_id = %ctx.box_id,
+            error = %error,
+            "Failed to archive auto-removed box logs"
+        );
+    }
+}
+
+fn remove_auto_removed_record(
+    box_id: &str,
+    exit_code: Option<i32>,
+    stopped_by_user: bool,
+) -> Result<Option<BoxRecord>, std::io::Error> {
+    StateFile::take_record(box_id).map(|record| {
+        record.map(|record| stopped_record_for_archive(&record, exit_code, stopped_by_user))
+    })
+}
+
+fn stopped_record_for_archive(
+    record: &BoxRecord,
+    exit_code: Option<i32>,
+    stopped_by_user: bool,
+) -> BoxRecord {
+    let mut record = record.clone();
+    record.status = "stopped".to_string();
+    record.pid = None;
+    record.exit_code = exit_code;
+    record.stopped_by_user = stopped_by_user;
+    record
 }
 
 fn mark_record_stopped(
@@ -1038,6 +1122,7 @@ mod tests {
             interactive: false,
             tty: false,
             rm: false,
+            package_cache: vec![],
             cmd: vec![],
             log_driver: "json-file".to_string(),
             log_opts: vec![],
@@ -1142,6 +1227,50 @@ mod tests {
         args.detach = true;
 
         assert!(validate_run_mode(&args, false).is_ok());
+    }
+
+    #[test]
+    fn test_apply_package_caches_adds_pnpm_volume_and_env() {
+        let mut volumes = Vec::new();
+        let mut env = std::collections::HashMap::new();
+
+        apply_package_caches(&[PackageCache::Pnpm], &mut volumes, &mut env);
+
+        assert_eq!(volumes, vec![PNPM_CACHE_VOLUME_SPEC.to_string()]);
+        assert_eq!(
+            env.get(PNPM_STORE_ENV).map(String::as_str),
+            Some(PNPM_STORE_DIR)
+        );
+    }
+
+    #[test]
+    fn test_apply_package_caches_preserves_user_pnpm_store_env() {
+        let mut volumes = Vec::new();
+        let mut env = std::collections::HashMap::from([(
+            PNPM_STORE_ENV.to_string(),
+            "/custom/pnpm-store".to_string(),
+        )]);
+
+        apply_package_caches(&[PackageCache::Pnpm], &mut volumes, &mut env);
+
+        assert_eq!(
+            env.get(PNPM_STORE_ENV).map(String::as_str),
+            Some("/custom/pnpm-store")
+        );
+    }
+
+    #[test]
+    fn test_apply_package_caches_deduplicates_pnpm_volume() {
+        let mut volumes = vec![PNPM_CACHE_VOLUME_SPEC.to_string()];
+        let mut env = std::collections::HashMap::new();
+
+        apply_package_caches(
+            &[PackageCache::Pnpm, PackageCache::Pnpm],
+            &mut volumes,
+            &mut env,
+        );
+
+        assert_eq!(volumes, vec![PNPM_CACHE_VOLUME_SPEC.to_string()]);
     }
 
     #[test]

--- a/src/cli/src/commands/wait.rs
+++ b/src/cli/src/commands/wait.rs
@@ -6,21 +6,37 @@ use crate::process;
 use crate::resolve;
 use crate::state::{BoxRecord, StateFile};
 
+const WAIT_POLL_MILLIS: u64 = 500;
+const DEFAULT_HEARTBEAT_SECS: u64 = 60;
+
 #[derive(Args)]
 pub struct WaitArgs {
     /// Box name(s) or ID(s)
     #[arg(required = true)]
     pub boxes: Vec<String>,
+
+    /// Seconds between stderr keepalive messages while waiting (0 disables)
+    #[arg(long, default_value_t = DEFAULT_HEARTBEAT_SECS)]
+    pub heartbeat_interval: u64,
+
+    /// Disable stderr keepalive messages while waiting
+    #[arg(long)]
+    pub no_heartbeat: bool,
 }
 
 pub async fn execute(args: WaitArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let heartbeat_interval = wait_heartbeat_interval(&args);
     for query in &args.boxes {
-        wait_one(query).await?;
+        wait_one(query, heartbeat_interval).await?;
     }
     Ok(())
 }
 
-async fn wait_one(query: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn wait_one(
+    query: &str,
+    heartbeat_interval: Option<std::time::Duration>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut heartbeat = WaitHeartbeat::new(heartbeat_interval);
     loop {
         let state = StateFile::load_default()?;
         let record = resolve::resolve(&state, query)?;
@@ -31,9 +47,53 @@ async fn wait_one(query: &str) -> Result<(), Box<dyn std::error::Error>> {
                 return Ok(());
             }
             WaitPollAction::Sleep => {
-                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                heartbeat.maybe_emit(query);
+                tokio::time::sleep(tokio::time::Duration::from_millis(WAIT_POLL_MILLIS)).await;
             }
         }
+    }
+}
+
+fn wait_heartbeat_interval(args: &WaitArgs) -> Option<std::time::Duration> {
+    if args.no_heartbeat || args.heartbeat_interval == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(args.heartbeat_interval))
+    }
+}
+
+struct WaitHeartbeat {
+    interval: Option<std::time::Duration>,
+    started: std::time::Instant,
+    next: std::time::Instant,
+}
+
+impl WaitHeartbeat {
+    fn new(interval: Option<std::time::Duration>) -> Self {
+        let now = std::time::Instant::now();
+        let next = interval.map(|interval| now + interval).unwrap_or(now);
+        Self {
+            interval,
+            started: now,
+            next,
+        }
+    }
+
+    fn maybe_emit(&mut self, query: &str) {
+        let Some(interval) = self.interval else {
+            return;
+        };
+
+        let now = std::time::Instant::now();
+        if now < self.next {
+            return;
+        }
+
+        eprintln!(
+            "a3s-box wait: still waiting for {query} ({}s)",
+            now.duration_since(self.started).as_secs()
+        );
+        self.next = now + interval;
     }
 }
 
@@ -95,5 +155,21 @@ mod tests {
         let record = crate::test_helpers::fixtures::make_record("id", "box", "paused", None);
 
         assert_eq!(wait_poll_action(&record), WaitPollAction::Finish(0));
+    }
+
+    #[test]
+    fn test_wait_heartbeat_interval_can_be_disabled() {
+        assert!(wait_heartbeat_interval(&WaitArgs {
+            boxes: vec!["box".to_string()],
+            heartbeat_interval: 60,
+            no_heartbeat: true,
+        })
+        .is_none());
+        assert!(wait_heartbeat_interval(&WaitArgs {
+            boxes: vec!["box".to_string()],
+            heartbeat_interval: 0,
+            no_heartbeat: false,
+        })
+        .is_none());
     }
 }

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -7,6 +7,7 @@ pub mod commands;
 pub mod health;
 pub mod image_usage;
 pub mod lifecycle;
+pub(crate) mod log_archive;
 pub mod output;
 pub mod platform;
 pub mod process;

--- a/src/cli/src/log_archive.rs
+++ b/src/cli/src/log_archive.rs
@@ -1,0 +1,217 @@
+//! Archived logs for auto-removed boxes.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::state::BoxRecord;
+
+const ARCHIVE_DIR: &str = "removed-logs";
+const METADATA_FILE: &str = "metadata.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct RemovedLogArchive {
+    pub id: String,
+    pub short_id: String,
+    pub name: String,
+    pub image: String,
+    pub removed_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub exit_code: Option<i32>,
+    pub log_config: a3s_box_core::log::LogConfig,
+}
+
+impl RemovedLogArchive {
+    pub(crate) fn log_dir(&self) -> PathBuf {
+        archive_dir(&self.id).join("logs")
+    }
+
+    pub(crate) fn console_log(&self) -> PathBuf {
+        self.log_dir().join("console.log")
+    }
+}
+
+pub(crate) fn archive_removed_logs(record: &BoxRecord) -> std::io::Result<Option<PathBuf>> {
+    if record.log_config.driver == a3s_box_core::log::LogDriver::None {
+        return Ok(None);
+    }
+
+    let source_log_dir = record.box_dir.join("logs");
+    if !source_log_dir.exists() && !record.console_log.exists() {
+        return Ok(None);
+    }
+
+    let archive_dir = archive_dir(&record.id);
+    if archive_dir.exists() {
+        std::fs::remove_dir_all(&archive_dir)?;
+    }
+    std::fs::create_dir_all(archive_dir.join("logs"))?;
+
+    if source_log_dir.exists() {
+        copy_dir_contents(&source_log_dir, &archive_dir.join("logs"))?;
+    } else if record.console_log.exists() {
+        std::fs::copy(
+            &record.console_log,
+            archive_dir.join("logs").join("console.log"),
+        )?;
+    }
+
+    let metadata = RemovedLogArchive {
+        id: record.id.clone(),
+        short_id: record.short_id.clone(),
+        name: record.name.clone(),
+        image: record.image.clone(),
+        removed_at: Utc::now(),
+        created_at: record.created_at,
+        started_at: record.started_at,
+        exit_code: record.exit_code,
+        log_config: record.log_config.clone(),
+    };
+    let data = serde_json::to_vec_pretty(&metadata).map_err(std::io::Error::other)?;
+    std::fs::write(archive_dir.join(METADATA_FILE), data)?;
+
+    Ok(Some(archive_dir))
+}
+
+pub(crate) fn resolve_archive(query: &str) -> Result<Option<RemovedLogArchive>, String> {
+    let archives = load_archives().map_err(|e| format!("Failed to read removed logs: {e}"))?;
+
+    if let Some(archive) = archives.iter().find(|archive| archive.id == query) {
+        return Ok(Some(archive.clone()));
+    }
+    if let Some(archive) = archives.iter().find(|archive| archive.short_id == query) {
+        return Ok(Some(archive.clone()));
+    }
+
+    let mut named: Vec<_> = archives
+        .iter()
+        .filter(|archive| archive.name == query)
+        .cloned()
+        .collect();
+    if !named.is_empty() {
+        named.sort_by_key(|archive| archive.removed_at);
+        return Ok(named.pop());
+    }
+
+    let prefix_matches: Vec<_> = archives
+        .into_iter()
+        .filter(|archive| archive.id.starts_with(query) || archive.short_id.starts_with(query))
+        .collect();
+    match prefix_matches.len() {
+        0 => Ok(None),
+        1 => Ok(prefix_matches.into_iter().next()),
+        count => Err(format!(
+            "Ambiguous removed-log reference \"{query}\" - matches {count} archives"
+        )),
+    }
+}
+
+fn load_archives() -> std::io::Result<Vec<RemovedLogArchive>> {
+    let root = archive_root();
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut archives = Vec::new();
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path().join(METADATA_FILE);
+        if !path.exists() {
+            continue;
+        }
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
+        };
+        if let Ok(archive) = serde_json::from_slice::<RemovedLogArchive>(&data) {
+            archives.push(archive);
+        }
+    }
+    Ok(archives)
+}
+
+fn copy_dir_contents(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_contents(&from, &to)?;
+        } else if file_type.is_file() {
+            std::fs::copy(from, to)?;
+        }
+    }
+    Ok(())
+}
+
+fn archive_root() -> PathBuf {
+    a3s_box_core::dirs_home().join(ARCHIVE_DIR)
+}
+
+fn archive_dir(id: &str) -> PathBuf {
+    archive_root().join(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &Path) -> Self {
+            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            let lock = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self {
+                _lock: lock,
+                key,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn archives_and_resolves_auto_removed_logs_by_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set("A3S_HOME", tmp.path());
+        let box_dir = tmp.path().join("box");
+        std::fs::create_dir_all(box_dir.join("logs")).unwrap();
+        std::fs::write(box_dir.join("logs").join("container.json"), "{}\n").unwrap();
+
+        let mut record = crate::test_helpers::fixtures::make_record(
+            "550e8400-e29b-41d4-a716-446655440000",
+            "web",
+            "dead",
+            None,
+        );
+        record.auto_remove = true;
+        record.box_dir = box_dir;
+        record.console_log = record.box_dir.join("logs").join("console.log");
+
+        let archive_path = archive_removed_logs(&record).unwrap().unwrap();
+        assert!(archive_path.join("logs").join("container.json").exists());
+
+        let archive = resolve_archive("web").unwrap().unwrap();
+        assert_eq!(archive.id, record.id);
+        assert!(archive.log_dir().join("container.json").exists());
+    }
+}

--- a/src/cli/src/state/file.rs
+++ b/src/cli/src/state/file.rs
@@ -226,6 +226,16 @@ impl StateFile {
         })
     }
 
+    /// Remove a record by id atomically under the state lock and return it.
+    pub(crate) fn take_record(id: &str) -> Result<Option<BoxRecord>, std::io::Error> {
+        Self::modify(|sf| {
+            let Some(index) = sf.records.iter().position(|record| record.id == id) else {
+                return Ok(None);
+            };
+            Ok::<Option<BoxRecord>, std::io::Error>(Some(sf.records.remove(index)))
+        })
+    }
+
     /// Add a record and persist.
     pub fn add(&mut self, record: BoxRecord) -> Result<(), std::io::Error> {
         self.records.push(record);

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -51,6 +51,7 @@ base64 = { workspace = true }
 
 # HTTP client
 reqwest = { workspace = true }
+oci-reqwest = { package = "reqwest", version = "0.12", default-features = false, features = ["json", "stream"] }
 
 # Time
 chrono = { workspace = true }

--- a/src/runtime/src/oci/build/engine/handlers.rs
+++ b/src/runtime/src/oci/build/engine/handlers.rs
@@ -18,6 +18,7 @@ use super::BuildState;
 
 #[cfg(target_os = "macos")]
 const UNSAFE_HOST_RUN_ENV: &str = "A3S_BOX_UNSAFE_HOST_RUN";
+const RUN_OUTPUT_CONTEXT_BYTES: usize = 16 * 1024;
 
 /// Whether a COPY/ADD source contains shell glob metacharacters.
 fn has_glob_meta(s: &str) -> bool {
@@ -278,9 +279,11 @@ pub(super) fn handle_run(
         use super::super::layer::DirSnapshot;
 
         validate_linux_run_preconditions(rootfs_dir, shell, linux_effective_uid())?;
+        prepare_linux_run_filesystem(rootfs_dir)?;
         let workdir_path = ensure_linux_run_workdir(rootfs_dir, workdir)?;
 
         let before = DirSnapshot::capture(rootfs_dir)?;
+        let run_mounts = LinuxRunMounts::mount(rootfs_dir)?;
 
         // Build the command using the configured shell
         let mut cmd = std::process::Command::new("chroot");
@@ -315,20 +318,10 @@ pub(super) fn handle_run(
             .map_err(|e| BoxError::BuildError(format!("Failed to execute RUN command: {}", e)))?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(BoxError::BuildError(format!(
-                "RUN command failed (exit {}): {}",
-                output.status.code().unwrap_or(-1),
-                stderr.trim()
-            )));
+            return Err(run_command_failed_error(command, &output));
         }
-
-        if !quiet {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            if !stdout.is_empty() {
-                print!("{}", stdout);
-            }
-        }
+        print_run_output(&output, quiet);
+        run_mounts.unmount()?;
 
         // Capture diff
         let after = DirSnapshot::capture(rootfs_dir)?;
@@ -429,6 +422,287 @@ fn ensure_linux_run_workdir(rootfs_dir: &Path, workdir: &str) -> Result<PathBuf>
     Ok(workdir_path)
 }
 
+fn print_run_output(output: &std::process::Output, quiet: bool) {
+    if quiet {
+        return;
+    }
+
+    if !output.stdout.is_empty() {
+        print!("{}", String::from_utf8_lossy(&output.stdout));
+    }
+    if !output.stderr.is_empty() {
+        use std::io::Write as _;
+        let _ = std::io::stderr().write_all(String::from_utf8_lossy(&output.stderr).as_bytes());
+    }
+}
+
+fn run_command_failed_error(command: &str, output: &std::process::Output) -> BoxError {
+    let exit = output
+        .status
+        .code()
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "signal".to_string());
+    let mut message = format!("RUN command failed (exit {exit}): {command}");
+
+    append_output_context(&mut message, "stdout", &output.stdout);
+    append_output_context(&mut message, "stderr", &output.stderr);
+
+    if output.stdout.is_empty() && output.stderr.is_empty() {
+        message.push_str("\n(no stdout or stderr captured)");
+    }
+
+    BoxError::BuildError(message)
+}
+
+fn append_output_context(message: &mut String, label: &str, bytes: &[u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+
+    message.push('\n');
+    message.push_str(label);
+    message.push_str(":\n");
+    message.push_str(&lossy_tail(bytes, RUN_OUTPUT_CONTEXT_BYTES));
+}
+
+fn lossy_tail(bytes: &[u8], max_bytes: usize) -> String {
+    let (slice, truncated) = if bytes.len() > max_bytes {
+        (&bytes[bytes.len() - max_bytes..], true)
+    } else {
+        (bytes, false)
+    };
+    let mut output = String::new();
+    if truncated {
+        output.push_str(&format!(
+            "[showing last {} bytes of {} captured bytes]\n",
+            max_bytes,
+            bytes.len()
+        ));
+    }
+    output.push_str(String::from_utf8_lossy(slice).trim_end());
+    output
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_linux_run_filesystem(rootfs_dir: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    for dir in ["dev", "proc", "tmp", "var/tmp", "etc"] {
+        std::fs::create_dir_all(rootfs_dir.join(dir)).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to prepare RUN directory {}: {}",
+                rootfs_dir.join(dir).display(),
+                e
+            ))
+        })?;
+    }
+
+    for dir in ["tmp", "var/tmp"] {
+        let path = rootfs_dir.join(dir);
+        let mut perms = std::fs::metadata(&path)
+            .map_err(|e| {
+                BoxError::BuildError(format!("Failed to inspect {}: {}", path.display(), e))
+            })?
+            .permissions();
+        perms.set_mode(0o1777);
+        std::fs::set_permissions(&path, perms).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to set sticky tmp permissions on {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+    }
+
+    for dev in ["null", "zero", "random", "urandom"] {
+        let target = rootfs_dir.join("dev").join(dev);
+        if !target.exists() {
+            std::fs::File::create(&target).map_err(|e| {
+                BoxError::BuildError(format!("Failed to create {}: {}", target.display(), e))
+            })?;
+        }
+    }
+
+    ensure_linux_run_symlink(rootfs_dir.join("dev/fd"), "/proc/self/fd")?;
+    ensure_linux_run_symlink(rootfs_dir.join("dev/stdin"), "/proc/self/fd/0")?;
+    ensure_linux_run_symlink(rootfs_dir.join("dev/stdout"), "/proc/self/fd/1")?;
+    ensure_linux_run_symlink(rootfs_dir.join("dev/stderr"), "/proc/self/fd/2")?;
+    ensure_linux_resolv_conf(rootfs_dir)?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_linux_run_symlink(path: PathBuf, target: &str) -> Result<()> {
+    match std::fs::symlink_metadata(&path) {
+        Ok(meta) if meta.file_type().is_symlink() => return Ok(()),
+        Ok(_) => return Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(BoxError::BuildError(format!(
+                "Failed to inspect {}: {}",
+                path.display(),
+                err
+            )));
+        }
+    }
+
+    std::os::unix::fs::symlink(target, &path).map_err(|e| {
+        BoxError::BuildError(format!(
+            "Failed to create RUN symlink {} -> {}: {}",
+            path.display(),
+            target,
+            e
+        ))
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_linux_resolv_conf(rootfs_dir: &Path) -> Result<()> {
+    let path = rootfs_dir.join("etc/resolv.conf");
+    if std::fs::metadata(&path)
+        .map(|m| m.len() > 0)
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string("/etc/resolv.conf")
+        .unwrap_or_else(|_| "nameserver 8.8.8.8\nnameserver 8.8.4.4\n".to_string());
+    std::fs::write(&path, content)
+        .map_err(|e| BoxError::BuildError(format!("Failed to write {}: {}", path.display(), e)))
+}
+
+#[cfg(target_os = "linux")]
+struct LinuxRunMounts {
+    mounted: Vec<PathBuf>,
+}
+
+#[cfg(target_os = "linux")]
+impl LinuxRunMounts {
+    fn mount(rootfs_dir: &Path) -> Result<Self> {
+        let mut mounts = Self {
+            mounted: Vec::new(),
+        };
+
+        mounts.mount_proc(&rootfs_dir.join("proc"))?;
+        for dev in ["null", "zero", "random", "urandom"] {
+            mounts.bind_mount(
+                Path::new("/dev").join(dev),
+                rootfs_dir.join("dev").join(dev),
+            )?;
+        }
+
+        Ok(mounts)
+    }
+
+    fn mount_proc(&mut self, target: &Path) -> Result<()> {
+        mount_linux(
+            Some(Path::new("proc")),
+            target,
+            Some("proc"),
+            libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_NODEV,
+        )?;
+        self.mounted.push(target.to_path_buf());
+        Ok(())
+    }
+
+    fn bind_mount(&mut self, source: PathBuf, target: PathBuf) -> Result<()> {
+        mount_linux(Some(&source), &target, None, libc::MS_BIND)?;
+        self.mounted.push(target);
+        Ok(())
+    }
+
+    fn unmount(mut self) -> Result<()> {
+        let mut first_error = None;
+        for target in self.mounted.iter().rev() {
+            if let Err(error) = unmount_linux(target) {
+                first_error.get_or_insert(error);
+            }
+        }
+        self.mounted.clear();
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for LinuxRunMounts {
+    fn drop(&mut self) {
+        for target in self.mounted.iter().rev() {
+            let _ = unmount_linux(target);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn unmount_linux(target: &Path) -> Result<()> {
+    let c_target = path_cstring(target, "unmount target")?;
+    let ret = unsafe { libc::umount2(c_target.as_ptr(), libc::MNT_DETACH) };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(BoxError::BuildError(format!(
+            "Failed to unmount RUN support at {}: {}",
+            target.display(),
+            std::io::Error::last_os_error()
+        )))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn mount_linux(
+    source: Option<&Path>,
+    target: &Path,
+    fstype: Option<&str>,
+    flags: libc::c_ulong,
+) -> Result<()> {
+    let c_source = source
+        .map(|source| path_cstring(source, "mount source"))
+        .transpose()?;
+    let c_target = path_cstring(target, "mount target")?;
+    let c_fstype = fstype
+        .map(std::ffi::CString::new)
+        .transpose()
+        .map_err(|_| BoxError::BuildError("Cannot mount fstype containing NUL".to_string()))?;
+
+    let ret = unsafe {
+        libc::mount(
+            c_source
+                .as_ref()
+                .map(|value| value.as_ptr())
+                .unwrap_or(std::ptr::null()),
+            c_target.as_ptr(),
+            c_fstype
+                .as_ref()
+                .map(|value| value.as_ptr())
+                .unwrap_or(std::ptr::null()),
+            flags,
+            std::ptr::null(),
+        )
+    };
+
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(BoxError::BuildError(format!(
+            "Failed to mount RUN support at {}: {}",
+            target.display(),
+            std::io::Error::last_os_error()
+        )))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn path_cstring(path: &Path, label: &str) -> Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| BoxError::BuildError(format!("{label} contains NUL: {}", path.display())))
+}
+
 #[cfg(target_os = "macos")]
 fn unsafe_host_run_enabled() -> bool {
     std::env::var(UNSAFE_HOST_RUN_ENV)
@@ -499,20 +773,9 @@ fn handle_run_on_host_unsafe(
         .map_err(|e| BoxError::BuildError(format!("Failed to execute command: {}", e)))?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(BoxError::BuildError(format!(
-            "RUN command failed (exit {}): {}",
-            output.status.code().unwrap_or(-1),
-            stderr.trim()
-        )));
+        return Err(run_command_failed_error(command, &output));
     }
-
-    if !quiet {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        if !stdout.is_empty() {
-            print!("{}", stdout);
-        }
-    }
+    print_run_output(&output, quiet);
 
     // Capture filesystem state after execution
     let after = DirSnapshot::capture(rootfs_dir)?;
@@ -905,9 +1168,10 @@ mod tests {
     use super::super::super::dockerfile::Instruction;
     use super::{
         execute_onbuild_trigger, expand_glob_sources, glob_segment_match, handle_add,
-        instruction_to_string,
+        instruction_to_string, run_command_failed_error,
     };
     use crate::oci::build::engine::{BuildConfig, BuildState};
+    use a3s_box_core::error::BoxError;
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -921,6 +1185,29 @@ mod tests {
         assert!(glob_segment_match("*", "anything"));
         assert!(glob_segment_match("pre*post", "pre_middle_post"));
         assert!(!glob_segment_match("pre*post", "pre_middle"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_run_command_failed_error_includes_stdout_and_stderr() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(2 << 8),
+            stdout: b"resolved package metadata\n".to_vec(),
+            stderr: b"corepack prepare failed\n".to_vec(),
+        };
+
+        let BoxError::BuildError(message) =
+            run_command_failed_error("corepack prepare pnpm@10.30.3 --activate", &output)
+        else {
+            panic!("expected build error");
+        };
+
+        assert!(message.contains("RUN command failed (exit 2)"));
+        assert!(message.contains("corepack prepare pnpm@10.30.3 --activate"));
+        assert!(message.contains("stdout:\nresolved package metadata"));
+        assert!(message.contains("stderr:\ncorepack prepare failed"));
     }
 
     #[test]

--- a/src/runtime/src/oci/credentials.rs
+++ b/src/runtime/src/oci/credentials.rs
@@ -4,9 +4,10 @@
 //! Uses atomic writes (write tmp, rename) for safety.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use a3s_box_core::error::{BoxError, Result};
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
 /// Per-registry credential entry.
@@ -20,6 +21,28 @@ struct CredentialEntry {
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct CredentialFile {
     registries: HashMap<String, CredentialEntry>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerConfigFile {
+    #[serde(default)]
+    auths: HashMap<String, DockerAuthEntry>,
+    #[serde(default, rename = "credsStore")]
+    creds_store: Option<String>,
+    #[serde(default, rename = "credHelpers")]
+    cred_helpers: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerAuthEntry {
+    #[serde(default)]
+    auth: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    password: Option<String>,
+    #[serde(default, rename = "identitytoken")]
+    identity_token: Option<String>,
 }
 
 /// Persistent credential store for container registries.
@@ -164,6 +187,214 @@ impl CredentialStore {
     }
 }
 
+/// Get credentials from Docker's config (`~/.docker/config.json` or
+/// `$DOCKER_CONFIG/config.json`), including credential helpers.
+pub(crate) fn docker_credentials(registry: &str) -> Option<(String, String)> {
+    let config_path = docker_config_path()?;
+    let config = load_docker_config(&config_path).ok()?;
+    let candidates = docker_registry_candidates(registry);
+
+    if let Some((key, helper)) = matching_credential_helper(&config, &candidates) {
+        if let Some(creds) =
+            docker_credential_helper_get(helper, &helper_server_candidates(key, registry))
+        {
+            return Some(creds);
+        }
+    }
+
+    if let Some(helper) = config.creds_store.as_deref() {
+        if let Some(creds) = docker_credential_helper_get(helper, &candidates) {
+            return Some(creds);
+        }
+    }
+
+    matching_docker_auth(&config, &candidates).and_then(docker_auth_entry_credentials)
+}
+
+fn docker_config_path() -> Option<PathBuf> {
+    if let Ok(config_dir) = std::env::var("DOCKER_CONFIG") {
+        return Some(PathBuf::from(config_dir).join("config.json"));
+    }
+    dirs::home_dir().map(|home| home.join(".docker").join("config.json"))
+}
+
+fn load_docker_config(path: &Path) -> Result<DockerConfigFile> {
+    let data = std::fs::read_to_string(path).map_err(|e| {
+        BoxError::ConfigError(format!(
+            "Failed to read Docker credential config {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    serde_json::from_str(&data).map_err(|e| {
+        BoxError::ConfigError(format!(
+            "Failed to parse Docker credential config {}: {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
+fn docker_registry_candidates(registry: &str) -> Vec<String> {
+    let normalized = normalize_registry(registry);
+    let mut candidates = vec![
+        registry.trim().to_string(),
+        normalized.clone(),
+        format!("https://{}", registry.trim()),
+        format!("http://{}", registry.trim()),
+        format!("https://{normalized}"),
+        format!("http://{normalized}"),
+    ];
+
+    if normalized == "index.docker.io" {
+        candidates.extend(
+            [
+                "docker.io",
+                "registry-1.docker.io",
+                "https://index.docker.io/v1/",
+                "https://index.docker.io/v1",
+                "index.docker.io/v1/",
+                "index.docker.io/v1",
+            ]
+            .into_iter()
+            .map(str::to_string),
+        );
+    }
+
+    candidates.sort();
+    candidates.dedup();
+    candidates
+}
+
+fn matching_credential_helper<'a>(
+    config: &'a DockerConfigFile,
+    candidates: &[String],
+) -> Option<(&'a str, &'a str)> {
+    config
+        .cred_helpers
+        .iter()
+        .find(|(key, _)| registry_key_matches(key, candidates))
+        .map(|(key, helper)| (key.as_str(), helper.as_str()))
+}
+
+fn matching_docker_auth<'a>(
+    config: &'a DockerConfigFile,
+    candidates: &[String],
+) -> Option<&'a DockerAuthEntry> {
+    config
+        .auths
+        .iter()
+        .find(|(key, _)| registry_key_matches(key, candidates))
+        .map(|(_, entry)| entry)
+}
+
+fn registry_key_matches(key: &str, candidates: &[String]) -> bool {
+    let key_norm = normalize_docker_server_key(key);
+    candidates
+        .iter()
+        .any(|candidate| key == candidate || key_norm == normalize_docker_server_key(candidate))
+}
+
+fn normalize_docker_server_key(value: &str) -> String {
+    let trimmed = value.trim().trim_end_matches('/');
+    let without_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    let without_v1 = without_scheme.strip_suffix("/v1").unwrap_or(without_scheme);
+    normalize_registry(without_v1)
+}
+
+fn helper_server_candidates(matched_key: &str, registry: &str) -> Vec<String> {
+    let mut candidates = vec![matched_key.to_string()];
+    candidates.extend(docker_registry_candidates(registry));
+    candidates.sort();
+    candidates.dedup();
+    candidates
+}
+
+fn docker_auth_entry_credentials(entry: &DockerAuthEntry) -> Option<(String, String)> {
+    if let (Some(username), Some(password)) = (&entry.username, &entry.password) {
+        if !username.is_empty() && !password.is_empty() {
+            return Some((username.clone(), password.clone()));
+        }
+    }
+
+    if let Some(auth) = entry.auth.as_deref() {
+        if let Some(creds) = decode_docker_auth(auth) {
+            return Some(creds);
+        }
+    }
+
+    entry
+        .identity_token
+        .as_ref()
+        .filter(|token| !token.is_empty())
+        .map(|token| ("oauth2accesstoken".to_string(), token.clone()))
+}
+
+fn decode_docker_auth(auth: &str) -> Option<(String, String)> {
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(auth.trim())
+        .ok()?;
+    let text = String::from_utf8(decoded).ok()?;
+    let (username, password) = text.split_once(':')?;
+    if username.is_empty() || password.is_empty() {
+        return None;
+    }
+    Some((username.to_string(), password.to_string()))
+}
+
+fn docker_credential_helper_get(
+    helper: &str,
+    server_candidates: &[String],
+) -> Option<(String, String)> {
+    for server in server_candidates {
+        if let Some(creds) = docker_credential_helper_get_one(helper, server) {
+            return Some(creds);
+        }
+    }
+    None
+}
+
+fn docker_credential_helper_get_one(helper: &str, server: &str) -> Option<(String, String)> {
+    let program = format!("docker-credential-{helper}");
+    let mut child = std::process::Command::new(program)
+        .arg("get")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+
+    {
+        use std::io::Write as _;
+        let stdin = child.stdin.as_mut()?;
+        if stdin.write_all(server.as_bytes()).is_err() {
+            let _ = child.kill();
+            return None;
+        }
+    }
+
+    let output = child.wait_with_output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    #[derive(Deserialize)]
+    #[allow(non_snake_case)]
+    struct HelperResponse {
+        Username: String,
+        Secret: String,
+    }
+
+    let response: HelperResponse = serde_json::from_slice(&output.stdout).ok()?;
+    if response.Username.is_empty() || response.Secret.is_empty() {
+        return None;
+    }
+    Some((response.Username, response.Secret))
+}
+
 /// Normalize registry names (e.g., "docker.io" and "index.docker.io" → "index.docker.io").
 fn normalize_registry(registry: &str) -> String {
     let r = registry.trim().to_lowercase();
@@ -191,10 +422,28 @@ impl a3s_box_core::traits::CredentialProvider for CredentialStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
     use tempfile::TempDir;
 
     fn test_store(dir: &TempDir) -> CredentialStore {
         CredentialStore::new(dir.path().join("credentials.json"))
+    }
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    fn with_docker_config_dir<R>(dir: &TempDir, f: impl FnOnce() -> R) -> R {
+        let _guard = env_lock();
+        let previous = std::env::var_os("DOCKER_CONFIG");
+        std::env::set_var("DOCKER_CONFIG", dir.path());
+        let result = f();
+        match previous {
+            Some(value) => std::env::set_var("DOCKER_CONFIG", value),
+            None => std::env::remove_var("DOCKER_CONFIG"),
+        }
+        result
     }
 
     // The advisory lock is per-open-file-description, so separate
@@ -310,6 +559,70 @@ mod tests {
 
         let creds = store.get("registry-1.docker.io").unwrap();
         assert_eq!(creds, Some(("user".to_string(), "pass".to_string())));
+    }
+
+    #[test]
+    fn docker_credentials_reads_auths_for_host_port_registry() {
+        use base64::Engine as _;
+
+        let dir = TempDir::new().unwrap();
+        let auth = base64::engine::general_purpose::STANDARD.encode("user:pass");
+        std::fs::write(
+            dir.path().join("config.json"),
+            format!(
+                r#"{{
+  "auths": {{
+    "10.12.111.133:49164": {{ "auth": "{auth}" }}
+  }}
+}}"#
+            ),
+        )
+        .unwrap();
+
+        let creds = with_docker_config_dir(&dir, || docker_credentials("10.12.111.133:49164"));
+        assert_eq!(creds, Some(("user".to_string(), "pass".to_string())));
+    }
+
+    #[test]
+    fn docker_credentials_matches_docker_hub_legacy_url() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "username": "dock",
+      "password": "secret"
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let creds = with_docker_config_dir(&dir, || docker_credentials("docker.io"));
+        assert_eq!(creds, Some(("dock".to_string(), "secret".to_string())));
+    }
+
+    #[test]
+    fn docker_credentials_uses_identity_token_as_oauth_password() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{
+  "auths": {
+    "registry.example.com": {
+      "identitytoken": "token-value"
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let creds = with_docker_config_dir(&dir, || docker_credentials("registry.example.com"));
+        assert_eq!(
+            creds,
+            Some(("oauth2accesstoken".to_string(), "token-value".to_string()))
+        );
     }
 
     #[test]

--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -8,9 +8,11 @@ use std::sync::Arc;
 
 use a3s_box_core::error::{BoxError, Result};
 use oci_distribution::client::{ClientConfig, ClientProtocol, Config, ImageLayer, PushResponse};
-use oci_distribution::manifest::{ImageIndexEntry, OciImageManifest};
+use oci_distribution::errors::{OciDistributionError, OciErrorCode};
+use oci_distribution::manifest::{ImageIndexEntry, OciImageManifest, OCI_IMAGE_MEDIA_TYPE};
 use oci_distribution::secrets::RegistryAuth as OciRegistryAuth;
 use oci_distribution::{Client, Reference};
+use oci_reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, LOCATION};
 
 use super::credentials::CredentialStore;
 use super::reference::ImageReference;
@@ -226,6 +228,9 @@ impl RegistryAuth {
                 return Self::basic(username, password);
             }
         }
+        if let Some((username, password)) = super::credentials::docker_credentials(registry) {
+            return Self::basic(username, password);
+        }
         // Fall back to env vars, then anonymous
         Self::from_env()
     }
@@ -235,6 +240,15 @@ impl RegistryAuth {
         match (&self.username, &self.password) {
             (Some(u), Some(p)) => OciRegistryAuth::Basic(u.clone(), p.clone()),
             _ => OciRegistryAuth::Anonymous,
+        }
+    }
+
+    fn basic_credentials(&self) -> Option<(String, String)> {
+        match (&self.username, &self.password) {
+            (Some(username), Some(password)) if !username.is_empty() && !password.is_empty() => {
+                Some((username.clone(), password.clone()))
+            }
+            _ => None,
         }
     }
 }
@@ -634,16 +648,16 @@ impl RegistryPusher {
             ));
         }
 
-        // Push to registry
-        let auth = self.auth.to_oci_auth();
-        let response: PushResponse = self
-            .client
-            .push(&oci_ref, &layers, config, &auth, Some(manifest))
-            .await
-            .map_err(|e| BoxError::RegistryError {
-                registry: reference.registry.clone(),
-                message: format!("Failed to push image: {}", e),
-            })?;
+        let response = self
+            .push_with_repository_create_retry(
+                reference,
+                &oci_ref,
+                &layers,
+                &config,
+                &manifest,
+                &manifest_data,
+            )
+            .await?;
 
         tracing::info!(
             reference = %reference,
@@ -670,6 +684,385 @@ impl RegistryPusher {
             BoxError::OciImageError(format!("Invalid OCI reference '{}': {}", ref_str, e))
         })
     }
+
+    async fn push_with_repository_create_retry(
+        &self,
+        reference: &ImageReference,
+        oci_ref: &Reference,
+        layers: &[ImageLayer],
+        config: &Config,
+        manifest: &OciImageManifest,
+        manifest_data: &[u8],
+    ) -> Result<PushResponse> {
+        match self
+            .push_once(reference, oci_ref, layers, config, manifest, manifest_data)
+            .await
+        {
+            Ok(response) => Ok(response),
+            Err(first_error) if is_repository_already_exists_push_error(&first_error) => {
+                tracing::warn!(
+                    reference = %reference,
+                    error = %push_error_summary(&first_error),
+                    "Registry reported repository already exists during push; retrying once"
+                );
+                self.push_once(reference, oci_ref, layers, config, manifest, manifest_data)
+                    .await
+                    .map_err(|retry_error| BoxError::RegistryError {
+                        registry: reference.registry.clone(),
+                        message: format!(
+                            "Failed to push image after retrying repository creation race: first error: {}; retry error: {}",
+                            push_error_summary(&first_error),
+                            push_error_summary(&retry_error)
+                        ),
+                    })
+            }
+            Err(error) => Err(BoxError::RegistryError {
+                registry: reference.registry.clone(),
+                message: format!("Failed to push image: {}", push_error_summary(&error)),
+            }),
+        }
+    }
+
+    async fn push_once(
+        &self,
+        reference: &ImageReference,
+        oci_ref: &Reference,
+        layers: &[ImageLayer],
+        config: &Config,
+        manifest: &OciImageManifest,
+        manifest_data: &[u8],
+    ) -> std::result::Result<PushResponse, OciDistributionError> {
+        let auth = self.auth.to_oci_auth();
+        match self
+            .client
+            .push(
+                oci_ref,
+                layers,
+                config.clone(),
+                &auth,
+                Some(manifest.clone()),
+            )
+            .await
+        {
+            Err(first_error)
+                if is_unauthorized_push_error(&first_error)
+                    && self.auth.basic_credentials().is_some() =>
+            {
+                tracing::warn!(
+                    reference = %reference,
+                    error = %push_error_summary(&first_error),
+                    "Registry rejected the default OCI push auth flow; retrying with preemptive Basic auth"
+                );
+                self.push_with_preemptive_basic_auth(
+                    reference,
+                    layers,
+                    config,
+                    manifest,
+                    manifest_data,
+                )
+                .await
+                .map_err(|fallback_error| {
+                    OciDistributionError::GenericError(Some(format!(
+                        "default push auth failed: {}; preemptive Basic auth retry failed: {}",
+                        push_error_summary(&first_error),
+                        push_error_summary(&fallback_error)
+                    )))
+                })
+            }
+            result => result,
+        }
+    }
+
+    async fn push_with_preemptive_basic_auth(
+        &self,
+        reference: &ImageReference,
+        layers: &[ImageLayer],
+        config: &Config,
+        manifest: &OciImageManifest,
+        manifest_data: &[u8],
+    ) -> std::result::Result<PushResponse, OciDistributionError> {
+        let (username, password) = self.auth.basic_credentials().ok_or_else(|| {
+            OciDistributionError::GenericError(Some(
+                "preemptive Basic auth retry requires non-empty credentials".to_string(),
+            ))
+        })?;
+        let http = oci_reqwest::Client::new();
+        let base = registry_base_url(reference)?;
+
+        for (layer, descriptor) in layers.iter().zip(&manifest.layers) {
+            push_blob_with_basic_auth(
+                &http,
+                &base,
+                &reference.repository,
+                &username,
+                &password,
+                &descriptor.digest,
+                &layer.data,
+            )
+            .await?;
+        }
+
+        let config_url = push_blob_with_basic_auth(
+            &http,
+            &base,
+            &reference.repository,
+            &username,
+            &password,
+            &manifest.config.digest,
+            &config.data,
+        )
+        .await?;
+
+        let manifest_ref = reference
+            .tag
+            .as_deref()
+            .or(reference.digest.as_deref())
+            .unwrap_or("latest");
+        let manifest_url = registry_manifest_url(&base, &reference.repository, manifest_ref)?;
+        let media_type = manifest
+            .media_type
+            .as_deref()
+            .unwrap_or(OCI_IMAGE_MEDIA_TYPE);
+        let response = http
+            .put(manifest_url.clone())
+            .basic_auth(&username, Some(&password))
+            .header(CONTENT_TYPE, media_type)
+            .body(manifest_data.to_vec())
+            .send()
+            .await?;
+        let response = ensure_registry_status(
+            response,
+            &[
+                oci_reqwest::StatusCode::CREATED,
+                oci_reqwest::StatusCode::OK,
+            ],
+            manifest_url.as_str(),
+        )
+        .await?;
+        let manifest_url = response_location_or_url(&response, &manifest_url)?;
+
+        Ok(PushResponse {
+            config_url,
+            manifest_url,
+        })
+    }
+}
+
+fn registry_base_url(
+    reference: &ImageReference,
+) -> std::result::Result<oci_reqwest::Url, OciDistributionError> {
+    let scheme = match registry_protocol_from_env() {
+        ClientProtocol::Http => "http",
+        ClientProtocol::Https | ClientProtocol::HttpsExcept(_) => "https",
+    };
+    oci_reqwest::Url::parse(&format!("{scheme}://{}", reference.registry))
+        .map_err(|e| OciDistributionError::UrlParseError(e.to_string()))
+}
+
+fn registry_blob_upload_url(
+    base: &oci_reqwest::Url,
+    repository: &str,
+) -> std::result::Result<oci_reqwest::Url, OciDistributionError> {
+    oci_reqwest::Url::parse(&format!(
+        "{}/v2/{repository}/blobs/uploads/",
+        base.as_str().trim_end_matches('/')
+    ))
+    .map_err(|e| OciDistributionError::UrlParseError(e.to_string()))
+}
+
+fn registry_manifest_url(
+    base: &oci_reqwest::Url,
+    repository: &str,
+    reference: &str,
+) -> std::result::Result<oci_reqwest::Url, OciDistributionError> {
+    oci_reqwest::Url::parse(&format!(
+        "{}/v2/{repository}/manifests/{reference}",
+        base.as_str().trim_end_matches('/')
+    ))
+    .map_err(|e| OciDistributionError::UrlParseError(e.to_string()))
+}
+
+fn resolve_registry_location(
+    base: &oci_reqwest::Url,
+    location: &str,
+) -> std::result::Result<oci_reqwest::Url, OciDistributionError> {
+    oci_reqwest::Url::parse(location)
+        .or_else(|_| base.join(location))
+        .map_err(|e| OciDistributionError::UrlParseError(e.to_string()))
+}
+
+fn append_digest_param(location: &oci_reqwest::Url, digest: &str) -> oci_reqwest::Url {
+    let mut url = location.clone();
+    url.query_pairs_mut().append_pair("digest", digest);
+    url
+}
+
+fn response_location_or_url(
+    response: &oci_reqwest::Response,
+    fallback: &oci_reqwest::Url,
+) -> std::result::Result<String, OciDistributionError> {
+    response
+        .headers()
+        .get(LOCATION)
+        .map(|value| value.to_str().map(str::to_string))
+        .transpose()
+        .map(|location| location.unwrap_or_else(|| fallback.as_str().to_string()))
+        .map_err(OciDistributionError::HeaderValueError)
+}
+
+async fn ensure_registry_status(
+    response: oci_reqwest::Response,
+    expected: &[oci_reqwest::StatusCode],
+    url: &str,
+) -> std::result::Result<oci_reqwest::Response, OciDistributionError> {
+    let status = response.status();
+    if expected.contains(&status) {
+        return Ok(response);
+    }
+
+    let message = response.text().await.unwrap_or_default();
+    if status == oci_reqwest::StatusCode::UNAUTHORIZED {
+        return Err(OciDistributionError::UnauthorizedError {
+            url: url.to_string(),
+        });
+    }
+
+    Err(OciDistributionError::ServerError {
+        code: status.as_u16(),
+        url: url.to_string(),
+        message,
+    })
+}
+
+async fn push_blob_with_basic_auth(
+    http: &oci_reqwest::Client,
+    base: &oci_reqwest::Url,
+    repository: &str,
+    username: &str,
+    password: &str,
+    digest: &str,
+    data: &[u8],
+) -> std::result::Result<String, OciDistributionError> {
+    if data.is_empty() {
+        return Err(OciDistributionError::PushNoDataError);
+    }
+
+    let upload_url = registry_blob_upload_url(base, repository)?;
+    let response = http
+        .post(upload_url.clone())
+        .basic_auth(username, Some(password))
+        .header(CONTENT_LENGTH, "0")
+        .send()
+        .await?;
+    let response = ensure_registry_status(
+        response,
+        &[oci_reqwest::StatusCode::ACCEPTED],
+        upload_url.as_str(),
+    )
+    .await?;
+    let location = response
+        .headers()
+        .get(LOCATION)
+        .ok_or(OciDistributionError::RegistryNoLocationError)?
+        .to_str()?;
+    let location = resolve_registry_location(base, location)?;
+
+    let response = http
+        .patch(location.clone())
+        .basic_auth(username, Some(password))
+        .header(CONTENT_TYPE, "application/octet-stream")
+        .header(CONTENT_LENGTH, data.len().to_string())
+        .body(data.to_vec())
+        .send()
+        .await?;
+    let response = ensure_registry_status(
+        response,
+        &[oci_reqwest::StatusCode::ACCEPTED],
+        location.as_str(),
+    )
+    .await?;
+    let location = response
+        .headers()
+        .get(LOCATION)
+        .map(|value| value.to_str())
+        .transpose()?
+        .map(|location| resolve_registry_location(base, location))
+        .transpose()?
+        .unwrap_or(location);
+
+    let complete_url = append_digest_param(&location, digest);
+    let response = http
+        .put(complete_url.clone())
+        .basic_auth(username, Some(password))
+        .header(CONTENT_LENGTH, "0")
+        .send()
+        .await?;
+    let response = ensure_registry_status(
+        response,
+        &[oci_reqwest::StatusCode::CREATED],
+        complete_url.as_str(),
+    )
+    .await?;
+    response_location_or_url(&response, &complete_url)
+}
+
+fn is_unauthorized_push_error(error: &OciDistributionError) -> bool {
+    match error {
+        OciDistributionError::UnauthorizedError { .. }
+        | OciDistributionError::AuthenticationFailure(_)
+        | OciDistributionError::ServerError { code: 401, .. } => true,
+        OciDistributionError::RegistryError { envelope, .. } => envelope
+            .errors
+            .iter()
+            .any(|err| matches!(err.code, OciErrorCode::Unauthorized)),
+        _ => false,
+    }
+}
+
+fn is_repository_already_exists_push_error(error: &OciDistributionError) -> bool {
+    match error {
+        OciDistributionError::ServerError { code, message, .. } => {
+            *code == 409 || looks_like_repository_already_exists(message)
+        }
+        OciDistributionError::RegistryError { envelope, .. } => envelope.errors.iter().any(|err| {
+            let name_error = matches!(
+                &err.code,
+                OciErrorCode::NameInvalid | OciErrorCode::NameUnknown
+            );
+            (name_error || matches!(&err.code, OciErrorCode::Denied))
+                && (looks_like_repository_already_exists(&err.message)
+                    || looks_like_repository_already_exists(&err.detail.to_string()))
+        }),
+        OciDistributionError::GenericError(Some(message))
+        | OciDistributionError::SpecViolationError(message) => {
+            looks_like_repository_already_exists(message)
+        }
+        _ => false,
+    }
+}
+
+fn looks_like_repository_already_exists(message: &str) -> bool {
+    let message = message.to_lowercase();
+    message.contains("already exists")
+        || message.contains("resource exists")
+        || message.contains("duplicate")
+        || message.contains("已存在")
+        || message.contains("重复创建")
+}
+
+fn push_error_summary(error: &OciDistributionError) -> String {
+    let mut message = error.to_string();
+    if matches!(
+        error,
+        OciDistributionError::UnauthorizedError { .. }
+            | OciDistributionError::AuthenticationFailure(_)
+            | OciDistributionError::ServerError { code: 401, .. }
+    ) {
+        message.push_str(
+            "; checked A3S credentials, Docker config/credential helpers, and REGISTRY_USERNAME/REGISTRY_PASSWORD",
+        );
+    }
+    message
 }
 
 /// Platform resolver that always selects linux images matching the host architecture.
@@ -869,6 +1262,38 @@ mod tests {
             ClientProtocol::Https
         ));
         std::env::remove_var(REGISTRY_PROTOCOL_ENV);
+    }
+
+    #[test]
+    fn test_repository_exists_push_error_matches_chinese_registry_message() {
+        let error = OciDistributionError::ServerError {
+            code: 500,
+            url: "http://10.12.111.133:49164/v2/a3s/api/blobs/uploads/".to_string(),
+            message: "该资源已存在，请勿重复创建".to_string(),
+        };
+
+        assert!(is_repository_already_exists_push_error(&error));
+    }
+
+    #[test]
+    fn test_repository_exists_push_error_retries_conflict_status() {
+        let error = OciDistributionError::ServerError {
+            code: 409,
+            url: "http://registry.example.com/v2/a3s/api/blobs/uploads/".to_string(),
+            message: "conflict".to_string(),
+        };
+
+        assert!(is_repository_already_exists_push_error(&error));
+    }
+
+    #[test]
+    fn test_unauthorized_push_error_is_not_repository_retryable() {
+        let error = OciDistributionError::UnauthorizedError {
+            url: "http://registry.example.com/v2/a3s/web/blobs/uploads/".to_string(),
+        };
+
+        assert!(!is_repository_already_exists_push_error(&error));
+        assert!(push_error_summary(&error).contains("Docker config/credential helpers"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- surface Dockerfile RUN stdout/stderr tails and mount Linux chroot runtime paths for corepack/pnpm builds
- read Docker credential helpers/config auths and add Basic registry fallback for private HTTP registries
- add pnpm package cache volumes, wait heartbeats, and archived logs for --rm containers
- bump Box workspace and install docs to v3.0.1

## Validation
- git diff --check
- cargo fmt --all -- --check
- cargo check -p a3s-box-runtime --lib
- cargo check -p a3s-box-cli --lib
- cargo test -p a3s-box-runtime oci::registry::tests --lib
- cargo test -p a3s-box-runtime oci::credentials::tests --lib
- cargo test -p a3s-box-runtime oci::build::engine::handlers::tests --lib
- cargo test -p a3s-box-cli commands::run::tests --lib
- cargo test -p a3s-box-cli commands::logs::tests --lib
- cargo test -p a3s-box-cli commands::wait::tests --lib
- cargo test -p a3s-box-cli log_archive::tests --lib
- verified on ShuAn OS server: corepack Dockerfile build, Basic-auth registry push, --rm archived logs, wait heartbeat, pnpm package cache