### PR TITLE
fix: resolve open runtime and macOS issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch -whitespace

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ As of **v2.4.0**, three adversarial audits — production-operability (24 findin
 | --- | --- |
 | Local CLI runtime | Implemented for macOS Apple Silicon/HVF and Linux/KVM style hosts. Real macOS HVF core and host smoke suites have passed with Alpine pulled from the registry; offline archive runs remain the release-gate default. |
 | OCI images | Pull, load, save, tag, inspect, history, remove, and local cache resolution are implemented. Push and cosign signing/verification paths exist and require registry access for end-to-end validation. |
-| Dockerfile build | Honest subset. `FROM`, metadata instructions, `COPY`/`ADD`, and shell-form `RUN` are implemented by the host engine on Linux. On macOS, `RUN` builds are delegated to BuildKit inside an A3S Linux VM (`--builder=buildkit-vm`); unsafe host execution remains an explicit experiment-only escape hatch. |
+| Dockerfile build | Honest subset. `FROM`, metadata instructions, `COPY`/`ADD`, and shell/exec-form `RUN` are implemented by the host engine on Linux. `--run-pool` can execute `RUN` through a leased warm-pool VM by mounting the mutable build rootfs into the guest. On macOS, auto `RUN` builds still delegate to BuildKit inside an A3S Linux VM (`--builder=buildkit-vm`) unless `--run-pool` is selected; unsafe host execution remains an explicit experiment-only escape hatch. |
 | Lifecycle and exec | `run`, `create`, `start`, `stop`, `restart`, `rm`, `wait`, foreground/detached runs, non-PTY exec, PTY exec, logs, stats, and inspect are implemented. |
 | Warm pool and snapshot-fork | A warm pool serves pre-booted sandboxes over a socket. Native snapshot-fork (Copy-on-Write microVM cloning) snapshots one booted template and restores many forks from it, each mapping the template RAM `MAP_PRIVATE`. Verified on `/dev/kvm`: ~4× faster than a cold boot per fork, 100 forks in under ~1 s (~8 ms amortized each). Requires `/dev/kvm`; opt in with `pool start --snapshot-fork` or the `KRUN_SNAPSHOT_*` / `KRUN_RESTORE_FROM` env. |
 | Networking | Default TSI networking, TCP `host:guest` publishing, user-defined bridge networks, network inspect/connect/disconnect/rm, and `/etc/hosts` peer discovery are implemented with documented platform boundaries. |
@@ -69,7 +69,7 @@ The ignored `core_smoke` suite covers the core CLI path on a real MicroVM host:
 - TCP published ports with host loopback HTTP reachability;
 - bridge network endpoint allocation, peer `/etc/hosts`, connect/disconnect, and force removal cleanup;
 - named volumes, `cp`, `diff`, `export`, `commit`, `snapshot`, restart-policy monitor recovery, and Compose health/volume flow;
-- warm pool (`pool start`/`pool run`): pre-warmed sandboxes served over a socket, with backpressure and multi-image lazy pools; `--deferred` runs each command as the box's real main for full box semantics (real exit code + json-file console logs) with no cold boot; `--snapshot-fork` fills the pool by Copy-on-Write restore from one booted template instead of cold booting each sandbox.
+- warm pool (`pool start`/`pool run`/`run --pool`): pre-warmed sandboxes served over a socket, with backpressure and multi-image lazy pools; `A3S_BOX_RUN_POOL_SOCKET` can auto-route compatible foreground `run --rm` commands through the daemon; `--deferred` runs each command as the box's real main for full box semantics (real exit code + json-file console logs) with no cold boot; `--snapshot-fork` fills the pool by Copy-on-Write restore from one booted template instead of cold booting each sandbox.
 
 The most recent local record, on June 29, 2026: all 15 ignored `core_smoke`
 tests passed on macOS Apple Silicon/HVF with Alpine pulled from the registry,
@@ -120,7 +120,7 @@ On macOS, use Apple Silicon. On Linux, use a host with KVM/libkrun support. On W
 Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform
 ```
 
-Run `a3s-box info` first; it reports virtualization, platform, bridge backend, port-publishing support, TEE availability, package-cache state, and the current virtio-fs cache mode.
+Run `a3s-box info` first; it reports virtualization, platform, bridge backend, port-publishing support, TEE availability, package-cache state, the current virtio-fs cache mode, and any reachable warm-pool daemon on the default or configured sockets.
 
 ## Quick start
 
@@ -187,6 +187,12 @@ Important supported options:
 
 For CI-style one-shot commands, prefer foreground `run --rm --timeout <seconds>` and avoid `-i` unless the command truly needs stdin. A timed-out foreground run stops/removes the box according to the usual `--rm` behavior and exits with code 124. `a3s-box wait` prints a low-frequency stderr keepalive while it is blocking so long CI or SSH sessions do not look idle; use `--no-heartbeat` or `--heartbeat-interval <seconds>` to tune it.
 
+Health checks for detached `run`, Compose services, and boxes brought back by
+`start`/`restart` are owned by a generation-fenced background worker, not by the
+short-lived creating CLI. The worker stops when that box generation stops or is
+replaced; an installed `a3s-box monitor` detects the worker lock and does not
+duplicate its probes.
+
 Unsupported or guarded options fail early instead of being silently stored: host devices, GPUs, AppArmor labels, SELinux labels, custom seccomp profiles, unsupported users, invalid workdirs, unsupported port syntax, and unsupported network policies.
 
 ## Images and builds
@@ -218,16 +224,19 @@ a3s-box build -t app:dev --build-arg VERSION=1.2.3 --platform linux/amd64 .
 a3s-box build -t builder --target builder --no-cache .   # stop at a stage, skip the cache
 a3s-box build --builder=buildkit-vm --platform linux/arm64 -t app:dev . # safe macOS RUN path
 a3s-box build --builder=buildkit-vm --push --plain-http -t 10.0.0.2:5000/app:v1 .
+a3s-box pool start --image alpine:latest --size 1 --socket /tmp/a3s-build-pool.sock
+a3s-box build --run-pool --run-pool-socket /tmp/a3s-build-pool.sock -t app:dev .
 ```
 
-Supported Dockerfile subset: `FROM` including `scratch`, shell-form `RUN`, shell-form `COPY`/`ADD` (incl. `COPY --from=<stage>`, `COPY`/`ADD --chown=user[:group]`), `WORKDIR`, `ENV`, `ENTRYPOINT`, `CMD`, `EXPOSE`, `LABEL`, `USER`, `ARG`, `SHELL`, `STOPSIGNAL`, `HEALTHCHECK`, `ONBUILD` metadata triggers, and `VOLUME`. A context-root `.dockerignore` is honored.
+Supported Dockerfile subset: `FROM` including `scratch`, shell/exec-form `RUN` (including `RUN --mount=type=cache,target=...` with Docker's default `sharing=shared`, or explicit `sharing=locked`, optional `from=<stage-or-image>,source=...` cache seeding, `RUN --mount=type=bind,source=...,target=...` from the build context or `RUN --mount=type=bind,from=<stage-or-image>,source=...,target=...`, `RUN --mount=type=tmpfs,target=...` without `size=`, and Docker's no-op defaults `RUN --network=default` / `RUN --security=sandbox`), shell-form `COPY`/`ADD` (incl. `COPY --from=<stage>`, `COPY`/`ADD --chown=user[:group]`), `WORKDIR`, `ENV`, `ENTRYPOINT`, `CMD`, `EXPOSE`, `LABEL`, `USER`, `ARG`, `SHELL`, `STOPSIGNAL`, `HEALTHCHECK`, `ONBUILD` metadata triggers, and `VOLUME`. A context-root `.dockerignore` is honored.
 
-Build flags: `-t/--tag`, `-f/--file`, `--build-arg`, `--platform`, `--target <stage>` (build only up to a stage), `--no-cache` (rebuild every layer), `--builder auto|host|buildkit-vm`, `--push`, `--plain-http`, `--buildkit-image <image>`, `--buildkit-cpus <n>`, `--buildkit-memory <size>`, `-q/--quiet`.
+Build flags: `-t/--tag`, `-f/--file`, `--build-arg`, `--platform`, `--target <stage>` (build only up to a stage), `--no-cache` (rebuild every layer), `--builder auto|host|buildkit-vm`, `--push`, `--plain-http`, `--buildkit-image <image>`, `--buildkit-cpus <n>`, `--buildkit-memory <size>`, `--run-pool`, `--run-pool-socket <path>`, `--run-pool-autostart`, `--run-pool-image <image>`, `--run-pool-cpus <n>`, `--run-pool-memory <size>`, `--run-pool-timeout <duration>`, `--run-cache-dir <path>`, `-q/--quiet`.
 
 Boundaries:
 
 - `RUN` uses isolated Linux `chroot`, requires root-capable Linux, validates shell/workdir preconditions, and has a Linux-only ignored smoke test;
-- macOS `RUN` auto-selects the BuildKit VM backend unless `A3S_BOX_UNSAFE_HOST_RUN=1` is set; explicit `--builder=host` keeps the built-in host engine behavior;
+- `--run-pool` is the built-in engine's isolated VM path for `RUN`: it leases one warm-pool VM per build stage, mounts that stage's mutable rootfs at `/run/a3s/build-rootfs`, executes shell-form RUN through the configured shell and exec-form RUN as argv with the Dockerfile `WORKDIR`, `ENV`, and `USER`, then diffs the host rootfs into OCI layers. It requires a running `a3s-box pool start` daemon. `RUN --mount=type=cache` is treated as a persistent cache overlay keyed by `id=` (or by `target=` when `id` is omitted); cache contents are visible during matching `RUN` commands but are restored before layer diffing, so they are not committed to the image. Successful RUNs publish cache writes; failed RUNs restore the rootfs without publishing partial cache contents. A new cache can be seeded from `from=<stage-or-image>,source=<dir>`; once the persistent cache exists, it is not re-seeded. The warm-pool path accepts Docker's default omitted `sharing=shared`, explicit `sharing=shared`, and `sharing=locked`; because the host overlay hydrates and publishes cache directories around each RUN, access to the same cache key is serialized across builds to avoid writeback races. Cache-root `mode=`, `uid=`, and `gid=` are supported; cache `sharing=private` remains unsupported. `RUN --mount=type=bind` can mount sources from the build context, a previous build stage, or an external image with `from=<stage-or-image>`, defaults `source=.` when omitted, resolves relative targets from `WORKDIR`, honors `.dockerignore` only for context sources, and discards writes before layer diffing. `RUN --mount=type=tmpfs` creates an empty temporary target, resolves relative targets from `WORKDIR`, restores the original target after RUN, and discards writes before layer diffing; `tmpfs size=` is not supported yet. `RUN --network=default` and `RUN --security=sandbox` are accepted as Docker's default no-op values; non-default per-RUN network/security modes are rejected until the warm-pool exec path can enforce them.
+- macOS `RUN` auto-selects the BuildKit VM backend unless `--run-pool` or `A3S_BOX_UNSAFE_HOST_RUN=1` is set; explicit `--builder=host` keeps the built-in host engine behavior;
 - the BuildKit VM backend loads `type=oci` output back into the A3S image store by default; `--push` writes directly to the tagged registry reference, uses the same credentials as `a3s-box push`, and `--plain-http` marks that registry as trusted HTTP for BuildKit;
 - Apple Silicon `--builder=buildkit-vm --platform linux/amd64` is handled by BuildKit's Linux builder path and may use emulation, so expect slower builds than native `linux/arm64`;
 - `A3S_BOX_UNSAFE_HOST_RUN=1` enables unsafe macOS host-side experiments only;
@@ -259,7 +268,15 @@ a3s-box snapshot prune --keep 5          # bound disk: keep the 5 newest
 
 `--package-cache pnpm` creates/reuses the named volume `a3s-cache-pnpm` and sets cache-friendly defaults: `PNPM_CONFIG_STORE_DIR=/a3s-cache/pnpm/store`, `npm_config_store_dir=/a3s-cache/pnpm/store`, `COREPACK_HOME=/a3s-cache/pnpm/corepack`, `PNPM_HOME=/a3s-cache/pnpm/home`, `npm_config_cache=/a3s-cache/pnpm/npm-cache`, `PNPM_CONFIG_PREFER_OFFLINE=true`, `npm_config_prefer_offline=true`, and `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`. Dependency downloads and the Corepack-prepared pnpm toolchain survive across `--rm` boxes without making the whole rootfs persistent. `--package-cache npm` creates/reuses `a3s-cache-npm` and sets `npm_config_cache=/a3s-cache/npm/cache` plus `npm_config_prefer_offline=true` for npm-only jobs. Override any of those with `-e KEY=VALUE` when a build needs a specific registry or cache policy. For throwaway install/build jobs, mounting `node_modules` as tmpfs avoids pushing thousands of small files through the project bind mount; prime the named cache volume before a release window when cold registry downloads or project-level supply-chain policy checks are known to dominate the first run. Use `bench/bench.sh pnpm` or `just bench-pnpm` to compare A3S project-mount, A3S tmpfs, and Docker cold/hot baselines. Auto-removed boxes also archive their last logs under `~/.a3s/removed-logs/`, and `a3s-box logs <name-or-id>` can read that archive after the box directory is gone.
 
-Host directory volumes are mounted with virtio-fs `cache=none` by default to favor stable traversal on macOS/HVF workloads with large source trees. Use `--virtiofs-cache=always` for release verification jobs where the host source tree is not changing during the run, or `--virtiofs-cache=auto|default` for local experiments; `A3S_VIRTIOFS_CACHE` remains available as a process-wide fallback and `a3s-box info` prints the active fallback setting. On macOS/APFS, the rootfs copy fallback uses recursive `copyfile(3)` cloning before byte-copying, so cached-image startup can share file blocks with the cached rootfs when the filesystem supports it.
+Host directory volumes are mounted with virtio-fs `cache=none` by default to favor stable traversal on macOS/HVF workloads with large source trees. Use `--virtiofs-cache=always` for release verification jobs where the host source tree is not changing during the run, or `--virtiofs-cache=auto|default` for local experiments; `A3S_VIRTIOFS_CACHE` remains available as a process-wide fallback and `a3s-box info` prints the active fallback setting. On macOS, each Linux rootfs lives below a private directory in a case-sensitive APFS sparse image. Cached sparse images are cloned with APFS copy-on-write, preserving Linux path identity without exposing APFS volume-management entries to the guest.
+
+Image extraction and `commit` preserve Linux uid, gid, mode, and symlink
+metadata even when the macOS backing filesystem cannot represent OCI ownership
+directly. Box records rootless layer metadata during extraction and guest-init
+replays it before mounting any host workspace or volume; stopped persistent
+boxes use a guest-captured terminal manifest so a committed image reflects the
+container's final Linux-visible metadata rather than the host user's APFS
+ownership.
 
 The `snapshot` command produces configuration/filesystem-oriented Box snapshots, not a live RAM checkpoint. The live RAM Copy-on-Write facility is a separate, lower-level mechanism described in [Warm pool and snapshot-fork](#warm-pool-and-snapshot-fork).
 
@@ -293,12 +310,54 @@ json-file console logs).
 
 ```bash
 a3s-box pool start --image alpine:latest --size 8     # pre-warm 8 sandboxes
+a3s-box pool start --image alpine:latest --lease-ttl 30m  # reclaim abandoned leases
 a3s-box pool start --image alpine:latest --size 8 --snapshot-fork   # CoW fill
 a3s-box pool start --image alpine:latest --metrics-addr 127.0.0.1:9101   # + Prometheus /metrics
 a3s-box pool run alpine:latest -- echo hi             # served from the pool
+a3s-box run --pool --rm alpine:latest -- echo hi      # Docker-like run shape
+a3s-box run --pool-autostart --rm alpine:latest -- echo hi
+a3s-box run --pool --rm -v "$PWD:/work:ro" -w /work alpine:latest -- cat README.md
+a3s-box build --run-pool --run-pool-socket /tmp/a3s-box-pool.sock -t app:dev .
+a3s-box build --run-pool-autostart --run-pool-image alpine:latest -t app:dev .
 a3s-box pool status
 a3s-box pool stop
 ```
+
+`run --pool` is intentionally a foreground one-shot path today: it requires
+`--rm` and supports the common hot-loop dimensions (`--user`, `--workdir`,
+`--env`, `--env-file`, `--volume`, `--cpus`, `--memory`, and
+`--package-cache`, plus foreground `--timeout`). Image, volumes, vCPUs, and
+memory are part of the warm-pool key because virtio-fs mounts and VM resources
+are fixed at boot. Set
+`A3S_BOX_RUN_POOL_SOCKET=/path/to/pool.sock` to auto-route compatible
+foreground `run --rm` commands through the same daemon; incompatible runs keep
+the normal cold-start path unless `--pool` was requested explicitly. Use
+`--pool-autostart` to start a daemon on `--pool-socket` when one is not already
+running. Options that require persistent box state or a named lifecycle, such as
+`--name`, stay on the normal run path instead of being silently ignored by the
+one-shot pool path.
+
+`build --run-pool` uses the same daemon but with a lease protocol instead of a
+one-shot sandbox: a build stage keeps one warm VM while it executes every
+Dockerfile `RUN` in that stage with the current Dockerfile `WORKDIR`, `ENV`, and
+`USER`, then releases it. The stage rootfs remains the single source of truth;
+the VM only provides isolated Linux execution. Because each stage rootfs mount is
+unique and short-lived, volume-bound build leases are filled on demand instead
+of pre-warming a whole idle pool for every stage. Use
+`--run-pool-autostart --run-pool-image <helper-image>` when the build command
+should start the helper daemon itself.
+
+`pool status` reports idle sandboxes, active checked-out sandboxes, and active
+leases per pool key, which is useful when Dockerfile `RUN` stages are holding a
+warm VM. `a3s-box info` also performs a best-effort daemon probe against
+`A3S_BOX_RUN_POOL_SOCKET`, `A3S_BOX_BUILD_RUN_POOL_SOCKET`, and the default
+socket, then prints the aggregate max/idle/active/leased counts when one is
+reachable. `pool start --lease-ttl <duration>` reclaims unreleased internal
+leases that have been idle for too long (default: `1h`, `0` disables this);
+running lease exec requests are never reclaimed mid-command. `pool stop` sends a
+stop request over the daemon socket, drains idle and leased VMs, removes the
+socket, and exits. It succeeds when no daemon is running so cleanup scripts can
+call it unconditionally.
 
 `pool start --metrics-addr` serves a Prometheus `/metrics` endpoint with warm-pool hit/miss, VM-boot, and cache metrics for the long-running daemon (alongside `monitor --metrics-addr`'s box-state metrics + `/healthz`).
 
@@ -334,7 +393,7 @@ A3S Box has three network modes:
 
 | Mode | What it does | Current boundary |
 | --- | --- | --- |
-| TSI default | Guest socket operations are proxied through the host. Use this for simple outbound access. | No user-defined peer network, and **no in-guest loopback** — a container cannot reach its own services over `localhost`/`127.0.0.1` (e.g. a `localhost` health check or `exec curl localhost` fails). Use a bridge network when you need working localhost. |
+| TSI default | Guest socket operations are proxied through the host. Use this for simple outbound access. On macOS, publishing a TCP port automatically selects an isolated netproxy-backed interface so application bytes and guest loopback remain reliable while the CLI/network-mode contract stays unchanged. | Plain TSI boxes have no user-defined peer network and no in-guest loopback. Use a bridge network for peer discovery; publishing a port on macOS activates the isolated compatibility data path automatically. |
 | Bridge | Creates a real guest network interface for user-defined networks and peer discovery. | Linux uses `passt` with outbound NAT. macOS uses built-in `netproxy` for peer networking and published TCP ports; macOS bridge outbound NAT is unsupported. |
 | None | No network. | Useful for intentionally isolated workloads. |
 
@@ -362,6 +421,13 @@ a3s-box compose -f compose.yaml down
 ```
 
 Supported Compose keys: `image`, `command`, `entrypoint`, `environment`, `env_file`, `ports`, `volumes`, `depends_on` with `service_started` or `service_healthy`, `networks`, `dns`, `tmpfs`, `working_dir`, `hostname`, `extra_hosts`, `labels`, `healthcheck`, `restart`, `cpus`, `mem_limit`, `cap_add`, `cap_drop`, and `privileged`.
+
+Compose scalar values support `$VAR`, `${VAR}`, `${VAR-default}`,
+`${VAR:-default}`, `${VAR+replacement}`, and `${VAR:+replacement}` (plus the
+standard required-value forms). Values come from the project `.env` file next
+to the selected Compose file, with the invoking shell environment taking
+precedence. Expansion happens before typed service and port validation;
+mapping keys are not expanded, and `$$` emits a literal dollar sign.
 
 ## TEE workflows
 
@@ -669,7 +735,7 @@ sudo -E scripts/host-integration-smoke.sh --linux-run --no-pure
 
 The Linux `RUN` smoke must run as root on a root-capable Linux builder.
 See `docs/host-integration.md` for the macOS HVF, Linux KVM, host command
-matrix, CRI smoke, and host soak procedures.
+matrix, warm-pool Dockerfile `RUN` smoke, CRI smoke, and host soak procedures.
 
 ## Environment variables
 
@@ -705,6 +771,9 @@ matrix, CRI smoke, and host soak procedures.
 | `A3S_BOX_BUILDKIT_IMAGE` | BuildKit image used by `--builder=buildkit-vm`. Default: `moby/buildkit:latest`. |
 | `A3S_BOX_BUILDKIT_CPUS` | CPU count for the BuildKit VM helper box. Default: `4`. |
 | `A3S_BOX_BUILDKIT_MEMORY` | Memory limit for the BuildKit VM helper box. Default: `8g`. |
+| `A3S_BOX_RUN_POOL_SOCKET` | Auto-route compatible foreground `a3s-box run --rm` commands through the warm-pool daemon at this socket. Explicit `--pool-socket` still applies when `--pool` is passed. |
+| `A3S_BOX_BUILD_RUN_POOL_SOCKET` | Enable Dockerfile `RUN` warm-pool execution and use this pool daemon socket, equivalent to `a3s-box build --run-pool-socket <path>`. |
+| `A3S_BOX_BUILD_RUN_CACHE_DIR` | Override the persistent Dockerfile `RUN --mount=type=cache` directory used by the warm-pool build path. Defaults to `~/.a3s/buildcache/run-cache`. |
 | `A3S_BOX_UNSAFE_HOST_RUN` | Opt into unsafe macOS host execution for Dockerfile `RUN` experiments. |
 | `A3S_BOX_BUILDCACHE_MAX_BYTES` | Cap on the total size of cached build layers at `~/.a3s/buildcache` (oldest evicted first). Default: 2 GiB. |
 | `A3S_BOX_MAX_LAYER_BYTES` | Cap on total decompressed bytes per OCI image layer during `pull` (decompression-bomb guard). Default: 16 GiB. |

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -10,7 +10,7 @@ root.
 | --- | --- | --- |
 | Stub baseline | macOS or Linux with Rust, C compiler, and protoc | `scripts/host-integration-smoke.sh` |
 | Core MicroVM smoke | macOS Apple Silicon/HVF or Linux KVM, libkrun, Linux guest init, runnable image | `scripts/host-integration-smoke.sh --core` |
-| Host command matrix | Same as core smoke; optional registry credentials for push coverage | `scripts/host-integration-smoke.sh --host` |
+| Host command and warm-pool smoke | Same as core smoke; optional registry credentials for push coverage | `scripts/host-integration-smoke.sh --host` |
 | Linux Dockerfile `RUN` | Linux, root, chroot-capable filesystem, local Alpine OCI archive | `sudo -E scripts/host-integration-smoke.sh --linux-run --no-pure` |
 | CRI smoke | macOS or Linux MicroVM host, `crictl`, CRI images | `scripts/host-integration-smoke.sh --cri` |
 | Host soak | Same as the selected host-backed suites; enough time to expose leaks and lost updates | `scripts/host-integration-smoke.sh --no-pure --core --host --soak` |
@@ -128,6 +128,61 @@ credential store, Docker config or helpers, then `REGISTRY_USERNAME` /
 `REGISTRY_PASSWORD`. Only the target registry auth is written to a temporary
 Docker config and mounted into the BuildKit VM.
 
+The built-in build engine also has an isolated VM path for Dockerfile `RUN`:
+start a warm-pool daemon, then pass `--run-pool` (or set
+`A3S_BOX_BUILD_RUN_POOL_SOCKET`). The build stage rootfs is mounted into a
+leased pool VM and each shell/exec-form `RUN` executes through the guest exec
+server with the current Dockerfile `WORKDIR`, `ENV`, and `USER`:
+
+```bash
+a3s-box pool start --image alpine:latest --size 1 --socket /tmp/a3s-build-pool.sock
+a3s-box build --builder=host --run-pool --run-pool-socket /tmp/a3s-build-pool.sock \
+  -t a3s/web:v1 .
+
+# Or let the build command start the helper daemon explicitly.
+a3s-box build --builder=host --run-pool-autostart \
+  --run-pool-image alpine:latest \
+  -t a3s/web:v1 .
+```
+
+`RUN --mount=type=cache` is available on this path as a persistent overlay:
+writes under the cache target are visible to matching `RUN` commands keyed by
+`id=` (or by `target=` when `id` is omitted) but are restored before layer
+diffing, so cache contents are not committed to the image. Docker/BuildKit's
+default omitted `sharing=shared` and explicit `sharing=shared` are accepted, as
+is `sharing=locked`; because the warm-pool overlay hydrates and publishes cache
+directories around each RUN, access to the same cache key is serialized across
+builds to avoid writeback races. Successful RUNs publish cache writes; failed
+RUNs restore the rootfs without publishing partial cache contents. New cache
+directories can be seeded from `from=<stage-or-image>,source=<dir>`; an existing
+cache is not re-seeded. Cache-root `mode=`, `uid=`, and `gid=` are applied when
+present. `sharing=private` remains unsupported.
+Set
+`A3S_BOX_BUILD_RUN_CACHE_DIR` to override the default
+`~/.a3s/buildcache/run-cache` location.
+
+The build rootfs volume is part of the pool key. Because that path is unique to
+one build stage and is destroyed after the stage completes, the daemon fills
+volume-bound build leases on demand (`min_idle=0`) instead of pre-warming a full
+idle pool for every temporary stage rootfs.
+
+`RUN --mount=type=bind` is also available for build-context sources, previous
+build stages, and external images on the warm-pool path. Omitted `source=`
+mounts the context root, relative `target=` paths resolve from the current
+Dockerfile `WORKDIR`, `.dockerignore` is honored for context sources, stage/image
+sources ignore `.dockerignore`, and writes under the bind target are discarded
+before layer diffing.
+
+`RUN --mount=type=tmpfs` creates an empty temporary target for the duration of a
+RUN, restores any original target contents afterwards, and discards tmpfs writes
+before layer diffing. Relative `target=` paths resolve from `WORKDIR`. The
+Docker/BuildKit `size=` option is rejected until the warm-pool overlay can
+enforce it honestly.
+
+`RUN --network=default` and `RUN --security=sandbox` are accepted as Docker's
+default no-op values. Non-default per-RUN network/security modes are rejected
+until the warm-pool exec path can enforce them.
+
 The unsafe host execution path is only for local experiments and requires
 `A3S_BOX_UNSAFE_HOST_RUN=1`; it is not part of the product smoke matrix.
 
@@ -137,7 +192,7 @@ For package-manager-heavy monorepo checks, prefer an explicit cache profile
 instead of a raw host mount:
 
 ```bash
-a3s-box run --rm --cpus 4 --memory 8g \
+a3s-box run --rm --timeout 120 --cpus 4 --memory 8g \
   --package-cache pnpm \
   --virtiofs-cache=always \
   -v "$PWD:/workspace" \
@@ -155,6 +210,41 @@ For npm-only checks, use `--package-cache npm` to keep the npm cache in
 through the host workspace mount. `--virtiofs-cache=always` is intended for
 release verification jobs where the host checkout is stable for the duration of
 the run; omit it or use `none` when host-side edits must be visible immediately.
+
+For repeated short checks, run a warm-pool daemon with the same image, resource
+shape, and workspace mount, then either pass `--pool` explicitly or export
+`A3S_BOX_RUN_POOL_SOCKET` so compatible foreground `run --rm` commands use the
+daemon automatically:
+
+```bash
+a3s-box pool start --image node:24-bookworm --size 2 --max 4 \
+  --socket /tmp/a3s-node-pool.sock
+
+export A3S_BOX_RUN_POOL_SOCKET=/tmp/a3s-node-pool.sock
+a3s-box run --rm --cpus 4 --memory 8g \
+  --package-cache pnpm \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  node:24-bookworm -- \
+  sh -lc 'corepack enable && pnpm --version'
+
+a3s-box pool stop --socket /tmp/a3s-node-pool.sock
+```
+
+For an explicit one-command local loop, `a3s-box run --pool-autostart --rm ...`
+starts a daemon on `--pool-socket` if none is already running. Foreground
+`--timeout` is passed through to the warm-pool exec request.
+
+`pool status` reports idle sandboxes, active checked-out sandboxes, and active
+leases for each pool key. During `build --run-pool`, a nonzero leased count means
+a Dockerfile stage currently holds a helper VM. `a3s-box info` performs the same
+best-effort daemon probe against the configured run/build pool sockets and the
+default socket, then prints aggregate max/idle/active/leased counts when a daemon
+is reachable. `pool start --lease-ttl <duration>` is the abandoned-lease
+guardrail for daemon-backed build leases; it reclaims only idle leases, never a
+lease with an exec currently running. The default is `1h`; use `0` to disable it
+for long manual debugging sessions.
+
 For cold package stores, registry downloads and project-level supply-chain
 policy checks can still dominate the first run. Prime the named cache volume
 before a release window when the monorepo depends on thousands of packages.

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -94,6 +94,27 @@ Current notes:
   inline overrides. CLI `--env` continues to override `--env-file`, Compose
   `environment` overrides `env_file`, and guest-init receives merged container
   variables as `BOX_EXEC_ENV_*` instead of dropping them into PID 1 only.
+- Compose scalar interpolation now supports unset-versus-empty default and
+  replacement operators. The project `.env` is loaded first, the invoking
+  shell overrides it, and expansion completes before typed port validation.
+- Detached health checks now run in one generation-fenced child worker per box
+  instead of a Tokio task owned by the short-lived creating CLI. Compose and
+  `start`/`restart` use the same worker; the long-running monitor skips a box
+  while its worker lock is held, preventing duplicate probes.
+- `commit` now captures tar headers inside the Linux guest instead of deriving
+  uid/gid/mode from the macOS virtio-fs backing tree. Persistent boxes also
+  save a terminal metadata manifest before shutdown. Rootless OCI extraction
+  carries layer ownership through a protected manifest, applies whiteout
+  semantics to it, and guest-init replays image then terminal metadata before
+  mounting procfs, workspaces, or user volumes. The real HVF commit/re-run test
+  verifies root-owned and `123:456` files plus `0755`, `0750`, `0644`, `0600`,
+  and `0711` modes.
+- macOS virtio-fs no longer manually closes the raw descriptor owned by the
+  DAX mapping `File`. The previous double-close raced with descriptor reuse and
+  could make GNU tar report `Cannot close: Bad file descriptor` for unrelated
+  files in a mounted source tree. Real HVF coverage repeatedly archives a
+  2,048-file read-only mount, and the original Node 24/GNU tar repository-copy
+  workflow has passed against `/Users/roylin/code/os`.
 - Foreground and interactive `run` cleanup now persists captured exit codes in
   the box record before marking it stopped, and `wait` prints that recorded code
   instead of always reporting success for stopped boxes.
@@ -280,13 +301,18 @@ Current notes:
 
 - Build documentation now describes an explicit Dockerfile subset instead of
   claiming full Dockerfile parity. The supported subset is `FROM` (including
-  `scratch`), shell-form `RUN`, shell-form `COPY`/`ADD`, `WORKDIR`, `ENV`,
+  `scratch`), shell/exec-form `RUN`, shell-form `COPY`/`ADD`, `WORKDIR`, `ENV`,
   `ENTRYPOINT`, `CMD`, `EXPOSE`, `LABEL`, `USER`, `ARG`, `SHELL`,
   `STOPSIGNAL`, `HEALTHCHECK`, `ONBUILD` metadata triggers, and `VOLUME`.
-- Unsupported Dockerfile flags and deprecated instructions now fail with
-  contextual errors rather than being ignored or approximated. Examples:
-  `RUN` exec form, `COPY`/`ADD` JSON form, `COPY --chown`, `ADD --chown`, and
-  `MAINTAINER` are rejected.
+- Unsupported Dockerfile flags now fail with contextual errors rather than
+  being ignored or approximated. Examples: `COPY`/`ADD` JSON form and
+  unsupported `RUN --mount` variants are rejected; warm-pool `RUN` supports
+  context/stage/image `type=bind`, target-only `type=tmpfs`, and persistent
+  `type=cache` mounts, including stage/image cache seeding, with explicit
+  limitations. `RUN --network=default` and `RUN --security=sandbox` are accepted
+  as no-op Docker defaults, while non-default per-RUN network/security modes
+  still fail explicitly. Deprecated `MAINTAINER` is accepted as a maintainer
+  label.
 - ONBUILD triggers inherited from a base image only run when they map to
   metadata-only instructions. Triggers that require build execution context,
   such as `RUN` or `COPY`, fail explicitly until full trigger execution is
@@ -296,9 +322,12 @@ Current notes:
   silently producing a single-platform or wrong-OS image. The default output
   platform is Linux with the host architecture, not the host OS.
 - Dockerfile `RUN` no longer has any silent skip path on unsupported hosts.
-  Linux uses isolated `chroot`; macOS `RUN` builds are moving to
-  BuildKit-in-A3S-VM. The MVP uses `a3s-box build --builder=buildkit-vm` and
-  imports BuildKit's OCI output back into the A3S image store by default, with
+  Linux uses isolated `chroot`; the built-in engine also has an isolated
+  warm-pool VM lease path via `--run-pool`, which mounts each mutable build
+  stage rootfs into a leased helper VM and executes shell/exec-form `RUN`
+  through the guest exec server. macOS auto `RUN` builds still use
+  BuildKit-in-A3S-VM by default unless `--run-pool` is selected. The BuildKit
+  VM backend imports OCI output back into the A3S image store by default, with
   `--push` / `--plain-http` for direct registry release output and targeted
   credential injection into the BuildKit VM. On Apple Silicon, `linux/amd64`
   builds are routed through BuildKit's Linux builder path and may use emulation,
@@ -317,9 +346,11 @@ Current notes:
   containers.
 - CLI build smoke coverage now includes a pure `FROM scratch` build that verifies
   `COPY`, image metadata, history, save/exported layer contents, and local image
-  removal without registry or VM access. An ignored Linux-only smoke harness
-  also covers `RUN` through the chroot path when a local Alpine OCI tar and root
-  privileges are available.
+  removal without registry or VM access. Ignored host smoke coverage now also
+  includes warm-pool `pool run`, `run --pool`, environment auto-routing, and
+  Dockerfile `RUN` through the warm-pool lease path. A separate ignored
+  Linux-only smoke harness covers `RUN` through the chroot path when a local
+  Alpine OCI tar and root privileges are available.
 - The real core lifecycle smoke harness can now preload an OCI image archive into
   its isolated `A3S_HOME` via `A3S_BOX_SMOKE_IMAGE_TAR` or
   `A3S_BOX_TEST_ALPINE_TAR`, so HVF/KVM validation can run offline with the same
@@ -543,6 +574,17 @@ Current notes:
   container rootfs snapshot and surfaced through `ContainerStatus`, while
   writable, SELinux relabel, non-private propagation, and device mounts fail
   explicitly until real runtime mount plumbing is added.
+- macOS box root filesystems now live on per-box case-sensitive APFS sparse
+  images before OCI layers are extracted. The provider remounts persistent
+  generations on restart and detaches/removes ephemeral images during teardown;
+  a real HVF regression verifies `/bin/sh` and `/BIN/SH` are distinct and that
+  writable `Foo`/`foo` files retain distinct contents and inodes across restart.
+- BuildKit-in-VM writes its full `buildctl` invocation to an owner-private
+  script in the already-mounted output directory and gives guest init only the
+  fixed `/bin/sh /out/a3s-buildkit-build.sh` argv. This avoids truncation or
+  loss in the libkrun `BOX_EXEC_ARG_*` transport. Real HVF coverage verifies
+  multiple `--build-arg` values, including spaces, and BuildKit failures retain
+  bounded progress/stderr plus the helper command status.
 
 ### Gate 5: Portable Networking
 
@@ -564,10 +606,19 @@ Current notes:
   macOS netproxy, so unsupported UDP/host-IP/range syntax cannot be silently
   treated as a TCP listener or forwarded to libkrun.
 - `a3s-box info` now reports the host platform, VM backend, control channel,
-  bridge-network backend, published-port support, and TEE availability. The
-  diagnostics make the macOS bridge-mode boundary explicit: netproxy supports
-  peer networking and published TCP ports, while outbound NAT remains
-  unsupported; Linux passt reports peer networking with outbound NAT.
+  bridge-network backend, published-port support, TEE availability, package
+  cache state, virtio-fs cache fallback, and reachable warm-pool daemon
+  aggregate counts. The diagnostics make the macOS bridge-mode boundary
+  explicit: netproxy supports peer networking and published TCP ports, while
+  outbound NAT remains unsupported; Linux passt reports peer networking with
+  outbound NAT.
+- The warm-pool daemon now has an abandoned-lease guardrail:
+  `pool start --lease-ttl <duration>` reclaims idle internal leases whose client
+  disappeared before release, while leaving active lease execs alone. The
+  default is `1h`; `0` disables lease reclamation.
+- Volume-bound build leases are treated as short-lived stage helpers and are
+  filled on demand (`min_idle=0`) instead of pre-warming a whole pool for each
+  unique stage rootfs mount.
 - The shim now routes macOS bridge-mode published ports through the netproxy
   path only, avoiding duplicate TSI port-map registration when a box combines
   `--network` with `-p`.
@@ -590,6 +641,13 @@ Current notes:
   allocation and peer `/etc/hosts` discovery across two macOS HVF boxes, plus
   pre-start `network connect`/`disconnect` persistence, force-removal state
   cleanup, and active hot-plug rejection.
+- macOS netproxy bridge peers now join a per-network Unix-datagram Ethernet
+  switch keyed by destination MAC. Unicast frames go directly to the matching
+  peer, broadcast/multicast frames are flooded while still reaching the local
+  gateway, and unknown unicast follows normal switch flooding. The switch path
+  is a short per-UID digest under `/private/tmp`, avoiding the macOS Unix-socket
+  limit for long A3S homes/network names. Real HVF coverage fetches an HTTP body
+  between two boxes both by peer name and by assigned IP.
 
 ### Gate 6: Confidential Computing
 
@@ -629,18 +687,21 @@ Current notes:
 
 1. Run `scripts/host-integration-smoke.sh --core --host` on both macOS HVF and
    Linux KVM hosts with the same offline Alpine OCI archive, then record the
-   exact host/image/test metadata in the release notes.
+   exact host/image/test metadata in the release notes. The `--host` suite now
+   includes warm-pool command smoke and Dockerfile `RUN` over the warm-pool
+   lease path.
 2. Run `sudo -E scripts/host-integration-smoke.sh --linux-run --no-pure` on a
    root-capable Linux host with a local Alpine OCI tar. The Linux chroot path
    now has root/shell/workdir preflight checks, but still needs real Linux
    execution validation in this branch.
-3. Run and harden the opt-in kubelet/crictl CRI smoke suite on a host with
+3. After the warm-pool build smoke passes on both HVF and KVM, decide whether
+   macOS `build --builder=auto` should keep defaulting to BuildKit-in-A3S-VM for
+   `RUN` or promote the warm-pool lease path when a daemon/socket is configured.
+   Keep `A3S_BOX_UNSAFE_HOST_RUN=1` as an explicit experiment-only escape hatch.
+4. Run and harden the opt-in kubelet/crictl CRI smoke suite on a host with
    `crictl`, image availability, and microVM support. Pure unit coverage now
    verifies one-container and multi-container CRI lifecycle paths through a fake
    ready VM and exec server, and `src/cri/tests/crictl_smoke.rs` provides the
    real CRI socket harness.
-4. Replace macOS host-side Dockerfile `RUN` execution with an isolated execution
-   path. It now fails by default and requires `A3S_BOX_UNSAFE_HOST_RUN=1` for
-   explicit unsafe local experiments.
 5. Add a Windows/WHPX command support matrix and make unsupported Windows
    commands hidden or explicitly documented.

--- a/scripts/host-integration-smoke.sh
+++ b/scripts/host-integration-smoke.sh
@@ -44,7 +44,7 @@ Options:
   --pure         Run stub-backed fmt, clippy, lib tests, and integration compile checks (default).
   --no-pure      Skip the stub-backed baseline checks.
   --core         Run the ignored real MicroVM core_smoke suite.
-  --host         Run ignored host_smoke VM, Compose, and optional registry suites.
+  --host         Run ignored host_smoke VM, warm-pool, Compose, and optional registry suites.
   --linux-run    Run the Linux-only Dockerfile RUN chroot smoke.
   --cri          Run the ignored crictl CRI smoke with A3S_BOX_CRI_SMOKE=1.
   --all          Run --core, --host, --linux-run, and --cri after the pure checks.
@@ -451,6 +451,10 @@ run_host_suite() {
     build_real_binaries
     log "Running host VM command matrix"
     run_real cargo test -p a3s-box-cli --test host_smoke test_real_vm_command_matrix -- --ignored --nocapture --test-threads=1
+    log "Running warm-pool command smoke"
+    run_real cargo test -p a3s-box-cli --test host_smoke test_real_pool_warm_run -- --ignored --nocapture --test-threads=1
+    log "Running warm-pool Dockerfile RUN smoke"
+    run_real cargo test -p a3s-box-cli --test host_smoke test_real_build_run_pool_smoke -- --ignored --nocapture --test-threads=1
     log "Running host Compose smoke"
     run_real cargo test -p a3s-box-cli --test host_smoke test_real_compose_smoke -- --ignored --nocapture --test-threads=1
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -40,6 +40,7 @@ version = "3.0.8"
 dependencies = [
  "a3s-common",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "dirs",
  "flate2",
@@ -99,6 +100,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/src/cli/src/boot.rs
+++ b/src/cli/src/boot.rs
@@ -360,17 +360,6 @@ pub async fn boot_from_record(
     let stop_signal =
         common::effective_stop_signal(record.stop_signal.as_deref(), image_stop_signal.as_deref());
 
-    // Spawn health checker if configured (self-terminates when box stops)
-    if let Some(ref hc) = health_check {
-        crate::health::spawn_health_checker(
-            record.id.clone(),
-            exec_socket_path
-                .clone()
-                .unwrap_or_else(|| record.exec_socket_path.clone()),
-            hc.clone(),
-        );
-    }
-
     Ok(BootResult {
         pid,
         exec_socket_path,

--- a/src/cli/src/cleanup.rs
+++ b/src/cli/src/cleanup.rs
@@ -86,6 +86,7 @@ pub fn cleanup_stopped_box(record: &BoxRecord) {
     // Release the overlayfs mount so a stopped box never leaves a live mount
     // (and a later restart re-mounts cleanly instead of stacking).
     a3s_box_runtime::rootfs::unmount_box_overlay(&record.box_dir.join("merged"));
+    a3s_box_runtime::rootfs::unmount_box_rootfs(&record.box_dir.join("rootfs"));
     cleanup_external_socket_dir(&record.box_dir, &record.exec_socket_path);
     remove_host_cgroup(&record.id);
 }
@@ -150,6 +151,7 @@ pub fn cleanup_removed_box(record: &BoxRecord) {
         // Release the overlayfs mount FIRST: otherwise remove_dir_all deletes
         // into the live mount ("Stale file handle") and leaks it.
         a3s_box_runtime::rootfs::unmount_box_overlay(&record.box_dir.join("merged"));
+        a3s_box_runtime::rootfs::unmount_box_rootfs(&record.box_dir.join("rootfs"));
         if let Err(err) = std::fs::remove_dir_all(&record.box_dir) {
             tracing::debug!(
                 path = %record.box_dir.display(),

--- a/src/cli/src/commands/build.rs
+++ b/src/cli/src/commands/build.rs
@@ -12,6 +12,10 @@ use clap::{Args, ValueEnum};
 #[path = "build_buildkit_vm.rs"]
 mod buildkit_vm;
 
+const BUILD_RUN_POOL_SOCKET_ENV: &str = "A3S_BOX_BUILD_RUN_POOL_SOCKET";
+const BUILD_RUN_CACHE_DIR_ENV: &str = "A3S_BOX_BUILD_RUN_CACHE_DIR";
+const DEFAULT_BUILD_RUN_POOL_GUEST_ROOTFS: &str = "/run/a3s/build-rootfs";
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum BuildBackend {
     /// Use the default backend for the host and Dockerfile.
@@ -85,6 +89,40 @@ pub struct BuildArgs {
     /// Use plain HTTP when pushing from the BuildKit VM to a trusted registry.
     #[arg(long, alias = "insecure")]
     pub plain_http: bool,
+
+    /// Execute Dockerfile RUN instructions through the warm-pool daemon.
+    #[arg(long = "run-pool")]
+    pub run_pool: bool,
+
+    /// Warm-pool daemon socket for Dockerfile RUN execution.
+    #[arg(long = "run-pool-socket", value_name = "PATH")]
+    pub run_pool_socket: Option<String>,
+
+    /// Start the Dockerfile RUN warm-pool daemon when one is not already running.
+    ///
+    /// Requires --run-pool-image so build leases use an explicit helper VM image.
+    #[arg(long = "run-pool-autostart")]
+    pub run_pool_autostart: bool,
+
+    /// Helper VM image for Dockerfile RUN pool leases; omitted uses daemon default.
+    #[arg(long = "run-pool-image", value_name = "IMAGE")]
+    pub run_pool_image: Option<String>,
+
+    /// CPUs for lazily-created Dockerfile RUN pool helper VMs.
+    #[arg(long = "run-pool-cpus", default_value_t = 2)]
+    pub run_pool_cpus: u32,
+
+    /// Memory for lazily-created Dockerfile RUN pool helper VMs.
+    #[arg(long = "run-pool-memory", default_value = "512m")]
+    pub run_pool_memory: String,
+
+    /// Timeout for each Dockerfile RUN command when using --run-pool.
+    #[arg(long = "run-pool-timeout", default_value = "1h", value_parser = crate::output::parse_duration_secs)]
+    pub run_pool_timeout: u64,
+
+    /// Persistent cache directory for Dockerfile RUN --mount=type=cache with --run-pool.
+    #[arg(long = "run-cache-dir", value_name = "PATH")]
+    pub run_cache_dir: Option<String>,
 }
 
 pub async fn execute(args: BuildArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -107,7 +145,22 @@ pub async fn execute(args: BuildArgs) -> Result<(), Box<dyn std::error::Error>> 
 
     let platforms = parse_platforms(args.platform.as_deref())?;
 
-    let use_buildkit_vm = should_use_buildkit_vm(args.builder, &dockerfile_path)?;
+    let run_pool = resolve_run_pool_config(&args)?;
+    if run_pool.is_some() && args.builder == BuildBackend::BuildkitVm {
+        return Err("--run-pool cannot be combined with --builder=buildkit-vm".into());
+    }
+    if args.run_pool_autostart {
+        if let Some(config) = &run_pool {
+            super::pool::ensure_pool_daemon_running(&pool_autostart_config_for_build(config)?)
+                .await?;
+        }
+    }
+
+    let use_buildkit_vm = if run_pool.is_some() {
+        false
+    } else {
+        should_use_buildkit_vm(args.builder, &dockerfile_path)?
+    };
     if args.push && !use_buildkit_vm {
         return Err("--push is currently supported only with --builder=buildkit-vm".into());
     }
@@ -153,6 +206,7 @@ pub async fn execute(args: BuildArgs) -> Result<(), Box<dyn std::error::Error>> 
         target: args.target.clone(),
         no_cache: args.no_cache,
         metrics: None,
+        run_pool,
     };
 
     let result = a3s_box_runtime::oci::build::engine::build(config, store).await?;
@@ -162,6 +216,75 @@ pub async fn execute(args: BuildArgs) -> Result<(), Box<dyn std::error::Error>> 
     }
 
     Ok(())
+}
+
+fn resolve_run_pool_config(
+    args: &BuildArgs,
+) -> Result<Option<a3s_box_runtime::BuildRunPoolConfig>, Box<dyn std::error::Error>> {
+    let env_socket = std::env::var(BUILD_RUN_POOL_SOCKET_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let env_cache_dir = std::env::var(BUILD_RUN_CACHE_DIR_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let enabled = args.run_pool
+        || args.run_pool_autostart
+        || args.run_pool_socket.is_some()
+        || env_socket.is_some()
+        || args.run_cache_dir.is_some()
+        || env_cache_dir.is_some();
+    if !enabled {
+        return Ok(None);
+    }
+
+    if args.run_pool_timeout == 0 {
+        return Err("--run-pool-timeout must be greater than 0".into());
+    }
+
+    let socket = args
+        .run_pool_socket
+        .clone()
+        .or(env_socket)
+        .unwrap_or_else(|| super::pool::DEFAULT_SOCKET.to_string());
+    let memory_mb = crate::output::parse_memory(&args.run_pool_memory)
+        .map_err(|e| format!("Invalid --run-pool-memory: {e}"))?;
+    if args.run_pool_autostart && args.run_pool_image.is_none() {
+        return Err(
+            "--run-pool-autostart requires --run-pool-image so the helper VM image is explicit"
+                .into(),
+        );
+    }
+    let run_cache_dir = args
+        .run_cache_dir
+        .clone()
+        .or(env_cache_dir)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            a3s_box_core::dirs_home()
+                .join("buildcache")
+                .join("run-cache")
+        });
+
+    Ok(Some(a3s_box_runtime::BuildRunPoolConfig {
+        socket,
+        image: args.run_pool_image.clone(),
+        vcpus: args.run_pool_cpus,
+        memory_mb,
+        guest_rootfs: DEFAULT_BUILD_RUN_POOL_GUEST_ROOTFS.to_string(),
+        timeout_ns: args.run_pool_timeout.saturating_mul(1_000_000_000),
+        run_cache_dir,
+    }))
+}
+
+fn pool_autostart_config_for_build(
+    config: &a3s_box_runtime::BuildRunPoolConfig,
+) -> Result<super::pool::PoolAutoStartConfig, Box<dyn std::error::Error>> {
+    Ok(super::pool::PoolAutoStartConfig {
+        socket: config.socket.clone(),
+        image: None,
+        size: super::pool::DEFAULT_AUTOSTART_POOL_SIZE,
+        max: super::pool::DEFAULT_AUTOSTART_POOL_MAX,
+    })
 }
 
 fn should_use_buildkit_vm(
@@ -274,6 +397,55 @@ fn resolve_build_file(
 mod tests {
     use super::*;
 
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    fn build_args() -> BuildArgs {
+        BuildArgs {
+            path: ".".to_string(),
+            tag: None,
+            file: None,
+            build_arg: vec![],
+            quiet: false,
+            platform: None,
+            target: None,
+            no_cache: false,
+            builder: BuildBackend::Auto,
+            buildkit_image: None,
+            buildkit_cpus: None,
+            buildkit_memory: None,
+            push: false,
+            plain_http: false,
+            run_pool: false,
+            run_pool_socket: None,
+            run_pool_autostart: false,
+            run_pool_image: None,
+            run_pool_cpus: 2,
+            run_pool_memory: "512m".to_string(),
+            run_pool_timeout: 3600,
+            run_cache_dir: None,
+        }
+    }
+
     #[test]
     fn test_parse_build_args_valid() {
         let args = vec!["VERSION=1.0".to_string(), "DEBUG=true".to_string()];
@@ -312,6 +484,87 @@ mod tests {
 
         assert!(should_use_buildkit_vm(BuildBackend::BuildkitVm, &dockerfile).unwrap());
         assert!(!should_use_buildkit_vm(BuildBackend::Host, &dockerfile).unwrap());
+    }
+
+    #[test]
+    fn test_resolve_run_pool_config_explicit_socket() {
+        let mut args = build_args();
+        args.run_pool = true;
+        args.run_pool_socket = Some("/tmp/a3s-build-pool.sock".to_string());
+        args.run_pool_image = Some("alpine:latest".to_string());
+        args.run_pool_cpus = 4;
+        args.run_pool_memory = "1g".to_string();
+        args.run_pool_timeout = 90;
+        args.run_cache_dir = Some("/tmp/a3s-run-cache".to_string());
+
+        let config = resolve_run_pool_config(&args).unwrap().unwrap();
+
+        assert_eq!(config.socket, "/tmp/a3s-build-pool.sock");
+        assert_eq!(config.image.as_deref(), Some("alpine:latest"));
+        assert_eq!(config.vcpus, 4);
+        assert_eq!(config.memory_mb, 1024);
+        assert_eq!(config.guest_rootfs, DEFAULT_BUILD_RUN_POOL_GUEST_ROOTFS);
+        assert_eq!(config.timeout_ns, 90_000_000_000);
+        assert_eq!(config.run_cache_dir, PathBuf::from("/tmp/a3s-run-cache"));
+    }
+
+    #[test]
+    fn test_resolve_run_pool_config_rejects_zero_timeout() {
+        let mut args = build_args();
+        args.run_pool = true;
+        args.run_pool_timeout = 0;
+
+        let err = resolve_run_pool_config(&args).unwrap_err().to_string();
+
+        assert!(err.contains("--run-pool-timeout"));
+    }
+
+    #[test]
+    fn test_resolve_run_pool_config_autostart_requires_image() {
+        let mut args = build_args();
+        args.run_pool_autostart = true;
+
+        let err = resolve_run_pool_config(&args).unwrap_err().to_string();
+
+        assert!(err.contains("--run-pool-autostart"));
+        assert!(err.contains("--run-pool-image"));
+    }
+
+    #[test]
+    fn test_pool_autostart_config_for_build_starts_lazy_helper_daemon() {
+        let mut args = build_args();
+        args.run_pool = true;
+        args.run_pool_autostart = true;
+        args.run_pool_socket = Some("/tmp/a3s-build-pool.sock".to_string());
+        args.run_pool_image = Some("alpine:latest".to_string());
+
+        let config = resolve_run_pool_config(&args).unwrap().unwrap();
+        let autostart = pool_autostart_config_for_build(&config).unwrap();
+
+        assert_eq!(config.image.as_deref(), Some("alpine:latest"));
+        assert_eq!(autostart.socket, "/tmp/a3s-build-pool.sock");
+        assert!(autostart.image.is_none());
+        assert_eq!(
+            autostart.size,
+            crate::commands::pool::DEFAULT_AUTOSTART_POOL_SIZE
+        );
+        assert_eq!(
+            autostart.max,
+            crate::commands::pool::DEFAULT_AUTOSTART_POOL_MAX
+        );
+    }
+
+    #[test]
+    fn test_resolve_run_pool_config_env_cache_dir_enables_pool() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("run-cache");
+        let _guard = EnvGuard::set(BUILD_RUN_CACHE_DIR_ENV, cache_dir.as_os_str());
+        let args = build_args();
+
+        let config = resolve_run_pool_config(&args).unwrap().unwrap();
+
+        assert_eq!(config.socket, crate::commands::pool::DEFAULT_SOCKET);
+        assert_eq!(config.run_cache_dir, cache_dir);
     }
 
     #[test]

--- a/src/cli/src/commands/build_buildkit_vm.rs
+++ b/src/cli/src/commands/build_buildkit_vm.rs
@@ -9,6 +9,7 @@ const DEFAULT_BUILDKIT_IMAGE: &str = "moby/buildkit:latest";
 const DEFAULT_BUILDKIT_CPUS: &str = "4";
 const DEFAULT_BUILDKIT_MEMORY: &str = "8g";
 const OUTPUT_TAR: &str = "image.tar";
+const BUILD_SCRIPT: &str = "a3s-buildkit-build.sh";
 const DOCKER_CONFIG_GUEST_PATH: &str = "/root/.docker/config.json";
 const BUILDKIT_STATE_DIR: &str = "/var/lib/buildkit";
 
@@ -58,11 +59,12 @@ pub(super) async fn execute(options: Build) -> Result<(), Box<dyn std::error::Er
         None
     };
 
+    let buildctl_args = buildctl_args(&options, &dockerfile_arg, &output_tar)?;
+    write_build_script(output_dir.path(), &buildctl_args)?;
+
     let run_args = run_args(
         &options,
-        &dockerfile_arg,
         output_dir.path(),
-        &output_tar,
         auth_config.as_ref().map(BuildkitAuthConfig::path),
     )?;
     if !options.quiet {
@@ -142,9 +144,7 @@ fn dockerfile_arg(
 
 fn run_args(
     options: &Build,
-    dockerfile_arg: &str,
     output_dir: &Path,
-    output_tar: &Path,
     auth_config: Option<&Path>,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let context = options.context_dir.to_str().ok_or_else(|| {
@@ -159,11 +159,6 @@ fn run_args(
             output_dir.display()
         )
     })?;
-    let output_name = output_tar
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| format!("Invalid BuildKit output file: {}", output_tar.display()))?;
-
     let mut args = vec![
         "run".to_string(),
         "--rm".to_string(),
@@ -194,9 +189,24 @@ fn run_args(
 
     args.extend([
         "--entrypoint".to_string(),
-        "buildctl-daemonless.sh".to_string(),
+        "/bin/sh".to_string(),
         options.image.clone(),
         "--".to_string(),
+        format!("/out/{BUILD_SCRIPT}"),
+    ]);
+    Ok(args)
+}
+
+fn buildctl_args(
+    options: &Build,
+    dockerfile_arg: &str,
+    output_tar: &Path,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let output_name = output_tar
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("Invalid BuildKit output file: {}", output_tar.display()))?;
+    let mut args = vec![
         "build".to_string(),
         "--frontend".to_string(),
         "dockerfile.v0".to_string(),
@@ -206,7 +216,7 @@ fn run_args(
         "dockerfile=/workspace".to_string(),
         "--opt".to_string(),
         format!("filename={dockerfile_arg}"),
-    ]);
+    ];
 
     for build_arg in &options.build_args {
         args.push("--opt".to_string());
@@ -227,6 +237,30 @@ fn run_args(
     args.push("--output".to_string());
     args.push(output_attr(options, output_name)?);
     Ok(args)
+}
+
+fn write_build_script(
+    output_dir: &Path,
+    args: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let script_path = output_dir.join(BUILD_SCRIPT);
+    let mut script = String::from("#!/bin/sh\nset -eu\nexec buildctl-daemonless.sh");
+    for arg in args {
+        script.push(' ');
+        script.push_str(&shell_quote(arg));
+    }
+    script.push('\n');
+    std::fs::write(&script_path, script).map_err(|error| {
+        format!(
+            "Failed to write BuildKit helper script {}: {error}",
+            script_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 fn buildkit_auth_config(
@@ -383,29 +417,29 @@ mod tests {
     #[test]
     fn test_run_args_buildkit_daemonless_oci_output() {
         let options = base_options();
-        let args = run_args(
+        let args = run_args(&options, Path::new("/tmp/out"), None).unwrap();
+        let build_args = buildctl_args(
             &options,
             "docker/Dockerfile.web",
-            Path::new("/tmp/out"),
             Path::new("/tmp/out/image.tar"),
-            None,
         )
         .unwrap();
 
         assert_eq!(args[0], "run");
         assert!(args.contains(&"--privileged".to_string()));
         assert!(args.contains(&"moby/buildkit:latest".to_string()));
-        assert!(args.contains(&"buildctl-daemonless.sh".to_string()));
-        assert!(args.contains(&"context=/workspace".to_string()));
-        assert!(args.contains(&"dockerfile=/workspace".to_string()));
-        assert!(args.contains(&"filename=docker/Dockerfile.web".to_string()));
+        assert!(args.contains(&"/bin/sh".to_string()));
+        assert!(args.contains(&format!("/out/{BUILD_SCRIPT}")));
         assert!(args.contains(&"--tmpfs".to_string()));
         assert!(args.contains(&"/var/lib/buildkit".to_string()));
-        assert!(args.contains(&"build-arg:VERSION=1.2.3".to_string()));
-        assert!(args.contains(&"platform=linux/arm64".to_string()));
-        assert!(args.contains(&"target=builder".to_string()));
-        assert!(args.contains(&"--no-cache".to_string()));
-        assert!(args.contains(&"type=oci,dest=/out/image.tar".to_string()));
+        assert!(build_args.contains(&"context=/workspace".to_string()));
+        assert!(build_args.contains(&"dockerfile=/workspace".to_string()));
+        assert!(build_args.contains(&"filename=docker/Dockerfile.web".to_string()));
+        assert!(build_args.contains(&"build-arg:VERSION=1.2.3".to_string()));
+        assert!(build_args.contains(&"platform=linux/arm64".to_string()));
+        assert!(build_args.contains(&"target=builder".to_string()));
+        assert!(build_args.contains(&"--no-cache".to_string()));
+        assert!(build_args.contains(&"type=oci,dest=/out/image.tar".to_string()));
     }
 
     #[test]
@@ -413,12 +447,10 @@ mod tests {
         let mut options = base_options();
         options.push = true;
         options.plain_http = true;
-        let args = run_args(
+        let args = buildctl_args(
             &options,
             "docker/Dockerfile.web",
-            Path::new("/tmp/out"),
             Path::new("/tmp/out/image.tar"),
-            None,
         )
         .unwrap();
 
@@ -433,14 +465,31 @@ mod tests {
         let options = base_options();
         let args = run_args(
             &options,
-            "docker/Dockerfile.web",
             Path::new("/tmp/out"),
-            Path::new("/tmp/out/image.tar"),
             Some(Path::new("/tmp/auth/config.json")),
         )
         .unwrap();
 
         assert!(args.contains(&"/tmp/auth/config.json:/root/.docker/config.json:ro".to_string()));
+    }
+
+    #[test]
+    fn test_build_script_preserves_spaces_quotes_and_multiple_build_args() {
+        let tmp = tempfile::tempdir().unwrap();
+        let args = vec![
+            "build".to_string(),
+            "--opt".to_string(),
+            "build-arg:PLAIN=custom".to_string(),
+            "--opt".to_string(),
+            "build-arg:QUOTED=two words and 'quote'".to_string(),
+        ];
+
+        write_build_script(tmp.path(), &args).unwrap();
+        let script = std::fs::read_to_string(tmp.path().join(BUILD_SCRIPT)).unwrap();
+
+        assert!(script.starts_with("#!/bin/sh\nset -eu\nexec buildctl-daemonless.sh "));
+        assert!(script.contains("'build-arg:PLAIN=custom'"));
+        assert!(script.contains("'build-arg:QUOTED=two words and '\"'\"'quote'\"'\"''"));
     }
 
     #[test]
@@ -501,12 +550,10 @@ mod tests {
         let mut options = base_options();
         options.platform = Some("linux/amd64".to_string());
 
-        let args = run_args(
+        let args = buildctl_args(
             &options,
             "docker/Dockerfile.web",
-            Path::new("/tmp/out"),
             Path::new("/tmp/out/image.tar"),
-            None,
         )
         .unwrap();
 

--- a/src/cli/src/commands/commit.rs
+++ b/src/cli/src/commands/commit.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+#[cfg(unix)]
 use base64::Engine;
 use clap::Args;
 use sha2::{Digest, Sha256};
@@ -110,6 +111,7 @@ pub async fn execute(args: CommitArgs) -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
+#[cfg(unix)]
 async fn capture_rootfs_tar(
     record: &crate::state::BoxRecord,
     rootfs_dir: &Path,
@@ -141,6 +143,16 @@ async fn capture_rootfs_tar(
         .validate()
         .map_err(|error| format!("Invalid guest rootfs metadata: {error}"))?;
     create_tar_from_guest_metadata(rootfs_dir, &manifest, output)
+}
+
+#[cfg(windows)]
+async fn capture_rootfs_tar(
+    _record: &crate::state::BoxRecord,
+    _rootfs_dir: &Path,
+    _output: &Path,
+    _pause: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    Err("committing box filesystems is not supported on Windows".into())
 }
 
 #[cfg(unix)]

--- a/src/cli/src/commands/commit.rs
+++ b/src/cli/src/commands/commit.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use base64::Engine;
 use clap::Args;
 use sha2::{Digest, Sha256};
 
@@ -41,15 +42,24 @@ pub async fn execute(args: CommitArgs) -> Result<(), Box<dyn std::error::Error>>
     let state = StateFile::load_default()?;
     let record = resolve::resolve(&state, &args.name)?;
 
-    let rootfs_dir = super::resolve_box_rootfs(&record.box_dir).ok_or_else(|| {
-        format!(
-            "Rootfs not found for box '{}' under {} (looked for merged/ and rootfs/). \
-             For overlay-backed boxes the filesystem is only available while the box exists; \
-             commit a running box.",
-            args.name,
-            record.box_dir.display()
-        )
-    })?;
+    let attached_rootfs = if record.status == "running" {
+        None
+    } else {
+        a3s_box_runtime::rootfs::attach_persistent_rootfs(&record.box_dir)?
+    };
+    let rootfs_dir = attached_rootfs
+        .as_ref()
+        .map(|rootfs| rootfs.path().to_path_buf())
+        .or_else(|| super::resolve_box_rootfs(&record.box_dir))
+        .ok_or_else(|| {
+            format!(
+                "Rootfs not found for box '{}' under {} (looked for merged/ and rootfs/). \
+                 For overlay-backed boxes the filesystem is only available while the box exists; \
+                 commit a running box.",
+                args.name,
+                record.box_dir.display()
+            )
+        })?;
 
     let reference = args.repository.unwrap_or_else(|| {
         format!(
@@ -63,16 +73,20 @@ pub async fn execute(args: CommitArgs) -> Result<(), Box<dyn std::error::Error>>
     // Create a temporary directory for the OCI image layout
     let tmp = tempfile::tempdir().map_err(|e| format!("Failed to create temp dir: {e}"))?;
     let image_dir = tmp.path();
+    let rootfs_tar = image_dir.join("rootfs.tar");
+
+    capture_rootfs_tar(record, &rootfs_dir, &rootfs_tar, args.pause).await?;
 
     // Build OCI image layout
-    build_oci_image(
+    build_oci_image_from_tar(
         image_dir,
-        &rootfs_dir,
+        &rootfs_tar,
         &reference,
         &args.message,
         &args.author,
         &args.change,
     )?;
+    std::fs::remove_file(&rootfs_tar)?;
 
     // Compute image digest from manifest
     let manifest_bytes = std::fs::read(image_dir.join("manifest.json")).or_else(|_| {
@@ -96,6 +110,163 @@ pub async fn execute(args: CommitArgs) -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
+async fn capture_rootfs_tar(
+    record: &crate::state::BoxRecord,
+    rootfs_dir: &Path,
+    output: &Path,
+    pause: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if record.status == "running" && record.exec_socket_path.exists() {
+        let client = a3s_box_runtime::ExecClient::connect(&record.exec_socket_path).await?;
+        let mut file = tokio::fs::File::create(output).await?;
+        let written = client.archive_rootfs(&mut file, pause).await?;
+        if written == 0 {
+            return Err("Guest rootfs archive was empty".into());
+        }
+        file.sync_all().await?;
+        return Ok(());
+    }
+
+    let metadata_path = rootfs_dir
+        .join(a3s_box_core::rootfs_metadata::ROOTFS_METADATA_PATH.trim_start_matches('/'));
+    let bytes = std::fs::read(&metadata_path).map_err(|error| {
+        format!(
+            "Guest rootfs metadata is unavailable at {}: {error}. Start the box with this A3S Box version and stop it cleanly before committing.",
+            metadata_path.display()
+        )
+    })?;
+    let manifest: a3s_box_core::rootfs_metadata::RootfsMetadataManifest =
+        serde_json::from_slice(&bytes)?;
+    manifest
+        .validate()
+        .map_err(|error| format!("Invalid guest rootfs metadata: {error}"))?;
+    create_tar_from_guest_metadata(rootfs_dir, &manifest, output)
+}
+
+#[cfg(unix)]
+fn create_tar_from_guest_metadata(
+    rootfs_dir: &Path,
+    manifest: &a3s_box_core::rootfs_metadata::RootfsMetadataManifest,
+    output: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use a3s_box_core::rootfs_metadata::RootfsEntryKind;
+    use std::collections::{HashMap, HashSet};
+    use std::ffi::OsString;
+    use std::io::Cursor;
+    use std::os::unix::ffi::OsStringExt;
+    use std::os::unix::fs::MetadataExt;
+
+    let mut decoded = Vec::with_capacity(manifest.entries.len());
+    let mut paths = HashSet::with_capacity(manifest.entries.len());
+    for entry in &manifest.entries {
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&entry.path_base64)
+            .map_err(|error| format!("Invalid rootfs metadata path: {error}"))?;
+        let path = std::path::PathBuf::from(OsString::from_vec(bytes));
+        validate_archive_path(&path)?;
+        if !paths.insert(path.clone()) {
+            return Err(format!("Duplicate rootfs metadata path: {}", path.display()).into());
+        }
+        decoded.push((path, entry));
+    }
+    decoded.sort_by(|left, right| left.0.as_os_str().cmp(right.0.as_os_str()));
+
+    let file = std::fs::File::create(output)?;
+    let mut builder = tar::Builder::new(file);
+    let mut hardlinks = HashMap::<(u64, u64), std::path::PathBuf>::new();
+    for (path, entry) in decoded {
+        let source = rootfs_dir.join(&path);
+        let host_metadata = std::fs::symlink_metadata(&source).map_err(|error| {
+            format!(
+                "Rootfs changed after terminal metadata capture at {}: {error}",
+                source.display()
+            )
+        })?;
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(entry.mode & 0o7777);
+        header.set_uid(entry.uid);
+        header.set_gid(entry.gid);
+        header.set_mtime(entry.mtime);
+
+        match entry.kind {
+            RootfsEntryKind::Directory => {
+                if !host_metadata.file_type().is_dir() {
+                    return Err(format!("Rootfs entry changed type: {}", path.display()).into());
+                }
+                header.set_entry_type(tar::EntryType::Directory);
+                header.set_size(0);
+                header.set_cksum();
+                builder.append_data(&mut header, &path, Cursor::new([]))?;
+            }
+            RootfsEntryKind::Regular => {
+                if !host_metadata.file_type().is_file() || host_metadata.len() != entry.size {
+                    return Err(
+                        format!("Rootfs entry changed after capture: {}", path.display()).into(),
+                    );
+                }
+                let inode = (host_metadata.dev(), host_metadata.ino());
+                if host_metadata.nlink() > 1 {
+                    if let Some(first_path) = hardlinks.get(&inode) {
+                        header.set_entry_type(tar::EntryType::Link);
+                        header.set_size(0);
+                        header.set_link_name(first_path)?;
+                        header.set_cksum();
+                        builder.append_data(&mut header, &path, Cursor::new([]))?;
+                        continue;
+                    }
+                    hardlinks.insert(inode, path.clone());
+                }
+                header.set_entry_type(tar::EntryType::Regular);
+                header.set_size(entry.size);
+                header.set_cksum();
+                let file = std::fs::File::open(&source)?;
+                builder.append_data(&mut header, &path, file)?;
+            }
+            RootfsEntryKind::Symlink => {
+                if !host_metadata.file_type().is_symlink() {
+                    return Err(format!("Rootfs entry changed type: {}", path.display()).into());
+                }
+                let target = entry
+                    .link_target_base64
+                    .as_ref()
+                    .ok_or_else(|| format!("Missing symlink target: {}", path.display()))?;
+                let target = base64::engine::general_purpose::STANDARD.decode(target)?;
+                let target = std::path::PathBuf::from(OsString::from_vec(target));
+                header.set_entry_type(tar::EntryType::Symlink);
+                header.set_size(0);
+                header.set_cksum();
+                builder.append_link(&mut header, &path, target)?;
+            }
+        }
+    }
+    builder.finish()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_tar_from_guest_metadata(
+    _rootfs_dir: &Path,
+    _manifest: &a3s_box_core::rootfs_metadata::RootfsMetadataManifest,
+    _output: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    Err("Stopped-box guest metadata commit is not supported on this host".into())
+}
+
+fn validate_archive_path(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return Err("Rootfs metadata contains an absolute or empty path".into());
+    }
+    if path.components().any(|component| {
+        !matches!(
+            component,
+            std::path::Component::Normal(_) | std::path::Component::CurDir
+        )
+    }) {
+        return Err(format!("Unsafe rootfs metadata path: {}", path.display()).into());
+    }
+    Ok(())
+}
+
 /// Find the manifest blob in the OCI layout.
 fn find_manifest_blob(image_dir: &Path) -> Result<Vec<u8>, std::io::Error> {
     let index_path = image_dir.join("index.json");
@@ -116,9 +287,32 @@ fn find_manifest_blob(image_dir: &Path) -> Result<Vec<u8>, std::io::Error> {
 }
 
 /// Build a minimal OCI image layout from a rootfs directory.
+#[cfg(test)]
 fn build_oci_image(
     output_dir: &Path,
     rootfs_dir: &Path,
+    _reference: &str,
+    message: &Option<String>,
+    author: &Option<String>,
+    changes: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tar_path = output_dir.join("rootfs.host.tar");
+    {
+        let file = std::fs::File::create(&tar_path)?;
+        let mut builder = tar::Builder::new(file);
+        builder.follow_symlinks(false);
+        builder.append_dir_all(".", rootfs_dir)?;
+        builder.finish()?;
+    }
+    let result =
+        build_oci_image_from_tar(output_dir, &tar_path, _reference, message, author, changes);
+    let _ = std::fs::remove_file(tar_path);
+    result
+}
+
+fn build_oci_image_from_tar(
+    output_dir: &Path,
+    rootfs_tar: &Path,
     _reference: &str,
     message: &Option<String>,
     author: &Option<String>,
@@ -134,15 +328,10 @@ fn build_oci_image(
     let layer_path = blobs_dir.join("layer.tmp");
     {
         let file = std::fs::File::create(&layer_path)?;
-        let encoder = GzEncoder::new(file, Compression::default());
-        let mut builder = tar::Builder::new(encoder);
-        builder.follow_symlinks(false);
-        builder
-            .append_dir_all(".", rootfs_dir)
-            .map_err(|e| format!("Failed to archive rootfs: {e}"))?;
-        builder
-            .finish()
-            .map_err(|e| format!("Failed to finalize layer: {e}"))?;
+        let mut encoder = GzEncoder::new(file, Compression::default());
+        let mut input = std::fs::File::open(rootfs_tar)?;
+        std::io::copy(&mut input, &mut encoder)?;
+        encoder.finish()?;
     }
 
     // Hash the layer
@@ -153,7 +342,7 @@ fn build_oci_image(
     std::fs::rename(&layer_path, &layer_blob)?;
 
     // Compute diff_id (sha256 of uncompressed tar)
-    let diff_id = compute_diff_id(rootfs_dir)?;
+    let diff_id = compute_file_sha256(rootfs_tar)?;
 
     // 2. Create image config
     let mut config_obj = serde_json::json!({
@@ -228,7 +417,23 @@ fn build_oci_image(
     Ok(())
 }
 
+fn compute_file_sha256(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
 /// Compute the diff_id (sha256 of uncompressed tar) for a directory.
+#[cfg(test)]
 fn compute_diff_id(rootfs_dir: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let mut hasher = Sha256::new();
     let buf = Vec::new();
@@ -376,6 +581,117 @@ mod tests {
         let id = compute_diff_id(dir.path()).unwrap();
         assert!(!id.is_empty());
         assert_eq!(id.len(), 64); // sha256 hex
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_guest_metadata_overrides_host_uid_gid_and_mode_in_tar() {
+        use a3s_box_core::rootfs_metadata::{
+            RootfsEntryKind, RootfsMetadataEntry, RootfsMetadataManifest,
+        };
+        use std::os::unix::ffi::OsStrExt;
+
+        let rootfs = tempfile::TempDir::new().unwrap();
+        let file = rootfs.path().join("probe");
+        std::fs::write(&file, b"payload").unwrap();
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode(Path::new("probe").as_os_str().as_bytes());
+        let manifest = RootfsMetadataManifest::new(vec![RootfsMetadataEntry {
+            path_base64: encoded,
+            kind: RootfsEntryKind::Regular,
+            mode: 0o100755,
+            uid: 0,
+            gid: 0,
+            mtime: 123,
+            size: 7,
+            link_target_base64: None,
+        }]);
+        let output = rootfs.path().join("rootfs.tar");
+
+        create_tar_from_guest_metadata(rootfs.path(), &manifest, &output).unwrap();
+
+        let mut archive = tar::Archive::new(std::fs::File::open(output).unwrap());
+        let entry = archive.entries().unwrap().next().unwrap().unwrap();
+        assert_eq!(entry.path().unwrap(), Path::new("probe"));
+        assert_eq!(entry.header().mode().unwrap() & 0o7777, 0o755);
+        assert_eq!(entry.header().uid().unwrap(), 0);
+        assert_eq!(entry.header().gid().unwrap(), 0);
+        assert_eq!(entry.header().mtime().unwrap(), 123);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_guest_metadata_preserves_hardlinks_without_duplicate_payloads() {
+        use a3s_box_core::rootfs_metadata::{
+            RootfsEntryKind, RootfsMetadataEntry, RootfsMetadataManifest,
+        };
+        use std::os::unix::ffi::OsStrExt;
+
+        let rootfs = tempfile::TempDir::new().unwrap();
+        std::fs::write(rootfs.path().join("busybox"), b"payload").unwrap();
+        std::fs::hard_link(rootfs.path().join("busybox"), rootfs.path().join("sh")).unwrap();
+        let entries = ["busybox", "sh"]
+            .into_iter()
+            .map(|path| RootfsMetadataEntry {
+                path_base64: base64::engine::general_purpose::STANDARD
+                    .encode(Path::new(path).as_os_str().as_bytes()),
+                kind: RootfsEntryKind::Regular,
+                mode: 0o100755,
+                uid: 0,
+                gid: 0,
+                mtime: 123,
+                size: 7,
+                link_target_base64: None,
+            })
+            .collect();
+        let output = rootfs.path().join("rootfs.tar");
+
+        create_tar_from_guest_metadata(
+            rootfs.path(),
+            &RootfsMetadataManifest::new(entries),
+            &output,
+        )
+        .unwrap();
+
+        let mut archive = tar::Archive::new(std::fs::File::open(output).unwrap());
+        let mut entries = archive.entries().unwrap();
+        let first = entries.next().unwrap().unwrap();
+        assert_eq!(first.header().entry_type(), tar::EntryType::Regular);
+        drop(first);
+        let second = entries.next().unwrap().unwrap();
+        assert_eq!(second.header().entry_type(), tar::EntryType::Link);
+        assert_eq!(second.link_name().unwrap().unwrap(), Path::new("busybox"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_guest_metadata_rejects_parent_traversal() {
+        use a3s_box_core::rootfs_metadata::{
+            RootfsEntryKind, RootfsMetadataEntry, RootfsMetadataManifest,
+        };
+        use std::os::unix::ffi::OsStrExt;
+
+        let rootfs = tempfile::TempDir::new().unwrap();
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode(Path::new("../escape").as_os_str().as_bytes());
+        let manifest = RootfsMetadataManifest::new(vec![RootfsMetadataEntry {
+            path_base64: encoded,
+            kind: RootfsEntryKind::Regular,
+            mode: 0o100600,
+            uid: 0,
+            gid: 0,
+            mtime: 0,
+            size: 0,
+            link_target_base64: None,
+        }]);
+
+        let error = create_tar_from_guest_metadata(
+            rootfs.path(),
+            &manifest,
+            &rootfs.path().join("rootfs.tar"),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("Unsafe rootfs metadata path"));
     }
 
     #[test]

--- a/src/cli/src/commands/commit.rs
+++ b/src/cli/src/commands/commit.rs
@@ -101,7 +101,7 @@ pub async fn execute(args: CommitArgs) -> Result<(), Box<dyn std::error::Error>>
 
     println!(
         "sha256:{}",
-        &stored
+        stored
             .digest
             .strip_prefix("sha256:")
             .unwrap_or(&stored.digest)

--- a/src/cli/src/commands/compose.rs
+++ b/src/cli/src/commands/compose.rs
@@ -115,6 +115,13 @@ pub async fn execute(args: ComposeArgs) -> Result<(), Box<dyn std::error::Error>
 fn load_compose_file(
     explicit_path: Option<&std::path::Path>,
 ) -> Result<(PathBuf, ComposeConfig), Box<dyn std::error::Error>> {
+    load_compose_file_with_environment(explicit_path, std::env::vars())
+}
+
+fn load_compose_file_with_environment(
+    explicit_path: Option<&std::path::Path>,
+    shell_environment: impl IntoIterator<Item = (String, String)>,
+) -> Result<(PathBuf, ComposeConfig), Box<dyn std::error::Error>> {
     let path = if let Some(p) = explicit_path {
         if !p.exists() {
             return Err(format!("Compose file not found: {}", p.display()).into());
@@ -138,6 +145,31 @@ fn load_compose_file(
     let yaml = std::fs::read_to_string(&path)
         .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
+    let mut environment = HashMap::new();
+    let environment_path = path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join(".env");
+    match std::fs::read_to_string(&environment_path) {
+        Ok(contents) => {
+            for (key, value) in a3s_box_core::env::parse_env_file_content(&contents) {
+                environment.insert(key, value);
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "Failed to read Compose environment file {}: {}",
+                environment_path.display(),
+                error
+            )
+            .into());
+        }
+    }
+    environment.extend(shell_environment);
+
+    let yaml = a3s_box_core::compose::interpolate_compose_yaml(&yaml, &environment)
+        .map_err(|e| format!("Failed to interpolate {}: {}", path.display(), e))?;
     let config = ComposeConfig::from_yaml_str(&yaml)
         .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
 
@@ -584,7 +616,7 @@ async fn execute_up(
         // Atomic append under the state lock (load-fresh + push + save): a plain
         // state.add() saved a snapshot loaded before concurrent health/sibling
         // writes, clobbering them (the lost-registration → orphan-VM race).
-        if let Err(error) = StateFile::add_record(record) {
+        if let Err(error) = StateFile::add_record(record.clone()) {
             let rollback_services = rollback_with_current(&started_services, service_box);
             return rollback_compose_up(&mut state, &rollback_services, &created_networks, error)
                 .await;
@@ -596,13 +628,19 @@ async fn execute_up(
         }
         started_services.push(service_box);
 
-        // Spawn health checker if configured
-        if let Some(ref hc) = health_check {
-            crate::health::spawn_health_checker(
-                box_id.clone(),
-                exec_socket_path.clone(),
-                hc.clone(),
-            );
+        // Compose returns after startup, so health ownership must outlive this
+        // CLI process. A generation-fenced worker updates the same state record.
+        if health_check.is_some() {
+            if let Err(error) = crate::health::spawn_detached_health_checker(&record) {
+                let rollback_services = started_services.clone();
+                return rollback_compose_up(
+                    &mut state,
+                    &rollback_services,
+                    &created_networks,
+                    error,
+                )
+                .await;
+            }
         }
 
         // Ensure the log dir exists; the shim runs the log processor (default
@@ -1207,6 +1245,72 @@ mod tests {
         let result = load_compose_file(Some(std::path::Path::new("/nonexistent/compose.yaml")));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_load_compose_file_interpolates_dotenv_and_shell_before_validation() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let compose_path = directory.path().join("compose.yaml");
+        std::fs::write(
+            &compose_path,
+            r#"
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    environment:
+      DASH_EMPTY: ${EMPTY-default}
+      COLON_DASH_EMPTY: ${EMPTY:-default}
+      PLUS_EMPTY: ${EMPTY+replacement}
+      COLON_PLUS_EMPTY: ${EMPTY:+replacement}
+      DOTENV_ONLY: ${DOTENV_ONLY}
+      SHELL_WINS: ${SHELL_WINS}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            directory.path().join(".env"),
+            "REDIS_PORT=6379\nEMPTY=\nDOTENV_ONLY=dotenv\nSHELL_WINS=dotenv\n",
+        )
+        .unwrap();
+        let shell = HashMap::from([
+            ("REDIS_PORT".to_string(), "16379".to_string()),
+            ("SHELL_WINS".to_string(), "shell".to_string()),
+        ]);
+
+        let (_, config) = load_compose_file_with_environment(Some(&compose_path), shell).unwrap();
+        let service = &config.services["redis"];
+        assert_eq!(service.ports, vec!["16379:6379"]);
+        let environment: HashMap<_, _> = service.environment.to_pairs().into_iter().collect();
+        assert_eq!(environment["DASH_EMPTY"], "");
+        assert_eq!(environment["COLON_DASH_EMPTY"], "default");
+        assert_eq!(environment["PLUS_EMPTY"], "replacement");
+        assert_eq!(environment["COLON_PLUS_EMPTY"], "");
+        assert_eq!(environment["DOTENV_ONLY"], "dotenv");
+        assert_eq!(environment["SHELL_WINS"], "shell");
+
+        a3s_box_runtime::ComposeProject::with_base_dir("test", config, directory.path())
+            .expect("interpolation must run before port validation");
+    }
+
+    #[test]
+    fn test_load_compose_file_reports_unreadable_dotenv() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let compose_path = directory.path().join("compose.yaml");
+        std::fs::write(&compose_path, "services: {}\n").unwrap();
+        std::fs::create_dir(directory.path().join(".env")).unwrap();
+
+        let error = load_compose_file_with_environment(
+            Some(&compose_path),
+            HashMap::<String, String>::new(),
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Failed to read Compose environment file"));
+        assert!(error.to_string().contains(".env"));
     }
 
     #[test]

--- a/src/cli/src/commands/info.rs
+++ b/src/cli/src/commands/info.rs
@@ -2,6 +2,7 @@
 
 use clap::Args;
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 use crate::state::BoxRecord;
 use crate::state::StateFile;
@@ -11,6 +12,11 @@ use super::images_dir;
 
 const PNPM_CACHE_VOLUME_NAME: &str = "a3s-cache-pnpm";
 const NPM_CACHE_VOLUME_NAME: &str = "a3s-cache-npm";
+const PACKAGE_CACHE_SIZE_ENV: &str = "A3S_BOX_INFO_CACHE_SIZE";
+const PACKAGE_CACHE_SIZE_BUDGET: Duration = Duration::from_millis(500);
+const DEFAULT_POOL_SOCKET: &str = "/tmp/a3s-box-pool.sock";
+const RUN_POOL_SOCKET_ENV: &str = "A3S_BOX_RUN_POOL_SOCKET";
+const BUILD_RUN_POOL_SOCKET_ENV: &str = "A3S_BOX_BUILD_RUN_POOL_SOCKET";
 
 #[derive(Args)]
 pub struct InfoArgs;
@@ -70,6 +76,7 @@ pub async fn execute(_args: InfoArgs) -> Result<(), Box<dyn std::error::Error>> 
     }
     print_package_cache_info();
     print_host_mount_info();
+    print_warm_pool_info().await;
 
     Ok(())
 }
@@ -122,16 +129,43 @@ fn print_package_cache_info() {
 fn print_named_package_cache(store: &a3s_box_runtime::VolumeStore, label: &str, volume_name: &str) {
     match store.get(volume_name) {
         Ok(Some(volume)) => {
-            let size = directory_size(Path::new(&volume.mount_point)).unwrap_or(0);
-            println!(
-                "Package cache ({label}): {} at {}",
-                crate::output::format_bytes(size),
-                volume.mount_point
-            );
+            if !scan_package_cache_size_enabled() {
+                println!(
+                    "Package cache ({label}): created at {} (size scan skipped; set {PACKAGE_CACHE_SIZE_ENV}=1 to enable)",
+                    volume.mount_point
+                );
+                return;
+            }
+
+            match directory_size_bounded(Path::new(&volume.mount_point), PACKAGE_CACHE_SIZE_BUDGET)
+            {
+                Ok(DirectorySize::Complete(size)) => {
+                    println!(
+                        "Package cache ({label}): {} at {}",
+                        crate::output::format_bytes(size),
+                        volume.mount_point
+                    );
+                }
+                Ok(DirectorySize::TimedOut(partial)) => {
+                    println!(
+                        "Package cache ({label}): at least {} at {} (size scan timed out after {}ms)",
+                        crate::output::format_bytes(partial),
+                        volume.mount_point,
+                        PACKAGE_CACHE_SIZE_BUDGET.as_millis()
+                    );
+                }
+                Err(error) => println!("Package cache ({label}): unavailable ({error})"),
+            }
         }
         Ok(None) => println!("Package cache ({label}): not created"),
         Err(error) => println!("Package cache ({label}): unavailable ({error})"),
     }
+}
+
+fn scan_package_cache_size_enabled() -> bool {
+    std::env::var(PACKAGE_CACHE_SIZE_ENV)
+        .ok()
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
 }
 
 fn print_host_mount_info() {
@@ -142,25 +176,135 @@ fn print_host_mount_info() {
     println!("VirtioFS cache mode: {cache_mode}");
 }
 
+#[cfg(not(windows))]
+async fn print_warm_pool_info() {
+    let sockets = warm_pool_info_sockets();
+    for socket in &sockets {
+        match a3s_box_runtime::pool::client::status_client(socket).await {
+            Ok(status) => {
+                print_warm_pool_status(socket, &status.images);
+                return;
+            }
+            Err(_) => continue,
+        }
+    }
+
+    println!(
+        "Warm pool daemon: not running (checked {})",
+        sockets.join(", ")
+    );
+}
+
+#[cfg(windows)]
+async fn print_warm_pool_info() {
+    println!("Warm pool daemon: unsupported on Windows");
+}
+
+#[cfg(not(windows))]
+fn warm_pool_info_sockets() -> Vec<String> {
+    warm_pool_info_sockets_from(
+        std::env::var(RUN_POOL_SOCKET_ENV).ok().as_deref(),
+        std::env::var(BUILD_RUN_POOL_SOCKET_ENV).ok().as_deref(),
+        DEFAULT_POOL_SOCKET,
+    )
+}
+
+#[cfg(not(windows))]
+fn warm_pool_info_sockets_from(
+    run_socket: Option<&str>,
+    build_socket: Option<&str>,
+    default_socket: &str,
+) -> Vec<String> {
+    let mut sockets = Vec::new();
+    for socket in [run_socket, build_socket, Some(default_socket)]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+    {
+        if !socket.is_empty() && !sockets.iter().any(|existing| existing == socket) {
+            sockets.push(socket.to_string());
+        }
+    }
+    sockets
+}
+
+#[cfg(not(windows))]
+fn print_warm_pool_status(socket: &str, images: &[a3s_box_runtime::pool::PoolImageStat]) {
+    if images.is_empty() {
+        println!("Warm pool daemon: running at {socket} (no warm pools yet)");
+        return;
+    }
+
+    let max: usize = images.iter().map(|image| image.max).sum();
+    let idle: usize = images.iter().map(|image| image.idle).sum();
+    let active: usize = images.iter().map(|image| image.active).sum();
+    let leased: usize = images.iter().map(|image| image.leased).sum();
+    println!(
+        "Warm pool daemon: running at {socket} ({} pools, max {}, {} idle, {} active, {} leased)",
+        images.len(),
+        max,
+        idle,
+        active,
+        leased
+    );
+}
+
+#[cfg(test)]
 fn directory_size(path: &Path) -> std::io::Result<u64> {
+    match directory_size_inner(path, None)? {
+        DirectorySize::Complete(size) | DirectorySize::TimedOut(size) => Ok(size),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirectorySize {
+    Complete(u64),
+    TimedOut(u64),
+}
+
+fn directory_size_bounded(path: &Path, budget: Duration) -> std::io::Result<DirectorySize> {
+    let deadline = Instant::now()
+        .checked_add(budget)
+        .unwrap_or_else(Instant::now);
+    directory_size_inner(path, Some(deadline))
+}
+
+fn directory_size_inner(path: &Path, deadline: Option<Instant>) -> std::io::Result<DirectorySize> {
+    if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+        return Ok(DirectorySize::TimedOut(0));
+    }
+
     let metadata = match std::fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(DirectorySize::Complete(0));
+        }
         Err(error) => return Err(error),
     };
     if metadata.is_file() {
-        return Ok(metadata.len());
+        return Ok(DirectorySize::Complete(metadata.len()));
     }
     if !metadata.is_dir() {
-        return Ok(0);
+        return Ok(DirectorySize::Complete(0));
     }
 
     let mut total = 0_u64;
     for entry in std::fs::read_dir(path)? {
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Ok(DirectorySize::TimedOut(total));
+        }
+
         let entry = entry?;
-        total = total.saturating_add(directory_size(&entry.path())?);
+        match directory_size_inner(&entry.path(), deadline)? {
+            DirectorySize::Complete(size) => {
+                total = total.saturating_add(size);
+            }
+            DirectorySize::TimedOut(size) => {
+                return Ok(DirectorySize::TimedOut(total.saturating_add(size)));
+            }
+        }
     }
-    Ok(total)
+    Ok(DirectorySize::Complete(total))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -239,5 +383,41 @@ mod tests {
 
         assert_eq!(directory_size(tmp.path()).unwrap(), 6);
         assert_eq!(directory_size(&tmp.path().join("missing")).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_directory_size_bounded_reports_timeout() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("one"), b"1234").unwrap();
+
+        assert_eq!(
+            directory_size_bounded(tmp.path(), Duration::ZERO).unwrap(),
+            DirectorySize::TimedOut(0)
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_warm_pool_info_sockets_prefers_env_and_deduplicates() {
+        assert_eq!(
+            warm_pool_info_sockets_from(
+                Some(" /tmp/runtime.sock "),
+                Some("/tmp/build.sock"),
+                DEFAULT_POOL_SOCKET,
+            ),
+            vec![
+                "/tmp/runtime.sock".to_string(),
+                "/tmp/build.sock".to_string(),
+                DEFAULT_POOL_SOCKET.to_string(),
+            ]
+        );
+        assert_eq!(
+            warm_pool_info_sockets_from(
+                Some(" /tmp/runtime.sock "),
+                Some("/tmp/runtime.sock"),
+                "/tmp/runtime.sock",
+            ),
+            vec!["/tmp/runtime.sock".to_string()]
+        );
     }
 }

--- a/src/cli/src/commands/mod.rs
+++ b/src/cli/src/commands/mod.rs
@@ -236,6 +236,10 @@ pub(crate) fn resolve_box_rootfs(box_dir: &std::path::Path) -> Option<PathBuf> {
         return Some(merged);
     }
     let rootfs = box_dir.join("rootfs");
+    let apfs_data = rootfs.join(".a3s-rootfs");
+    if apfs_data.is_dir() {
+        return Some(apfs_data);
+    }
     if rootfs.is_dir() {
         return Some(rootfs);
     }

--- a/src/cli/src/commands/monitor.rs
+++ b/src/cli/src/commands/monitor.rs
@@ -47,6 +47,14 @@ pub struct MonitorArgs {
     /// `127.0.0.1:9100`). Off when unset. Bind loopback — there is no auth.
     #[arg(long)]
     pub metrics_addr: Option<String>,
+
+    /// Internal: run the process-owned health checker for one box.
+    #[arg(long, hide = true, requires = "health_generation")]
+    pub health_worker: Option<String>,
+
+    /// Internal: identify the exact boot generation owned by --health-worker.
+    #[arg(long, hide = true, requires = "health_worker")]
+    pub health_generation: Option<i64>,
 }
 
 /// Per-box backoff state for restart attempts.
@@ -149,6 +157,10 @@ impl BackoffTracker {
 }
 
 pub async fn execute(args: MonitorArgs) -> Result<(), Box<dyn std::error::Error>> {
+    if let (Some(box_id), Some(generation)) = (args.health_worker.as_ref(), args.health_generation)
+    {
+        return crate::health::run_detached_health_worker(box_id.clone(), generation).await;
+    }
     if args.install {
         return super::monitor_service::install(args.interval);
     }
@@ -427,6 +439,7 @@ async fn run_due_health_checks(state: &StateFile) -> Result<(), Box<dyn std::err
         .records()
         .iter()
         .filter(|record| health::should_probe(record, now))
+        .filter(|record| !health::detached_health_worker_active(record))
         .filter_map(|record| {
             record.health_check.as_ref().map(|hc| {
                 (

--- a/src/cli/src/commands/pool.rs
+++ b/src/cli/src/commands/pool.rs
@@ -14,14 +14,155 @@
 //!   pool stop / pool status                          Discoverability helpers
 
 use clap::{Parser, Subcommand};
-use serde::{Deserialize, Serialize};
 
-use a3s_box_core::config::{BoxConfig, PoolConfig};
+use a3s_box_core::config::{BoxConfig, PoolConfig, ResourceConfig};
 use a3s_box_core::event::EventEmitter;
-use a3s_box_runtime::pool::{PoolStats, WarmPool};
+#[cfg(not(windows))]
+use a3s_box_runtime::pool::client::{read_frame, run_client, stop_client, write_frame};
+use a3s_box_runtime::pool::{
+    PoolClientRun, PoolImageStat, PoolLeaseExecRequest, PoolLeaseReleaseRequest,
+    PoolLeaseReleaseResponse, PoolLeaseRequest, PoolLeaseResponse, PoolRequest, PoolRunRequest,
+    PoolRunResponse, PoolStats, PoolStatusResponse, PoolStopResponse, WarmPool,
+};
 
 /// Default Unix socket the `pool` daemon listens on.
-const DEFAULT_SOCKET: &str = "/tmp/a3s-box-pool.sock";
+pub(crate) const DEFAULT_SOCKET: &str = "/tmp/a3s-box-pool.sock";
+const DEFAULT_POOL_VCPUS: u32 = 2;
+const DEFAULT_POOL_MEMORY: &str = "512m";
+const DEFAULT_POOL_MEMORY_MB: u32 = 512;
+const DEFAULT_POOL_LEASE_TTL_SECS: u64 = 3600;
+pub(crate) const DEFAULT_AUTOSTART_POOL_SIZE: usize = 1;
+pub(crate) const DEFAULT_AUTOSTART_POOL_MAX: usize = 8;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PoolAutoStartConfig {
+    pub socket: String,
+    pub image: Option<String>,
+    pub size: usize,
+    pub max: usize,
+}
+
+impl PoolAutoStartConfig {
+    fn start_args(&self) -> Vec<String> {
+        let mut args = vec![
+            "pool".to_string(),
+            "start".to_string(),
+            "--socket".to_string(),
+            self.socket.clone(),
+            "--size".to_string(),
+            self.size.to_string(),
+            "--max".to_string(),
+            self.max.to_string(),
+        ];
+        if let Some(image) = &self.image {
+            args.push("--image".to_string());
+            args.push(image.clone());
+        }
+        args
+    }
+}
+
+#[cfg(unix)]
+struct PoolAutoStartLock {
+    _file: std::fs::File,
+}
+
+#[cfg(unix)]
+impl PoolAutoStartLock {
+    fn acquire(socket: &str) -> std::io::Result<Self> {
+        use std::os::unix::io::AsRawFd;
+
+        let lock_path = pool_autostart_lock_path(socket);
+        if let Some(parent) = lock_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(Self { _file: file })
+    }
+}
+
+#[cfg(unix)]
+fn pool_autostart_lock_path(socket: &str) -> std::path::PathBuf {
+    let mut path = std::ffi::OsString::from(socket);
+    path.push(".autostart.lock");
+    std::path::PathBuf::from(path)
+}
+
+#[cfg(not(windows))]
+pub(crate) async fn ensure_pool_daemon_running(
+    config: &PoolAutoStartConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if a3s_box_runtime::pool::client::status_client(&config.socket)
+        .await
+        .is_ok()
+    {
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    let _autostart_lock = PoolAutoStartLock::acquire(&config.socket)?;
+
+    if a3s_box_runtime::pool::client::status_client(&config.socket)
+        .await
+        .is_ok()
+    {
+        return Ok(());
+    }
+
+    if let Some(parent) = std::path::Path::new(&config.socket)
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let exe = std::env::current_exe()?;
+    let mut child = std::process::Command::new(exe)
+        .args(config.start_args())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("Failed to auto-start warm-pool daemon: {e}"))?;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while std::time::Instant::now() < deadline {
+        if a3s_box_runtime::pool::client::status_client(&config.socket)
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+        if let Some(status) = child.try_wait()? {
+            return Err(format!("Auto-started warm-pool daemon exited early: {status}").into());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    Err(format!(
+        "Timed out waiting for auto-started warm-pool daemon at {}",
+        config.socket
+    )
+    .into())
+}
+
+#[cfg(windows)]
+pub(crate) async fn ensure_pool_daemon_running(
+    _config: &PoolAutoStartConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    Err("warm-pool daemon auto-start is not supported on Windows".into())
+}
 
 /// Manage the warm VM pool.
 #[derive(Parser)]
@@ -62,6 +203,13 @@ pub struct PoolStartArgs {
     /// Idle TTL in seconds before evicting a pre-booted VM (0 = unlimited)
     #[arg(long, default_value = "300")]
     pub ttl: u64,
+
+    /// Idle TTL before reclaiming an unreleased lease (0 = unlimited).
+    ///
+    /// This protects the daemon when an internal lease client exits before it can
+    /// send release. Running lease exec requests are never reclaimed mid-command.
+    #[arg(long = "lease-ttl", default_value_t = DEFAULT_POOL_LEASE_TTL_SECS, value_parser = crate::output::parse_duration_secs)]
+    pub lease_ttl: u64,
 
     /// Unix socket to serve `pool run` requests on
     #[arg(long, default_value = DEFAULT_SOCKET)]
@@ -122,6 +270,21 @@ pub struct PoolRunArgs {
     #[arg(long, short = 'e')]
     pub env: Vec<String>,
 
+    /// Bind mount a host path into the pre-warmed sandbox, HOST:CONTAINER[:ro|rw].
+    ///
+    /// Volumes are part of the warm-pool key because virtio-fs mounts must exist
+    /// before the VM boots; requests with different mounts use different pools.
+    #[arg(long = "volume", short = 'v')]
+    pub volumes: Vec<String>,
+
+    /// Number of vCPUs for lazily-created pools.
+    #[arg(long, default_value_t = DEFAULT_POOL_VCPUS)]
+    pub cpus: u32,
+
+    /// Memory for lazily-created pools.
+    #[arg(long, default_value = DEFAULT_POOL_MEMORY)]
+    pub memory: String,
+
     /// On a --deferred daemon: run via exec instead of as the box's main —
     /// faster (the VM survives and is returned to use), output via the exec
     /// stream rather than the json-file logs.
@@ -136,6 +299,10 @@ pub struct PoolRunArgs {
 /// Arguments for `pool stop`.
 #[derive(Parser)]
 pub struct PoolStopArgs {
+    /// Unix socket of the `pool start` daemon
+    #[arg(long, default_value = DEFAULT_SOCKET)]
+    pub socket: String,
+
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -151,61 +318,6 @@ pub struct PoolStatusArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
-}
-
-/// Wire protocol for the `pool` Unix socket (length-prefixed JSON).
-///
-/// Client→daemon request: run a command, or query status. Tagged so the daemon
-/// can dispatch; the client parses the response type matching what it sent.
-#[derive(Serialize, Deserialize)]
-#[serde(tag = "op", rename_all = "snake_case")]
-enum Request {
-    Run(RunRequest),
-    Status,
-}
-
-#[derive(Serialize, Deserialize)]
-struct RunRequest {
-    /// Image to run in; `None` means use the daemon's default image.
-    #[serde(default)]
-    image: Option<String>,
-    /// User to run as (uid[:gid] or name); `None` runs as the image default.
-    #[serde(default)]
-    user: Option<String>,
-    /// Working directory inside the sandbox.
-    #[serde(default)]
-    workdir: Option<String>,
-    /// Extra KEY=VALUE environment entries.
-    #[serde(default)]
-    env: Vec<String>,
-    /// Force exec mode for this request (valid on a --deferred daemon, whose
-    /// IDLE VMs still serve exec; a keepalive daemon is always exec).
-    #[serde(default)]
-    exec: bool,
-    cmd: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize)]
-struct RunResponse {
-    stdout: Vec<u8>,
-    stderr: Vec<u8>,
-    exit_code: i32,
-    error: Option<String>,
-}
-
-/// Live stats for one image's warm pool.
-#[derive(Serialize, Deserialize)]
-struct ImageStat {
-    image: String,
-    idle: usize,
-    total_created: u64,
-    total_acquired: u64,
-    total_evicted: u64,
-}
-
-#[derive(Serialize, Deserialize)]
-struct StatusResponse {
-    images: Vec<ImageStat>,
 }
 
 /// Execute a pool command.
@@ -231,7 +343,7 @@ fn keepalive_cmd() -> Vec<String> {
 /// Build the `spawn-main` JSON spec for a deferred-mode pool command (executable +
 /// args + a standard PATH so the binary resolves like a normal container main,
 /// plus optional user/workdir and extra env from the request).
-fn deferred_spec_json(req: &RunRequest) -> Vec<u8> {
+fn deferred_spec_json(req: &PoolRunRequest) -> Vec<u8> {
     let mut env: Vec<(String, String)> = vec![(
         "PATH".to_string(),
         "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string(),
@@ -277,16 +389,118 @@ fn parse_warm_spec(entry: &str, default_size: usize) -> Result<(String, usize), 
 struct PoolEntry {
     pool: std::sync::Arc<WarmPool>,
     sem: std::sync::Arc<tokio::sync::Semaphore>,
+    max_size: usize,
+}
+
+/// Boot-time dimensions that define whether a pre-warmed VM can satisfy a run.
+///
+/// Image alone is not enough: virtio-fs mounts, vCPUs, and memory are fixed in
+/// the VM spec at boot. Keep those in the key so a request with a workspace bind
+/// mount does not accidentally acquire a sandbox that lacks it.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct PoolKey {
+    image: String,
+    volumes: Vec<String>,
+    vcpus: u32,
+    memory_mb: u32,
+}
+
+impl PoolKey {
+    fn default_for_image(image: impl Into<String>) -> Self {
+        Self {
+            image: image.into(),
+            volumes: Vec::new(),
+            vcpus: DEFAULT_POOL_VCPUS,
+            memory_mb: DEFAULT_POOL_MEMORY_MB,
+        }
+    }
+
+    fn from_request(image: String, req: &PoolRunRequest) -> Self {
+        Self {
+            image,
+            volumes: req.volumes.clone(),
+            vcpus: req.vcpus.unwrap_or(DEFAULT_POOL_VCPUS),
+            memory_mb: req.memory_mb.unwrap_or(DEFAULT_POOL_MEMORY_MB),
+        }
+    }
+
+    fn from_lease(image: String, req: &PoolLeaseRequest) -> Self {
+        Self {
+            image,
+            volumes: req.volumes.clone(),
+            vcpus: req.vcpus.unwrap_or(DEFAULT_POOL_VCPUS),
+            memory_mb: req.memory_mb.unwrap_or(DEFAULT_POOL_MEMORY_MB),
+        }
+    }
+
+    fn label(&self) -> String {
+        if self.volumes.is_empty()
+            && self.vcpus == DEFAULT_POOL_VCPUS
+            && self.memory_mb == DEFAULT_POOL_MEMORY_MB
+        {
+            return self.image.clone();
+        }
+
+        format!(
+            "{} [vcpus={}, memory={}m, volumes={}]",
+            self.image,
+            self.vcpus,
+            self.memory_mb,
+            self.volumes.len()
+        )
+    }
+}
+
+#[cfg(not(windows))]
+struct LeasedVm {
+    key: PoolKey,
+    vm: std::sync::Arc<tokio::sync::Mutex<a3s_box_runtime::VmManager>>,
+    last_used_ms: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    active_execs: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+#[cfg(not(windows))]
+struct LeaseExecGuard {
+    last_used_ms: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    active_execs: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[cfg(not(windows))]
+impl LeaseExecGuard {
+    fn new(leased: &LeasedVm) -> Self {
+        leased
+            .active_execs
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Self {
+            last_used_ms: leased.last_used_ms.clone(),
+            active_execs: leased.active_execs.clone(),
+        }
+    }
+}
+
+#[cfg(not(windows))]
+impl Drop for LeaseExecGuard {
+    fn drop(&mut self) {
+        self.last_used_ms
+            .store(now_millis(), std::sync::atomic::Ordering::SeqCst);
+        self.active_execs
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 /// A registry of warm pools keyed by image, created lazily on first use, so one
 /// daemon can serve sandboxes of different images.
 struct PoolRegistry {
-    pools: tokio::sync::Mutex<std::collections::HashMap<String, PoolEntry>>,
+    pools: tokio::sync::Mutex<std::collections::HashMap<PoolKey, PoolEntry>>,
+    #[cfg(not(windows))]
+    leases: tokio::sync::Mutex<std::collections::HashMap<String, LeasedVm>>,
     default_image: Option<String>,
     size: usize,
     max: usize,
     ttl: u64,
+    #[cfg(not(windows))]
+    lease_ttl: u64,
     /// When true, pooled VMs boot IDLE and `pool run` spawns the command as the
     /// box's real MAIN (full box semantics), instead of exec-into-keepalive.
     deferred: bool,
@@ -305,9 +519,13 @@ impl PoolRegistry {
     /// on first use, with `min_idle = size`. `WarmPool::start` returns once the
     /// replenisher is spawned, so holding the map lock across it is brief. The
     /// concurrency semaphore is sized to the pool's `max_size`.
-    async fn get_or_create_with_size(&self, image: &str, size: usize) -> Result<PoolEntry, String> {
+    async fn get_or_create_with_size(
+        &self,
+        key: PoolKey,
+        size: usize,
+    ) -> Result<PoolEntry, String> {
         let mut pools = self.pools.lock().await;
-        if let Some(entry) = pools.get(image) {
+        if let Some(entry) = pools.get(&key) {
             return Ok(entry.clone());
         }
         let max_size = self.max.max(size);
@@ -320,7 +538,13 @@ impl PoolRegistry {
             ..Default::default()
         };
         let box_config = BoxConfig {
-            image: image.to_string(),
+            image: key.image.clone(),
+            resources: ResourceConfig {
+                vcpus: key.vcpus,
+                memory_mb: key.memory_mb,
+                ..Default::default()
+            },
+            volumes: key.volumes.clone(),
             // In deferred mode the VM boots IDLE (keepalive cmd is stashed but
             // unused — the per-request command arrives via spawn-main).
             cmd: keepalive_cmd(),
@@ -342,14 +566,26 @@ impl PoolRegistry {
         let entry = PoolEntry {
             pool,
             sem: std::sync::Arc::new(tokio::sync::Semaphore::new(max_size)),
+            max_size,
         };
-        pools.insert(image.to_string(), entry.clone());
+        pools.insert(key, entry.clone());
         Ok(entry)
     }
 
-    /// Lazy pool for `image` at the daemon's default size.
-    async fn get_or_create(&self, image: &str) -> Result<PoolEntry, String> {
-        self.get_or_create_with_size(image, self.size).await
+    /// Lazy pool for `key` at the daemon's default size.
+    async fn get_or_create(&self, key: PoolKey) -> Result<PoolEntry, String> {
+        self.get_or_create_with_size(key, self.size).await
+    }
+
+    /// Lease pools with boot-time volumes are usually build-stage rootfs mounts:
+    /// unique, short-lived, and useful only to the single holder. Do not pre-warm
+    /// a whole pool for those keys; acquire will cold-fill exactly the VM needed.
+    fn lease_min_idle(&self, key: &PoolKey) -> usize {
+        if key.volumes.is_empty() {
+            self.size
+        } else {
+            0
+        }
     }
 
     /// Resolve the image for a request: the requested one, else the daemon default.
@@ -359,6 +595,14 @@ impl PoolRegistry {
 
     /// Stop replenishment and destroy idle VMs across all pools (shutdown).
     async fn drain_all(&self) {
+        #[cfg(not(windows))]
+        {
+            let mut leases = self.leases.lock().await;
+            for (_, leased) in leases.drain() {
+                let _ = leased.vm.lock().await.destroy().await;
+            }
+        }
+
         let pools = self.pools.lock().await;
         for entry in pools.values() {
             entry.pool.signal_shutdown();
@@ -367,21 +611,173 @@ impl PoolRegistry {
     }
 
     /// Snapshot live per-image stats, sorted by image name.
-    async fn stats(&self) -> Vec<ImageStat> {
-        let pools = self.pools.lock().await;
+    async fn stats(&self) -> Vec<PoolImageStat> {
+        let pools = {
+            let pools = self.pools.lock().await;
+            pools
+                .iter()
+                .map(|(key, entry)| (key.clone(), entry.clone()))
+                .collect::<Vec<_>>()
+        };
+        #[cfg(not(windows))]
+        let leased_by_key = {
+            let leases = self.leases.lock().await;
+            let mut counts = std::collections::HashMap::<PoolKey, usize>::new();
+            for leased in leases.values() {
+                *counts.entry(leased.key.clone()).or_default() += 1;
+            }
+            counts
+        };
         let mut out = Vec::with_capacity(pools.len());
-        for (image, entry) in pools.iter() {
+        for (key, entry) in pools {
             let s = entry.pool.stats().await;
-            out.push(ImageStat {
-                image: image.clone(),
+            let active = entry.max_size.saturating_sub(entry.sem.available_permits());
+            #[cfg(not(windows))]
+            let leased = leased_by_key.get(&key).copied().unwrap_or(0);
+            #[cfg(windows)]
+            let leased = 0;
+            out.push(PoolImageStat {
+                image: key.image.clone(),
+                pool: key.label(),
+                max: entry.max_size,
                 idle: s.idle_count,
+                active,
+                leased,
                 total_created: s.total_created,
                 total_acquired: s.total_acquired,
                 total_evicted: s.total_evicted,
             });
         }
-        out.sort_by(|a, b| a.image.cmp(&b.image));
+        out.sort_by(|a, b| a.image.cmp(&b.image).then_with(|| a.pool.cmp(&b.pool)));
         out
+    }
+
+    #[cfg(not(windows))]
+    async fn lease_vm(&self, req: PoolLeaseRequest) -> Result<String, String> {
+        let image = self.resolve_image(req.image.clone()).ok_or_else(|| {
+            "no image: pass an image or start the daemon with --image".to_string()
+        })?;
+        let key = PoolKey::from_lease(image.clone(), &req);
+        let entry = self
+            .get_or_create_with_size(key.clone(), self.lease_min_idle(&key))
+            .await
+            .map_err(|e| format!("pool for {image}: {e}"))?;
+        let permit = entry
+            .sem
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| "pool semaphore closed".to_string())?;
+        let vm = entry
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| format!("acquire failed: {e}"))?;
+        let lease_id = uuid::Uuid::new_v4().to_string();
+        self.leases.lock().await.insert(
+            lease_id.clone(),
+            LeasedVm {
+                key,
+                vm: std::sync::Arc::new(tokio::sync::Mutex::new(vm)),
+                last_used_ms: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(now_millis())),
+                active_execs: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                _permit: permit,
+            },
+        );
+        Ok(lease_id)
+    }
+
+    #[cfg(not(windows))]
+    async fn exec_lease(&self, req: PoolLeaseExecRequest) -> PoolRunResponse {
+        let (vm, _guard) = {
+            let leases = self.leases.lock().await;
+            let Some(leased) = leases.get(&req.lease_id) else {
+                return err_resp(format!("unknown pool lease '{}'", req.lease_id));
+            };
+            (leased.vm.clone(), LeaseExecGuard::new(leased))
+        };
+        let output = vm
+            .lock()
+            .await
+            .exec_request(&a3s_box_core::exec::ExecRequest {
+                cmd: req.cmd,
+                timeout_ns: req.timeout_ns.unwrap_or(60_000_000_000),
+                env: req.env,
+                working_dir: req.working_dir,
+                rootfs: req.rootfs,
+                stdin: req.stdin,
+                stdin_streaming: false,
+                user: req.user,
+                streaming: false,
+            })
+            .await;
+        match output {
+            Ok(o) => PoolRunResponse {
+                stdout: o.stdout,
+                stderr: o.stderr,
+                exit_code: o.exit_code,
+                error: None,
+            },
+            Err(e) => err_resp(e.to_string()),
+        }
+    }
+
+    #[cfg(not(windows))]
+    async fn release_lease(&self, req: PoolLeaseReleaseRequest) -> Option<String> {
+        let leased = match self.leases.lock().await.remove(&req.lease_id) {
+            Some(leased) => leased,
+            None => return Some(format!("unknown pool lease '{}'", req.lease_id)),
+        };
+        let result = {
+            let mut vm = leased.vm.lock().await;
+            vm.destroy().await.err().map(|e| e.to_string())
+        };
+        result
+    }
+
+    #[cfg(not(windows))]
+    async fn expired_lease_ids(&self, now_ms: u64) -> Vec<String> {
+        if self.lease_ttl == 0 {
+            return Vec::new();
+        }
+        let leases = self.leases.lock().await;
+        let mut ids = leases
+            .iter()
+            .filter(|(_, leased)| lease_is_expired(leased, self.lease_ttl, now_ms))
+            .map(|(lease_id, _)| lease_id.clone())
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids
+    }
+
+    #[cfg(not(windows))]
+    async fn reap_expired_leases(&self) -> usize {
+        let expired_ids = self.expired_lease_ids(now_millis()).await;
+        if expired_ids.is_empty() {
+            return 0;
+        }
+
+        let mut expired = Vec::new();
+        {
+            let mut leases = self.leases.lock().await;
+            for lease_id in expired_ids {
+                if let Some(leased) = leases.remove(&lease_id) {
+                    expired.push((lease_id, leased));
+                }
+            }
+        }
+
+        let mut count = 0;
+        for (lease_id, leased) in expired {
+            if !lease_is_expired(&leased, self.lease_ttl, now_millis()) {
+                self.leases.lock().await.insert(lease_id, leased);
+                continue;
+            }
+            tracing::warn!(lease_id = %lease_id, "Reclaiming expired warm-pool lease");
+            let _ = leased.vm.lock().await.destroy().await;
+            count += 1;
+        }
+        count
     }
 }
 
@@ -405,10 +801,14 @@ async fn execute_start(args: PoolStartArgs) -> Result<(), Box<dyn std::error::Er
 
     let registry = std::sync::Arc::new(PoolRegistry {
         pools: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+        #[cfg(not(windows))]
+        leases: tokio::sync::Mutex::new(std::collections::HashMap::new()),
         default_image: args.image.clone(),
         size: args.size,
         max: args.max,
         ttl: args.ttl,
+        #[cfg(not(windows))]
+        lease_ttl: args.lease_ttl,
         deferred: args.deferred,
         ksm: args.ksm,
         snapshot_fork: args.snapshot_fork,
@@ -420,9 +820,33 @@ async fn execute_start(args: PoolStartArgs) -> Result<(), Box<dyn std::error::Er
         tokio::spawn(serve_pool_metrics(addr, metrics));
     }
 
+    #[cfg(not(windows))]
+    if args.lease_ttl > 0 {
+        tokio::spawn(reap_expired_leases_task(registry.clone(), args.lease_ttl));
+    }
+
+    // Bind the control socket before pre-warming. Large images can take longer
+    // than the autostart client's safety cap to cold boot; keeping the daemon
+    // undiscoverable until that work completed made a healthy startup look like
+    // a timeout. Requests may connect immediately and naturally wait on the
+    // per-pool creation lock until the first VM is truly exec-ready.
+    #[cfg(not(windows))]
+    let serve_task = {
+        let serve_registry = registry.clone();
+        let serve_socket = args.socket.clone();
+        let serve_json = args.json;
+        tokio::spawn(async move {
+            serve(serve_registry, &serve_socket, serve_json)
+                .await
+                .map_err(|error| error.to_string())
+        })
+    };
+
     // Pre-warm the default image, if one was given.
     let default_stats = if let Some(ref image) = args.image {
-        let entry = registry.get_or_create(image).await?;
+        let entry = registry
+            .get_or_create(PoolKey::default_for_image(image.clone()))
+            .await?;
         Some((image.clone(), entry.pool.stats().await))
     } else {
         None
@@ -435,7 +859,9 @@ async fn execute_start(args: PoolStartArgs) -> Result<(), Box<dyn std::error::Er
         if count == 0 {
             return Err(format!("--warm count must be > 0 (in '{entry}')").into());
         }
-        registry.get_or_create_with_size(&image, count).await?;
+        registry
+            .get_or_create_with_size(PoolKey::default_for_image(&image), count)
+            .await?;
         warmed_extra.push((image, count));
     }
 
@@ -458,15 +884,69 @@ async fn execute_start(args: PoolStartArgs) -> Result<(), Box<dyn std::error::Er
         }
         println!("  max:      {}", args.max);
         println!("  ttl:      {}s", args.ttl);
+        println!("  lease ttl: {}s", args.lease_ttl);
         println!("  socket:   {}", args.socket);
     }
 
+    #[cfg(not(windows))]
+    serve_task.await??;
+    #[cfg(windows)]
     serve(registry, &args.socket, args.json).await?;
 
     if !args.json {
         println!("Done.");
     }
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn lease_is_expired(leased: &LeasedVm, lease_ttl_secs: u64, now_ms: u64) -> bool {
+    if lease_ttl_secs == 0 {
+        return false;
+    }
+    if leased
+        .active_execs
+        .load(std::sync::atomic::Ordering::SeqCst)
+        != 0
+    {
+        return false;
+    }
+    let ttl_ms = lease_ttl_secs.saturating_mul(1000);
+    let cutoff = now_ms.saturating_sub(ttl_ms);
+    leased
+        .last_used_ms
+        .load(std::sync::atomic::Ordering::SeqCst)
+        <= cutoff
+}
+
+#[cfg(not(windows))]
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(not(windows))]
+fn lease_reaper_interval(lease_ttl_secs: u64) -> std::time::Duration {
+    let secs = if lease_ttl_secs <= 4 {
+        1
+    } else {
+        (lease_ttl_secs / 4).clamp(1, 60)
+    };
+    std::time::Duration::from_secs(secs)
+}
+
+#[cfg(not(windows))]
+async fn reap_expired_leases_task(registry: std::sync::Arc<PoolRegistry>, lease_ttl_secs: u64) {
+    let mut interval = tokio::time::interval(lease_reaper_interval(lease_ttl_secs));
+    loop {
+        interval.tick().await;
+        let reaped = registry.reap_expired_leases().await;
+        if reaped > 0 {
+            tracing::warn!(reaped, "Reaped expired warm-pool leases");
+        }
+    }
 }
 
 /// Serve a Prometheus `/metrics` endpoint exposing the pool daemon's runtime
@@ -529,16 +1009,27 @@ async fn serve(
         println!("Listening on {} (Ctrl-C to drain and stop)", socket);
     }
 
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+
     loop {
         tokio::select! {
             accepted = listener.accept() => {
                 let (mut stream, _) = accepted?;
                 let registry = registry.clone();
+                let shutdown_tx = shutdown_tx.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = handle_conn(&registry, &mut stream).await {
+                    if let Err(e) = handle_conn(&registry, &shutdown_tx, &mut stream).await {
                         tracing::warn!(error = %e, "pool connection failed");
                     }
                 });
+            }
+            _ = shutdown_rx.recv() => {
+                let _ = std::fs::remove_file(socket);
+                if !json {
+                    println!("Draining warm pools...");
+                }
+                registry.drain_all().await;
+                break;
             }
             _ = tokio::signal::ctrl_c() => {
                 let _ = std::fs::remove_file(socket);
@@ -554,8 +1045,8 @@ async fn serve(
 }
 
 #[cfg(not(windows))]
-fn err_resp(msg: impl Into<String>) -> RunResponse {
-    RunResponse {
+fn err_resp(msg: impl Into<String>) -> PoolRunResponse {
+    PoolRunResponse {
         stdout: vec![],
         stderr: vec![],
         exit_code: -1,
@@ -564,27 +1055,68 @@ fn err_resp(msg: impl Into<String>) -> RunResponse {
 }
 
 #[cfg(not(windows))]
+fn timeout_duration(timeout_ns: Option<u64>, default_ns: u64) -> std::time::Duration {
+    std::time::Duration::from_nanos(timeout_ns.unwrap_or(default_ns))
+}
+
+#[cfg(not(windows))]
 async fn handle_conn(
     registry: &PoolRegistry,
+    shutdown_tx: &tokio::sync::mpsc::UnboundedSender<()>,
     stream: &mut tokio::net::UnixStream,
 ) -> std::io::Result<()> {
     // 60s exec cap — generous for a sandbox command.
     const EXEC_TIMEOUT_NS: u64 = 60_000_000_000;
 
-    let req: Request = serde_json::from_slice(&read_frame(stream).await?)
+    let req: PoolRequest = serde_json::from_slice(&read_frame(stream).await?)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
-    // `status` is a simple query — answer and return.
     let run = match req {
-        Request::Status => {
-            let resp = StatusResponse {
+        PoolRequest::Status => {
+            let resp = PoolStatusResponse {
                 images: registry.stats().await,
             };
             let bytes = serde_json::to_vec(&resp)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
             return write_frame(stream, &bytes).await;
         }
-        Request::Run(run) => run,
+        PoolRequest::Stop => {
+            let bytes = serde_json::to_vec(&PoolStopResponse { error: None })
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            write_frame(stream, &bytes).await?;
+            let _ = shutdown_tx.send(());
+            return Ok(());
+        }
+        PoolRequest::Lease(lease) => {
+            let resp = match registry.lease_vm(lease).await {
+                Ok(lease_id) => PoolLeaseResponse {
+                    lease_id: Some(lease_id),
+                    error: None,
+                },
+                Err(error) => PoolLeaseResponse {
+                    lease_id: None,
+                    error: Some(error),
+                },
+            };
+            let bytes = serde_json::to_vec(&resp)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            return write_frame(stream, &bytes).await;
+        }
+        PoolRequest::Exec(exec) => {
+            let resp = registry.exec_lease(exec).await;
+            let bytes = serde_json::to_vec(&resp)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            return write_frame(stream, &bytes).await;
+        }
+        PoolRequest::Release(release) => {
+            let resp = PoolLeaseReleaseResponse {
+                error: registry.release_lease(release).await,
+            };
+            let bytes = serde_json::to_vec(&resp)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            return write_frame(stream, &bytes).await;
+        }
+        PoolRequest::Run(run) => run,
     };
 
     // Resolve the image, get-or-create its pool, acquire a warm VM, run the
@@ -596,7 +1128,10 @@ async fn handle_conn(
     let mut used = None;
     let resp = match registry.resolve_image(run.image.clone()) {
         None => err_resp("no image: pass --image or start the daemon with --image"),
-        Some(image) => match registry.get_or_create(&image).await {
+        Some(image) => match registry
+            .get_or_create(PoolKey::from_request(image.clone(), &run))
+            .await
+        {
             Err(e) => err_resp(format!("pool for {image}: {e}")),
             Ok(entry) => {
                 // Backpressure: wait for a slot so a burst doesn't boot unbounded VMs.
@@ -618,16 +1153,16 @@ async fn handle_conn(
                         let result = if registry.deferred && !run.exec {
                             vm.run_deferred_main(
                                 &deferred_spec_json(&run),
-                                std::time::Duration::from_secs(60),
+                                timeout_duration(run.timeout_ns, EXEC_TIMEOUT_NS),
                             )
                             .await
                         } else {
                             vm.exec_request(&a3s_box_core::exec::ExecRequest {
                                 cmd: run.cmd,
-                                timeout_ns: EXEC_TIMEOUT_NS,
+                                timeout_ns: run.timeout_ns.unwrap_or(EXEC_TIMEOUT_NS),
                                 env: run.env,
                                 working_dir: run.workdir,
-                                rootfs: None,
+                                rootfs: run.rootfs,
                                 stdin: None,
                                 stdin_streaming: false,
                                 user: run.user,
@@ -636,7 +1171,7 @@ async fn handle_conn(
                             .await
                         };
                         let resp = match result {
-                            Ok(o) => RunResponse {
+                            Ok(o) => PoolRunResponse {
                                 stdout: o.stdout,
                                 stderr: o.stderr,
                                 exit_code: o.exit_code,
@@ -670,36 +1205,29 @@ async fn handle_conn(
 #[cfg(not(windows))]
 async fn execute_run(args: PoolRunArgs) -> Result<(), Box<dyn std::error::Error>> {
     use std::io::Write;
-    use tokio::net::UnixStream;
 
-    let mut stream = UnixStream::connect(&args.socket).await.map_err(|e| {
-        format!(
-            "Failed to connect to pool daemon at {} ({}). Is `a3s-box pool start` running?",
-            args.socket, e
-        )
-    })?;
+    let memory_mb =
+        crate::output::parse_memory(&args.memory).map_err(|e| format!("Invalid --memory: {e}"))?;
 
-    write_frame(
-        &mut stream,
-        &serde_json::to_vec(&Request::Run(RunRequest {
-            image: args.image,
-            user: args.user,
-            workdir: args.workdir,
-            env: args.env,
-            exec: args.exec,
-            cmd: args.cmd,
-        }))?,
-    )
+    let output = run_client(PoolClientRun {
+        socket: args.socket,
+        image: args.image,
+        user: args.user,
+        workdir: args.workdir,
+        rootfs: None,
+        env: args.env,
+        volumes: args.volumes,
+        vcpus: args.cpus,
+        memory_mb,
+        exec: args.exec,
+        timeout_ns: None,
+        cmd: args.cmd,
+    })
     .await?;
-    let resp: RunResponse = serde_json::from_slice(&read_frame(&mut stream).await?)?;
 
-    if let Some(err) = resp.error {
-        eprintln!("pool error: {err}");
-        std::process::exit(1);
-    }
-    std::io::stdout().write_all(&resp.stdout)?;
-    std::io::stderr().write_all(&resp.stderr)?;
-    std::process::exit(resp.exit_code);
+    std::io::stdout().write_all(&output.stdout)?;
+    std::io::stderr().write_all(&output.stderr)?;
+    std::process::exit(output.exit_code);
 }
 
 #[cfg(windows)]
@@ -720,30 +1248,30 @@ async fn execute_run(_args: PoolRunArgs) -> Result<(), Box<dyn std::error::Error
     Err("`pool run` is not supported on Windows".into())
 }
 
-/// Length-prefixed (u32 LE) framing for the Unix-socket protocol.
 #[cfg(not(windows))]
-async fn write_frame<W: tokio::io::AsyncWriteExt + Unpin>(
-    w: &mut W,
-    data: &[u8],
-) -> std::io::Result<()> {
-    w.write_all(&(data.len() as u32).to_le_bytes()).await?;
-    w.write_all(data).await?;
-    w.flush().await
-}
-
-#[cfg(not(windows))]
-async fn read_frame<R: tokio::io::AsyncReadExt + Unpin>(r: &mut R) -> std::io::Result<Vec<u8>> {
-    let mut len = [0u8; 4];
-    r.read_exact(&mut len).await?;
-    let mut buf = vec![0u8; u32::from_le_bytes(len) as usize];
-    r.read_exact(&mut buf).await?;
-    Ok(buf)
-}
-
-async fn execute_stop(_args: PoolStopArgs) -> Result<(), Box<dyn std::error::Error>> {
-    // Pool stop is handled by sending SIGINT to the `pool start` process.
-    eprintln!("Send SIGINT (Ctrl-C) to the running `a3s-box pool start` process to drain and stop the pool.");
+async fn execute_stop(args: PoolStopArgs) -> Result<(), Box<dyn std::error::Error>> {
+    match stop_client(&args.socket).await {
+        Ok(()) => {
+            if args.json {
+                println!(r#"{{"stopped":true}}"#);
+            } else {
+                println!("Warm pool daemon stopped.");
+            }
+        }
+        Err(_) => {
+            if args.json {
+                println!(r#"{{"stopped":false,"reason":"not_running"}}"#);
+            } else {
+                println!("No pool daemon running.");
+            }
+        }
+    }
     Ok(())
+}
+
+#[cfg(windows)]
+async fn execute_stop(_args: PoolStopArgs) -> Result<(), Box<dyn std::error::Error>> {
+    Err("`pool stop` is not supported on Windows".into())
 }
 
 #[cfg(not(windows))]
@@ -764,8 +1292,8 @@ async fn execute_status(args: PoolStatusArgs) -> Result<(), Box<dyn std::error::
         }
     };
 
-    write_frame(&mut stream, &serde_json::to_vec(&Request::Status)?).await?;
-    let resp: StatusResponse = serde_json::from_slice(&read_frame(&mut stream).await?)?;
+    write_frame(&mut stream, &serde_json::to_vec(&PoolRequest::Status)?).await?;
+    let resp: PoolStatusResponse = serde_json::from_slice(&read_frame(&mut stream).await?)?;
 
     if args.json {
         println!("{}", serde_json::to_string(&resp.images)?);
@@ -773,13 +1301,20 @@ async fn execute_status(args: PoolStatusArgs) -> Result<(), Box<dyn std::error::
         println!("No warm pools yet (no images warmed).");
     } else {
         println!(
-            "{:<40} {:>5} {:>8} {:>9} {:>8}",
-            "IMAGE", "IDLE", "CREATED", "ACQUIRED", "EVICTED"
+            "{:<60} {:>5} {:>5} {:>5} {:>6} {:>8} {:>9} {:>8}",
+            "POOL", "MAX", "IDLE", "ACT", "LEASED", "CREATED", "ACQUIRED", "EVICTED"
         );
         for s in &resp.images {
             println!(
-                "{:<40} {:>5} {:>8} {:>9} {:>8}",
-                s.image, s.idle, s.total_created, s.total_acquired, s.total_evicted
+                "{:<60} {:>5} {:>5} {:>5} {:>6} {:>8} {:>9} {:>8}",
+                s.pool,
+                s.max,
+                s.idle,
+                s.active,
+                s.leased,
+                s.total_created,
+                s.total_acquired,
+                s.total_evicted
             );
         }
     }
@@ -868,6 +1403,67 @@ mod tests {
     }
 
     #[test]
+    fn test_pool_autostart_start_args() {
+        let config = PoolAutoStartConfig {
+            socket: "/tmp/a3s-pool.sock".to_string(),
+            image: Some("alpine:latest".to_string()),
+            size: 1,
+            max: 4,
+        };
+
+        assert_eq!(
+            config.start_args(),
+            vec![
+                "pool",
+                "start",
+                "--socket",
+                "/tmp/a3s-pool.sock",
+                "--size",
+                "1",
+                "--max",
+                "4",
+                "--image",
+                "alpine:latest"
+            ]
+        );
+
+        let lazy = PoolAutoStartConfig {
+            image: None,
+            ..config
+        };
+        assert!(!lazy.start_args().contains(&"--image".to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_pool_autostart_lock_serializes_same_socket() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("pool.sock").display().to_string();
+        let lock_path = pool_autostart_lock_path(&socket);
+        let guard = PoolAutoStartLock::acquire(&socket).unwrap();
+        assert!(lock_path.exists());
+
+        let thread_socket = socket.clone();
+        let (tx, rx) = mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            let _guard = PoolAutoStartLock::acquire(&thread_socket).unwrap();
+            tx.send(()).unwrap();
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "second auto-start lock should block while the first guard is alive"
+        );
+        drop(guard);
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("second auto-start lock should proceed after drop");
+        waiter.join().unwrap();
+    }
+
+    #[test]
     fn test_parse_warm_spec() {
         // image=count
         assert_eq!(
@@ -890,16 +1486,49 @@ mod tests {
     }
 
     #[test]
+    fn test_pool_key_includes_boot_time_dimensions() {
+        let base = PoolKey::default_for_image("node:24-bookworm");
+        let mounted = PoolKey::from_request(
+            "node:24-bookworm".to_string(),
+            &PoolRunRequest {
+                image: None,
+                user: None,
+                workdir: None,
+                rootfs: None,
+                env: vec![],
+                volumes: vec!["/host/work:/workspace:ro".into()],
+                vcpus: Some(4),
+                memory_mb: Some(8192),
+                exec: false,
+                timeout_ns: None,
+                cmd: vec!["node".into(), "--version".into()],
+            },
+        );
+
+        assert_ne!(base, mounted);
+        assert_eq!(mounted.image, "node:24-bookworm");
+        assert_eq!(mounted.volumes, vec!["/host/work:/workspace:ro"]);
+        assert_eq!(mounted.vcpus, 4);
+        assert_eq!(mounted.memory_mb, 8192);
+        assert!(mounted.label().contains("volumes=1"));
+    }
+
+    #[test]
     fn test_deferred_spec_json() {
         // The spawn-main spec for a deferred pool run: executable + args + a PATH
         // so the binary resolves like a normal container main, plus per-request
         // user/workdir and extra env.
-        let req = RunRequest {
+        let req = PoolRunRequest {
             image: None,
             user: Some("1000".into()),
             workdir: Some("/work".into()),
+            rootfs: None,
             env: vec!["FOO=bar".into(), "not-a-pair".into()],
+            volumes: vec![],
+            vcpus: None,
+            memory_mb: None,
             exec: false,
+            timeout_ns: None,
             cmd: vec!["sh".into(), "-c".into(), "echo hi".into()],
         };
         let json = deferred_spec_json(&req);
@@ -915,17 +1544,172 @@ mod tests {
         assert_eq!(v["user"], "1000");
         assert_eq!(v["workdir"], "/work");
         // Empty cmd falls back to a shell rather than panicking.
-        let req2 = RunRequest {
+        let req2 = PoolRunRequest {
             image: None,
             user: None,
             workdir: None,
+            rootfs: None,
             env: vec![],
+            volumes: vec![],
+            vcpus: None,
+            memory_mb: None,
             exec: false,
+            timeout_ns: None,
             cmd: vec![],
         };
         let v2: serde_json::Value = serde_json::from_slice(&deferred_spec_json(&req2)).unwrap();
         assert_eq!(v2["executable"], "/bin/sh");
         assert!(v2["user"].is_null());
+    }
+
+    #[test]
+    fn test_timeout_duration_uses_request_or_default() {
+        assert_eq!(
+            timeout_duration(Some(7_000_000_000), 60_000_000_000),
+            std::time::Duration::from_secs(7)
+        );
+        assert_eq!(
+            timeout_duration(None, 60_000_000_000),
+            std::time::Duration::from_secs(60)
+        );
+    }
+
+    #[cfg(not(windows))]
+    fn test_registry_with_lease_ttl(lease_ttl: u64) -> std::sync::Arc<PoolRegistry> {
+        std::sync::Arc::new(PoolRegistry {
+            pools: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            leases: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            default_image: Some("alpine:latest".to_string()),
+            size: 1,
+            max: 4,
+            ttl: 0,
+            lease_ttl,
+            deferred: false,
+            ksm: false,
+            snapshot_fork: false,
+            metrics: None,
+        })
+    }
+
+    #[cfg(not(windows))]
+    async fn insert_test_lease(
+        registry: &PoolRegistry,
+        lease_id: &str,
+        last_used_ms: u64,
+        active_execs: usize,
+    ) {
+        let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = sem.acquire_owned().await.unwrap();
+        let config = BoxConfig {
+            image: "alpine:latest".to_string(),
+            ..Default::default()
+        };
+        let vm = a3s_box_runtime::VmManager::with_box_id(
+            config,
+            EventEmitter::new(16),
+            format!("test-lease-{lease_id}"),
+        );
+        registry.leases.lock().await.insert(
+            lease_id.to_string(),
+            LeasedVm {
+                key: PoolKey::default_for_image("alpine:latest"),
+                vm: std::sync::Arc::new(tokio::sync::Mutex::new(vm)),
+                last_used_ms: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(last_used_ms)),
+                active_execs: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(
+                    active_execs,
+                )),
+                _permit: permit,
+            },
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_expired_lease_ids_only_reports_idle_stale_leases() {
+        let registry = test_registry_with_lease_ttl(60);
+        let now = 1_000_000;
+        insert_test_lease(&registry, "busy", now - 120_000, 1).await;
+        insert_test_lease(&registry, "fresh", now - 10_000, 0).await;
+        insert_test_lease(&registry, "stale", now - 120_000, 0).await;
+
+        let expired = registry.expired_lease_ids(now).await;
+
+        assert_eq!(expired, vec!["stale".to_string()]);
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_expired_lease_ids_disabled_when_ttl_zero() {
+        let registry = test_registry_with_lease_ttl(0);
+        let now = 1_000_000;
+        insert_test_lease(&registry, "stale", now - 120_000, 0).await;
+
+        assert!(registry.expired_lease_ids(now).await.is_empty());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_lease_min_idle_skips_prewarm_for_volume_bound_leases() {
+        let registry = test_registry_with_lease_ttl(60);
+        let plain_key = PoolKey::default_for_image("alpine:latest");
+        let volume_key = PoolKey {
+            image: "alpine:latest".to_string(),
+            volumes: vec!["/host/stage:/run/a3s/build-rootfs:rw".to_string()],
+            vcpus: DEFAULT_POOL_VCPUS,
+            memory_mb: DEFAULT_POOL_MEMORY_MB,
+        };
+
+        assert_eq!(registry.lease_min_idle(&plain_key), registry.size);
+        assert_eq!(registry.lease_min_idle(&volume_key), 0);
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_lease_exec_guard_marks_busy_and_refreshes_activity() {
+        let registry = test_registry_with_lease_ttl(60);
+        let now = now_millis();
+        insert_test_lease(&registry, "lease", now.saturating_sub(120_000), 0).await;
+
+        let (last_used, active_execs) = {
+            let leases = registry.leases.lock().await;
+            let leased = leases.get("lease").unwrap();
+            let guard = LeaseExecGuard::new(leased);
+            assert_eq!(
+                leased
+                    .active_execs
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                1
+            );
+            assert!(!lease_is_expired(
+                leased,
+                registry.lease_ttl,
+                now.saturating_add(120_000)
+            ));
+            let last_used = leased.last_used_ms.clone();
+            let active_execs = leased.active_execs.clone();
+            drop(guard);
+            (last_used, active_execs)
+        };
+
+        assert_eq!(active_execs.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(
+            last_used.load(std::sync::atomic::Ordering::SeqCst) >= now,
+            "dropping the guard should refresh lease activity"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_lease_reaper_interval_is_bounded() {
+        assert_eq!(lease_reaper_interval(1), std::time::Duration::from_secs(1));
+        assert_eq!(
+            lease_reaper_interval(60),
+            std::time::Duration::from_secs(15)
+        );
+        assert_eq!(
+            lease_reaper_interval(3600),
+            std::time::Duration::from_secs(60)
+        );
     }
 
     #[tokio::test]
@@ -962,35 +1746,46 @@ mod tests {
 
     #[test]
     fn test_run_request_response_roundtrip() {
-        let req = RunRequest {
+        let req = PoolRunRequest {
             image: Some("alpine:latest".into()),
             user: Some("1000".into()),
             workdir: Some("/tmp".into()),
+            rootfs: None,
             env: vec!["FOO=bar".into()],
+            volumes: vec!["/host:/work:ro".into()],
+            vcpus: Some(4),
+            memory_mb: Some(2048),
             exec: false,
+            timeout_ns: None,
             cmd: vec!["echo".into(), "hi".into()],
         };
         let bytes = serde_json::to_vec(&req).unwrap();
-        let parsed: RunRequest = serde_json::from_slice(&bytes).unwrap();
+        let parsed: PoolRunRequest = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(parsed.cmd, vec!["echo", "hi"]);
         assert_eq!(parsed.image.as_deref(), Some("alpine:latest"));
         assert_eq!(parsed.user.as_deref(), Some("1000"));
         assert_eq!(parsed.workdir.as_deref(), Some("/tmp"));
         assert_eq!(parsed.env, vec!["FOO=bar"]);
+        assert_eq!(parsed.volumes, vec!["/host:/work:ro"]);
+        assert_eq!(parsed.vcpus, Some(4));
+        assert_eq!(parsed.memory_mb, Some(2048));
 
         // image/user/workdir/env are optional on the wire (older clients).
-        let no_img: RunRequest = serde_json::from_slice(br#"{"cmd":["ls"]}"#).unwrap();
+        let no_img: PoolRunRequest = serde_json::from_slice(br#"{"cmd":["ls"]}"#).unwrap();
         assert!(no_img.image.is_none());
         assert!(no_img.user.is_none() && no_img.workdir.is_none() && no_img.env.is_empty());
+        assert!(no_img.volumes.is_empty());
+        assert!(no_img.vcpus.is_none());
+        assert!(no_img.memory_mb.is_none());
 
-        let resp = RunResponse {
+        let resp = PoolRunResponse {
             stdout: b"hi\n".to_vec(),
             stderr: vec![],
             exit_code: 0,
             error: None,
         };
         let rb = serde_json::to_vec(&resp).unwrap();
-        let rp: RunResponse = serde_json::from_slice(&rb).unwrap();
+        let rp: PoolRunResponse = serde_json::from_slice(&rb).unwrap();
         assert_eq!(rp.stdout, b"hi\n");
         assert_eq!(rp.exit_code, 0);
         assert!(rp.error.is_none());
@@ -1003,6 +1798,7 @@ mod tests {
             size: 0,
             max: 5,
             ttl: 300,
+            lease_ttl: DEFAULT_POOL_LEASE_TTL_SECS,
             socket: DEFAULT_SOCKET.to_string(),
             warm: vec![],
             deferred: false,
@@ -1023,6 +1819,7 @@ mod tests {
             size: 10,
             max: 5,
             ttl: 300,
+            lease_ttl: DEFAULT_POOL_LEASE_TTL_SECS,
             socket: DEFAULT_SOCKET.to_string(),
             warm: vec![],
             deferred: false,
@@ -1041,8 +1838,55 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_stop_is_ok() {
-        let result = execute_stop(PoolStopArgs { json: false }).await;
+        let result = execute_stop(PoolStopArgs {
+            socket: "/tmp/a3s-box-pool-does-not-exist.sock".to_string(),
+            json: false,
+        })
+        .await;
         assert!(result.is_ok());
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_stop_request_shuts_down_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("pool.sock");
+        let socket_arg = socket.display().to_string();
+        let server_socket = socket_arg.clone();
+        let registry = std::sync::Arc::new(PoolRegistry {
+            pools: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            leases: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            default_image: None,
+            size: 1,
+            max: 1,
+            ttl: 0,
+            lease_ttl: DEFAULT_POOL_LEASE_TTL_SECS,
+            deferred: false,
+            ksm: false,
+            snapshot_fork: false,
+            metrics: None,
+        });
+
+        let server = tokio::spawn(async move {
+            serve(registry, &server_socket, true)
+                .await
+                .expect("pool server should stop cleanly");
+        });
+
+        for _ in 0..50 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(socket.exists(), "pool socket should be bound before stop");
+
+        stop_client(&socket_arg).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), server)
+            .await
+            .expect("pool server should exit after stop")
+            .unwrap();
+        assert!(!socket.exists(), "pool socket should be removed on stop");
     }
 
     #[cfg(not(windows))]
@@ -1060,36 +1904,84 @@ mod tests {
 
     #[test]
     fn test_request_envelope_tagging() {
-        // Run carries an op tag + the flattened RunRequest; Status is a bare tag.
-        let run = serde_json::to_string(&Request::Run(RunRequest {
+        // Run carries an op tag + the flattened PoolRunRequest; Status is a bare tag.
+        let run = serde_json::to_string(&PoolRequest::Run(PoolRunRequest {
             image: Some("alpine".into()),
             user: None,
             workdir: None,
+            rootfs: None,
             env: vec![],
+            volumes: vec![],
+            vcpus: None,
+            memory_mb: None,
             exec: false,
+            timeout_ns: None,
             cmd: vec!["echo".into(), "hi".into()],
         }))
         .unwrap();
         assert!(run.contains(r#""op":"run""#));
         assert!(run.contains(r#""cmd":["echo","hi"]"#));
 
-        let status = serde_json::to_string(&Request::Status).unwrap();
+        let status = serde_json::to_string(&PoolRequest::Status).unwrap();
         assert_eq!(status, r#"{"op":"status"}"#);
 
-        // StatusResponse round-trips.
-        let sr = StatusResponse {
-            images: vec![ImageStat {
+        let stop = serde_json::to_string(&PoolRequest::Stop).unwrap();
+        assert_eq!(stop, r#"{"op":"stop"}"#);
+
+        let lease = serde_json::to_string(&PoolRequest::Lease(PoolLeaseRequest {
+            image: Some("alpine".into()),
+            volumes: vec!["/host/rootfs:/run/a3s/build-rootfs:rw".into()],
+            vcpus: Some(2),
+            memory_mb: Some(512),
+        }))
+        .unwrap();
+        assert!(lease.contains(r#""op":"lease""#));
+        assert!(lease.contains("/run/a3s/build-rootfs"));
+
+        let exec = serde_json::to_string(&PoolRequest::Exec(PoolLeaseExecRequest {
+            lease_id: "lease-1".into(),
+            cmd: vec!["/bin/sh".into(), "-c".into(), "echo hi".into()],
+            timeout_ns: Some(5_000_000_000),
+            env: vec!["FOO=bar".into()],
+            working_dir: Some("/".into()),
+            rootfs: Some("/run/a3s/build-rootfs".into()),
+            stdin: None,
+            user: None,
+        }))
+        .unwrap();
+        assert!(exec.contains(r#""op":"exec""#));
+        assert!(exec.contains(r#""lease_id":"lease-1""#));
+        assert!(exec.contains(r#""rootfs":"/run/a3s/build-rootfs""#));
+
+        // PoolStatusResponse round-trips.
+        let sr = PoolStatusResponse {
+            images: vec![PoolImageStat {
                 image: "alpine".into(),
+                pool: "alpine".into(),
+                max: 4,
                 idle: 2,
+                active: 1,
+                leased: 1,
                 total_created: 5,
                 total_acquired: 3,
                 total_evicted: 1,
             }],
         };
-        let parsed: StatusResponse =
+        let parsed: PoolStatusResponse =
             serde_json::from_slice(&serde_json::to_vec(&sr).unwrap()).unwrap();
         assert_eq!(parsed.images[0].image, "alpine");
         assert_eq!(parsed.images[0].idle, 2);
+        assert_eq!(parsed.images[0].max, 4);
+        assert_eq!(parsed.images[0].active, 1);
+        assert_eq!(parsed.images[0].leased, 1);
+
+        let legacy: PoolStatusResponse = serde_json::from_str(
+            r#"{"images":[{"image":"alpine","pool":"alpine","idle":2,"total_created":5,"total_acquired":3,"total_evicted":1}]}"#,
+        )
+        .unwrap();
+        assert_eq!(legacy.images[0].max, 0);
+        assert_eq!(legacy.images[0].active, 0);
+        assert_eq!(legacy.images[0].leased, 0);
     }
 
     #[cfg(not(windows))]
@@ -1097,18 +1989,23 @@ mod tests {
     async fn test_frame_roundtrip() {
         // write_frame then read_frame must return the exact bytes.
         let (mut a, mut b) = tokio::io::duplex(4096);
-        let payload = serde_json::to_vec(&RunRequest {
+        let payload = serde_json::to_vec(&PoolRunRequest {
             image: None,
             user: None,
             workdir: None,
+            rootfs: None,
             env: vec![],
+            volumes: vec![],
+            vcpus: None,
+            memory_mb: None,
             exec: false,
+            timeout_ns: None,
             cmd: vec!["echo".into(), "hi there".into()],
         })
         .unwrap();
         write_frame(&mut a, &payload).await.unwrap();
         let got = read_frame(&mut b).await.unwrap();
-        let parsed: RunRequest = serde_json::from_slice(&got).unwrap();
+        let parsed: PoolRunRequest = serde_json::from_slice(&got).unwrap();
         assert_eq!(parsed.cmd, vec!["echo", "hi there"]);
     }
 
@@ -1118,7 +2015,7 @@ mod tests {
         // Exercise the full client/server wire protocol over a real Unix socket
         // (the exact framing `serve` and `pool run` use), with a stub server
         // standing in for the VM pool's acquire+exec.
-        use tokio::net::{UnixListener, UnixStream};
+        use tokio::net::UnixListener;
 
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("pool.sock");
@@ -1126,9 +2023,12 @@ mod tests {
 
         let server = tokio::spawn(async move {
             let (mut s, _) = listener.accept().await.unwrap();
-            let req: RunRequest =
+            let req: PoolRequest =
                 serde_json::from_slice(&read_frame(&mut s).await.unwrap()).unwrap();
-            let resp = RunResponse {
+            let PoolRequest::Run(req) = req else {
+                panic!("expected run request");
+            };
+            let resp = PoolRunResponse {
                 stdout: format!("ran {:?}", req.cmd).into_bytes(),
                 stderr: vec![],
                 exit_code: 0,
@@ -1139,24 +2039,25 @@ mod tests {
                 .unwrap();
         });
 
-        let mut client = UnixStream::connect(&sock).await.unwrap();
-        let req = RunRequest {
+        let output = run_client(PoolClientRun {
+            socket: sock.display().to_string(),
             image: Some("alpine:latest".into()),
             user: None,
             workdir: None,
+            rootfs: None,
             env: vec![],
+            volumes: vec![],
+            vcpus: 2,
+            memory_mb: 512,
             exec: false,
+            timeout_ns: None,
             cmd: vec!["ls".into(), "-la".into()],
-        };
-        write_frame(&mut client, &serde_json::to_vec(&req).unwrap())
-            .await
-            .unwrap();
-        let resp: RunResponse =
-            serde_json::from_slice(&read_frame(&mut client).await.unwrap()).unwrap();
+        })
+        .await
+        .unwrap();
 
-        assert_eq!(resp.exit_code, 0);
-        assert!(resp.error.is_none());
-        assert!(String::from_utf8_lossy(&resp.stdout).contains("ls"));
+        assert_eq!(output.exit_code, 0);
+        assert!(String::from_utf8_lossy(&output.stdout).contains("ls"));
         server.await.unwrap();
     }
 

--- a/src/cli/src/commands/restart.rs
+++ b/src/cli/src/commands/restart.rs
@@ -99,6 +99,11 @@ async fn restart_one(
             return Err(format!("{name} was removed during restart").into());
         }
     }
+    let current = StateFile::load_default()?;
+    if let Some(record) = current.find_by_id(&box_id) {
+        crate::health::spawn_detached_health_checker(record)
+            .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
+    }
     Ok(())
 }
 

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -491,7 +491,7 @@ async fn setup_and_boot(args: &RunArgs) -> Result<RunContext, Box<dyn std::error
     println!(
         "Creating box {} ({})...",
         name,
-        &BoxRecord::make_short_id(&box_id)
+        BoxRecord::make_short_id(&box_id)
     );
 
     let image_name = args.common.image.clone();

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -12,8 +12,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use super::common::{self, CommonBoxArgs};
+use super::pool::{
+    PoolAutoStartConfig, DEFAULT_AUTOSTART_POOL_MAX, DEFAULT_AUTOSTART_POOL_SIZE, DEFAULT_SOCKET,
+};
 use crate::output::parse_memory;
 use crate::state::{generate_name, BoxRecord, StateFile};
+use a3s_box_runtime::pool::PoolClientRun;
 
 const PNPM_CACHE_VOLUME_SPEC: &str = "a3s-cache-pnpm:/a3s-cache/pnpm";
 const PNPM_CONFIG_STORE_ENV: &str = "PNPM_CONFIG_STORE_DIR";
@@ -35,6 +39,7 @@ const NPM_PREFER_OFFLINE_ENV: &str = "npm_config_prefer_offline";
 const NPM_PREFER_OFFLINE_VALUE: &str = "true";
 const COREPACK_DOWNLOAD_PROMPT_ENV: &str = "COREPACK_ENABLE_DOWNLOAD_PROMPT";
 const COREPACK_DOWNLOAD_PROMPT_VALUE: &str = "0";
+const RUN_POOL_SOCKET_ENV: &str = "A3S_BOX_RUN_POOL_SOCKET";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum PackageCache {
@@ -70,6 +75,25 @@ pub struct RunArgs {
     /// Automatically remove the box when it stops
     #[arg(long)]
     pub rm: bool,
+
+    /// Run the command through the warm-pool daemon instead of cold-starting a box.
+    ///
+    /// Pool mode is currently for foreground one-shot commands (`--rm`) and
+    /// supports image/user/workdir/env/volumes/resources/package-cache/timeout.
+    #[arg(long)]
+    pub pool: bool,
+
+    /// Unix socket of the warm-pool daemon used by `--pool`.
+    #[arg(long = "pool-socket", default_value = DEFAULT_SOCKET)]
+    pub pool_socket: String,
+
+    /// Start a warm-pool daemon on --pool-socket when one is not already running.
+    #[arg(long = "pool-autostart")]
+    pub pool_autostart: bool,
+
+    /// Force exec mode against a deferred pool daemon.
+    #[arg(long = "pool-exec")]
+    pub pool_exec: bool,
 
     /// Mount a persistent package-manager cache (pnpm or npm)
     #[arg(long = "package-cache", value_enum)]
@@ -132,7 +156,19 @@ pub async fn execute(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     validate_run_mode(&args, std::io::stdin().is_terminal())
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
 
-    let ctx = setup_and_boot(&args).await?;
+    let env_pool_socket = std::env::var(RUN_POOL_SOCKET_ENV).ok();
+    if let Some(pool_socket) = selected_pool_socket(&args, env_pool_socket.as_deref()) {
+        if args.pool_autostart {
+            super::pool::ensure_pool_daemon_running(&pool_autostart_config_for_run(
+                &args,
+                &pool_socket,
+            )?)
+            .await?;
+        }
+        return execute_pool_run(&args, &pool_socket).await;
+    }
+
+    let mut ctx = setup_and_boot(&args).await?;
     crate::audit::record(
         a3s_box_core::audit::AuditAction::BoxStart,
         a3s_box_core::audit::AuditOutcome::Success,
@@ -140,9 +176,19 @@ pub async fn execute(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
         &format!("started box from image {}", args.common.image),
     );
     if args.detach {
+        crate::health::spawn_detached_health_checker(&ctx.record)
+            .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
         println!("{}", ctx.box_id);
         return Ok(());
     }
+
+    ctx.health_checker = ctx.record.health_check.as_ref().map(|health_check| {
+        crate::health::spawn_health_checker(
+            ctx.box_id.clone(),
+            ctx.exec_socket_path.clone(),
+            health_check.clone(),
+        )
+    });
 
     if args.tty {
         return run_tty(ctx, &args).await;
@@ -170,7 +216,177 @@ fn validate_run_mode(args: &RunArgs, stdin_is_terminal: bool) -> Result<(), &'st
     if args.tty && !stdin_is_terminal {
         return Err("The -t flag requires a terminal (stdin is not a TTY)");
     }
+    if args.pool || args.pool_autostart {
+        validate_pool_run_mode(args)?;
+    }
     Ok(())
+}
+
+fn validate_pool_run_mode(args: &RunArgs) -> Result<(), &'static str> {
+    match pool_run_mode_error(args) {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+fn pool_run_mode_error(args: &RunArgs) -> Option<&'static str> {
+    if !args.rm {
+        return Some("--pool currently requires --rm");
+    }
+    if args.detach {
+        return Some("Cannot use --pool with -d (detach)");
+    }
+    if args.tty {
+        return Some("Cannot use --pool with -t (tty)");
+    }
+    if args.interactive {
+        return Some("Cannot use --pool with --interactive");
+    }
+    if args.cmd.is_empty() {
+        return Some("--pool currently requires an explicit command");
+    }
+    if has_unsupported_pool_common_options(&args.common)
+        || args.log_driver != "json-file"
+        || !args.log_opts.is_empty()
+        || args.tee
+        || args.tee_simulate
+        || args.tee_workload_id.is_some()
+        || args.sidecar.is_some()
+    {
+        return Some("--pool currently supports only image, --rm, command, --user, --workdir, --env, --env-file, --volume, --cpus, --memory, --timeout, and --package-cache");
+    }
+    None
+}
+
+fn selected_pool_socket(args: &RunArgs, env_socket: Option<&str>) -> Option<String> {
+    if args.pool || args.pool_autostart {
+        return Some(args.pool_socket.clone());
+    }
+    let socket = env_socket
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    if pool_run_mode_error(args).is_none() {
+        Some(socket.to_string())
+    } else {
+        None
+    }
+}
+
+fn pool_autostart_config_for_run(
+    args: &RunArgs,
+    socket: &str,
+) -> Result<PoolAutoStartConfig, Box<dyn std::error::Error>> {
+    let memory_mb =
+        parse_memory(&args.common.memory).map_err(|e| format!("Invalid --memory: {e}"))?;
+    let prewarm_image = if args.common.volumes.is_empty()
+        && args.package_cache.is_empty()
+        && args.common.cpus == 2
+        && memory_mb == 512
+    {
+        Some(args.common.image.clone())
+    } else {
+        None
+    };
+
+    Ok(PoolAutoStartConfig {
+        socket: socket.to_string(),
+        image: prewarm_image,
+        size: DEFAULT_AUTOSTART_POOL_SIZE,
+        max: DEFAULT_AUTOSTART_POOL_MAX,
+    })
+}
+
+fn has_unsupported_pool_common_options(common: &CommonBoxArgs) -> bool {
+    common.name.is_some()
+        || !common.publish.is_empty()
+        || !common.dns.is_empty()
+        || common.entrypoint.is_some()
+        || common.hostname.is_some()
+        || common.restart != "no"
+        || !common.labels.is_empty()
+        || !common.tmpfs.is_empty()
+        || common.virtiofs_cache.is_some()
+        || common.network.is_some()
+        || common.health_cmd.is_some()
+        || common.health_interval != 30
+        || common.health_timeout != 5
+        || common.health_retries != 3
+        || common.health_start_period != 0
+        || common.pids_limit.is_some()
+        || common.cpuset_cpus.is_some()
+        || !common.ulimits.is_empty()
+        || common.cpu_shares.is_some()
+        || common.cpu_quota.is_some()
+        || common.cpu_period.is_some()
+        || common.memory_reservation.is_some()
+        || common.memory_swap.is_some()
+        || !common.add_host.is_empty()
+        || common.platform.is_some()
+        || common.init
+        || common.read_only
+        || !common.cap_add.is_empty()
+        || !common.cap_drop.is_empty()
+        || !common.security_opt.is_empty()
+        || common.privileged
+        || !common.device.is_empty()
+        || common.gpus.is_some()
+        || common.shm_size.is_some()
+        || common.stop_signal.is_some()
+        || common.stop_timeout.is_some()
+        || common.no_healthcheck
+        || common.oom_kill_disable
+        || common.oom_score_adj.is_some()
+        || common.persistent
+}
+
+async fn execute_pool_run(args: &RunArgs, socket: &str) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write;
+
+    let output =
+        a3s_box_runtime::pool::client::run_client(build_pool_client_run(args, socket)?).await?;
+
+    std::io::stdout().write_all(&output.stdout)?;
+    std::io::stderr().write_all(&output.stderr)?;
+    if output.exit_code != 0 {
+        std::process::exit(output.exit_code);
+    }
+    Ok(())
+}
+
+fn build_pool_client_run(
+    args: &RunArgs,
+    socket: &str,
+) -> Result<PoolClientRun, Box<dyn std::error::Error>> {
+    common::validate_runtime_options(&args.common)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let memory_mb =
+        parse_memory(&args.common.memory).map_err(|e| format!("Invalid --memory: {e}"))?;
+    let mut env = common::build_env_map(&args.common)?;
+    let mut volume_specs = args.common.volumes.clone();
+    apply_package_caches(&args.package_cache, &mut volume_specs, &mut env);
+    let (resolved_volumes, _) = resolve_volumes(&volume_specs)?;
+    let mut env_entries: Vec<String> = env
+        .into_iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect();
+    env_entries.sort();
+
+    Ok(PoolClientRun {
+        socket: socket.to_string(),
+        image: Some(args.common.image.clone()),
+        user: common::normalize_user_option(args.common.user.as_deref())
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?,
+        workdir: args.common.workdir.clone(),
+        rootfs: None,
+        env: env_entries,
+        volumes: resolved_volumes,
+        vcpus: args.common.cpus,
+        memory_mb,
+        exec: args.pool_exec,
+        timeout_ns: args.timeout.map(|secs| secs.saturating_mul(1_000_000_000)),
+        cmd: args.cmd.clone(),
+    })
 }
 
 // ============================================================================
@@ -428,11 +644,18 @@ async fn setup_and_boot(args: &RunArgs) -> Result<RunContext, Box<dyn std::error
         return Err(error.into());
     }
 
-    if let Err(error) = super::diff::create_box_baseline_snapshot(&box_dir) {
-        tracing::warn!(
+    if should_create_diff_baseline(args) {
+        if let Err(error) = super::diff::create_box_baseline_snapshot(&box_dir) {
+            tracing::warn!(
+                box_id = %box_id,
+                error = %error,
+                "Failed to create rootfs diff baseline snapshot"
+            );
+        }
+    } else {
+        tracing::debug!(
             box_id = %box_id,
-            error = %error,
-            "Failed to create rootfs diff baseline snapshot"
+            "Skipping rootfs diff baseline snapshot for foreground --rm box"
         );
     }
 
@@ -454,10 +677,6 @@ async fn setup_and_boot(args: &RunArgs) -> Result<RunContext, Box<dyn std::error
     // container.json has a home.)
     let _ = &log_dir;
 
-    let health_checker = health_check.as_ref().map(|hc| {
-        crate::health::spawn_health_checker(box_id.clone(), exec_socket_path.clone(), hc.clone())
-    });
-
     Ok(RunContext {
         vm,
         box_id,
@@ -468,7 +687,7 @@ async fn setup_and_boot(args: &RunArgs) -> Result<RunContext, Box<dyn std::error
         pty_socket_path,
         volume_names,
         anonymous_volumes,
-        health_checker,
+        health_checker: None,
         stop_signal,
         stop_timeout_ms,
     })
@@ -556,6 +775,10 @@ fn build_box_config(
         persistent: args.common.persistent || !args.rm,
         ..Default::default()
     })
+}
+
+fn should_create_diff_baseline(args: &RunArgs) -> bool {
+    !args.rm || args.detach
 }
 
 /// Initial process used only to keep the guest init alive for `run -it`.
@@ -1278,6 +1501,10 @@ mod tests {
             tty: false,
             timeout: None,
             rm: false,
+            pool: false,
+            pool_socket: DEFAULT_SOCKET.to_string(),
+            pool_autostart: false,
+            pool_exec: false,
             package_cache: vec![],
             cmd: vec![],
             log_driver: "json-file".to_string(),
@@ -1288,6 +1515,38 @@ mod tests {
             sidecar: None,
             sidecar_vsock_port: 4092,
         }
+    }
+
+    fn default_pool_run_args() -> RunArgs {
+        let mut args = default_run_args();
+        args.pool = true;
+        args.rm = true;
+        args.cmd = vec!["echo".to_string(), "hello".to_string()];
+        args
+    }
+
+    #[test]
+    fn test_foreground_auto_remove_skips_diff_baseline() {
+        let mut args = default_run_args();
+        args.rm = true;
+
+        assert!(!should_create_diff_baseline(&args));
+    }
+
+    #[test]
+    fn test_detached_auto_remove_keeps_diff_baseline_while_running() {
+        let mut args = default_run_args();
+        args.rm = true;
+        args.detach = true;
+
+        assert!(should_create_diff_baseline(&args));
+    }
+
+    #[test]
+    fn test_persistent_run_keeps_diff_baseline() {
+        let args = default_run_args();
+
+        assert!(should_create_diff_baseline(&args));
     }
 
     #[test]
@@ -1415,6 +1674,160 @@ mod tests {
         let err = validate_run_mode(&args, true).unwrap_err();
         assert!(err.contains("--timeout"));
         assert!(err.contains("tty"));
+    }
+
+    #[test]
+    fn test_validate_pool_run_mode_requires_auto_remove_and_command() {
+        let mut args = default_pool_run_args();
+        args.rm = false;
+        let err = validate_run_mode(&args, true).unwrap_err();
+        assert!(err.contains("requires --rm"));
+
+        let mut args = default_pool_run_args();
+        args.cmd = vec![];
+        let err = validate_run_mode(&args, true).unwrap_err();
+        assert!(err.contains("explicit command"));
+    }
+
+    #[test]
+    fn test_validate_pool_run_mode_rejects_unsupported_modes() {
+        let mut args = default_pool_run_args();
+        args.detach = true;
+        let err = validate_run_mode(&args, true).unwrap_err();
+        assert!(err.contains("--pool"));
+        assert!(err.contains("detach"));
+
+        let mut args = default_pool_run_args();
+        args.interactive = true;
+        let err = validate_run_mode(&args, true).unwrap_err();
+        assert!(err.contains("--interactive"));
+
+        let mut args = default_pool_run_args();
+        args.common.publish = vec!["8080:80".to_string()];
+        let err = validate_run_mode(&args, true).unwrap_err();
+        assert!(err.contains("currently supports only"));
+
+        let mut args = default_pool_run_args();
+        args.common.name = Some("named-pool-run".to_string());
+        let err = validate_run_mode(&args, true).unwrap_err();
+        assert!(err.contains("currently supports only"));
+    }
+
+    #[test]
+    fn test_validate_pool_run_mode_allows_timeout() {
+        let mut args = default_pool_run_args();
+        args.timeout = Some(30);
+
+        assert!(validate_run_mode(&args, true).is_ok());
+    }
+
+    #[test]
+    fn test_selected_pool_socket_prefers_explicit_pool_socket() {
+        let mut args = default_pool_run_args();
+        args.pool_socket = "/tmp/explicit.sock".to_string();
+
+        assert_eq!(
+            selected_pool_socket(&args, Some("/tmp/env.sock")).as_deref(),
+            Some("/tmp/explicit.sock")
+        );
+    }
+
+    #[test]
+    fn test_selected_pool_socket_uses_env_for_compatible_foreground_run() {
+        let mut args = default_run_args();
+        args.rm = true;
+        args.cmd = vec!["bash".to_string(), "-lc".to_string(), "echo ok".to_string()];
+        args.package_cache = vec![PackageCache::Pnpm];
+        args.common.volumes = vec!["/host/work:/workspace:rw".to_string()];
+        args.common.workdir = Some("/workspace".to_string());
+
+        assert_eq!(
+            selected_pool_socket(&args, Some(" /tmp/runtime.sock ")).as_deref(),
+            Some("/tmp/runtime.sock")
+        );
+    }
+
+    #[test]
+    fn test_selected_pool_socket_ignores_env_for_incompatible_run() {
+        let mut args = default_run_args();
+        args.rm = true;
+        args.detach = true;
+        args.cmd = vec!["echo".to_string(), "ok".to_string()];
+
+        assert!(selected_pool_socket(&args, Some("/tmp/runtime.sock")).is_none());
+
+        let mut named = default_run_args();
+        named.rm = true;
+        named.common.name = Some("named-run".to_string());
+        named.cmd = vec!["echo".to_string(), "ok".to_string()];
+        assert!(selected_pool_socket(&named, Some("/tmp/runtime.sock")).is_none());
+        assert!(selected_pool_socket(&args, Some("")).is_none());
+    }
+
+    #[test]
+    fn test_selected_pool_socket_uses_autostart_flag() {
+        let mut args = default_pool_run_args();
+        args.pool = false;
+        args.pool_autostart = true;
+        args.pool_socket = "/tmp/autostart.sock".to_string();
+
+        assert_eq!(
+            selected_pool_socket(&args, None).as_deref(),
+            Some("/tmp/autostart.sock")
+        );
+    }
+
+    #[test]
+    fn test_pool_autostart_config_prewarms_simple_run() {
+        let args = default_pool_run_args();
+        let config = pool_autostart_config_for_run(&args, "/tmp/pool.sock").unwrap();
+
+        assert_eq!(config.socket, "/tmp/pool.sock");
+        assert_eq!(config.image.as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn test_pool_autostart_config_skips_prewarm_for_volume_shape() {
+        let mut args = default_pool_run_args();
+        args.common.volumes = vec!["/host:/work:ro".to_string()];
+        let config = pool_autostart_config_for_run(&args, "/tmp/pool.sock").unwrap();
+
+        assert!(config.image.is_none());
+    }
+
+    #[test]
+    fn test_build_pool_client_run_plumbs_supported_options() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env_file = tmp.path().join("env.list");
+        std::fs::write(&env_file, "B=file\nC=file\n").unwrap();
+        let bind = format!("{}:/workspace:ro", tmp.path().display());
+
+        let mut args = default_pool_run_args();
+        args.common.image = "node:24-bookworm".to_string();
+        args.common.cpus = 4;
+        args.common.memory = "2g".to_string();
+        args.common.volumes = vec![bind.clone()];
+        args.common.env = vec!["A=cli".to_string(), "B=cli".to_string()];
+        args.common.env_file = vec![env_file.display().to_string()];
+        args.common.user = Some("root".to_string());
+        args.common.workdir = Some("/workspace".to_string());
+        args.pool_socket = "/tmp/a3s-box-test-pool.sock".to_string();
+        args.pool_exec = true;
+        args.timeout = Some(45);
+
+        let req = build_pool_client_run(&args, &args.pool_socket).unwrap();
+
+        assert_eq!(req.socket, "/tmp/a3s-box-test-pool.sock");
+        assert_eq!(req.image.as_deref(), Some("node:24-bookworm"));
+        assert_eq!(req.user.as_deref(), Some("0"));
+        assert_eq!(req.workdir.as_deref(), Some("/workspace"));
+        assert_eq!(req.volumes, vec![bind]);
+        assert_eq!(req.vcpus, 4);
+        assert_eq!(req.memory_mb, 2048);
+        assert!(req.exec);
+        assert_eq!(req.timeout_ns, Some(45_000_000_000));
+        assert_eq!(req.cmd, vec!["echo", "hello"]);
+        assert_eq!(req.env, vec!["A=cli", "B=cli", "C=file"]);
     }
 
     #[test]

--- a/src/cli/src/commands/start.rs
+++ b/src/cli/src/commands/start.rs
@@ -45,12 +45,16 @@ async fn start_one(state: &StateFile, query: &str) -> Result<(), Box<dyn std::er
     // Persist the boot result atomically (load-fresh + mutate + save under the
     // state lock) so it cannot clobber a concurrent writer with our pre-boot
     // snapshot.
-    StateFile::modify(move |s| {
-        if let Some(record) = s.find_by_id_mut(&box_id) {
+    let started_record = StateFile::modify(move |s| {
+        Ok::<_, std::io::Error>(s.find_by_id_mut(&box_id).map(|record| {
             boot::apply_boot_result(record, result, boot::RestartCountUpdate::Reset);
-        }
-        Ok::<(), std::io::Error>(())
+            record.clone()
+        }))
     })?;
+    if let Some(record) = started_record {
+        crate::health::spawn_detached_health_checker(&record)
+            .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
+    }
 
     println!("{name}");
     Ok(())

--- a/src/cli/src/health.rs
+++ b/src/cli/src/health.rs
@@ -1,7 +1,8 @@
 //! Health check executor for running containers.
 //!
-//! Spawns a background task that periodically runs the user-defined health
-//! check command via the exec socket and updates the box state accordingly.
+//! Runs user-defined health checks through the exec socket and updates box
+//! state. Foreground commands use a Tokio task; detached boxes use a
+//! generation-fenced child process so scheduling survives the creating CLI.
 //!
 //! Follows Docker health check semantics:
 //! - Wait `start_period_secs` before the first check
@@ -10,7 +11,7 @@
 //! - After `retries` consecutive failures → status becomes "unhealthy"
 //! - Socket disappearing → box has stopped; checker exits
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[cfg(any(not(windows), test))]
 use crate::state::BoxRecord;
@@ -21,8 +22,8 @@ use crate::state::StateFile;
 /// Spawn a background health checker task for a running box.
 ///
 /// Returns a `JoinHandle` that the caller can abort when the box stops.
-/// In detached/daemon scenarios the handle may be dropped; the task will
-/// self-terminate once the exec socket disappears.
+/// Foreground callers abort the handle during cleanup. Detached callers must
+/// use [`spawn_detached_health_checker`] instead.
 pub fn spawn_health_checker(
     box_id: String,
     exec_socket_path: PathBuf,
@@ -31,7 +32,7 @@ pub fn spawn_health_checker(
     #[cfg(not(windows))]
     {
         tokio::spawn(async move {
-            run_health_loop(box_id, exec_socket_path, health_check).await;
+            run_health_loop(box_id, exec_socket_path, health_check, None).await;
         })
     }
     #[cfg(windows)]
@@ -42,8 +43,165 @@ pub fn spawn_health_checker(
     }
 }
 
+/// Start a process-owned health checker for a detached box.
+///
+/// A Tokio task owned by `run -d`, `compose up`, or `start` disappears when that
+/// short-lived CLI exits. The child process uses a generation-specific lock so
+/// duplicate launch attempts collapse to one worker, while a restarted box can
+/// immediately acquire a new generation lock.
 #[cfg(not(windows))]
-async fn run_health_loop(box_id: String, exec_socket_path: PathBuf, hc: HealthCheck) {
+pub(crate) fn spawn_detached_health_checker(record: &BoxRecord) -> Result<(), String> {
+    if record.health_check.is_none() {
+        return Ok(());
+    }
+    let generation = health_generation(record)
+        .ok_or_else(|| format!("box '{}' has no health-check generation", record.name))?;
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("failed to locate a3s-box for health checker: {error}"))?;
+    let arguments = detached_health_worker_args(&record.id, generation);
+
+    std::process::Command::new(executable)
+        .args(arguments)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| {
+            format!(
+                "failed to start detached health checker for '{}': {error}",
+                record.name
+            )
+        })
+}
+
+#[cfg(any(not(windows), test))]
+fn detached_health_worker_args(box_id: &str, generation: i64) -> Vec<String> {
+    vec![
+        "monitor".to_string(),
+        "--health-worker".to_string(),
+        box_id.to_string(),
+        "--health-generation".to_string(),
+        generation.to_string(),
+    ]
+}
+
+#[cfg(windows)]
+pub(crate) fn spawn_detached_health_checker(_record: &BoxRecord) -> Result<(), String> {
+    Ok(())
+}
+
+/// Run the hidden process-owned health worker for one box generation.
+#[cfg(not(windows))]
+pub(crate) async fn run_detached_health_worker(
+    box_id: String,
+    generation: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(_lock) = HealthWorkerLock::try_acquire(&box_id, generation)? else {
+        return Ok(());
+    };
+
+    let state = StateFile::load_default()?;
+    let Some(record) = state.find_by_id(&box_id) else {
+        return Ok(());
+    };
+    if health_generation(record) != Some(generation) || record.status != "running" {
+        return Ok(());
+    }
+    let Some(health_check) = record.health_check.clone() else {
+        return Ok(());
+    };
+
+    run_health_loop(
+        box_id,
+        record.exec_socket_path.clone(),
+        health_check,
+        Some(generation),
+    )
+    .await;
+    Ok(())
+}
+
+#[cfg(windows)]
+pub(crate) async fn run_detached_health_worker(
+    _box_id: String,
+    _generation: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+#[cfg(not(windows))]
+struct HealthWorkerLock {
+    _file: std::fs::File,
+}
+
+#[cfg(not(windows))]
+impl HealthWorkerLock {
+    fn try_acquire(box_id: &str, generation: i64) -> std::io::Result<Option<Self>> {
+        Self::try_acquire_path(&health_worker_lock_path(box_id, generation))
+    }
+
+    fn try_acquire_path(path: &Path) -> std::io::Result<Option<Self>> {
+        use std::os::fd::AsRawFd;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if result == 0 {
+            return Ok(Some(Self { _file: file }));
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::WouldBlock {
+            Ok(None)
+        } else {
+            Err(error)
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn health_worker_lock_path(box_id: &str, generation: i64) -> PathBuf {
+    a3s_box_core::dirs_home()
+        .join("locks")
+        .join(format!("{box_id}.{generation}.health.lock"))
+}
+
+#[cfg(any(not(windows), test))]
+fn health_generation(record: &BoxRecord) -> Option<i64> {
+    record
+        .started_at
+        .and_then(|started_at| started_at.timestamp_nanos_opt())
+}
+
+#[cfg(not(windows))]
+pub(crate) fn detached_health_worker_active(record: &BoxRecord) -> bool {
+    let Some(generation) = health_generation(record) else {
+        return false;
+    };
+    match HealthWorkerLock::try_acquire(&record.id, generation) {
+        Ok(Some(lock)) => {
+            drop(lock);
+            false
+        }
+        Ok(None) => true,
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(windows))]
+async fn run_health_loop(
+    box_id: String,
+    exec_socket_path: PathBuf,
+    hc: HealthCheck,
+    expected_generation: Option<i64>,
+) {
     use std::time::Duration;
 
     // Honour start_period before the first probe
@@ -57,8 +215,7 @@ async fn run_health_loop(box_id: String, exec_socket_path: PathBuf, hc: HealthCh
     loop {
         tokio::time::sleep(interval).await;
 
-        // Box stopped — exec socket is gone
-        if !exec_socket_path.exists() {
+        if !health_worker_is_current(&box_id, expected_generation) {
             break;
         }
 
@@ -73,6 +230,9 @@ async fn run_health_loop(box_id: String, exec_socket_path: PathBuf, hc: HealthCh
             if record.status != "running" {
                 return Ok(false); // box stopped
             }
+            if expected_generation.is_some() && health_generation(record) != expected_generation {
+                return Ok(false); // box restarted; a new generation owns probes
+            }
             apply_probe_result(record, healthy, chrono::Utc::now());
             Ok(true)
         });
@@ -82,6 +242,19 @@ async fn run_health_loop(box_id: String, exec_socket_path: PathBuf, hc: HealthCh
             Err(_) => continue,
         }
     }
+}
+
+#[cfg(not(windows))]
+fn health_worker_is_current(box_id: &str, expected_generation: Option<i64>) -> bool {
+    let Ok(state) = StateFile::load_default() else {
+        return true;
+    };
+    state.find_by_id(box_id).is_some_and(|record| {
+        record.status == "running"
+            && expected_generation
+                .map(|generation| health_generation(record) == Some(generation))
+                .unwrap_or(true)
+    })
 }
 
 #[cfg(not(windows))]
@@ -290,5 +463,33 @@ mod tests {
         apply_probe_result(&mut record, true, now);
         assert_eq!(record.health_status, "none");
         assert!(record.health_last_check.is_none());
+    }
+
+    #[test]
+    fn test_detached_worker_args_bind_box_generation() {
+        assert_eq!(
+            detached_health_worker_args("box-id", 1234),
+            vec![
+                "monitor",
+                "--health-worker",
+                "box-id",
+                "--health-generation",
+                "1234",
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_health_worker_lock_allows_one_owner_per_generation() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let path = directory.path().join("worker.lock");
+
+        let first = HealthWorkerLock::try_acquire_path(&path)
+            .unwrap()
+            .expect("first worker should own the generation");
+        assert!(HealthWorkerLock::try_acquire_path(&path).unwrap().is_none());
+        drop(first);
+        assert!(HealthWorkerLock::try_acquire_path(&path).unwrap().is_some());
     }
 }

--- a/src/cli/src/health.rs
+++ b/src/cli/src/health.rs
@@ -11,9 +11,10 @@
 //! - After `retries` consecutive failures → status becomes "unhealthy"
 //! - Socket disappearing → box has stopped; checker exits
 
-use std::path::{Path, PathBuf};
+#[cfg(not(windows))]
+use std::path::Path;
+use std::path::PathBuf;
 
-#[cfg(any(not(windows), test))]
 use crate::state::BoxRecord;
 use crate::state::HealthCheck;
 #[cfg(not(windows))]

--- a/src/cli/tests/command_coverage.rs
+++ b/src/cli/tests/command_coverage.rs
@@ -620,3 +620,185 @@ fn test_noninteractive_boundary_command_smoke() {
         "monitor did not announce startup\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 }
+
+#[test]
+fn test_compose_config_interpolates_shell_over_project_dotenv() {
+    let cli = CliTest::new();
+    let project = cli.home_path().join("compose-interpolation");
+    std::fs::create_dir_all(&project).expect("create Compose project directory");
+    let compose = project.join("compose.yaml");
+    std::fs::write(
+        &compose,
+        r#"services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${A3S_COMPOSE_TEST_PORT:-6379}:6379"
+    environment:
+      FROM_DOTENV: ${A3S_COMPOSE_TEST_DOTENV-default}
+      EMPTY_DEFAULT: ${A3S_COMPOSE_TEST_EMPTY:-default}
+      EMPTY_SET: ${A3S_COMPOSE_TEST_EMPTY+replacement}
+      EMPTY_NONEMPTY: ${A3S_COMPOSE_TEST_EMPTY:+replacement}
+"#,
+    )
+    .expect("write Compose file");
+    std::fs::write(
+        project.join(".env"),
+        "A3S_COMPOSE_TEST_PORT=6379\nA3S_COMPOSE_TEST_DOTENV=dotenv\nA3S_COMPOSE_TEST_EMPTY=\n",
+    )
+    .expect("write project .env");
+    let compose_arg = compose.to_string_lossy().to_string();
+
+    let output = cli.ok_with_env(
+        &["compose", "--file", &compose_arg, "config"],
+        &[("A3S_COMPOSE_TEST_PORT", "16379")],
+    );
+
+    assert!(output.contains("ports: 16379:6379"));
+    assert!(output.contains("FROM_DOTENV=dotenv"));
+    assert!(output.contains("EMPTY_DEFAULT=default"));
+    assert!(output.contains("EMPTY_SET=replacement"));
+    assert!(output.contains("EMPTY_NONEMPTY="));
+    assert!(output.contains("Configuration is valid."));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_pool_status_json_reports_runtime_counters() {
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixListener;
+
+    let cli = CliTest::new();
+    let socket = cli.home_path().join("fake-pool.sock");
+    let listener = UnixListener::bind(&socket).expect("bind fake pool socket");
+
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept pool status client");
+        let mut len = [0_u8; 4];
+        stream.read_exact(&mut len).expect("read request length");
+        let mut request = vec![0_u8; u32::from_le_bytes(len) as usize];
+        stream
+            .read_exact(&mut request)
+            .expect("read status request");
+        let request: serde_json::Value =
+            serde_json::from_slice(&request).expect("status request should be JSON");
+        assert_eq!(request["op"], "status");
+
+        let response = br#"{"images":[{"image":"alpine:latest","pool":"alpine:latest|vcpus=2|memory=512m","max":4,"idle":2,"active":1,"leased":1,"total_created":5,"total_acquired":3,"total_evicted":1}]}"#;
+        stream
+            .write_all(&(response.len() as u32).to_le_bytes())
+            .expect("write response length");
+        stream.write_all(response).expect("write status response");
+    });
+
+    let socket_arg = socket.to_string_lossy().to_string();
+    let stdout = cli.ok(&["pool", "status", "--json", "--socket", socket_arg.as_str()]);
+    server.join().expect("fake pool server should finish");
+
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("pool status output should be JSON");
+    let image = &value.as_array().expect("status JSON should be an array")[0];
+    assert_eq!(image["pool"], "alpine:latest|vcpus=2|memory=512m");
+    assert_eq!(image["max"], 4);
+    assert_eq!(image["idle"], 2);
+    assert_eq!(image["active"], 1);
+    assert_eq!(image["leased"], 1);
+    assert_eq!(image["total_created"], 5);
+    assert_eq!(image["total_acquired"], 3);
+    assert_eq!(image["total_evicted"], 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_info_reports_warm_pool_daemon_status() {
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixListener;
+
+    let cli = CliTest::new();
+    let socket = cli.home_path().join("fake-info-pool.sock");
+    let listener = UnixListener::bind(&socket).expect("bind fake pool socket");
+
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept pool status client");
+        let mut len = [0_u8; 4];
+        stream.read_exact(&mut len).expect("read status length");
+        let mut request = vec![0_u8; u32::from_le_bytes(len) as usize];
+        stream
+            .read_exact(&mut request)
+            .expect("read status request");
+        let request: serde_json::Value =
+            serde_json::from_slice(&request).expect("status request should be JSON");
+        assert_eq!(request["op"], "status");
+
+        let response = br#"{"images":[{"image":"alpine:latest","pool":"alpine:latest|vcpus=2|memory=512m","max":4,"idle":2,"active":1,"leased":1,"total_created":5,"total_acquired":3,"total_evicted":1}]}"#;
+        stream
+            .write_all(&(response.len() as u32).to_le_bytes())
+            .expect("write status response length");
+        stream.write_all(response).expect("write status response");
+    });
+
+    let socket_arg = socket.to_string_lossy().to_string();
+    let stdout = cli.ok_with_env(
+        &["info"],
+        &[("A3S_BOX_RUN_POOL_SOCKET", socket_arg.as_str())],
+    );
+    server.join().expect("fake pool server should finish");
+
+    assert!(
+        stdout.contains("Warm pool daemon: running at"),
+        "info output did not report a running warm pool:\n{stdout}"
+    );
+    assert!(stdout.contains("max 4"));
+    assert!(stdout.contains("2 idle"));
+    assert!(stdout.contains("1 active"));
+    assert!(stdout.contains("1 leased"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_pool_timeout_is_sent_to_daemon() {
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixListener;
+
+    let cli = CliTest::new();
+    let socket = cli.home_path().join("fake-run-pool.sock");
+    let listener = UnixListener::bind(&socket).expect("bind fake pool socket");
+
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept pool run client");
+        let mut len = [0_u8; 4];
+        stream.read_exact(&mut len).expect("read request length");
+        let mut request = vec![0_u8; u32::from_le_bytes(len) as usize];
+        stream.read_exact(&mut request).expect("read run request");
+        let request: serde_json::Value =
+            serde_json::from_slice(&request).expect("run request should be JSON");
+        assert_eq!(request["op"], "run");
+        assert_eq!(request["image"], "docker.io/library/alpine:latest");
+        assert_eq!(request["timeout_ns"], 7_000_000_000_u64);
+        assert_eq!(request["cmd"][0], "echo");
+
+        let response = br#"{"stdout":[111,107,10],"stderr":[],"exit_code":0,"error":null}"#;
+        stream
+            .write_all(&(response.len() as u32).to_le_bytes())
+            .expect("write response length");
+        stream.write_all(response).expect("write run response");
+    });
+
+    let socket_arg = socket.to_string_lossy().to_string();
+    let stdout = cli.ok(&[
+        "run",
+        "--pool",
+        "--pool-socket",
+        socket_arg.as_str(),
+        "--rm",
+        "--timeout",
+        "7",
+        "docker.io/library/alpine:latest",
+        "--",
+        "echo",
+        "ok",
+    ]);
+    server.join().expect("fake pool server should finish");
+
+    assert_eq!(stdout, "ok\n");
+}

--- a/src/cli/tests/core_smoke.rs
+++ b/src/cli/tests/core_smoke.rs
@@ -494,6 +494,26 @@ impl CoreSmoke {
         panic!("timeout waiting for {name} to become {expected}\nlast inspect:\n{last}");
     }
 
+    fn wait_for_named_health(&self, name: &str, expected: &str) -> serde_json::Value {
+        let start = Instant::now();
+        let mut last = String::new();
+
+        while start.elapsed() < self.timeout {
+            let value = self.inspect_json(name);
+            last = value.to_string();
+            if json_string_field(&value, "health_status") == expected
+                && value
+                    .get("health_last_check")
+                    .is_some_and(|value| !value.is_null())
+            {
+                return value;
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+
+        panic!("timeout waiting for {name} health={expected}\nlast inspect:\n{last}");
+    }
+
     fn wait_for_named_restart(
         &self,
         monitor: &mut BackgroundCommand,
@@ -1104,6 +1124,91 @@ fn real_core_published_port_http_smoke() {
     smoke.ok(&["rm", &smoke.name]);
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore]
+fn real_core_tsi_published_redis_nonblocking_accept_and_exec() {
+    use std::io::{Read, Write};
+
+    let smoke = CoreSmoke::new();
+    let image =
+        std::env::var("A3S_BOX_REDIS_SMOKE_IMAGE").unwrap_or_else(|_| "redis:7-alpine".to_string());
+    let host_port = unused_tcp_port();
+    let publish = format!("{host_port}:6379");
+    let _cleanup = NamedBoxCleanup {
+        smoke: &smoke,
+        name: smoke.name.clone(),
+    };
+
+    smoke.ok(&["pull", &image]);
+    smoke.ok(&["run", "-d", "--name", &smoke.name, "-p", &publish, &image]);
+    smoke.wait_for_running();
+    smoke.wait_for_logs("Ready to accept connections");
+
+    let address = std::net::SocketAddr::from(([127, 0, 0, 1], host_port));
+    for connection in 1..=2 {
+        let mut stream = std::net::TcpStream::connect_timeout(&address, Duration::from_secs(5))
+            .unwrap_or_else(|error| panic!("connect Redis client {connection}: {error}"));
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        stream.write_all(b"*1\r\n$4\r\nPING\r\n").unwrap();
+        let mut pong = [0u8; 7];
+        stream
+            .read_exact(&mut pong)
+            .unwrap_or_else(|error| panic!("read Redis PONG for client {connection}: {error}"));
+        assert_eq!(&pong, b"+PONG\r\n");
+    }
+
+    let exec = smoke.ok(&[
+        "exec",
+        &smoke.name,
+        "--",
+        "/bin/sh",
+        "-c",
+        "echo EXEC_AFTER_PONG",
+    ]);
+    assert_contains(&exec, "EXEC_AFTER_PONG", "exec after Redis PONG");
+
+    smoke.ok(&["rm", "-f", &smoke.name]);
+}
+
+#[test]
+#[ignore]
+fn real_core_virtiofs_tar_closes_every_source_file_cleanly() {
+    let smoke = CoreSmoke::new();
+    let image = smoke_image();
+    let source = tempfile::tempdir().expect("temporary virtiofs source");
+    for directory in 0..16 {
+        let root = source.path().join(format!("tree-{directory}"));
+        std::fs::create_dir_all(&root).expect("create source directory");
+        for file in 0..128 {
+            std::fs::write(
+                root.join(format!("file-{file}.txt")),
+                format!("virtiofs-close-{directory}-{file}\n"),
+            )
+            .expect("write source fixture");
+        }
+    }
+    let mount = format!("{}:/source:ro", source.path().display());
+
+    seed_smoke_image(&smoke, &image);
+    smoke.ok(&[
+        "run",
+        "--rm",
+        "--virtiofs-cache=none",
+        "-v",
+        &mount,
+        "-w",
+        "/source",
+        &image,
+        "--",
+        "/bin/sh",
+        "-c",
+        "set -eu; for pass in 1 2 3 4 5; do tar -cf /dev/null .; done",
+    ]);
+}
+
 #[test]
 #[ignore]
 fn real_core_named_volume_persists_across_stop_start() {
@@ -1225,7 +1330,7 @@ fn real_core_bridge_network_hosts_and_endpoint_lifecycle() {
         "--",
         "/bin/sh",
         "-c",
-        "echo core-smoke-bridge-db-ready; sleep 3600",
+        "mkdir -p /www; printf core-smoke-bridge-peer-ok >/www/index.html; echo core-smoke-bridge-db-ready; exec httpd -f -p 8080 -h /www",
     ]);
     smoke.wait_for_named_running(&db_box);
     smoke.wait_for_named_logs(&db_box, "core-smoke-bridge-db-ready");
@@ -1255,6 +1360,22 @@ fn real_core_bridge_network_hosts_and_endpoint_lifecycle() {
     assert_contains(&inspect, &web_box, "network inspect");
     assert_contains(&inspect, "10.91.0.2", "network inspect");
     assert_contains(&inspect, "10.91.0.3", "network inspect");
+
+    let peer_http = smoke.ok(&[
+        "exec",
+        &web_box,
+        "--",
+        "/bin/sh",
+        "-c",
+        &format!(
+            "test \"$(wget -T 5 -qO- http://{db_box}:8080)\" = core-smoke-bridge-peer-ok; test \"$(wget -T 5 -qO- http://10.91.0.2:8080)\" = core-smoke-bridge-peer-ok; echo core-smoke-bridge-peer-tcp-ok"
+        ),
+    ]);
+    assert_contains(
+        &peer_http,
+        "core-smoke-bridge-peer-tcp-ok",
+        "bridge peer TCP by name and IP",
+    );
 
     smoke.ok(&["stop", &web_box]);
     smoke.ok(&["rm", &web_box]);
@@ -1518,6 +1639,68 @@ fn real_core_filesystem_image_snapshot_commands() {
     smoke.ok(&["rm", &smoke.name]);
 }
 
+#[cfg(unix)]
+#[test]
+#[ignore]
+fn real_core_commit_preserves_guest_ownership_and_modes_after_stop() {
+    let smoke = CoreSmoke::new();
+    let image = smoke_image();
+    let committed_image = format!("{}-metadata:latest", smoke.name);
+    let _box_cleanup = NamedBoxCleanup {
+        smoke: &smoke,
+        name: smoke.name.clone(),
+    };
+    let _image_cleanup = ImageCleanup {
+        smoke: &smoke,
+        reference: committed_image.clone(),
+    };
+    seed_smoke_image(&smoke, &image);
+
+    smoke.ok(&[
+        "run",
+        "--name",
+        &smoke.name,
+        "--persistent",
+        &image,
+        "--",
+        "/bin/sh",
+        "-c",
+        "cp /bin/busybox /tmp/root-exec; chmod 0755 /tmp/root-exec; \
+         cp /bin/busybox /tmp/user-exec; chown 123:456 /tmp/user-exec; chmod 0750 /tmp/user-exec; \
+         printf config >/tmp/config; chmod 0644 /tmp/config; \
+         printf secret >/tmp/secret; chmod 0600 /tmp/secret; \
+         mkdir /tmp/mode-dir; chmod 0711 /tmp/mode-dir; \
+         ln -s root-exec /tmp/root-link",
+    ]);
+    smoke.wait_for_named_status(&smoke.name, "stopped");
+
+    smoke.ok(&["commit", &smoke.name, &committed_image]);
+    let output = smoke.ok(&[
+        "run",
+        "--rm",
+        &committed_image,
+        "--",
+        "/bin/sh",
+        "-c",
+        "stat -c '%u:%g:%a' /tmp/root-exec /tmp/user-exec /tmp/config /tmp/secret /tmp/mode-dir; \
+         test -x /tmp/root-exec; test \"$(readlink /tmp/root-link)\" = root-exec",
+    ]);
+
+    let lines: Vec<_> = output
+        .lines()
+        .filter(|line| {
+            line.matches(':').count() == 2
+                && line
+                    .chars()
+                    .all(|character| character.is_ascii_digit() || character == ':')
+        })
+        .collect();
+    assert_eq!(
+        lines,
+        ["0:0:755", "123:456:750", "0:0:644", "0:0:600", "0:0:711"]
+    );
+}
+
 #[test]
 #[ignore]
 fn real_core_snapshot_cow_isolation_and_rm_guard() {
@@ -1708,6 +1891,43 @@ fn real_core_restart_policy_monitor_recovers_dead_box() {
 
     smoke.ok(&["stop", &smoke.name]);
     smoke.ok(&["rm", &smoke.name]);
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore]
+fn real_core_detached_health_worker_survives_run_cli_exit() {
+    let smoke = CoreSmoke::new();
+    let image = smoke_image();
+    seed_smoke_image(&smoke, &image);
+    let _cleanup = NamedBoxCleanup {
+        smoke: &smoke,
+        name: smoke.name.clone(),
+    };
+
+    smoke.ok(&[
+        "run",
+        "--detach",
+        "--name",
+        &smoke.name,
+        "--health-cmd",
+        "true",
+        "--health-interval",
+        "1s",
+        "--health-timeout",
+        "1s",
+        "--health-retries",
+        "2",
+        &image,
+        "--",
+        "sh",
+        "-c",
+        "sleep 300",
+    ]);
+
+    let healthy = smoke.wait_for_named_health(&smoke.name, "healthy");
+    assert_eq!(json_string_field(&healthy, "health_status"), "healthy");
+    assert_eq!(json_u64_field(&healthy, "health_retries"), 0);
 }
 
 #[test]
@@ -2102,4 +2322,159 @@ fn real_core_interactive_pty_commands() {
 
     smoke.ok(&["stop", &smoke.name]);
     smoke.ok(&["rm", &smoke.name]);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore]
+fn real_core_rootfs_is_case_sensitive_and_persists_across_restart() {
+    let smoke = CoreSmoke::new();
+    let image = smoke_image();
+    seed_smoke_image(&smoke, &image);
+    let _cleanup = NamedBoxCleanup {
+        smoke: &smoke,
+        name: smoke.name.clone(),
+    };
+
+    let script = r#"set -eu
+test -e /bin/sh
+test ! -e /BIN/SH
+if [ -e /case/Foo ]; then
+  test "$(cat /case/Foo)" = upper
+  test "$(cat /case/foo)" = lower
+  test "$(stat -c %i /case/Foo)" != "$(stat -c %i /case/foo)"
+  echo CASE_SENSITIVE_PERSISTED
+else
+  mkdir /case
+  printf upper >/case/Foo
+  printf lower >/case/foo
+  test "$(stat -c %i /case/Foo)" != "$(stat -c %i /case/foo)"
+  echo CASE_SENSITIVE_CREATED
+fi"#;
+
+    smoke.ok(&[
+        "run",
+        "-d",
+        "--name",
+        &smoke.name,
+        "--entrypoint",
+        "/bin/sh",
+        &image,
+        "--",
+        "-c",
+        script,
+    ]);
+    let first = smoke.wait_for_named_logs(&smoke.name, "CASE_SENSITIVE_CREATED");
+    assert_contains(&first, "CASE_SENSITIVE_CREATED", "first case-sensitive run");
+    smoke.wait_for_named_status(&smoke.name, "dead");
+
+    smoke.ok(&["start", &smoke.name]);
+    let second = smoke.wait_for_named_logs(&smoke.name, "CASE_SENSITIVE_PERSISTED");
+    assert_contains(
+        &second,
+        "CASE_SENSITIVE_PERSISTED",
+        "persistent case-sensitive restart",
+    );
+
+    smoke.ok(&["rm", &smoke.name]);
+    let boxes_dir = smoke.home_path().join("boxes");
+    assert!(
+        std::fs::read_dir(&boxes_dir)
+            .map(|mut entries| entries.next().is_none())
+            .unwrap_or(true),
+        "removed box left its APFS rootfs directory behind"
+    );
+
+    let cached = smoke.ok(&[
+        "run",
+        "--rm",
+        "--entrypoint",
+        "/bin/sh",
+        &image,
+        "--",
+        "-c",
+        script,
+    ]);
+    assert_contains(
+        &cached,
+        "CASE_SENSITIVE_CREATED",
+        "case-sensitive cached rootfs clone",
+    );
+    assert!(
+        smoke
+            .home_path()
+            .join("cache/rootfs-apfs")
+            .read_dir()
+            .map(|mut entries| entries.next().is_some())
+            .unwrap_or(false),
+        "macOS run did not persist a case-sensitive APFS rootfs cache image"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore]
+fn real_core_buildkit_vm_preserves_multiple_build_args_with_spaces() {
+    let smoke = CoreSmoke::new();
+    let base = smoke_image();
+    let tag = format!("{}-build-args:latest", smoke.name);
+    let context = smoke.home_path().join("buildkit-context");
+    std::fs::create_dir_all(&context).unwrap();
+    std::fs::write(
+        context.join("Dockerfile"),
+        format!(
+            "FROM {base} AS chosen\nARG FIRST=default\nARG SECOND=none\nRUN printf '%s|%s' \"$FIRST\" \"$SECOND\" >/ok\n\nFROM {base} AS default\nRUN printf wrong >/ok\n"
+        ),
+    )
+    .unwrap();
+    let context_arg = context.to_string_lossy().to_string();
+
+    smoke.ok(&[
+        "build",
+        "--builder",
+        "buildkit-vm",
+        "--platform",
+        "linux/arm64",
+        "--build-arg",
+        "FIRST=two words",
+        "--build-arg",
+        "SECOND=custom",
+        "--target",
+        "chosen",
+        "-f",
+        "Dockerfile",
+        "-t",
+        &tag,
+        &context_arg,
+    ]);
+    let result = smoke.ok(&["run", "--rm", "--entrypoint", "/bin/cat", &tag, "--", "/ok"]);
+    assert_contains(&result, "two words|custom", "BuildKit build args");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore]
+fn real_core_buildkit_vm_executes_amd64_run_on_arm64_host() {
+    let smoke = CoreSmoke::new();
+    let base = smoke_image();
+    let tag = format!("{}-amd64-run:latest", smoke.name);
+    let context = smoke.home_path().join("buildkit-amd64-context");
+    std::fs::create_dir_all(&context).unwrap();
+    std::fs::write(
+        context.join("Dockerfile"),
+        format!("FROM {base}\nRUN test \"$(uname -m)\" = x86_64 && printf x86_64 >/arch\n"),
+    )
+    .unwrap();
+    let context_arg = context.to_string_lossy().to_string();
+
+    smoke.ok(&[
+        "build",
+        "--platform",
+        "linux/amd64",
+        "-f",
+        "Dockerfile",
+        "-t",
+        &tag,
+        &context_arg,
+    ]);
 }

--- a/src/cli/tests/host_smoke.rs
+++ b/src/cli/tests/host_smoke.rs
@@ -516,7 +516,7 @@ fn test_real_pool_warm_run() {
     let start = std::time::Instant::now();
     while !sock_path.exists() {
         if start.elapsed() > Duration::from_secs(120) {
-            let _ = daemon.kill();
+            cli.interrupt_background(&mut daemon);
             panic!("pool daemon never created its socket");
         }
         if let Ok(Some(status)) = daemon.try_wait() {
@@ -539,6 +539,41 @@ fn test_real_pool_warm_run() {
     ]);
     assert!(ok, "pool run failed.\nstdout:\n{out}\nstderr:\n{err}");
     assert!(out.contains("pool-e2e-ok"), "unexpected output: {out:?}");
+
+    // Docker-like entrypoint: `run --pool --rm` should hit the same daemon.
+    let run_pool_out = cli.ok(&[
+        "run",
+        "--pool",
+        "--pool-socket",
+        socket.as_str(),
+        "--rm",
+        image.as_str(),
+        "--",
+        "echo",
+        "run-pool-e2e-ok",
+    ]);
+    assert!(
+        run_pool_out.contains("run-pool-e2e-ok"),
+        "unexpected run --pool output: {run_pool_out:?}"
+    );
+
+    // Env auto-route: compatible foreground `run --rm` uses the daemon without
+    // changing the CLI shape users already script.
+    let env_pool_out = cli.ok_with_env(
+        &[
+            "run",
+            "--rm",
+            image.as_str(),
+            "--",
+            "echo",
+            "env-pool-e2e-ok",
+        ],
+        &[("A3S_BOX_RUN_POOL_SOCKET", socket.as_str())],
+    );
+    assert!(
+        env_pool_out.contains("env-pool-e2e-ok"),
+        "unexpected env auto-routed run output: {env_pool_out:?}"
+    );
 
     // Concurrent runs — the daemon serves them concurrently.
     std::thread::scope(|s| {
@@ -597,7 +632,113 @@ fn test_real_pool_warm_run() {
         "status should list both warmed images:\n{status}"
     );
 
-    let _ = daemon.kill();
+    cli.interrupt_background(&mut daemon);
+}
+
+/// Dockerfile RUN over the warm-pool lease path: one build stage keeps a pooled
+/// helper VM, shell-form and exec-form RUN mutate the mounted rootfs, and cache
+/// mounts persist across RUN commands without committing cache contents.
+#[test]
+#[ignore]
+fn test_real_build_run_pool_smoke() {
+    let cli = CliTest::new();
+    let image = host_smoke_image();
+    seed_runnable_alpine_image(&cli, &image);
+    let built_image = format!("coverage-run-pool:{}", unique_tag("build"));
+    let socket = cli
+        .home_path()
+        .join("build-pool.sock")
+        .to_str()
+        .expect("utf8 socket path")
+        .to_string();
+
+    let mut daemon = cli.spawn_background(&[
+        "pool",
+        "start",
+        "--image",
+        image.as_str(),
+        "--size",
+        "1",
+        "--max",
+        "2",
+        "--socket",
+        socket.as_str(),
+    ]);
+
+    let sock_path = cli.home_path().join("build-pool.sock");
+    let start = std::time::Instant::now();
+    while !sock_path.exists() {
+        if start.elapsed() > Duration::from_secs(120) {
+            cli.interrupt_background(&mut daemon);
+            panic!("build pool daemon never created its socket");
+        }
+        if let Ok(Some(status)) = daemon.try_wait() {
+            panic!("build pool daemon exited early: {status}");
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    std::thread::sleep(Duration::from_secs(5));
+
+    let build_dir = cli.home_path().join("run-pool-build");
+    std::fs::create_dir_all(&build_dir).expect("create build --run-pool context");
+    std::fs::write(
+        build_dir.join("Dockerfile"),
+        format!(
+            r#"FROM {image}
+WORKDIR /work
+RUN printf 'shell-ok\n' > /shell.txt
+RUN ["/bin/sh", "-c", "printf 'exec-ok\n' > exec.txt"]
+RUN --mount=type=cache,id=warm-smoke,sharing=locked,mode=0750,target=/root/.cache printf 'cache-only\n' > /root/.cache/cache.txt
+RUN --mount=type=cache,id=warm-smoke,sharing=locked,target=/root/.cache cat /root/.cache/cache.txt > /cache-result.txt
+"#
+        ),
+    )
+    .expect("write build --run-pool Dockerfile");
+
+    let build_dir_arg = build_dir.to_string_lossy().to_string();
+    let run_cache_dir = cli.home_path().join("run-cache");
+    let run_cache_arg = run_cache_dir.to_string_lossy().to_string();
+    cli.ok(&[
+        "build",
+        "--run-pool",
+        "--run-pool-socket",
+        socket.as_str(),
+        "--run-cache-dir",
+        &run_cache_arg,
+        "--tag",
+        &built_image,
+        "--quiet",
+        &build_dir_arg,
+    ]);
+
+    let status = cli.ok(&["pool", "status", "--socket", socket.as_str()]);
+    assert!(
+        status.contains("LEASED"),
+        "pool status should expose lease columns:\n{status}"
+    );
+
+    let image_tar = cli.home_path().join("run-pool-build.tar");
+    let image_tar_arg = image_tar.to_string_lossy().to_string();
+    cli.ok(&["save", &built_image, "--output", &image_tar_arg]);
+    assert_eq!(
+        read_file_from_saved_oci_tar(&image_tar, "/shell.txt").as_deref(),
+        Some("shell-ok\n")
+    );
+    assert_eq!(
+        read_file_from_saved_oci_tar(&image_tar, "/work/exec.txt").as_deref(),
+        Some("exec-ok\n")
+    );
+    assert_eq!(
+        read_file_from_saved_oci_tar(&image_tar, "/cache-result.txt").as_deref(),
+        Some("cache-only\n")
+    );
+    assert!(
+        read_file_from_saved_oci_tar(&image_tar, "/root/.cache/cache.txt").is_none(),
+        "RUN cache mount contents must not be committed to the final image"
+    );
+
+    cli.ok(&["rmi", "--force", &built_image]);
+    cli.ok(&["pool", "stop", "--socket", socket.as_str()]);
     let _ = daemon.wait();
 }
 
@@ -636,7 +777,7 @@ fn test_real_pool_deferred_main() {
     let start = std::time::Instant::now();
     while !sock_path.exists() {
         if start.elapsed() > Duration::from_secs(120) {
-            let _ = daemon.kill();
+            cli.interrupt_background(&mut daemon);
             panic!("deferred pool daemon never created its socket");
         }
         if let Ok(Some(status)) = daemon.try_wait() {
@@ -677,6 +818,5 @@ fn test_real_pool_deferred_main() {
     ]);
     assert!(!ok2, "expected a non-zero exit from the deferred main");
 
-    let _ = daemon.kill();
-    let _ = daemon.wait();
+    cli.interrupt_background(&mut daemon);
 }

--- a/src/cli/tests/support/mod.rs
+++ b/src/cli/tests/support/mod.rs
@@ -144,6 +144,29 @@ impl CliTest {
             })
     }
 
+    pub fn interrupt_background(&self, child: &mut std::process::Child) {
+        #[cfg(unix)]
+        unsafe {
+            let _ = libc::kill(child.id() as libc::pid_t, libc::SIGINT);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = child.kill();
+        }
+
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(30) {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => std::thread::sleep(Duration::from_millis(100)),
+                Err(_) => return,
+            }
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
     pub fn output_with_stdin(&self, args: &[&str], stdin: &[u8]) -> (String, String, bool) {
         eprintln!("    $ printf ... | a3s-box {}", args.join(" "));
 

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
 flate2 = "1.0"
+base64 = { workspace = true }
 
 [lib]
 name = "a3s_box_core"

--- a/src/core/src/compose.rs
+++ b/src/core/src/compose.rs
@@ -6,6 +6,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+mod interpolation;
+
+pub use interpolation::{interpolate_compose_yaml, ComposeInterpolationError};
+
 /// Top-level compose file configuration.
 ///
 /// Compatible with a subset of docker-compose v3 syntax:

--- a/src/core/src/compose/interpolation.rs
+++ b/src/core/src/compose/interpolation.rs
@@ -1,0 +1,356 @@
+//! Docker Compose-style variable interpolation for YAML scalar values.
+
+use std::collections::HashMap;
+
+use thiserror::Error;
+
+const MAX_INTERPOLATION_DEPTH: usize = 32;
+
+/// Failure while parsing or expanding Compose variable expressions.
+#[derive(Debug, Error)]
+pub enum ComposeInterpolationError {
+    /// The Compose YAML could not be parsed or serialized.
+    #[error("invalid Compose YAML: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    /// A variable expression is malformed or uses an unsupported operator.
+    #[error("invalid Compose variable expression at byte {offset}: {message}")]
+    InvalidExpression {
+        /// Byte offset of the opening `$` in its scalar value.
+        offset: usize,
+        /// Human-readable reason.
+        message: String,
+    },
+
+    /// A required variable is unset or empty.
+    #[error("required Compose variable '{name}' is unavailable: {message}")]
+    RequiredVariable {
+        /// Variable name.
+        name: String,
+        /// Expression-provided diagnostic.
+        message: String,
+    },
+}
+
+/// Expand Compose variables in YAML scalar values while leaving mapping keys intact.
+pub fn interpolate_compose_yaml(
+    input: &str,
+    environment: &HashMap<String, String>,
+) -> Result<String, ComposeInterpolationError> {
+    let mut yaml: serde_yaml::Value = serde_yaml::from_str(input)?;
+    interpolate_value(&mut yaml, environment)?;
+    serde_yaml::to_string(&yaml).map_err(ComposeInterpolationError::from)
+}
+
+fn interpolate_value(
+    value: &mut serde_yaml::Value,
+    environment: &HashMap<String, String>,
+) -> Result<(), ComposeInterpolationError> {
+    match value {
+        serde_yaml::Value::String(scalar) => {
+            *scalar = interpolate_scalar(scalar, environment, 0)?;
+        }
+        serde_yaml::Value::Sequence(sequence) => {
+            for item in sequence {
+                interpolate_value(item, environment)?;
+            }
+        }
+        serde_yaml::Value::Mapping(mapping) => {
+            // Compose interpolation applies to YAML values, not mapping keys.
+            for item in mapping.values_mut() {
+                interpolate_value(item, environment)?;
+            }
+        }
+        serde_yaml::Value::Tagged(tagged) => {
+            interpolate_value(&mut tagged.value, environment)?;
+        }
+        serde_yaml::Value::Null | serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_) => {}
+    }
+    Ok(())
+}
+
+fn interpolate_scalar(
+    input: &str,
+    environment: &HashMap<String, String>,
+    depth: usize,
+) -> Result<String, ComposeInterpolationError> {
+    if depth > MAX_INTERPOLATION_DEPTH {
+        return Err(invalid_expression(
+            0,
+            format!("nesting exceeds {MAX_INTERPOLATION_DEPTH} levels"),
+        ));
+    }
+
+    let mut output = String::with_capacity(input.len());
+    let mut offset = 0;
+
+    while offset < input.len() {
+        let rest = &input[offset..];
+        let Some(character) = rest.chars().next() else {
+            break;
+        };
+
+        if character != '$' {
+            output.push(character);
+            offset += character.len_utf8();
+            continue;
+        }
+
+        if rest.starts_with("$$") {
+            output.push('$');
+            offset += 2;
+            continue;
+        }
+
+        if rest.starts_with("${") {
+            let closing = find_closing_brace(input, offset)?;
+            let expression = &input[offset + 2..closing];
+            output.push_str(&expand_expression(expression, environment, depth, offset)?);
+            offset = closing + 1;
+            continue;
+        }
+
+        let name_start = offset + 1;
+        let name_end = scan_variable_name(input, name_start);
+        if name_end == name_start {
+            output.push('$');
+            offset += 1;
+            continue;
+        }
+
+        let name = &input[name_start..name_end];
+        if let Some(value) = environment.get(name) {
+            output.push_str(value);
+        }
+        offset = name_end;
+    }
+
+    Ok(output)
+}
+
+fn find_closing_brace(input: &str, opening: usize) -> Result<usize, ComposeInterpolationError> {
+    let mut depth = 1usize;
+    let mut offset = opening + 2;
+
+    while offset < input.len() {
+        let rest = &input[offset..];
+        if rest.starts_with("${") {
+            depth += 1;
+            offset += 2;
+            continue;
+        }
+
+        let Some(character) = rest.chars().next() else {
+            break;
+        };
+        if character == '}' {
+            depth -= 1;
+            if depth == 0 {
+                return Ok(offset);
+            }
+        }
+        offset += character.len_utf8();
+    }
+
+    Err(invalid_expression(opening, "unterminated `${...}`"))
+}
+
+fn scan_variable_name(input: &str, start: usize) -> usize {
+    let mut end = start;
+    for (relative, character) in input[start..].char_indices() {
+        let valid = if relative == 0 {
+            character == '_' || character.is_ascii_alphabetic()
+        } else {
+            character == '_' || character.is_ascii_alphanumeric()
+        };
+        if !valid {
+            break;
+        }
+        end = start + relative + character.len_utf8();
+    }
+    end
+}
+
+fn expand_expression(
+    expression: &str,
+    environment: &HashMap<String, String>,
+    depth: usize,
+    offset: usize,
+) -> Result<String, ComposeInterpolationError> {
+    let name_end = scan_variable_name(expression, 0);
+    if name_end == 0 {
+        return Err(invalid_expression(offset, "variable name is missing"));
+    }
+
+    let name = &expression[..name_end];
+    let remainder = &expression[name_end..];
+    let value = environment.get(name);
+    let is_set = value.is_some();
+    let is_nonempty = value.is_some_and(|value| !value.is_empty());
+
+    if remainder.is_empty() {
+        return Ok(value.cloned().unwrap_or_default());
+    }
+
+    let (operator, word) = [":-", ":+", ":?", "-", "+", "?"]
+        .into_iter()
+        .find_map(|operator| {
+            remainder
+                .strip_prefix(operator)
+                .map(|word| (operator, word))
+        })
+        .ok_or_else(|| {
+            invalid_expression(
+                offset,
+                format!("unsupported operator in `${{{expression}}}`"),
+            )
+        })?;
+
+    let expand_word = || interpolate_scalar(word, environment, depth + 1);
+    match operator {
+        "-" if !is_set => expand_word(),
+        ":-" if !is_nonempty => expand_word(),
+        "+" if is_set => expand_word(),
+        ":+" if is_nonempty => expand_word(),
+        "?" if !is_set => required_variable(name, word, environment, depth),
+        ":?" if !is_nonempty => required_variable(name, word, environment, depth),
+        "-" | ":-" => Ok(value.cloned().unwrap_or_default()),
+        "+" | ":+" => Ok(String::new()),
+        "?" | ":?" => Ok(value.cloned().unwrap_or_default()),
+        _ => unreachable!("operator matched the closed list above"),
+    }
+}
+
+fn required_variable(
+    name: &str,
+    word: &str,
+    environment: &HashMap<String, String>,
+    depth: usize,
+) -> Result<String, ComposeInterpolationError> {
+    let message = if word.is_empty() {
+        "variable is required".to_string()
+    } else {
+        interpolate_scalar(word, environment, depth + 1)?
+    };
+    Err(ComposeInterpolationError::RequiredVariable {
+        name: name.to_string(),
+        message,
+    })
+}
+
+fn invalid_expression(offset: usize, message: impl Into<String>) -> ComposeInterpolationError {
+    ComposeInterpolationError::InvalidExpression {
+        offset,
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn environment(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    fn interpolated_value(yaml: &str, env: &[(&str, &str)]) -> serde_yaml::Value {
+        let output = interpolate_compose_yaml(yaml, &environment(env)).unwrap();
+        serde_yaml::from_str(&output).unwrap()
+    }
+
+    #[test]
+    fn expands_unset_and_empty_default_operators() {
+        let value = interpolated_value(
+            r#"
+dash_unset: ${UNSET-default}
+dash_empty: ${EMPTY-default}
+colon_dash_unset: ${UNSET:-default}
+colon_dash_empty: ${EMPTY:-default}
+"#,
+            &[("EMPTY", "")],
+        );
+
+        assert_eq!(value["dash_unset"].as_str(), Some("default"));
+        assert_eq!(value["dash_empty"].as_str(), Some(""));
+        assert_eq!(value["colon_dash_unset"].as_str(), Some("default"));
+        assert_eq!(value["colon_dash_empty"].as_str(), Some("default"));
+    }
+
+    #[test]
+    fn expands_set_and_nonempty_replacement_operators() {
+        let value = interpolated_value(
+            r#"
+plus_unset: ${UNSET+replacement}
+plus_empty: ${EMPTY+replacement}
+plus_value: ${VALUE+replacement}
+colon_plus_unset: ${UNSET:+replacement}
+colon_plus_empty: ${EMPTY:+replacement}
+colon_plus_value: ${VALUE:+replacement}
+"#,
+            &[("EMPTY", ""), ("VALUE", "present")],
+        );
+
+        assert_eq!(value["plus_unset"].as_str(), Some(""));
+        assert_eq!(value["plus_empty"].as_str(), Some("replacement"));
+        assert_eq!(value["plus_value"].as_str(), Some("replacement"));
+        assert_eq!(value["colon_plus_unset"].as_str(), Some(""));
+        assert_eq!(value["colon_plus_empty"].as_str(), Some(""));
+        assert_eq!(value["colon_plus_value"].as_str(), Some("replacement"));
+    }
+
+    #[test]
+    fn expands_bare_braced_nested_and_escaped_dollars() {
+        let value = interpolated_value(
+            r#"
+bare: $VALUE
+braced: ${VALUE}
+nested: ${UNSET:-${FALLBACK:-final}}
+escaped: $$VALUE and $${VALUE}
+"#,
+            &[("VALUE", "resolved")],
+        );
+
+        assert_eq!(value["bare"].as_str(), Some("resolved"));
+        assert_eq!(value["braced"].as_str(), Some("resolved"));
+        assert_eq!(value["nested"].as_str(), Some("final"));
+        assert_eq!(value["escaped"].as_str(), Some("$VALUE and ${VALUE}"));
+    }
+
+    #[test]
+    fn interpolates_values_but_not_mapping_keys() {
+        let value = interpolated_value(
+            r#"
+${KEY}: unchanged-key
+environment:
+  VALUE: ${VALUE:-fallback}
+ports:
+  - "${PORT:-6379}:6379"
+"#,
+            &[
+                ("KEY", "expanded-key"),
+                ("VALUE", "shell"),
+                ("PORT", "16379"),
+            ],
+        );
+
+        assert_eq!(value["${KEY}"].as_str(), Some("unchanged-key"));
+        assert!(value.get("expanded-key").is_none());
+        assert_eq!(value["environment"]["VALUE"].as_str(), Some("shell"));
+        assert_eq!(value["ports"][0].as_str(), Some("16379:6379"));
+    }
+
+    #[test]
+    fn reports_required_and_malformed_expressions() {
+        let required =
+            interpolate_compose_yaml("value: ${MISSING:?set MISSING}\n", &HashMap::new())
+                .unwrap_err();
+        assert!(required.to_string().contains("set MISSING"));
+
+        let malformed =
+            interpolate_compose_yaml("value: ${MISSING\n", &HashMap::new()).unwrap_err();
+        assert!(malformed.to_string().contains("unterminated"));
+    }
+}

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod operator;
 pub mod platform;
 pub mod port;
 pub mod pty;
+pub mod rootfs_metadata;
 pub mod scale;
 pub mod security;
 pub mod snapshot;

--- a/src/core/src/log.rs
+++ b/src/core/src/log.rs
@@ -210,10 +210,24 @@ fn tail_next_line(
     stop: &AtomicBool,
     on_eof: Option<&dyn Fn() -> bool>,
 ) -> Option<String> {
+    // `krun_start_enter()` can return a few scheduler ticks before the
+    // virtio-console backend's final host write becomes visible. Treat the
+    // first stopped EOFs as provisional; otherwise a very short detached
+    // command can leave bytes in console.log after the processor has exited.
+    const STOPPED_EOF_SETTLE_POLLS: u8 = 25;
+    const STOPPED_EOF_SETTLE_MILLIS: u64 = 20;
+    let mut stopped_eof_polls = 0u8;
     loop {
         match reader.read_line(buf) {
             Ok(0) | Err(_) => {
                 if stop.load(Ordering::Relaxed) {
+                    stopped_eof_polls = stopped_eof_polls.saturating_add(1);
+                    if stopped_eof_polls < STOPPED_EOF_SETTLE_POLLS {
+                        std::thread::sleep(std::time::Duration::from_millis(
+                            STOPPED_EOF_SETTLE_MILLIS,
+                        ));
+                        continue;
+                    }
                     // VM exited and we are at EOF: flush a trailing partial line
                     // (no newline) once, then signal completion.
                     if buf.is_empty() {
@@ -235,7 +249,7 @@ fn tail_next_line(
                 std::thread::sleep(std::time::Duration::from_millis(100));
                 continue;
             }
-            Ok(_) => {}
+            Ok(_) => stopped_eof_polls = 0,
         }
         if !buf.ends_with('\n') {
             // Partial line at EOF — keep it buffered and wait for the rest.
@@ -256,6 +270,19 @@ pub fn run_log_processor(
     config: &LogConfig,
     stop: &AtomicBool,
 ) {
+    run_log_processor_with_ready(console_log, log_dir, config, stop, None);
+}
+
+/// Run the processor and optionally count each console reader once it has
+/// opened its file. A VM launcher can wait for two ready readers before start,
+/// preventing a short guest from exiting before the tail threads are alive.
+pub fn run_log_processor_with_ready(
+    console_log: &Path,
+    log_dir: &Path,
+    config: &LogConfig,
+    stop: &AtomicBool,
+    ready: Option<&std::sync::atomic::AtomicUsize>,
+) {
     match config.driver {
         // `none` produces no structured output, but libkrun still writes the raw
         // console for the VM's lifetime — drain + bound it so a chatty box with
@@ -265,6 +292,7 @@ pub fn run_log_processor(
             console_log,
             Some(console_cap(config.max_size(), config.max_file())),
             stop,
+            ready,
         ),
         LogDriver::JsonFile => run_json_file_processor(
             console_log,
@@ -272,6 +300,7 @@ pub fn run_log_processor(
             config.max_size(),
             config.max_file(),
             stop,
+            ready,
         ),
         LogDriver::Syslog => run_syslog_processor(
             console_log,
@@ -280,6 +309,7 @@ pub fn run_log_processor(
             config.tag().unwrap_or("a3s-box"),
             Some(console_cap(config.max_size(), config.max_file())),
             stop,
+            ready,
         ),
     }
 }
@@ -316,11 +346,15 @@ fn run_tagged_tail(
     bound: Option<u64>,
     stop: &AtomicBool,
     emit: &(dyn Fn(&str, &str) + Sync),
+    ready: Option<&std::sync::atomic::AtomicUsize>,
 ) {
     let f = match open_console(file, stop) {
         Some(f) => f,
         None => return,
     };
+    if let Some(ready) = ready {
+        ready.fetch_add(1, Ordering::Release);
+    }
     let mut reader = BufReader::new(f);
     let mut buf = String::new();
     // Bound the raw console file's growth at clean line boundaries (see
@@ -346,13 +380,18 @@ fn console_cap(max_size: u64, max_file: u32) -> u64 {
 /// (advancing to clean line boundaries) and truncate when over `cap`, emitting
 /// nothing. Without this, `--log-driver none` would leave libkrun's raw
 /// `console.log`/`console.err.log` to grow without limit.
-fn run_discard_processor(console_log: &Path, cap: Option<u64>, stop: &AtomicBool) {
+fn run_discard_processor(
+    console_log: &Path,
+    cap: Option<u64>,
+    stop: &AtomicBool,
+    ready: Option<&std::sync::atomic::AtomicUsize>,
+) {
     let err_log = stderr_console_path(console_log);
     let discard = |_line: &str, _stream: &str| {};
     let discard: &(dyn Fn(&str, &str) + Sync) = &discard;
     std::thread::scope(|s| {
-        s.spawn(|| run_tagged_tail(console_log, "stdout", false, cap, stop, discard));
-        s.spawn(|| run_tagged_tail(&err_log, "stderr", false, cap, stop, discard));
+        s.spawn(|| run_tagged_tail(console_log, "stdout", false, cap, stop, discard, ready));
+        s.spawn(|| run_tagged_tail(&err_log, "stderr", false, cap, stop, discard, ready));
     });
 }
 
@@ -362,6 +401,7 @@ fn run_json_file_processor(
     max_size: u64,
     max_file: u32,
     stop: &AtomicBool,
+    ready: Option<&std::sync::atomic::AtomicUsize>,
 ) {
     let json_path = json_log_path(log_dir);
     let writer = std::sync::Mutex::new(match RotatingWriter::new(&json_path, max_size, max_file) {
@@ -388,10 +428,10 @@ fn run_json_file_processor(
 
     let cap = Some(console_cap(max_size, max_file));
     std::thread::scope(|s| {
-        s.spawn(|| run_tagged_tail(console_log, "stdout", true, cap, stop, emit));
+        s.spawn(|| run_tagged_tail(console_log, "stdout", true, cap, stop, emit, ready));
         // libkrun's `init.krun:` preamble can land on EITHER stream, so filter
         // the noise on stderr too.
-        s.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit));
+        s.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready));
     });
 }
 
@@ -403,6 +443,7 @@ fn run_syslog_processor(
     tag: &str,
     cap: Option<u64>,
     stop: &AtomicBool,
+    ready: Option<&std::sync::atomic::AtomicUsize>,
 ) {
     use std::net::UdpSocket;
 
@@ -428,8 +469,8 @@ fn run_syslog_processor(
             };
             let emit: &(dyn Fn(&str, &str) + Sync) = &emit;
             std::thread::scope(|s| {
-                s.spawn(|| run_tagged_tail(console_log, "stdout", true, cap, stop, emit));
-                s.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit));
+                s.spawn(|| run_tagged_tail(console_log, "stdout", true, cap, stop, emit, ready));
+                s.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready));
             });
         }
         "tcp" => {
@@ -450,8 +491,8 @@ fn run_syslog_processor(
             };
             let emit: &(dyn Fn(&str, &str) + Sync) = &emit;
             std::thread::scope(|sc| {
-                sc.spawn(|| run_tagged_tail(console_log, "stdout", true, cap, stop, emit));
-                sc.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit));
+                sc.spawn(|| run_tagged_tail(console_log, "stdout", true, cap, stop, emit, ready));
+                sc.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready));
             });
         }
         _ => {}
@@ -716,7 +757,7 @@ mod tests {
         let handle = std::thread::spawn(move || {
             let emit = move |line: &str, _stream: &str| c2.lock().unwrap().push(line.to_string());
             let emit: &(dyn Fn(&str, &str) + Sync) = &emit;
-            run_tagged_tail(&p2, "stdout", false, Some(cap), &s2, emit);
+            run_tagged_tail(&p2, "stdout", false, Some(cap), &s2, emit, None);
         });
 
         // Let the tail drain l1..l3, hit EOF, and truncate (9 bytes > cap 4).
@@ -745,6 +786,36 @@ mod tests {
             final_len <= cap + 6,
             "console.log unbounded: {final_len} bytes"
         );
+    }
+
+    #[test]
+    fn test_stopped_tail_waits_for_delayed_final_console_write() {
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("console.log");
+        std::fs::write(&path, b"").unwrap();
+        let writer_path = path.clone();
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(30));
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(writer_path)
+                .unwrap();
+            file.write_all(b"late-final-line\n").unwrap();
+            file.flush().unwrap();
+        });
+
+        let file = std::fs::File::open(&path).unwrap();
+        let mut reader = BufReader::new(file);
+        let mut buffer = String::new();
+        let stop = AtomicBool::new(true);
+        assert_eq!(
+            tail_next_line(&mut reader, &mut buffer, &stop, None),
+            Some("late-final-line".to_string())
+        );
+        assert_eq!(tail_next_line(&mut reader, &mut buffer, &stop, None), None);
+        writer.join().unwrap();
     }
 
     #[test]
@@ -799,7 +870,7 @@ mod tests {
         let console = dir.path().join("console.log");
         std::fs::write(&console, "AAA\ninit.krun: noise\nBBB\n").unwrap();
         let stop = AtomicBool::new(true);
-        run_json_file_processor(&console, dir.path(), 10 * 1024 * 1024, 3, &stop);
+        run_json_file_processor(&console, dir.path(), 10 * 1024 * 1024, 3, &stop, None);
         let json = std::fs::read_to_string(json_log_path(dir.path())).unwrap();
         assert!(json.contains("\"log\":\"AAA\\n\""), "AAA missing: {json}");
         assert!(

--- a/src/core/src/rootfs_metadata.rs
+++ b/src/core/src/rootfs_metadata.rs
@@ -1,0 +1,59 @@
+//! Guest-captured filesystem metadata used by stopped-box commit.
+
+use serde::{Deserialize, Serialize};
+
+/// Location written inside a persistent rootfs before guest shutdown.
+pub const ROOTFS_METADATA_PATH: &str = "/.a3s_rootfs_metadata_v1.json";
+/// Location used to carry OCI header ownership across a rootless host extraction.
+pub const IMAGE_ROOTFS_METADATA_PATH: &str = "/.a3s_image_metadata_v1.json";
+/// Stable manifest schema identifier.
+pub const ROOTFS_METADATA_SCHEMA: &str = "a3s.box.rootfs-metadata.v1";
+
+/// Metadata kind supported by OCI rootfs archives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RootfsEntryKind {
+    Directory,
+    Regular,
+    Symlink,
+}
+
+/// One guest-visible filesystem entry. Paths are base64-encoded raw Unix bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootfsMetadataEntry {
+    pub path_base64: String,
+    pub kind: RootfsEntryKind,
+    pub mode: u32,
+    pub uid: u64,
+    pub gid: u64,
+    pub mtime: u64,
+    pub size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_target_base64: Option<String>,
+}
+
+/// Complete terminal metadata snapshot for one rootfs generation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootfsMetadataManifest {
+    pub schema: String,
+    pub entries: Vec<RootfsMetadataEntry>,
+}
+
+impl RootfsMetadataManifest {
+    pub fn new(entries: Vec<RootfsMetadataEntry>) -> Self {
+        Self {
+            schema: ROOTFS_METADATA_SCHEMA.to_string(),
+            entries,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema != ROOTFS_METADATA_SCHEMA {
+            return Err(format!(
+                "unsupported rootfs metadata schema: {}",
+                self.schema
+            ));
+        }
+        Ok(())
+    }
+}

--- a/src/core/src/vmm.rs
+++ b/src/core/src/vmm.rs
@@ -73,6 +73,11 @@ pub struct NetworkInstanceConfig {
     #[serde(default)]
     pub net_proxy_fd: Option<RawFd>,
 
+    /// Shared Unix-datagram Ethernet switch directory for this bridge network.
+    #[cfg(target_os = "macos")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bridge_socket_dir: Option<PathBuf>,
+
     /// Assigned IPv4 address for this VM.
     pub ip_address: Ipv4Addr,
 
@@ -507,6 +512,8 @@ mod tests {
                 net_socket_fd: Some(42),
                 #[cfg(target_os = "macos")]
                 net_proxy_fd: Some(43),
+                #[cfg(target_os = "macos")]
+                bridge_socket_dir: Some(PathBuf::from("/tmp/a3s-switch")),
                 ip_address: "10.0.0.2".parse().unwrap(),
                 gateway: "10.0.0.1".parse().unwrap(),
                 prefix_len: 24,

--- a/src/deps/libkrun-sys/build.rs
+++ b/src/deps/libkrun-sys/build.rs
@@ -16,23 +16,23 @@ use std::process::{Command, Stdio};
 // macOS: Download prebuilt kernel.c, compile locally to .dylib
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const LIBKRUNFW_PREBUILT_URL: &str =
-    "https://github.com/boxlite-ai/libkrunfw/releases/download/v5.1.0/libkrunfw-prebuilt-aarch64.tgz";
+    "https://github.com/boxlite-ai/libkrunfw/releases/download/v5.3.0/libkrunfw-prebuilt-aarch64.tgz";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-const LIBKRUNFW_SHA256: &str = "2b2801d2e414140d8d0a30d7e30a011077b7586eabbbecdca42aea804b59de8b";
+const LIBKRUNFW_SHA256: &str = "12b9401d7735d1682450e4d025273c5016ec2237dcbfb76b2f0a152be6e606d6";
 
 // Linux x86_64: Download pre-compiled .so directly (no build needed)
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 const LIBKRUNFW_SO_URL: &str =
-    "https://github.com/boxlite-ai/libkrunfw/releases/download/v5.1.0/libkrunfw-x86_64.tgz";
+    "https://github.com/boxlite-ai/libkrunfw/releases/download/v5.3.0/libkrunfw-x86_64.tgz";
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-const LIBKRUNFW_SHA256: &str = "faca64a3581ce281498b8ae7eccc6bd0da99b167984f9ee39c47754531d4b37d";
+const LIBKRUNFW_SHA256: &str = "0a7bb64a35a273b8501801dd69b75736a8c676aa21aa62fb5642842cda9dc91d";
 
 // Linux aarch64: Download pre-compiled .so directly (no build needed)
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 const LIBKRUNFW_SO_URL: &str =
-    "https://github.com/boxlite-ai/libkrunfw/releases/download/v5.1.0/libkrunfw-aarch64.tgz";
+    "https://github.com/boxlite-ai/libkrunfw/releases/download/v5.3.0/libkrunfw-aarch64.tgz";
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-const LIBKRUNFW_SHA256: &str = "e254bc3fb07b32e26a258d9958967b2f22eb6c3136cfedf358c332308b6d35ea";
+const LIBKRUNFW_SHA256: &str = "8b5b9211da5445d9301dafb2201431f4392ab96455512bce63a5cfbd33c49839";
 
 // libkrun build features (NET=1 BLK=1 enables network and block device support)
 // Note: TEE support (krun_set_tee_config_file) is loaded via dlsym at runtime
@@ -56,6 +56,8 @@ fn main() {
     println!("cargo:rerun-if-changed=vendor/libkrun");
     // Re-evaluate the system-vs-vendored decision when the toggle changes.
     println!("cargo:rerun-if-env-changed=A3S_BUILD_LIBKRUN");
+    println!("cargo:rerun-if-env-changed=A3S_USE_SYSTEM_LIBKRUN");
+    println!("cargo:rerun-if-env-changed=A3S_LIBKRUNFW_DYLIB");
 
     // Check for stub mode (for CI linting without building)
     // Set A3S_DEPS_STUB=1 to skip building and emit stub link directives
@@ -74,8 +76,18 @@ fn main() {
 
     #[cfg(not(target_os = "windows"))]
     {
+        // The vendored macOS libkrun carries required TSI flow-control and
+        // reverse-proxy fixes newer than the 1.17.0 library shipped by older
+        // A3S Box formulae. Silently preferring that system dylib produces TCP
+        // listeners that accept connections but never move application data.
+        // Keep system linking as an explicit developer escape hatch only.
+        #[cfg(target_os = "macos")]
+        let force_vendored = env::var("A3S_USE_SYSTEM_LIBKRUN").is_err();
+        #[cfg(not(target_os = "macos"))]
+        let force_vendored = false;
+
         // Try to find system-installed libkrun first (unless A3S_BUILD_LIBKRUN is set)
-        if env::var("A3S_BUILD_LIBKRUN").is_err() {
+        if env::var("A3S_BUILD_LIBKRUN").is_err() && !force_vendored {
             if let Ok(lib_dir) = find_system_libkrun() {
                 println!(
                     "cargo:warning=Using system-installed libkrun from {}",
@@ -368,6 +380,15 @@ fn make_command(
     cmd.stderr(Stdio::inherit());
     cmd.args(["-j", &num_cpus::get().to_string()])
         .arg("MAKEFLAGS=")
+        // libkrun's Makefile invokes a nested Cargo build. Do not leak the
+        // outer workspace's clippy wrapper or lint flags into that independent
+        // vendored workspace: `cargo clippy -- -D warnings` must lint A3S code,
+        // not turn upstream warnings into a build-script failure.
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .env_remove("RUSTFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("CLIPPY_ARGS")
         .env("PREFIX", install_dir)
         .current_dir(source_dir);
 
@@ -409,10 +430,68 @@ fn configure_linking(libkrun_dir: &Path, libkrunfw_dir: &Path) {
             "cargo:rustc-link-arg=-Wl,-rpath,{}",
             libkrunfw_dir.display()
         );
+        stage_macos_runtime_libraries(libkrun_dir, libkrunfw_dir);
     }
 
     println!("cargo:LIBKRUN_A3S_DEP={}", libkrun_dir.display());
     println!("cargo:LIBKRUNFW_A3S_DEP={}", libkrunfw_dir.display());
+}
+
+#[cfg(target_os = "macos")]
+fn stage_macos_runtime_libraries(libkrun_dir: &Path, libkrunfw_dir: &Path) {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR is required"));
+    let target_root = target_root_from_out_dir(&out_dir)
+        .expect("failed to derive Cargo target root from OUT_DIR");
+    let runtime_dir = target_root.join("lib");
+    fs::create_dir_all(&runtime_dir).unwrap_or_else(|error| {
+        panic!(
+            "failed to create runtime library directory {}: {error}",
+            runtime_dir.display()
+        )
+    });
+
+    for source_dir in [libkrun_dir, libkrunfw_dir] {
+        for entry in fs::read_dir(source_dir)
+            .unwrap_or_else(|error| panic!("failed to inspect {}: {error}", source_dir.display()))
+        {
+            let entry = entry.expect("failed to inspect runtime library entry");
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if !name.ends_with(".dylib")
+                || !(name.starts_with("libkrun.") || name.starts_with("libkrunfw."))
+            {
+                continue;
+            }
+            let resolved = path.canonicalize().unwrap_or_else(|error| {
+                panic!(
+                    "failed to resolve runtime library {}: {error}",
+                    path.display()
+                )
+            });
+            let destination = runtime_dir.join(name);
+            let temporary = runtime_dir.join(format!(".{name}.tmp-{}", std::process::id()));
+            fs::copy(&resolved, &temporary).unwrap_or_else(|error| {
+                panic!(
+                    "failed to stage runtime library {} at {}: {error}",
+                    resolved.display(),
+                    temporary.display()
+                )
+            });
+            fs::rename(&temporary, &destination).unwrap_or_else(|error| {
+                panic!(
+                    "failed to activate runtime library {} at {}: {error}",
+                    temporary.display(),
+                    destination.display()
+                )
+            });
+        }
+    }
+    println!(
+        "cargo:warning=Staged macOS runtime libraries in {}",
+        runtime_dir.display()
+    );
 }
 
 /// Downloads a file from URL to the specified path.
@@ -663,11 +742,17 @@ fn fix_macos_libs(lib_dir: &Path, lib_prefix: &str) -> Result<(), String> {
 /// Downloads and extracts the prebuilt libkrunfw tarball (macOS).
 #[cfg(target_os = "macos")]
 fn download_libkrunfw_prebuilt(out_dir: &Path) -> PathBuf {
-    let tarball_path = out_dir.join("libkrunfw-prebuilt.tar.gz");
+    let tarball_path = out_dir.join(format!(
+        "libkrunfw-prebuilt-{}.tar.gz",
+        &LIBKRUNFW_SHA256[..12]
+    ));
     let extract_dir = out_dir.join("libkrunfw-src");
     let src_dir = extract_dir.join("libkrunfw");
+    let marker = extract_dir.join(".source-sha256");
 
-    if src_dir.join("kernel.c").exists() {
+    if src_dir.join("kernel.c").exists()
+        && fs::read_to_string(&marker).is_ok_and(|value| value == LIBKRUNFW_SHA256)
+    {
         println!("cargo:warning=Using cached libkrunfw source");
         return src_dir;
     }
@@ -685,6 +770,8 @@ fn download_libkrunfw_prebuilt(out_dir: &Path) -> PathBuf {
     }
     extract_tarball(&tarball_path, &extract_dir)
         .unwrap_or_else(|e| panic!("Failed to extract libkrunfw: {}", e));
+    fs::write(&marker, LIBKRUNFW_SHA256)
+        .unwrap_or_else(|e| panic!("Failed to record libkrunfw source digest: {}", e));
 
     println!("cargo:warning=Extracted libkrunfw to {}", src_dir.display());
     src_dir
@@ -706,11 +793,22 @@ fn build() {
     let libkrun_install = out_dir.join("libkrun");
     let libkrunfw_lib = libkrunfw_install.join(LIB_DIR);
     let libkrun_lib = libkrun_install.join(LIB_DIR);
+    let firmware_marker = out_dir.join("libkrunfw-src/.source-sha256");
+    let firmware_current =
+        fs::read_to_string(&firmware_marker).is_ok_and(|value| value == LIBKRUNFW_SHA256);
 
     // Skip build if outputs already exist (incremental build optimization)
-    if has_library(&libkrunfw_lib, "libkrunfw") && has_library(&libkrun_lib, "libkrun") {
+    if env::var("A3S_BUILD_LIBKRUN").is_err()
+        && firmware_current
+        && has_library(&libkrunfw_lib, "libkrunfw")
+        && has_library(&libkrun_lib, "libkrun")
+    {
         configure_linking(&libkrun_lib, &libkrunfw_lib);
         return;
+    }
+    if !firmware_current {
+        let _ = fs::remove_dir_all(&libkrunfw_install);
+        let _ = fs::remove_dir_all(&libkrun_install);
     }
 
     println!("cargo:warning=Building libkrun-sys for macOS (using prebuilt libkrunfw)");
@@ -723,16 +821,34 @@ fn build() {
     // Setup LIBCLANG_PATH for bindgen if needed
     setup_libclang_path();
 
-    // 1. Download and extract prebuilt libkrunfw
-    let libkrunfw_src = download_libkrunfw_prebuilt(&out_dir);
-
-    // 2. Build libkrunfw from prebuilt source (fast, just compiles kernel.c)
-    build_with_make(
-        &libkrunfw_src,
-        &libkrunfw_install,
-        "libkrunfw",
-        HashMap::new(),
-    );
+    // 1-2. Use an explicitly built patched firmware when supplied; otherwise
+    // build the checksum-verified upstream prebuilt source bundle. The override
+    // is path-only and opt-in so release builds cannot silently consume ambient
+    // firmware. `firmware/build-patched-darwin-arm64.sh` produces this artifact.
+    if let Ok(override_path) = env::var("A3S_LIBKRUNFW_DYLIB") {
+        let override_path = PathBuf::from(override_path);
+        if !override_path.is_file() {
+            panic!(
+                "A3S_LIBKRUNFW_DYLIB is not a file: {}",
+                override_path.display()
+            );
+        }
+        fs::create_dir_all(&libkrunfw_lib).expect("create libkrunfw override directory");
+        fs::copy(&override_path, libkrunfw_lib.join("libkrunfw.5.dylib"))
+            .unwrap_or_else(|error| panic!("Failed to stage patched libkrunfw: {error}"));
+        println!(
+            "cargo:warning=Using explicit patched libkrunfw from {}",
+            override_path.display()
+        );
+    } else {
+        let libkrunfw_src = download_libkrunfw_prebuilt(&out_dir);
+        build_with_make(
+            &libkrunfw_src,
+            &libkrunfw_install,
+            "libkrunfw",
+            HashMap::new(),
+        );
+    }
 
     // 3. Build libkrun from vendored source
     build_with_make(
@@ -797,16 +913,24 @@ fn fix_linux_libs(lib_dir: &Path, lib_prefix: &str) -> Result<(), String> {
 #[cfg(target_os = "linux")]
 fn download_libkrunfw_so(install_dir: &Path) {
     let lib_dir = install_dir.join(LIB_DIR);
+    let marker = install_dir.join(".source-sha256");
 
-    if has_library(&lib_dir, "libkrunfw") {
+    if has_library(&lib_dir, "libkrunfw")
+        && fs::read_to_string(&marker).is_ok_and(|value| value == LIBKRUNFW_SHA256)
+    {
         println!("cargo:warning=Using cached libkrunfw.so");
         return;
+    }
+
+    if lib_dir.exists() {
+        fs::remove_dir_all(&lib_dir)
+            .unwrap_or_else(|e| panic!("Failed to remove stale libkrunfw cache: {}", e));
     }
 
     fs::create_dir_all(install_dir)
         .unwrap_or_else(|e| panic!("Failed to create install dir: {}", e));
 
-    let tarball_path = install_dir.join("libkrunfw.tgz");
+    let tarball_path = install_dir.join(format!("libkrunfw-{}.tgz", &LIBKRUNFW_SHA256[..12]));
 
     if !tarball_path.exists() {
         download_file(LIBKRUNFW_SO_URL, &tarball_path)
@@ -818,6 +942,8 @@ fn download_libkrunfw_so(install_dir: &Path) {
 
     extract_tarball(&tarball_path, install_dir)
         .unwrap_or_else(|e| panic!("Failed to extract libkrunfw: {}", e));
+    fs::write(&marker, LIBKRUNFW_SHA256)
+        .unwrap_or_else(|e| panic!("Failed to record libkrunfw source digest: {}", e));
 
     println!(
         "cargo:warning=Extracted libkrunfw.so to {}",
@@ -916,11 +1042,20 @@ fn build() {
     let libkrun_install = out_dir.join("libkrun");
     let libkrunfw_lib_dir = libkrunfw_install.join(LIB_DIR);
     let libkrun_lib_dir = libkrun_install.join(LIB_DIR);
+    let firmware_current = fs::read_to_string(libkrunfw_install.join(".source-sha256"))
+        .is_ok_and(|value| value == LIBKRUNFW_SHA256);
 
     // Skip build if outputs already exist (incremental build optimization)
-    if has_library(&libkrunfw_lib_dir, "libkrunfw") && has_library(&libkrun_lib_dir, "libkrun") {
+    if env::var("A3S_BUILD_LIBKRUN").is_err()
+        && firmware_current
+        && has_library(&libkrunfw_lib_dir, "libkrunfw")
+        && has_library(&libkrun_lib_dir, "libkrun")
+    {
         configure_linking(&libkrun_lib_dir, &libkrunfw_lib_dir);
         return;
+    }
+    if !firmware_current {
+        let _ = fs::remove_dir_all(&libkrun_install);
     }
 
     println!("cargo:warning=Building libkrun-sys for Linux (using prebuilt libkrunfw)");

--- a/src/deps/libkrun-sys/firmware/build-patched-darwin-arm64.sh
+++ b/src/deps/libkrun-sys/firmware/build-patched-darwin-arm64.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+firmware_dir="$root/deps/libkrun-sys/firmware"
+work_dir=${A3S_LIBKRUNFW_WORK_DIR:-"$root/target/libkrunfw-a3s"}
+source_dir="$work_dir/source"
+builder_image=${A3S_LIBKRUNFW_BUILDER_IMAGE:-fedora:42}
+upstream=https://github.com/boxlite-ai/libkrunfw.git
+revision=v5.3.0
+
+mkdir -p "$work_dir"
+if [ ! -d "$source_dir/.git" ]; then
+    git clone --depth 1 --branch "$revision" "$upstream" "$source_dir"
+fi
+
+if [ ! -d "$source_dir/linux-6.12.76" ]; then
+    docker run --rm --platform linux/arm64 \
+        -v "$source_dir:/src" -w /src "$builder_image" \
+        /bin/bash -lc 'dnf install -y make patch curl xz && make linux-6.12.76'
+fi
+
+patch_file="$firmware_dir/patches/0001-tsi-nonblocking-accept-probe-local-vsock-first.patch"
+if patch --dry-run -N -p1 -d "$source_dir/linux-6.12.76" < "$patch_file" >/dev/null; then
+    patch -N -p1 -d "$source_dir/linux-6.12.76" < "$patch_file"
+elif ! patch --dry-run -R -p1 -d "$source_dir/linux-6.12.76" < "$patch_file" >/dev/null; then
+    echo "firmware patch does not apply cleanly" >&2
+    exit 1
+fi
+rm -f "$source_dir/kernel.c" "$source_dir/linux-6.12.76/arch/arm64/boot/Image"
+
+docker run --rm --platform linux/arm64 \
+    -v "$source_dir:/src" -w /src "$builder_image" \
+    /bin/bash -lc 'dnf install -y make gcc bc bison flex elfutils-libelf-devel openssl-devel python3 python3-pyelftools cpio diffutils perl && make -j"$(nproc)" kernel.c'
+
+make -C "$source_dir" libkrunfw.5.dylib
+cp "$source_dir/libkrunfw.5.dylib" "$work_dir/libkrunfw.5.dylib"
+codesign --force --sign - "$work_dir/libkrunfw.5.dylib"
+shasum -a 256 "$work_dir/libkrunfw.5.dylib"
+printf '%s\n' "$work_dir/libkrunfw.5.dylib"

--- a/src/deps/libkrun-sys/firmware/patches/0001-tsi-nonblocking-accept-probe-local-vsock-first.patch
+++ b/src/deps/libkrun-sys/firmware/patches/0001-tsi-nonblocking-accept-probe-local-vsock-first.patch
@@ -1,0 +1,82 @@
+From: A3S Box maintainers
+Subject: [PATCH] tsi: probe local vsock before nonblocking host accept
+
+TSI currently sends TSI_ACCEPT to the host before calling the underlying
+vsock accept operation. For a nonblocking listener, the first accepted
+connection consumes the host pending count, but the conventional second
+accept used to drain an edge-triggered accept queue can block waiting for a
+host control response. Event-driven servers such as Redis then never service
+the already accepted client.
+
+Probe the local vsock accept queue first for O_NONBLOCK. Return EAGAIN without
+contacting the host when it is empty. When a connection is present, retain the
+host request to consume the corresponding pending-accept count. Blocking
+accept keeps the existing ordering.
+
+--- a/net/tsi/af_tsi.c
++++ b/net/tsi/af_tsi.c
+@@ -493,8 +493,29 @@ static int tsi_accept_vsock(struct tsi_sock *tsk, struct socket **newsock,
+ 	struct socket *nsock;
+ 	struct tsi_accept_req ta_req;
+ 	struct tsi_accept_rsp ta_rsp;
++	bool accepted_locally = false;
+ 	int err;
+ 
++	nsock = sock_alloc();
++	if (!nsock)
++		return -ENOMEM;
++	nsock->type = socket->type;
++	nsock->ops = socket->ops;
++
++	/*
++	 * Do not ask the host whether an O_NONBLOCK accept queue is empty.
++	 * The local vsock queue already has the authoritative readiness state,
++	 * and the host control round trip may block the guest event loop.
++	 */
++	if (arg->flags & O_NONBLOCK) {
++		err = socket->ops->accept(socket, nsock, arg);
++		if (err < 0) {
++			sock_release(nsock);
++			return err;
++		}
++		accepted_locally = true;
++	}
++
+ 	ta_req.svm_port = tsk->svm_port;
+ 	ta_req.flags = arg->flags;
+@@ -506,6 +527,7 @@ static int tsi_accept_vsock(struct tsi_sock *tsk, struct socket **newsock,
+ 				  sizeof(struct tsi_accept_req));
+ 	if (err < 0) {
+ 		pr_debug("%s: error sending accept request\n", __func__);
++		sock_release(nsock);
+ 		return err;
+ 	}
+ 
+@@ -514,6 +536,7 @@ static int tsi_accept_vsock(struct tsi_sock *tsk, struct socket **newsock,
+ 				  sizeof(struct tsi_accept_rsp));
+ 	if (err < 0) {
+ 		pr_debug("%s: error receiving accept response\n", __func__);
++		sock_release(nsock);
+ 		return err;
+ 	}
+@@ -521,17 +544,12 @@ static int tsi_accept_vsock(struct tsi_sock *tsk, struct socket **newsock,
+ 	pr_debug("%s: response result: %d\n", __func__, ta_rsp.result);
+ 
+ 	if (ta_rsp.result != 0) {
++		sock_release(nsock);
+ 		return ta_rsp.result;
+ 	}
+ 
+-	nsock = sock_alloc();
+-	if (!nsock)
+-		return -ENOMEM;
+-
+-	nsock->type = socket->type;
+-	nsock->ops = socket->ops;
+-
+-	err = socket->ops->accept(socket, nsock, arg);
++	if (!accepted_locally)
++		err = socket->ops->accept(socket, nsock, arg);
+ 
+ 	if (err < 0) {
+ 		pr_debug("%s: vsock accept failed: %d\n", __func__, err);

--- a/src/guest/init/Cargo.toml
+++ b/src/guest/init/Cargo.toml
@@ -35,6 +35,7 @@ sha2 = { workspace = true }
 # Sealed storage
 ring = { workspace = true }
 base64 = { workspace = true }
+tar = "0.4"
 
 [features]
 default = []

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -6,6 +6,8 @@
 
 use std::io::Read;
 use std::io::Write;
+#[cfg(target_os = "linux")]
+use std::path::Path;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
@@ -59,6 +61,13 @@ const EXEC_CONTROL_SPAWN_MAIN: &[u8] = b"spawn-main:";
 const EXEC_SPAWN_MAIN_ACK: &[u8] = b"spawn-main-ack";
 #[cfg(target_os = "linux")]
 const EXEC_SPAWN_MAIN_NACK: &[u8] = b"spawn-main-nack:";
+/// Stream a guest-metadata-preserving tar of the root filesystem.
+#[cfg(target_os = "linux")]
+const EXEC_CONTROL_ARCHIVE_ROOTFS: &[u8] = b"archive-rootfs-v1";
+#[cfg(target_os = "linux")]
+const EXEC_CONTROL_ARCHIVE_ROOTFS_PAUSE: &[u8] = b"archive-rootfs-v1:pause";
+#[cfg(target_os = "linux")]
+const EXEC_ARCHIVE_ROOTFS_DONE: &[u8] = b"archive-rootfs-v1-done";
 
 /// Deliver `sig` to the main container process (best-effort).
 #[cfg(target_os = "linux")]
@@ -422,6 +431,18 @@ fn handle_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::error:
             std::mem::forget(fd);
             return Ok(());
         }
+        if frame_type == FrameType::Control as u8
+            && (payload == EXEC_CONTROL_ARCHIVE_ROOTFS
+                || payload == EXEC_CONTROL_ARCHIVE_ROOTFS_PAUSE)
+        {
+            let pause = payload == EXEC_CONTROL_ARCHIVE_ROOTFS_PAUSE;
+            let result = stream_rootfs_archive(&mut stream, pause);
+            if let Err(error) = result {
+                send_error_frame(&mut stream, &format!("rootfs archive failed: {error}"))?;
+            }
+            std::mem::forget(fd);
+            return Ok(());
+        }
         send_error_frame(&mut stream, "Expected Data frame")?;
         std::mem::forget(fd);
         return Ok(());
@@ -474,6 +495,126 @@ fn handle_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::error:
 
     std::mem::forget(fd);
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn stream_rootfs_archive(
+    stream: &mut impl Write,
+    pause: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _pause_guard = pause.then(PausedContainerTree::pause);
+    {
+        let mut writer = ArchiveFrameWriter::new(&mut *stream);
+        crate::rootfs_archive::write_rootfs_archive(Path::new("/"), &mut writer)?;
+        writer.finish()?;
+    }
+    write_frame(stream, FrameType::Control as u8, EXEC_ARCHIVE_ROOTFS_DONE)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+struct PausedContainerTree {
+    pids: Vec<i32>,
+}
+
+#[cfg(target_os = "linux")]
+impl PausedContainerTree {
+    fn pause() -> Self {
+        let root = container_pid();
+        let mut pids = Vec::new();
+        if root > 0 {
+            collect_process_tree(root, &mut pids);
+            // Stop descendants before their parent so no parent can immediately
+            // create more work after its children are frozen.
+            for pid in pids.iter().rev() {
+                unsafe {
+                    libc::kill(*pid, libc::SIGSTOP);
+                }
+            }
+        }
+        Self { pids }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for PausedContainerTree {
+    fn drop(&mut self) {
+        for pid in &self.pids {
+            unsafe {
+                libc::kill(*pid, libc::SIGCONT);
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn collect_process_tree(pid: i32, output: &mut Vec<i32>) {
+    if output.contains(&pid) {
+        return;
+    }
+    output.push(pid);
+    let children = format!("/proc/{pid}/task/{pid}/children");
+    let Ok(children) = std::fs::read_to_string(children) else {
+        return;
+    };
+    for child in children
+        .split_whitespace()
+        .filter_map(|value| value.parse::<i32>().ok())
+    {
+        collect_process_tree(child, output);
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct ArchiveFrameWriter<'a, W: Write> {
+    stream: &'a mut W,
+    buffer: Vec<u8>,
+}
+
+#[cfg(target_os = "linux")]
+impl<'a, W: Write> ArchiveFrameWriter<'a, W> {
+    const CHUNK_BYTES: usize = 64 * 1024;
+
+    fn new(stream: &'a mut W) -> Self {
+        Self {
+            stream,
+            buffer: Vec::with_capacity(Self::CHUNK_BYTES),
+        }
+    }
+
+    fn flush_frame(&mut self) -> std::io::Result<()> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+        write_frame(self.stream, FrameType::Data as u8, &self.buffer)?;
+        self.buffer.clear();
+        Ok(())
+    }
+
+    fn finish(&mut self) -> std::io::Result<()> {
+        self.flush_frame()
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl<W: Write> Write for ArchiveFrameWriter<'_, W> {
+    fn write(&mut self, mut bytes: &[u8]) -> std::io::Result<usize> {
+        let total = bytes.len();
+        while !bytes.is_empty() {
+            let available = Self::CHUNK_BYTES - self.buffer.len();
+            let copied = available.min(bytes.len());
+            self.buffer.extend_from_slice(&bytes[..copied]);
+            bytes = &bytes[copied..];
+            if self.buffer.len() == Self::CHUNK_BYTES {
+                self.flush_frame()?;
+            }
+        }
+        Ok(total)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.flush_frame()
+    }
 }
 
 /// Write a frame: [type:u8][length:u32 BE][payload].

--- a/src/guest/init/src/lib.rs
+++ b/src/guest/init/src/lib.rs
@@ -15,6 +15,8 @@ pub mod network;
 pub mod port_forward;
 pub mod pty_server;
 pub mod reaper;
+#[cfg(any(target_os = "linux", test))]
+pub mod rootfs_archive;
 pub mod user;
 
 pub use namespace::{spawn_isolated, NamespaceConfig, NamespaceError};

--- a/src/guest/init/src/main.rs
+++ b/src/guest/init/src/main.rs
@@ -539,6 +539,7 @@ fn main() {
     // Run init process
     if let Err(e) = run_init() {
         error!("Init process failed: {}", e);
+        eprintln!("a3s-box guest init failed: {e}");
         process::exit(1);
     }
 
@@ -546,6 +547,11 @@ fn main() {
 }
 
 fn run_init() -> Result<(), Box<dyn std::error::Error>> {
+    // Restore Linux uid/gid/mode before mounting procfs, workspace, or user
+    // volumes so metadata replay can never mutate an attached host path.
+    #[cfg(target_os = "linux")]
+    a3s_box_guest_init::rootfs_archive::restore_rootfs_metadata(std::path::Path::new("/"))?;
+
     // Step 1: Mount essential filesystems
     mount_essential_filesystems()?;
 
@@ -815,6 +821,8 @@ fn run_init() -> Result<(), Box<dyn std::error::Error>> {
 
     // Step 9: Wait for agent process (reap zombies, handle SIGTERM)
     wait_for_children(container_pid)?;
+
+    persist_terminal_rootfs_metadata();
 
     // Drain the stdio relays on the graceful-shutdown / no-children return paths
     // (the container-exit path flushes before its own process::exit).
@@ -1547,10 +1555,17 @@ fn wait_for_children(container_pid: nix::unistd::Pid) -> Result<(), Box<dyn std:
                 } else {
                     info!("Container process {} exited with status {}", pid, code);
                 }
+                persist_terminal_rootfs_metadata();
                 persist_exit_code(code);
                 // Flush the stdout/stderr relays so the container's last output
                 // reaches the console before this process::exit halts the VM.
                 flush_stdio_relays();
+                // The relay write has reached virtio-console, but libkrun exits
+                // the host shim as soon as PID 1 exits. Give the already-ready
+                // host tail threads one bounded poll interval to consume those
+                // bytes; without this handoff, short detached commands could
+                // leave a complete console.log and an empty container.json.
+                std::thread::sleep(std::time::Duration::from_millis(250));
                 process::exit(code);
             } else if reaper::is_managed(pid.as_raw()) {
                 // Owned by an exec/PTY handler, which reaps it for the real status.
@@ -1566,6 +1581,21 @@ fn wait_for_children(container_pid: nix::unistd::Pid) -> Result<(), Box<dyn std:
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
+
+#[cfg(target_os = "linux")]
+fn persist_terminal_rootfs_metadata() {
+    if std::env::var("BOX_PERSIST_ROOTFS_METADATA").as_deref() != Ok("1") {
+        return;
+    }
+    if let Err(error) =
+        a3s_box_guest_init::rootfs_archive::persist_rootfs_metadata(std::path::Path::new("/"))
+    {
+        warn!(%error, "Failed to persist terminal rootfs metadata");
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn persist_terminal_rootfs_metadata() {}
 
 /// Non-Linux development stub: just wait for the container process to exit.
 #[cfg(not(target_os = "linux"))]

--- a/src/guest/init/src/namespace.rs
+++ b/src/guest/init/src/namespace.rs
@@ -282,7 +282,7 @@ fn child_process(
     // entrypoint is "docker-entrypoint.sh".
     let resolved_command = resolve_command_path(command, env);
     if let Some(command_path) = &resolved_command {
-        let metadata = std::fs::metadata(&command_path).ok();
+        let metadata = std::fs::metadata(command_path).ok();
         tracing::debug!(
             path = %command_path.display(),
             size = metadata.as_ref().map(|m| m.len()).unwrap_or(0),

--- a/src/guest/init/src/rootfs_archive.rs
+++ b/src/guest/init/src/rootfs_archive.rs
@@ -1,0 +1,467 @@
+//! Guest-side rootfs tar creation.
+//!
+//! Tar headers must be generated from guest-visible Linux metadata. Reading the
+//! virtio-fs backing directory on macOS can expose different uid/gid/mode values.
+
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "linux")]
+use a3s_box_core::rootfs_metadata::IMAGE_ROOTFS_METADATA_PATH;
+use a3s_box_core::rootfs_metadata::{
+    RootfsEntryKind, RootfsMetadataEntry, RootfsMetadataManifest, ROOTFS_METADATA_PATH,
+};
+use base64::Engine;
+
+/// Write a tar stream for `root`, excluding nested mount points such as procfs,
+/// sysfs, tmpfs, and user volumes.
+pub(crate) fn write_rootfs_archive(
+    root: &Path,
+    output: &mut impl Write,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let excluded_mounts = nested_mount_points(root)?;
+    let mut builder = tar::Builder::new(output);
+    builder.follow_symlinks(false);
+    append_tree(&mut builder, root, root, Path::new("."), &excluded_mounts)?;
+    builder.finish()?;
+    Ok(())
+}
+
+/// Persist a compact terminal metadata snapshot for a stopped persistent box.
+pub fn persist_rootfs_metadata(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let excluded_mounts = nested_mount_points(root)?;
+    let mut entries = Vec::new();
+    collect_metadata(root, root, Path::new("."), &excluded_mounts, &mut entries)?;
+    entries.sort_by(|left, right| left.path_base64.cmp(&right.path_base64));
+    let manifest = RootfsMetadataManifest::new(entries);
+    let destination = root.join(ROOTFS_METADATA_PATH.trim_start_matches('/'));
+    let temporary = destination.with_extension("json.tmp");
+    let bytes = serde_json::to_vec(&manifest)?;
+    {
+        let mut file = std::fs::File::create(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+    }
+    std::fs::rename(temporary, destination)?;
+    Ok(())
+}
+
+/// Replay rootless-host OCI ownership and the last persistent guest generation.
+/// This must run before procfs, workspace, or user volumes are mounted.
+#[cfg(target_os = "linux")]
+pub fn restore_rootfs_metadata(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    // Runtime may update generated files such as resolv.conf after the image
+    // rootfs cache is composed, so image replay validates type and symlink
+    // identity but not regular-file size. The terminal snapshot was captured
+    // after all container writes and remains strict.
+    apply_metadata_manifest(root, IMAGE_ROOTFS_METADATA_PATH, false)?;
+    apply_metadata_manifest(root, ROOTFS_METADATA_PATH, true)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn apply_metadata_manifest(
+    root: &Path,
+    manifest_path: &str,
+    strict_content: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::collections::HashSet;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let source = root.join(manifest_path.trim_start_matches('/'));
+    let bytes = match std::fs::read(&source) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let manifest: RootfsMetadataManifest = serde_json::from_slice(&bytes)?;
+    manifest.validate()?;
+    let mut decoded = Vec::with_capacity(manifest.entries.len());
+    let mut unique = HashSet::with_capacity(manifest.entries.len());
+    for entry in manifest.entries {
+        if entry.uid > u32::MAX as u64 || entry.gid > u32::MAX as u64 {
+            return Err("rootfs metadata uid/gid exceeds Linux range".into());
+        }
+        let raw = base64::engine::general_purpose::STANDARD.decode(&entry.path_base64)?;
+        let relative = PathBuf::from(std::ffi::OsString::from_vec(raw));
+        let relative = safe_relative_path(&relative)?;
+        if relative == Path::new(IMAGE_ROOTFS_METADATA_PATH.trim_start_matches('/'))
+            || relative == Path::new(ROOTFS_METADATA_PATH.trim_start_matches('/'))
+            || !unique.insert(relative.clone())
+        {
+            return Err("duplicate or reserved rootfs metadata path".into());
+        }
+        let target = resolve_without_symlink_parent(root, &relative)?;
+        let metadata = std::fs::symlink_metadata(&target)?;
+        let actual_kind = if metadata.file_type().is_dir() {
+            RootfsEntryKind::Directory
+        } else if metadata.file_type().is_file() {
+            RootfsEntryKind::Regular
+        } else if metadata.file_type().is_symlink() {
+            RootfsEntryKind::Symlink
+        } else {
+            return Err(format!("unsupported rootfs entry at {}", target.display()).into());
+        };
+        if actual_kind != entry.kind
+            || (strict_content
+                && actual_kind == RootfsEntryKind::Regular
+                && metadata.size() != entry.size)
+        {
+            return Err(format!("rootfs metadata mismatch at {}", target.display()).into());
+        }
+        if actual_kind == RootfsEntryKind::Symlink {
+            let expected = entry
+                .link_target_base64
+                .as_ref()
+                .ok_or("symlink metadata is missing its target")?;
+            let expected = base64::engine::general_purpose::STANDARD.decode(expected)?;
+            if std::fs::read_link(&target)?.as_os_str().as_bytes() != expected {
+                return Err(format!("rootfs symlink mismatch at {}", target.display()).into());
+            }
+        }
+        decoded.push((
+            entry,
+            target,
+            metadata.uid() as u64,
+            metadata.gid() as u64,
+            metadata.mode(),
+        ));
+    }
+
+    for (entry, target, current_uid, current_gid, current_mode) in &decoded {
+        if entry.uid == *current_uid && entry.gid == *current_gid {
+            continue;
+        }
+        if entry.kind != RootfsEntryKind::Symlink && current_mode & 0o200 == 0 {
+            std::fs::set_permissions(
+                target,
+                std::fs::Permissions::from_mode((current_mode & 0o7777) | 0o200),
+            )
+            .map_err(|error| {
+                format!(
+                    "failed to make {} writable for ownership replay: {error}",
+                    target.display()
+                )
+            })?;
+        }
+        let path = std::ffi::CString::new(target.as_os_str().as_bytes())?;
+        if unsafe { libc::lchown(path.as_ptr(), entry.uid as u32, entry.gid as u32) } != 0 {
+            return Err(format!(
+                "failed to restore ownership at {} from {}:{} to {}:{}: {}",
+                target.display(),
+                current_uid,
+                current_gid,
+                entry.uid,
+                entry.gid,
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
+    }
+    decoded.sort_by_key(|(_, path, _, _, _)| std::cmp::Reverse(path.components().count()));
+    for (entry, target, _, _, _) in &decoded {
+        if entry.kind != RootfsEntryKind::Symlink {
+            let current_mode = std::fs::symlink_metadata(target)?.mode() & 0o7777;
+            if current_mode == entry.mode & 0o7777 {
+                continue;
+            }
+            std::fs::set_permissions(target, std::fs::Permissions::from_mode(entry.mode & 0o7777))
+                .map_err(|error| {
+                    format!(
+                        "failed to restore mode at {} to {:o}: {error}",
+                        target.display(),
+                        entry.mode & 0o7777
+                    )
+                })?;
+        }
+    }
+    std::fs::remove_file(source)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn safe_relative_path(path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    use std::path::Component;
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(name) => result.push(name),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err("unsafe rootfs metadata path".into())
+            }
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_without_symlink_parent(
+    root: &Path,
+    relative: &Path,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let mut current = root.to_path_buf();
+    let components: Vec<_> = relative.components().collect();
+    for (index, component) in components.iter().enumerate() {
+        let std::path::Component::Normal(name) = component else {
+            continue;
+        };
+        current.push(name);
+        if index + 1 < components.len()
+            && std::fs::symlink_metadata(&current)?
+                .file_type()
+                .is_symlink()
+        {
+            return Err(format!(
+                "symlink parent in rootfs metadata path: {}",
+                current.display()
+            )
+            .into());
+        }
+    }
+    Ok(current)
+}
+
+fn append_tree<W: Write>(
+    builder: &mut tar::Builder<W>,
+    root: &Path,
+    source: &Path,
+    archive_path: &Path,
+    excluded_mounts: &HashSet<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if should_skip(root, source, excluded_mounts) {
+        return Ok(());
+    }
+
+    let metadata = std::fs::symlink_metadata(source)?;
+    let file_type = metadata.file_type();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileTypeExt;
+        if file_type.is_socket() {
+            return Ok(());
+        }
+    }
+
+    if file_type.is_dir() {
+        builder.append_dir(archive_path, source)?;
+        let mut entries: Vec<_> = std::fs::read_dir(source)?.collect::<Result<_, _>>()?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            append_tree(
+                builder,
+                root,
+                &entry.path(),
+                &archive_path.join(entry.file_name()),
+                excluded_mounts,
+            )?;
+        }
+    } else {
+        builder.append_path_with_name(source, archive_path)?;
+    }
+    Ok(())
+}
+
+fn collect_metadata(
+    root: &Path,
+    source: &Path,
+    archive_path: &Path,
+    excluded_mounts: &HashSet<PathBuf>,
+    entries: &mut Vec<RootfsMetadataEntry>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
+
+    if should_skip(root, source, excluded_mounts) {
+        return Ok(());
+    }
+    let metadata = std::fs::symlink_metadata(source)?;
+    let file_type = metadata.file_type();
+    let (kind, link_target_base64) = if file_type.is_dir() {
+        (RootfsEntryKind::Directory, None)
+    } else if file_type.is_file() {
+        (RootfsEntryKind::Regular, None)
+    } else if file_type.is_symlink() {
+        let target = std::fs::read_link(source)?;
+        (
+            RootfsEntryKind::Symlink,
+            Some(base64::engine::general_purpose::STANDARD.encode(target.as_os_str().as_bytes())),
+        )
+    } else {
+        return Ok(());
+    };
+    entries.push(RootfsMetadataEntry {
+        path_base64: base64::engine::general_purpose::STANDARD
+            .encode(archive_path.as_os_str().as_bytes()),
+        kind,
+        mode: metadata.mode(),
+        uid: metadata.uid() as u64,
+        gid: metadata.gid() as u64,
+        mtime: metadata.mtime().max(0) as u64,
+        size: metadata.size(),
+        link_target_base64,
+    });
+
+    if file_type.is_dir() {
+        let mut children: Vec<_> = std::fs::read_dir(source)?.collect::<Result<_, _>>()?;
+        children.sort_by_key(|entry| entry.file_name());
+        for child in children {
+            collect_metadata(
+                root,
+                &child.path(),
+                &archive_path.join(child.file_name()),
+                excluded_mounts,
+                entries,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn should_skip(root: &Path, source: &Path, excluded_mounts: &HashSet<PathBuf>) -> bool {
+    if source != root && excluded_mounts.contains(source) {
+        return true;
+    }
+    let Ok(relative) = source.strip_prefix(root) else {
+        return true;
+    };
+    matches!(
+        relative.to_str(),
+        Some(".a3s_rootfs_metadata_v1.json")
+            | Some(".a3s_rootfs_metadata_v1.json.tmp")
+            | Some(".a3s_image_metadata_v1.json")
+            | Some(".a3s_image_metadata_v1.json.tmp")
+            | Some(".a3s_exit_code")
+            // Written by libkrun's pre-PID1 init on every boot, before
+            // guest-init can replay terminal metadata. It is runtime
+            // diagnostics, not persistent container filesystem state.
+            | Some("init.trace.log")
+    )
+}
+
+fn nested_mount_points(root: &Path) -> Result<HashSet<PathBuf>, std::io::Error> {
+    #[cfg(target_os = "linux")]
+    {
+        let mountinfo = std::fs::read_to_string("/proc/self/mountinfo")?;
+        Ok(parse_nested_mount_points(root, &mountinfo))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = root;
+        Ok(HashSet::new())
+    }
+}
+
+fn parse_nested_mount_points(root: &Path, mountinfo: &str) -> HashSet<PathBuf> {
+    mountinfo
+        .lines()
+        .filter_map(|line| line.split_whitespace().nth(4))
+        .map(decode_mountinfo_path)
+        .map(PathBuf::from)
+        .filter(|mount| mount != root && mount.starts_with(root))
+        .collect()
+}
+
+fn decode_mountinfo_path(path: &str) -> String {
+    path.replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn archive_preserves_guest_visible_mode_uid_gid_and_symlink() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let directory = tempfile::TempDir::new().unwrap();
+        let executable = directory.path().join("executable");
+        std::fs::write(&executable, b"payload").unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o751)).unwrap();
+        std::os::unix::fs::symlink("executable", directory.path().join("link")).unwrap();
+        let metadata = std::fs::metadata(&executable).unwrap();
+
+        let mut bytes = Vec::new();
+        write_rootfs_archive(directory.path(), &mut bytes).unwrap();
+        let mut archive = tar::Archive::new(bytes.as_slice());
+        let mut saw_executable = false;
+        let mut saw_link = false;
+        for entry in archive.entries().unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path().unwrap();
+            let path = path.strip_prefix(".").unwrap_or(path.as_ref());
+            match path.to_string_lossy().as_ref() {
+                "executable" => {
+                    saw_executable = true;
+                    assert_eq!(entry.header().mode().unwrap() & 0o7777, 0o751);
+                    assert_eq!(entry.header().uid().unwrap(), metadata.uid() as u64);
+                    assert_eq!(entry.header().gid().unwrap(), metadata.gid() as u64);
+                }
+                "link" => {
+                    saw_link = true;
+                    assert_eq!(entry.link_name().unwrap().unwrap(), Path::new("executable"));
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_executable);
+        assert!(saw_link);
+    }
+
+    #[test]
+    fn mountinfo_parser_decodes_and_keeps_only_nested_mounts() {
+        let mounts = parse_nested_mount_points(
+            Path::new("/"),
+            "1 0 0:1 / / rw - rootfs rootfs rw\n\
+             2 1 0:2 / /proc rw - proc proc rw\n\
+             3 1 0:3 / /with\\040space rw - tmpfs tmpfs rw\n",
+        );
+
+        assert!(mounts.contains(Path::new("/proc")));
+        assert!(mounts.contains(Path::new("/with space")));
+        assert!(!mounts.contains(Path::new("/")));
+    }
+
+    #[test]
+    fn persisted_manifest_records_terminal_metadata_and_excludes_internal_files() {
+        use base64::Engine;
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::TempDir::new().unwrap();
+        let executable = directory.path().join("probe");
+        std::fs::write(&executable, b"probe").unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::write(directory.path().join(".a3s_exit_code"), b"0").unwrap();
+        std::fs::write(directory.path().join("init.trace.log"), b"runtime trace").unwrap();
+
+        persist_rootfs_metadata(directory.path()).unwrap();
+        let manifest_path = directory.path().join(".a3s_rootfs_metadata_v1.json");
+        let manifest: RootfsMetadataManifest =
+            serde_json::from_slice(&std::fs::read(manifest_path).unwrap()).unwrap();
+        manifest.validate().unwrap();
+        let probe_path = base64::engine::general_purpose::STANDARD
+            .encode(Path::new("./probe").as_os_str().as_bytes());
+        let probe = manifest
+            .entries
+            .iter()
+            .find(|entry| entry.path_base64 == probe_path)
+            .unwrap();
+        assert_eq!(probe.mode & 0o7777, 0o755);
+        assert!(!manifest.entries.iter().any(|entry| {
+            base64::engine::general_purpose::STANDARD
+                .decode(&entry.path_base64)
+                .is_ok_and(|path| path.ends_with(b".a3s_exit_code"))
+        }));
+        assert!(!manifest.entries.iter().any(|entry| {
+            base64::engine::general_purpose::STANDARD
+                .decode(&entry.path_base64)
+                .is_ok_and(|path| path.ends_with(b"init.trace.log"))
+        }));
+    }
+}

--- a/src/netproxy/src/lib.rs
+++ b/src/netproxy/src/lib.rs
@@ -108,6 +108,7 @@ impl NetStats {
 /// ECONNRESET / EDESTADDRREQ in the peer's receive path.
 struct UnixgramDevice {
     socket: UnixDatagram,
+    bridge: Option<BridgePort>,
     rx_queue: VecDeque<Vec<u8>>,
     stats: Arc<NetStats>,
 }
@@ -115,6 +116,9 @@ struct UnixgramDevice {
 impl UnixgramDevice {
     /// Drain the socket into `rx_queue` (non-blocking, batch up to 64 frames).
     fn drain(&mut self) {
+        if let Some(bridge) = &self.bridge {
+            bridge.drain_to_guest(&self.socket, &self.stats);
+        }
         let mut buf = vec![0u8; MAX_FRAME];
         for _ in 0..64 {
             match self.socket.recv(&mut buf) {
@@ -124,7 +128,15 @@ impl UnixgramDevice {
                         "NetProxy received ethernet frame from guest/libkrun"
                     );
                     self.stats.record_tx(n);
-                    self.rx_queue.push_back(buf[..n].to_vec())
+                    let frame = &buf[..n];
+                    let deliver_locally = self
+                        .bridge
+                        .as_ref()
+                        .map(|bridge| bridge.forward_from_guest(frame))
+                        .unwrap_or(true);
+                    if deliver_locally {
+                        self.rx_queue.push_back(frame.to_vec());
+                    }
                 }
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
                 Err(e) => {
@@ -134,6 +146,111 @@ impl UnixgramDevice {
             }
         }
     }
+}
+
+struct BridgePort {
+    socket: UnixDatagram,
+    directory: PathBuf,
+    own_path: PathBuf,
+}
+
+impl BridgePort {
+    fn bind(directory: &Path, own_mac: [u8; 6]) -> io::Result<Self> {
+        std::fs::create_dir_all(directory)?;
+        let own_path = directory.join(mac_socket_name(own_mac));
+        match std::fs::remove_file(&own_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        let socket = UnixDatagram::bind(&own_path)?;
+        socket.set_nonblocking(true)?;
+        Ok(Self {
+            socket,
+            directory: directory.to_path_buf(),
+            own_path,
+        })
+    }
+
+    /// Forward one guest frame. Returns whether the local gateway must also
+    /// receive it (broadcast/multicast or non-peer traffic).
+    fn forward_from_guest(&self, frame: &[u8]) -> bool {
+        let Some(destination) = ethernet_destination(frame) else {
+            return true;
+        };
+        if destination == GATEWAY_MAC.0 {
+            return true;
+        }
+        if is_group_mac(destination) {
+            self.flood(frame);
+            return true;
+        }
+
+        let peer = self.directory.join(mac_socket_name(destination));
+        if peer != self.own_path && peer.exists() {
+            if let Err(error) = self.socket.send_to(frame, &peer) {
+                tracing::debug!(%error, peer = %peer.display(), "Bridge peer send failed");
+            }
+            return false;
+        }
+
+        // Unknown unicast uses normal switch flooding while still allowing the
+        // local gateway stack to inspect traffic addressed outside this switch.
+        self.flood(frame);
+        true
+    }
+
+    fn flood(&self, frame: &[u8]) {
+        let Ok(entries) = std::fs::read_dir(&self.directory) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path == self.own_path || path.extension().and_then(|v| v.to_str()) != Some("sock") {
+                continue;
+            }
+            let _ = self.socket.send_to(frame, path);
+        }
+    }
+
+    fn drain_to_guest(&self, guest: &UnixDatagram, stats: &NetStats) {
+        let mut buf = [0u8; MAX_FRAME];
+        for _ in 0..64 {
+            match self.socket.recv(&mut buf) {
+                Ok(size) => {
+                    if guest.send(&buf[..size]).is_ok() {
+                        stats.record_rx(size);
+                    }
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                Err(error) => {
+                    tracing::debug!(%error, "Bridge peer receive failed");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+impl Drop for BridgePort {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.own_path);
+    }
+}
+
+fn ethernet_destination(frame: &[u8]) -> Option<[u8; 6]> {
+    frame.get(..6)?.try_into().ok()
+}
+
+fn is_group_mac(mac: [u8; 6]) -> bool {
+    mac[0] & 1 == 1
+}
+
+fn mac_socket_name(mac: [u8; 6]) -> String {
+    format!(
+        "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}.sock",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+    )
 }
 
 /// Owned received frame — consumed by smoltcp's interface layer.
@@ -235,6 +352,7 @@ struct ProxyEngineConfig {
     shutdown: Arc<AtomicBool>,
     stats: Arc<NetStats>,
     stats_path: Option<PathBuf>,
+    bridge: Option<BridgePort>,
 }
 
 struct ProxyEngine {
@@ -262,10 +380,12 @@ impl ProxyEngine {
             shutdown,
             stats,
             stats_path,
+            bridge,
         } = config;
 
         let mut device = UnixgramDevice {
             socket,
+            bridge,
             rx_queue: VecDeque::new(),
             stats: Arc::clone(&stats),
         };
@@ -641,21 +761,41 @@ impl Drop for NetProxyManager {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-pub fn spawn_inherited_netproxy(
-    fd: RawFd,
-    guest_ip: Ipv4Addr,
-    gateway: Ipv4Addr,
-    prefix_len: u8,
-    dns_servers: &[Ipv4Addr],
-    port_map: &[String],
-    stats_path: Option<PathBuf>,
-) -> Result<()> {
+pub struct InheritedNetProxyConfig<'a> {
+    pub guest_ip: Ipv4Addr,
+    pub gateway: Ipv4Addr,
+    pub prefix_len: u8,
+    pub dns_servers: &'a [Ipv4Addr],
+    pub port_map: &'a [String],
+    pub stats_path: Option<PathBuf>,
+    pub bridge_socket_dir: Option<PathBuf>,
+    pub own_mac: [u8; 6],
+}
+
+pub fn spawn_inherited_netproxy(fd: RawFd, config: InheritedNetProxyConfig<'_>) -> Result<()> {
+    let InheritedNetProxyConfig {
+        guest_ip,
+        gateway,
+        prefix_len,
+        dns_servers,
+        port_map,
+        stats_path,
+        bridge_socket_dir,
+        own_mac,
+    } = config;
     let socket = unsafe { UnixDatagram::from_raw_fd(fd) };
     let port_forwards = parse_port_forwards(port_map, guest_ip)
         .map_err(|e| BoxError::NetworkError(format!("invalid port_map: {}", e)))?;
     let dns_servers = dns_servers.to_vec();
     let shutdown = Arc::new(AtomicBool::new(false));
     let stats = Arc::new(NetStats::default());
+    let bridge = bridge_socket_dir
+        .as_deref()
+        .map(|directory| BridgePort::bind(directory, own_mac))
+        .transpose()
+        .map_err(|error| {
+            BoxError::NetworkError(format!("failed to join bridge Ethernet switch: {error}"))
+        })?;
 
     std::thread::Builder::new()
         .name("a3s-netproxy".to_string())
@@ -675,6 +815,7 @@ pub fn spawn_inherited_netproxy(
                 shutdown,
                 stats,
                 stats_path,
+                bridge,
             });
             engine.run();
             tracing::info!("NetProxy thread exiting");
@@ -785,6 +926,53 @@ mod tests {
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let smol_ip = to_smoltcp_ipv4(ip);
         assert_eq!(smol_ip.as_bytes(), &[127, 0, 0, 1]);
+    }
+
+    fn ethernet_frame(destination: [u8; 6], source: [u8; 6]) -> Vec<u8> {
+        let mut frame = vec![0u8; 64];
+        frame[..6].copy_from_slice(&destination);
+        frame[6..12].copy_from_slice(&source);
+        frame[12..14].copy_from_slice(&[0x08, 0x00]);
+        frame[14..].fill(0x5a);
+        frame
+    }
+
+    #[test]
+    fn bridge_port_unicasts_frame_to_matching_peer_mac() {
+        let dir = tempfile::tempdir().unwrap();
+        let mac_a = [0x02, 0x42, 10, 88, 0, 2];
+        let mac_b = [0x02, 0x42, 10, 88, 0, 3];
+        let bridge_a = BridgePort::bind(dir.path(), mac_a).unwrap();
+        let bridge_b = BridgePort::bind(dir.path(), mac_b).unwrap();
+        let (guest_b, proxy_b) = UnixDatagram::pair().unwrap();
+        guest_b.set_nonblocking(true).unwrap();
+        let frame = ethernet_frame(mac_b, mac_a);
+
+        assert!(!bridge_a.forward_from_guest(&frame));
+        bridge_b.drain_to_guest(&proxy_b, &NetStats::default());
+
+        let mut received = [0u8; MAX_FRAME];
+        let size = guest_b.recv(&mut received).unwrap();
+        assert_eq!(&received[..size], frame.as_slice());
+    }
+
+    #[test]
+    fn bridge_port_floods_broadcast_and_keeps_gateway_delivery() {
+        let dir = tempfile::tempdir().unwrap();
+        let mac_a = [0x02, 0x42, 10, 88, 0, 2];
+        let mac_b = [0x02, 0x42, 10, 88, 0, 3];
+        let bridge_a = BridgePort::bind(dir.path(), mac_a).unwrap();
+        let bridge_b = BridgePort::bind(dir.path(), mac_b).unwrap();
+        let (guest_b, proxy_b) = UnixDatagram::pair().unwrap();
+        guest_b.set_nonblocking(true).unwrap();
+        let frame = ethernet_frame([0xff; 6], mac_a);
+
+        assert!(bridge_a.forward_from_guest(&frame));
+        bridge_b.drain_to_guest(&proxy_b, &NetStats::default());
+
+        let mut received = [0u8; MAX_FRAME];
+        let size = guest_b.recv(&mut received).unwrap();
+        assert_eq!(&received[..size], frame.as_slice());
     }
 
     #[test]

--- a/src/runtime/src/grpc/exec.rs
+++ b/src/runtime/src/grpc/exec.rs
@@ -12,6 +12,11 @@ const EXEC_CONTROL_CANCEL: &[u8] = b"cancel";
 const EXEC_CONTROL_STDIN_CLOSE: &[u8] = b"stdin-close";
 /// Host→guest control: flush all buffered output and reply with a flush-ack.
 const EXEC_CONTROL_FLUSH: &[u8] = b"flush";
+/// Host→guest control: stream a tar archive of the guest-visible rootfs.
+const EXEC_CONTROL_ARCHIVE_ROOTFS: &[u8] = b"archive-rootfs-v1";
+const EXEC_CONTROL_ARCHIVE_ROOTFS_PAUSE: &[u8] = b"archive-rootfs-v1:pause";
+/// Guest→host marker after every archive data frame has been sent.
+const EXEC_ARCHIVE_ROOTFS_DONE: &[u8] = b"archive-rootfs-v1-done";
 /// Guest→host marker (carried in a Control frame) acknowledging a flush. Kept
 /// distinct from an `ExecExit` JSON payload so `next_event` can tell them apart.
 /// Must match the guest's `EXEC_FLUSH_ACK` in `guest/init/src/exec_server.rs`.
@@ -24,6 +29,9 @@ const EXEC_SIGNAL_MAIN_ACK: &[u8] = b"signal-main-ack";
 /// received and the container main spawned. Matches the guest's
 /// `EXEC_SPAWN_MAIN_ACK` in `guest/init/src/exec_server.rs`.
 const EXEC_SPAWN_MAIN_ACK: &[u8] = b"spawn-main-ack";
+/// Guest→host negative acknowledgement for `spawn-main`, followed by a UTF-8-ish
+/// diagnostic string from guest-init.
+const EXEC_SPAWN_MAIN_NACK: &[u8] = b"spawn-main-nack:";
 
 /// Host-side slack added to a one-shot exec's in-guest `timeout_ns` before the
 /// host gives up reading the reply. The in-guest timeout cannot fire if the
@@ -181,6 +189,83 @@ impl ExecClient {
             stderr_bytes: 0,
             done: false,
         })
+    }
+
+    /// Stream a guest-created rootfs tar archive into `output`.
+    ///
+    /// The guest performs `stat` and tar-header creation, preserving Linux
+    /// uid/gid/mode even when the host virtio-fs backing directory exposes
+    /// different macOS metadata. Mounted subtrees are excluded by guest-init.
+    pub async fn archive_rootfs<W>(&self, output: &mut W, pause: bool) -> Result<u64>
+    where
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        let mut stream = UnixStream::connect(&self.socket_path)
+            .await
+            .map_err(|error| {
+                BoxError::ExecError(format!(
+                    "Rootfs archive connection failed to {}: {error}",
+                    self.socket_path.display()
+                ))
+            })?;
+
+        let control = if pause {
+            EXEC_CONTROL_ARCHIVE_ROOTFS_PAUSE
+        } else {
+            EXEC_CONTROL_ARCHIVE_ROOTFS
+        };
+        let request = a3s_transport::Frame::control(control.to_vec());
+        stream
+            .write_all(&request.encode().map_err(|error| {
+                BoxError::ExecError(format!("Rootfs archive request encode failed: {error}"))
+            })?)
+            .await
+            .map_err(|error| {
+                BoxError::ExecError(format!("Rootfs archive request write failed: {error}"))
+            })?;
+
+        let (reader, _writer) = tokio::io::split(stream);
+        let mut reader = a3s_transport::FrameReader::new(reader);
+        let mut written = 0u64;
+        loop {
+            let frame = reader
+                .read_frame()
+                .await
+                .map_err(|error| {
+                    BoxError::ExecError(format!("Rootfs archive read failed: {error}"))
+                })?
+                .ok_or_else(|| {
+                    BoxError::ExecError(
+                        "Rootfs archive stream closed before completion".to_string(),
+                    )
+                })?;
+
+            match frame.frame_type {
+                a3s_transport::FrameType::Data => {
+                    output.write_all(&frame.payload).await.map_err(|error| {
+                        BoxError::ExecError(format!("Rootfs archive output write failed: {error}"))
+                    })?;
+                    written = written.saturating_add(frame.payload.len() as u64);
+                }
+                a3s_transport::FrameType::Control if frame.payload == EXEC_ARCHIVE_ROOTFS_DONE => {
+                    output.flush().await.map_err(|error| {
+                        BoxError::ExecError(format!("Rootfs archive output flush failed: {error}"))
+                    })?;
+                    return Ok(written);
+                }
+                a3s_transport::FrameType::Error => {
+                    return Err(BoxError::ExecError(format!(
+                        "Guest rootfs archive failed: {}",
+                        String::from_utf8_lossy(&frame.payload)
+                    )));
+                }
+                other => {
+                    return Err(BoxError::ExecError(format!(
+                        "Unexpected rootfs archive frame: {other:?}"
+                    )));
+                }
+            }
+        }
     }
 
     /// Transfer a file to/from the guest.
@@ -341,6 +426,15 @@ impl ExecClient {
                     && f.payload == EXEC_SPAWN_MAIN_ACK =>
             {
                 Ok(true)
+            }
+            Ok(Some(f))
+                if f.frame_type == a3s_transport::FrameType::Control
+                    && f.payload.starts_with(EXEC_SPAWN_MAIN_NACK) =>
+            {
+                let reason = String::from_utf8_lossy(&f.payload[EXEC_SPAWN_MAIN_NACK.len()..]);
+                Err(BoxError::ExecError(format!(
+                    "spawn-main rejected by guest: {reason}"
+                )))
             }
             _ => Ok(false),
         }
@@ -692,6 +786,45 @@ mod tests {
         };
         let result = client.heartbeat().await.unwrap();
         assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn test_archive_rootfs_streams_data_until_done_marker() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock_path = tmp.path().join("archive.sock");
+        let Some(listener) = bind_test_listener(&sock_path) else {
+            return;
+        };
+
+        tokio::spawn(async move {
+            // ExecClient::connect performs one reachability connection first.
+            let (stream, _) = listener.accept().await.unwrap();
+            drop(stream);
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut header = [0u8; 5];
+            stream.read_exact(&mut header).await.unwrap();
+            assert_eq!(header[0], a3s_transport::FrameType::Control as u8);
+            let length = u32::from_be_bytes(header[1..5].try_into().unwrap()) as usize;
+            let mut payload = vec![0u8; length];
+            stream.read_exact(&mut payload).await.unwrap();
+            assert_eq!(payload, EXEC_CONTROL_ARCHIVE_ROOTFS);
+
+            for payload in [b"first".as_slice(), b"-second".as_slice()] {
+                let frame = a3s_transport::Frame::data(payload.to_vec());
+                stream.write_all(&frame.encode().unwrap()).await.unwrap();
+            }
+            let done = a3s_transport::Frame::control(EXEC_ARCHIVE_ROOTFS_DONE.to_vec());
+            stream.write_all(&done.encode().unwrap()).await.unwrap();
+        });
+
+        let client = ExecClient::connect(&sock_path).await.unwrap();
+        let output_path = tmp.path().join("rootfs.tar");
+        let mut output = tokio::fs::File::create(&output_path).await.unwrap();
+        let written = client.archive_rootfs(&mut output, false).await.unwrap();
+        drop(output);
+
+        assert_eq!(written, 12);
+        assert_eq!(std::fs::read(output_path).unwrap(), b"first-second");
     }
 
     #[tokio::test]

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -107,7 +107,7 @@ pub use volume::VolumeStore;
 // ── Feature-gated re-exports ──
 
 #[cfg(feature = "build")]
-pub use oci::{BuildConfig, Dockerfile, Instruction};
+pub use oci::{BuildConfig, BuildRunPoolConfig, Dockerfile, Instruction};
 
 #[cfg(feature = "compose")]
 pub use compose::{ComposeProject, HealthCheckSpec};

--- a/src/runtime/src/oci/build/dockerfile/mod.rs
+++ b/src/runtime/src/oci/build/dockerfile/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Parses a Dockerfile into a sequence of build instructions.
 //! Supports line continuations (`\`), comments, and both shell and JSON
-//! (exec) forms for CMD/ENTRYPOINT.
+//! (exec) forms for RUN/CMD/ENTRYPOINT.
 
 use a3s_box_core::error::{BoxError, Result};
 
@@ -18,10 +18,12 @@ pub enum Instruction {
         image: String,
         alias: Option<String>,
     },
-    /// `RUN [--mount=type=cache,...] <command>` (shell form)
+    /// `RUN [--mount=type=cache|bind|tmpfs,...] <command>` (shell or exec form)
     Run {
-        command: String,
+        command: RunCommand,
         cache_mounts: Vec<RunCacheMount>,
+        bind_mounts: Vec<RunBindMount>,
+        tmpfs_mounts: Vec<RunTmpfsMount>,
     },
     /// `COPY [--from=<stage>] [--chown=user[:group]] <src>... <dst>`
     Copy {
@@ -75,11 +77,65 @@ pub enum Instruction {
     Volume { paths: Vec<String> },
 }
 
+/// Dockerfile RUN command form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunCommand {
+    /// Shell form: `RUN echo hello`.
+    Shell(String),
+    /// Exec form: `RUN ["echo", "hello"]`.
+    Exec(Vec<String>),
+}
+
 /// Supported subset of Docker BuildKit `RUN --mount=...`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunCacheMount {
     pub raw: String,
+    pub id: Option<String>,
+    /// Optional source stage/image used to seed a new cache directory.
+    pub from: Option<String>,
+    /// Source path inside `from`; defaults to root.
+    pub source: String,
+    pub sharing: RunCacheSharing,
+    /// Optional mode for the cache mount root, parsed as octal.
+    pub mode: Option<u32>,
+    /// Optional owner uid for the cache mount root.
+    pub uid: Option<u32>,
+    /// Optional owner gid for the cache mount root.
+    pub gid: Option<u32>,
     pub target: String,
+}
+
+/// Supported subset of Docker BuildKit `RUN --mount=type=bind`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunBindMount {
+    pub raw: String,
+    /// Optional source stage/index. `None` means the build context.
+    pub from: Option<String>,
+    /// Source path inside the build context or source stage. Defaults to root.
+    pub source: String,
+    /// Target path inside the build rootfs; relative targets resolve from WORKDIR.
+    pub target: String,
+    /// `rw`/`readwrite` allows writes during RUN. Like BuildKit, writes are
+    /// discarded after the RUN and are not committed into the image layer.
+    pub read_write: bool,
+}
+
+/// Supported subset of Docker BuildKit `RUN --mount=type=tmpfs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunTmpfsMount {
+    pub raw: String,
+    /// Target path inside the build rootfs; relative targets resolve from WORKDIR.
+    pub target: String,
+}
+
+/// Supported cache sharing behavior for `RUN --mount=type=cache`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunCacheSharing {
+    /// Docker/BuildKit default. The warm-pool overlay persists the shared cache
+    /// but serializes hydrate/publish for one key to avoid writeback races.
+    Shared,
+    /// Serialize writers for the same cache key.
+    Locked,
 }
 
 /// Parsed Dockerfile: a list of instructions in order.

--- a/src/runtime/src/oci/build/dockerfile/parsers.rs
+++ b/src/runtime/src/oci/build/dockerfile/parsers.rs
@@ -3,7 +3,10 @@
 use a3s_box_core::error::{BoxError, Result};
 
 use super::utils::{parse_duration_secs, parse_json_array, shell_split, unquote};
-use super::{split_first_word, Instruction, RunCacheMount};
+use super::{
+    split_first_word, Instruction, RunBindMount, RunCacheMount, RunCacheSharing, RunCommand,
+    RunTmpfsMount,
+};
 
 pub(super) fn parse_from(rest: &str, line_num: usize) -> Result<Instruction> {
     if rest.is_empty() {
@@ -32,32 +35,73 @@ pub(super) fn parse_run(rest: &str, line_num: usize) -> Result<Instruction> {
         )));
     }
 
-    if rest.starts_with('[') {
-        return Err(BoxError::BuildError(format!(
-            "Line {}: RUN exec form is not supported yet; use shell form",
-            line_num
-        )));
-    }
-
-    let (cache_mounts, command) = parse_run_options(rest, line_num)?;
+    let options = parse_run_options(rest, line_num)?;
+    let command = options.command;
+    let command = if command.starts_with('[') {
+        let exec = parse_json_array(command, line_num)?;
+        if exec.is_empty() {
+            return Err(BoxError::BuildError(format!(
+                "Line {}: RUN exec form requires at least one argument",
+                line_num
+            )));
+        }
+        RunCommand::Exec(exec)
+    } else {
+        RunCommand::Shell(command.to_string())
+    };
 
     Ok(Instruction::Run {
-        command: command.to_string(),
-        cache_mounts,
+        command,
+        cache_mounts: options.cache_mounts,
+        bind_mounts: options.bind_mounts,
+        tmpfs_mounts: options.tmpfs_mounts,
     })
 }
 
-fn parse_run_options(rest: &str, line_num: usize) -> Result<(Vec<RunCacheMount>, &str)> {
+struct RunOptions<'a> {
+    cache_mounts: Vec<RunCacheMount>,
+    bind_mounts: Vec<RunBindMount>,
+    tmpfs_mounts: Vec<RunTmpfsMount>,
+    command: &'a str,
+}
+
+fn parse_run_options(rest: &str, line_num: usize) -> Result<RunOptions<'_>> {
     let mut remaining = rest.trim_start();
     let mut cache_mounts = Vec::new();
+    let mut bind_mounts = Vec::new();
+    let mut tmpfs_mounts = Vec::new();
 
     while remaining.starts_with("--") {
         let (flag, tail) = split_first_word(remaining);
         if let Some(spec) = flag.strip_prefix("--mount=") {
-            cache_mounts.push(parse_run_cache_mount(flag, spec, line_num)?);
+            match run_mount_type(flag, spec, line_num)? {
+                "cache" => cache_mounts.push(parse_run_cache_mount(flag, spec, line_num)?),
+                "bind" => bind_mounts.push(parse_run_bind_mount(flag, spec, line_num)?),
+                "tmpfs" => tmpfs_mounts.push(parse_run_tmpfs_mount(flag, spec, line_num)?),
+                other => {
+                    return Err(BoxError::BuildError(format!(
+                        "Line {}: RUN mount '{}' is not supported yet; only type=cache, type=bind, and type=tmpfs are supported (got type={})",
+                        line_num, flag, other
+                    )));
+                }
+            }
+        } else if let Some(network) = flag.strip_prefix("--network=") {
+            if network != "default" {
+                return Err(BoxError::BuildError(format!(
+                    "Line {}: RUN option '--network={}' is not supported yet by the warm-pool build path; only --network=default is supported",
+                    line_num, network
+                )));
+            }
+        } else if let Some(security) = flag.strip_prefix("--security=") {
+            if security != "sandbox" {
+                return Err(BoxError::BuildError(format!(
+                    "Line {}: RUN option '--security={}' is not supported yet by the warm-pool build path; only --security=sandbox is supported",
+                    line_num, security
+                )));
+            }
         } else {
             return Err(BoxError::BuildError(format!(
-                "Line {}: RUN option '{}' is not supported yet; only BuildKit cache mounts (--mount=type=cache,...) are supported",
+                "Line {}: RUN option '{}' is not supported yet; only BuildKit cache/bind/tmpfs mounts plus --network=default and --security=sandbox are supported",
                 line_num, flag
             )));
         }
@@ -71,11 +115,38 @@ fn parse_run_options(rest: &str, line_num: usize) -> Result<(Vec<RunCacheMount>,
         )));
     }
 
-    Ok((cache_mounts, remaining))
+    Ok(RunOptions {
+        cache_mounts,
+        bind_mounts,
+        tmpfs_mounts,
+        command: remaining,
+    })
+}
+
+fn run_mount_type<'a>(raw: &str, spec: &'a str, line_num: usize) -> Result<&'a str> {
+    for part in spec.split(',') {
+        let Some((key, value)) = part.split_once('=') else {
+            continue;
+        };
+        if key == "type" {
+            return Ok(value);
+        }
+    }
+    Err(BoxError::BuildError(format!(
+        "Line {}: RUN mount '{}' requires type=cache, type=bind, or type=tmpfs",
+        line_num, raw
+    )))
 }
 
 fn parse_run_cache_mount(raw: &str, spec: &str, line_num: usize) -> Result<RunCacheMount> {
     let mut mount_type = None;
+    let mut id = None;
+    let mut from = None;
+    let mut source = None;
+    let mut sharing = None;
+    let mut mode = None;
+    let mut uid = None;
+    let mut gid = None;
     let mut target = None;
 
     for part in spec.split(',') {
@@ -87,8 +158,35 @@ fn parse_run_cache_mount(raw: &str, spec: &str, line_num: usize) -> Result<RunCa
         })?;
         match key {
             "type" => mount_type = Some(value),
+            "id" => id = Some(value),
+            "from" => from = Some(value),
+            "source" | "src" => source = Some(value),
+            "mode" => mode = Some(parse_run_cache_mount_mode(value, raw, line_num)?),
+            "uid" => uid = Some(parse_run_cache_mount_id("uid", value, raw, line_num)?),
+            "gid" => gid = Some(parse_run_cache_mount_id("gid", value, raw, line_num)?),
+            "sharing" => match value {
+                "shared" => sharing = Some(RunCacheSharing::Shared),
+                "locked" => sharing = Some(RunCacheSharing::Locked),
+                "private" => {
+                    return Err(BoxError::BuildError(format!(
+                        "Line {}: RUN cache mount sharing='private' is not supported yet by the warm-pool build path",
+                        line_num
+                    )));
+                }
+                _ => {
+                    return Err(BoxError::BuildError(format!(
+                        "Line {}: Invalid RUN cache mount sharing value '{}'",
+                        line_num, value
+                    )));
+                }
+            },
             "target" | "dst" | "destination" => target = Some(value),
-            _ => {}
+            _ => {
+                return Err(BoxError::BuildError(format!(
+                    "Line {}: RUN cache mount option '{}=' is not supported",
+                    line_num, key
+                )));
+            }
         }
     }
 
@@ -106,6 +204,16 @@ fn parse_run_cache_mount(raw: &str, spec: &str, line_num: usize) -> Result<RunCa
         )));
     };
 
+    let sharing = sharing.unwrap_or(RunCacheSharing::Shared);
+
+    let from = from.filter(|from| !from.is_empty()).map(str::to_string);
+    if source.is_some() && from.is_none() {
+        return Err(BoxError::BuildError(format!(
+            "Line {}: RUN cache mount source= requires from=<stage-or-image>",
+            line_num
+        )));
+    }
+
     if !target.starts_with('/') {
         return Err(BoxError::BuildError(format!(
             "Line {}: RUN cache mount target '{}' must be absolute",
@@ -115,7 +223,163 @@ fn parse_run_cache_mount(raw: &str, spec: &str, line_num: usize) -> Result<RunCa
 
     Ok(RunCacheMount {
         raw: raw.to_string(),
+        id: id.filter(|id| !id.is_empty()).map(str::to_string),
+        from,
+        source: source.unwrap_or(".").to_string(),
+        sharing,
+        mode,
+        uid,
+        gid,
         target: target.to_string(),
+    })
+}
+
+fn parse_run_bind_mount(raw: &str, spec: &str, line_num: usize) -> Result<RunBindMount> {
+    let mut mount_type = None;
+    let mut from = None;
+    let mut source = None;
+    let mut target = None;
+    let mut read_write = false;
+
+    for part in spec.split(',') {
+        if let Some((key, value)) = part.split_once('=') {
+            match key {
+                "type" => mount_type = Some(value),
+                "from" => from = Some(value),
+                "source" | "src" => source = Some(value),
+                "target" | "dst" | "destination" => target = Some(value),
+                "rw" | "readwrite" => {
+                    read_write = parse_bool_mount_flag(key, value, raw, line_num)?;
+                }
+                _ => {
+                    return Err(BoxError::BuildError(format!(
+                        "Line {}: RUN bind mount option '{}=' is not supported",
+                        line_num, key
+                    )));
+                }
+            }
+        } else {
+            match part {
+                "rw" | "readwrite" => read_write = true,
+                _ => {
+                    return Err(BoxError::BuildError(format!(
+                        "Line {}: RUN bind mount option '{}' is not supported",
+                        line_num, part
+                    )));
+                }
+            }
+        }
+    }
+
+    if mount_type != Some("bind") {
+        return Err(BoxError::BuildError(format!(
+            "Line {}: RUN bind mount '{}' has invalid type",
+            line_num, raw
+        )));
+    }
+
+    let Some(target) = target.filter(|target| !target.is_empty()) else {
+        return Err(BoxError::BuildError(format!(
+            "Line {}: RUN bind mount '{}' requires a target= path",
+            line_num, raw
+        )));
+    };
+
+    Ok(RunBindMount {
+        raw: raw.to_string(),
+        from: from.filter(|from| !from.is_empty()).map(str::to_string),
+        source: source.unwrap_or(".").to_string(),
+        target: target.to_string(),
+        read_write,
+    })
+}
+
+fn parse_run_tmpfs_mount(raw: &str, spec: &str, line_num: usize) -> Result<RunTmpfsMount> {
+    let mut mount_type = None;
+    let mut target = None;
+
+    for part in spec.split(',') {
+        let (key, value) = part.split_once('=').ok_or_else(|| {
+            BoxError::BuildError(format!(
+                "Line {}: Invalid RUN tmpfs mount option '{}'",
+                line_num, raw
+            ))
+        })?;
+        match key {
+            "type" => mount_type = Some(value),
+            "target" | "dst" | "destination" => target = Some(value),
+            "size" => {
+                return Err(BoxError::BuildError(format!(
+                    "Line {}: RUN tmpfs mount option 'size=' is not supported yet by the warm-pool build path",
+                    line_num
+                )));
+            }
+            _ => {
+                return Err(BoxError::BuildError(format!(
+                    "Line {}: RUN tmpfs mount option '{}=' is not supported",
+                    line_num, key
+                )));
+            }
+        }
+    }
+
+    if mount_type != Some("tmpfs") {
+        return Err(BoxError::BuildError(format!(
+            "Line {}: RUN tmpfs mount '{}' has invalid type",
+            line_num, raw
+        )));
+    }
+
+    let Some(target) = target.filter(|target| !target.is_empty()) else {
+        return Err(BoxError::BuildError(format!(
+            "Line {}: RUN tmpfs mount '{}' requires a target= path",
+            line_num, raw
+        )));
+    };
+
+    Ok(RunTmpfsMount {
+        raw: raw.to_string(),
+        target: target.to_string(),
+    })
+}
+
+fn parse_bool_mount_flag(key: &str, value: &str, raw: &str, line_num: usize) -> Result<bool> {
+    match value {
+        "1" | "true" | "True" | "TRUE" => Ok(true),
+        "0" | "false" | "False" | "FALSE" => Ok(false),
+        _ => Err(BoxError::BuildError(format!(
+            "Line {}: RUN mount '{}' has invalid boolean {}='{}'",
+            line_num, raw, key, value
+        ))),
+    }
+}
+
+fn parse_run_cache_mount_mode(value: &str, raw: &str, line_num: usize) -> Result<u32> {
+    let value = value
+        .strip_prefix("0o")
+        .or_else(|| value.strip_prefix("0O"))
+        .unwrap_or(value);
+    let mode = u32::from_str_radix(value, 8).map_err(|_| {
+        BoxError::BuildError(format!(
+            "Line {}: RUN cache mount '{}' has invalid octal mode '{}'",
+            line_num, raw, value
+        ))
+    })?;
+    if mode > 0o7777 {
+        return Err(BoxError::BuildError(format!(
+            "Line {}: RUN cache mount '{}' mode '{}' exceeds 07777",
+            line_num, raw, value
+        )));
+    }
+    Ok(mode)
+}
+
+fn parse_run_cache_mount_id(key: &str, value: &str, raw: &str, line_num: usize) -> Result<u32> {
+    value.parse::<u32>().map_err(|_| {
+        BoxError::BuildError(format!(
+            "Line {}: RUN cache mount '{}' has invalid {} '{}'",
+            line_num, raw, key, value
+        ))
     })
 }
 

--- a/src/runtime/src/oci/build/dockerfile/tests.rs
+++ b/src/runtime/src/oci/build/dockerfile/tests.rs
@@ -72,26 +72,310 @@ mod tests {
         assert_eq!(
             result,
             Instruction::Run {
-                command: "apt-get update && apt-get install -y curl".to_string(),
+                command: RunCommand::Shell("apt-get update && apt-get install -y curl".to_string()),
                 cache_mounts: vec![],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
             }
         );
     }
 
     #[test]
+    fn test_parse_run_exec_form() {
+        let result = parsers::parse_run(r#"["/bin/sh", "-c", "echo exec > /out"]"#, 1).unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Exec(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    "echo exec > /out".to_string(),
+                ]),
+                cache_mounts: vec![],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_exec_form_empty_rejected() {
+        let err = parsers::parse_run("[]", 1).unwrap_err().to_string();
+        assert!(err.contains("requires at least one argument"));
+    }
+
+    #[test]
+    fn test_parse_run_default_network_and_security_options() {
+        let result =
+            parsers::parse_run("--network=default --security=sandbox echo hello", 1).unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("echo hello".to_string()),
+                cache_mounts: vec![],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_rejects_non_default_network_and_security_options() {
+        let err = parsers::parse_run("--network=none echo hello", 1)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--network=none"));
+        assert!(err.contains("only --network=default"));
+
+        let err = parsers::parse_run("--security=insecure echo hello", 1)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--security=insecure"));
+        assert!(err.contains("only --security=sandbox"));
+    }
+
+    #[test]
     fn test_parse_run_buildkit_cache_mount() {
+        let result = parsers::parse_run(
+            "--mount=type=cache,sharing=locked,target=/root/.cache pnpm install",
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("pnpm install".to_string()),
+                cache_mounts: vec![RunCacheMount {
+                    raw: "--mount=type=cache,sharing=locked,target=/root/.cache".to_string(),
+                    id: None,
+                    from: None,
+                    source: ".".to_string(),
+                    sharing: RunCacheSharing::Locked,
+                    mode: None,
+                    uid: None,
+                    gid: None,
+                    target: "/root/.cache".to_string(),
+                }],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_id() {
+        let result = parsers::parse_run(
+            "--mount=type=cache,id=pnpm,sharing=locked,target=/root/.cache pnpm install",
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("pnpm install".to_string()),
+                cache_mounts: vec![RunCacheMount {
+                    raw: "--mount=type=cache,id=pnpm,sharing=locked,target=/root/.cache"
+                        .to_string(),
+                    id: Some("pnpm".to_string()),
+                    from: None,
+                    source: ".".to_string(),
+                    sharing: RunCacheSharing::Locked,
+                    mode: None,
+                    uid: None,
+                    gid: None,
+                    target: "/root/.cache".to_string(),
+                }],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_sharing_locked() {
+        let result = parsers::parse_run(
+            "--mount=type=cache,id=apt,sharing=locked,target=/var/cache/apt apt-get update",
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("apt-get update".to_string()),
+                cache_mounts: vec![RunCacheMount {
+                    raw: "--mount=type=cache,id=apt,sharing=locked,target=/var/cache/apt"
+                        .to_string(),
+                    id: Some("apt".to_string()),
+                    from: None,
+                    source: ".".to_string(),
+                    sharing: RunCacheSharing::Locked,
+                    mode: None,
+                    uid: None,
+                    gid: None,
+                    target: "/var/cache/apt".to_string(),
+                }],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_mode_uid_gid() {
+        let result = parsers::parse_run(
+            "--mount=type=cache,id=apt,sharing=locked,mode=0750,uid=1000,gid=1001,target=/var/cache/apt apt-get update",
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("apt-get update".to_string()),
+                cache_mounts: vec![RunCacheMount {
+                    raw: "--mount=type=cache,id=apt,sharing=locked,mode=0750,uid=1000,gid=1001,target=/var/cache/apt"
+                        .to_string(),
+                    id: Some("apt".to_string()),
+                    from: None,
+                    source: ".".to_string(),
+                    sharing: RunCacheSharing::Locked,
+                    mode: Some(0o750),
+                    uid: Some(1000),
+                    gid: Some(1001),
+                    target: "/var/cache/apt".to_string(),
+                }],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_rejects_invalid_mode() {
+        let err = parsers::parse_run(
+            "--mount=type=cache,sharing=locked,mode=0999,target=/root/.cache pnpm install",
+            1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("invalid octal mode"));
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_from_source() {
+        let result = parsers::parse_run(
+            "--mount=type=cache,id=seeded,sharing=locked,from=builder,source=/seed,target=/root/.cache pnpm install",
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("pnpm install".to_string()),
+                cache_mounts: vec![RunCacheMount {
+                    raw: "--mount=type=cache,id=seeded,sharing=locked,from=builder,source=/seed,target=/root/.cache"
+                        .to_string(),
+                    id: Some("seeded".to_string()),
+                    from: Some("builder".to_string()),
+                    source: "/seed".to_string(),
+                    sharing: RunCacheSharing::Locked,
+                    mode: None,
+                    uid: None,
+                    gid: None,
+                    target: "/root/.cache".to_string(),
+                }],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_rejects_source_without_from() {
+        let err = parsers::parse_run(
+            "--mount=type=cache,sharing=locked,source=/seed,target=/root/.cache pnpm install",
+            1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("source="));
+        assert!(err.contains("requires from="));
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_rejects_unknown_option() {
+        let err = parsers::parse_run(
+            "--mount=type=cache,sharing=locked,foo=bar,target=/root/.cache pnpm install",
+            1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("foo="));
+        assert!(err.contains("not supported"));
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_sharing_shared() {
+        let result = parsers::parse_run(
+            "--mount=type=cache,sharing=shared,target=/root/.cache pnpm install",
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("pnpm install".to_string()),
+                cache_mounts: vec![RunCacheMount {
+                    raw: "--mount=type=cache,sharing=shared,target=/root/.cache".to_string(),
+                    id: None,
+                    from: None,
+                    source: ".".to_string(),
+                    sharing: RunCacheSharing::Shared,
+                    mode: None,
+                    uid: None,
+                    gid: None,
+                    target: "/root/.cache".to_string(),
+                }],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_omitted_sharing_defaults_to_shared() {
         let result =
             parsers::parse_run("--mount=type=cache,target=/root/.cache pnpm install", 1).unwrap();
         assert_eq!(
             result,
             Instruction::Run {
-                command: "pnpm install".to_string(),
+                command: RunCommand::Shell("pnpm install".to_string()),
                 cache_mounts: vec![RunCacheMount {
                     raw: "--mount=type=cache,target=/root/.cache".to_string(),
+                    id: None,
+                    from: None,
+                    source: ".".to_string(),
+                    sharing: RunCacheSharing::Shared,
+                    mode: None,
+                    uid: None,
+                    gid: None,
                     target: "/root/.cache".to_string(),
                 }],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
             }
         );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_cache_mount_rejects_private_sharing() {
+        let err = parsers::parse_run(
+            "--mount=type=cache,sharing=private,target=/root/.cache pnpm install",
+            1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("sharing='private'"));
+        assert!(err.contains("not supported yet"));
     }
 
     #[test]
@@ -99,15 +383,129 @@ mod tests {
         let err = parsers::parse_run("--mount=type=secret,id=npmrc npm install", 1)
             .unwrap_err()
             .to_string();
-        assert!(err.contains("only type=cache is supported"));
+        assert!(err.contains("only type=cache, type=bind, and type=tmpfs are supported"));
     }
 
     #[test]
-    fn test_parse_run_exec_form_rejected() {
-        let err = parsers::parse_run(r#"["echo", "hello"]"#, 1)
+    fn test_parse_run_buildkit_bind_mount_defaults_to_context_root() {
+        let result = parsers::parse_run("--mount=type=bind,target=. go build ./...", 1).unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("go build ./...".to_string()),
+                cache_mounts: vec![],
+                bind_mounts: vec![RunBindMount {
+                    from: None,
+                    raw: "--mount=type=bind,target=.".to_string(),
+                    source: ".".to_string(),
+                    target: ".".to_string(),
+                    read_write: false,
+                }],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_bind_mount_source_and_rw() {
+        let result = parsers::parse_run(
+            "--mount=type=bind,source=src,target=/mnt,readwrite=true make",
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("make".to_string()),
+                cache_mounts: vec![],
+                bind_mounts: vec![RunBindMount {
+                    from: None,
+                    raw: "--mount=type=bind,source=src,target=/mnt,readwrite=true".to_string(),
+                    source: "src".to_string(),
+                    target: "/mnt".to_string(),
+                    read_write: true,
+                }],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_bind_mount_from_stage() {
+        let result = parsers::parse_run(
+            "--mount=type=bind,from=builder,source=/src,target=/mnt make",
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("make".to_string()),
+                cache_mounts: vec![],
+                bind_mounts: vec![RunBindMount {
+                    from: Some("builder".to_string()),
+                    raw: "--mount=type=bind,from=builder,source=/src,target=/mnt".to_string(),
+                    source: "/src".to_string(),
+                    target: "/mnt".to_string(),
+                    read_write: false,
+                }],
+                tmpfs_mounts: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_tmpfs_mount() {
+        let result = parsers::parse_run("--mount=type=tmpfs,target=/tmp make test", 1).unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Shell("make test".to_string()),
+                cache_mounts: vec![],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![RunTmpfsMount {
+                    raw: "--mount=type=tmpfs,target=/tmp".to_string(),
+                    target: "/tmp".to_string(),
+                }],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_run_buildkit_tmpfs_mount_rejects_size() {
+        let err = parsers::parse_run("--mount=type=tmpfs,target=/tmp,size=64m make test", 1)
             .unwrap_err()
             .to_string();
-        assert!(err.contains("RUN exec form is not supported yet"));
+        assert!(err.contains("size="));
+        assert!(err.contains("not supported yet"));
+    }
+
+    #[test]
+    fn test_parse_run_exec_form_with_cache_mount() {
+        let result = parsers::parse_run(
+            r#"--mount=type=cache,sharing=locked,target=/cache ["echo", "hello"]"#,
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Instruction::Run {
+                command: RunCommand::Exec(vec!["echo".to_string(), "hello".to_string()]),
+                cache_mounts: vec![RunCacheMount {
+                    raw: "--mount=type=cache,sharing=locked,target=/cache".to_string(),
+                    id: None,
+                    from: None,
+                    source: ".".to_string(),
+                    sharing: RunCacheSharing::Locked,
+                    mode: None,
+                    uid: None,
+                    gid: None,
+                    target: "/cache".to_string(),
+                }],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
+            }
+        );
     }
 
     #[test]
@@ -580,7 +978,11 @@ CMD ["app.py"]
         let content = "FROM alpine:3.19\nRUN apk add --no-cache \\\n    curl \\\n    wget";
         let df = Dockerfile::parse(content).unwrap();
         assert_eq!(df.instructions.len(), 2);
-        if let Instruction::Run { command, .. } = &df.instructions[1] {
+        if let Instruction::Run {
+            command: RunCommand::Shell(command),
+            ..
+        } = &df.instructions[1]
+        {
             assert!(command.contains("curl"));
             assert!(command.contains("wget"));
         } else {
@@ -930,8 +1332,10 @@ CMD ["app.py"]
             result,
             Instruction::OnBuild {
                 instruction: Box::new(Instruction::Run {
-                    command: "echo hello".to_string(),
+                    command: RunCommand::Shell("echo hello".to_string()),
                     cache_mounts: vec![],
+                    bind_mounts: vec![],
+                    tmpfs_mounts: vec![],
                 }),
             }
         );
@@ -1112,8 +1516,10 @@ CMD ["app.py"]
         assert_eq!(
             instruction,
             Instruction::Run {
-                command: "echo ready".to_string(),
+                command: RunCommand::Shell("echo ready".to_string()),
                 cache_mounts: vec![],
+                bind_mounts: vec![],
+                tmpfs_mounts: vec![],
             }
         );
     }

--- a/src/runtime/src/oci/build/engine/handlers.rs
+++ b/src/runtime/src/oci/build/engine/handlers.rs
@@ -4,12 +4,15 @@ use std::path::{Path, PathBuf};
 
 use a3s_box_core::error::{BoxError, Result};
 
-use super::super::dockerfile::{Instruction, RunCacheMount};
+use super::super::dockerfile::{
+    Instruction, RunBindMount, RunCacheMount, RunCommand, RunTmpfsMount,
+};
 use super::super::dockerignore::DockerIgnore;
 use super::super::layer::{
     create_layer_from_dir_with_chown, create_layer_with_chown, create_layer_with_deletions,
-    LayerInfo,
+    sha256_bytes, LayerInfo,
 };
+use super::stages::resolve_stage_rootfs;
 use super::utils::{
     assert_within, copy_dir_filtered, expand_args, extract_tar_to_dst, is_tar_archive,
     reject_path_traversal, resolve_chown, resolve_path,
@@ -242,8 +245,12 @@ pub(super) fn handle_copy(
 /// Returns Some(LayerInfo) if a layer was created, None if skipped.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn handle_run(
-    command: &str,
+    command: &RunCommand,
     cache_mounts: &[RunCacheMount],
+    bind_mounts: &[RunBindMount],
+    tmpfs_mounts: &[RunTmpfsMount],
+    context_dir: &Path,
+    completed_stages: &[(Option<String>, PathBuf)],
     rootfs_dir: &Path,
     layers_dir: &Path,
     workdir: &str,
@@ -251,6 +258,7 @@ pub(super) fn handle_run(
     shell: &[String],
     layer_index: usize,
     quiet: bool,
+    ignore: Option<&DockerIgnore>,
 ) -> Result<Option<LayerInfo>> {
     #[cfg(target_os = "macos")]
     {
@@ -266,6 +274,10 @@ pub(super) fn handle_run(
         handle_run_on_host_unsafe(
             command,
             cache_mounts,
+            bind_mounts,
+            tmpfs_mounts,
+            context_dir,
+            completed_stages,
             rootfs_dir,
             layers_dir,
             workdir,
@@ -273,6 +285,7 @@ pub(super) fn handle_run(
             shell,
             layer_index,
             quiet,
+            ignore,
         )
     }
 
@@ -281,57 +294,54 @@ pub(super) fn handle_run(
     {
         use super::super::layer::DirSnapshot;
 
-        validate_linux_run_preconditions(rootfs_dir, shell, linux_effective_uid())?;
+        validate_linux_run_preconditions(rootfs_dir, command, shell, linux_effective_uid())?;
         prepare_linux_run_filesystem(rootfs_dir)?;
         ensure_linux_run_workdir(rootfs_dir, workdir)?;
         ensure_run_cache_mount_targets(rootfs_dir, cache_mounts)?;
 
         let before = DirSnapshot::capture(rootfs_dir)?;
+        let bind_mount_guard = RunBindMountOverlays::activate(
+            rootfs_dir,
+            context_dir,
+            completed_stages,
+            bind_mounts,
+            workdir,
+            ignore,
+        )?;
+        let tmpfs_mount_guard = RunTmpfsMountOverlays::activate(rootfs_dir, tmpfs_mounts, workdir)?;
         let run_mounts = LinuxRunMounts::mount(rootfs_dir)?;
-        let run_mounts = run_mounts.with_cache_mounts(rootfs_dir, cache_mounts)?;
+        let run_mounts =
+            run_mounts.with_cache_mounts(rootfs_dir, cache_mounts, completed_stages)?;
 
-        // Build the command using the configured shell
-        let mut cmd = std::process::Command::new("chroot");
-        cmd.arg(rootfs_dir);
-        if shell.len() >= 2 {
-            cmd.arg(&shell[0]);
-            for arg in &shell[1..] {
-                cmd.arg(arg);
-            }
-        } else if shell.len() == 1 {
-            cmd.arg(&shell[0]);
-        } else {
-            cmd.arg("/bin/sh");
-            cmd.arg("-c");
-        }
-        let run_command = shell_command_in_workdir(workdir, command);
-        cmd.arg(&run_command);
-
-        // Set environment
-        cmd.env_clear();
-        cmd.env(
-            "PATH",
-            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        );
-        cmd.env("HOME", "/root");
-        for (key, value) in env {
-            cmd.env(key, value);
-        }
-
-        let output = cmd
-            .output()
-            .map_err(|e| BoxError::BuildError(format!("Failed to execute RUN command: {}", e)))?;
+        let output = execute_linux_run_command(rootfs_dir, command, workdir, env, shell)?;
 
         if !output.status.success() {
-            return Err(run_command_failed_error(command, &output));
+            return Err(run_command_failed_error(
+                &run_command_to_string(command),
+                &output,
+            ));
         }
         print_run_output(&output, quiet);
         run_mounts.unmount()?;
+        tmpfs_mount_guard.restore()?;
+        bind_mount_guard.restore()?;
 
         // Capture diff
         let after = DirSnapshot::capture(rootfs_dir)?;
-        let changed = before.diff(&after);
-        let deleted = before.deletions(&after);
+        let changed = filter_run_mount_paths(
+            before.diff(&after),
+            cache_mounts,
+            bind_mounts,
+            tmpfs_mounts,
+            workdir,
+        );
+        let deleted = filter_run_mount_paths(
+            before.deletions(&after),
+            cache_mounts,
+            bind_mounts,
+            tmpfs_mounts,
+            workdir,
+        );
 
         if changed.is_empty() && deleted.is_empty() {
             return Ok(None);
@@ -349,17 +359,160 @@ pub(super) fn handle_run(
             rootfs_dir,
             layers_dir,
             cache_mounts,
+            bind_mounts,
+            tmpfs_mounts,
+            context_dir,
+            completed_stages,
             workdir,
             env,
             shell,
             layer_index,
             quiet,
+            ignore,
         );
         Err(BoxError::BuildError(format!(
             "Dockerfile RUN is not supported on this platform yet because isolated Linux build execution is not implemented: {}",
-            command
+            run_command_to_string(command)
         )))
     }
+}
+
+/// Handle RUN through a warm-pool VM lease.
+///
+/// The build stage rootfs is mounted into the leased helper VM and the command
+/// executes with `ExecRequest.rootfs`, so mutations land back in `rootfs_dir`.
+#[cfg(feature = "pool")]
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn handle_run_with_pool(
+    command: &RunCommand,
+    cache_mounts: &[RunCacheMount],
+    bind_mounts: &[RunBindMount],
+    tmpfs_mounts: &[RunTmpfsMount],
+    context_dir: &Path,
+    completed_stages: &[(Option<String>, PathBuf)],
+    rootfs_dir: &Path,
+    layers_dir: &Path,
+    workdir: &str,
+    env: &[(String, String)],
+    shell: &[String],
+    user: Option<&str>,
+    layer_index: usize,
+    quiet: bool,
+    session: &super::BuildRunPoolSession,
+    ignore: Option<&DockerIgnore>,
+) -> Result<Option<LayerInfo>> {
+    use super::super::layer::DirSnapshot;
+
+    validate_run_command_preconditions(rootfs_dir, command, shell)?;
+    prepare_pool_run_filesystem(rootfs_dir)?;
+    ensure_linux_run_workdir(rootfs_dir, workdir)?;
+    ensure_run_cache_mount_targets(rootfs_dir, cache_mounts)?;
+
+    let before = DirSnapshot::capture(rootfs_dir)?;
+    let bind_mount_guard = RunBindMountOverlays::activate(
+        rootfs_dir,
+        context_dir,
+        completed_stages,
+        bind_mounts,
+        workdir,
+        ignore,
+    )?;
+    let tmpfs_mount_guard = RunTmpfsMountOverlays::activate(rootfs_dir, tmpfs_mounts, workdir)?;
+    let cache_mount_guard = PoolRunCacheMounts::activate_with_cache_root(
+        rootfs_dir,
+        cache_mounts,
+        &session.run_cache_dir,
+        completed_stages,
+    )?;
+    let output = match session
+        .lease
+        .exec(crate::pool::PoolLeaseExec {
+            cmd: build_pool_run_cmd(command, shell, workdir),
+            timeout_ns: Some(session.timeout_ns),
+            env: run_env_entries(env),
+            working_dir: build_pool_run_workdir(command, workdir),
+            rootfs: Some(session.guest_rootfs.clone()),
+            stdin: None,
+            user: user.map(str::to_string),
+        })
+        .await
+    {
+        Ok(output) => output,
+        Err(error) => {
+            cache_mount_guard.restore_without_sync()?;
+            tmpfs_mount_guard.restore()?;
+            bind_mount_guard.restore()?;
+            return Err(BoxError::BuildError(format!(
+                "Failed to execute RUN in warm pool: {error}"
+            )));
+        }
+    };
+
+    if output.exit_code != 0 {
+        cache_mount_guard.restore_without_sync()?;
+        tmpfs_mount_guard.restore()?;
+        bind_mount_guard.restore()?;
+        return Err(run_command_failed_error_parts(
+            &run_command_to_string(command),
+            output.exit_code,
+            &output.stdout,
+            &output.stderr,
+        ));
+    }
+    cache_mount_guard.restore()?;
+    tmpfs_mount_guard.restore()?;
+    bind_mount_guard.restore()?;
+    print_output_parts(&output.stdout, &output.stderr, quiet);
+
+    let after = DirSnapshot::capture(rootfs_dir)?;
+    let changed = filter_run_mount_paths(
+        before.diff(&after),
+        cache_mounts,
+        bind_mounts,
+        tmpfs_mounts,
+        workdir,
+    );
+    let deleted = filter_run_mount_paths(
+        before.deletions(&after),
+        cache_mounts,
+        bind_mounts,
+        tmpfs_mounts,
+        workdir,
+    );
+
+    if changed.is_empty() && deleted.is_empty() {
+        return Ok(None);
+    }
+
+    let layer_path = layers_dir.join(format!("layer_{}.tar.gz", layer_index));
+    let layer_info = create_layer_with_deletions(rootfs_dir, &changed, &deleted, &layer_path)?;
+    Ok(Some(layer_info))
+}
+
+#[cfg(not(feature = "pool"))]
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn handle_run_with_pool(
+    command: &RunCommand,
+    _cache_mounts: &[RunCacheMount],
+    _bind_mounts: &[RunBindMount],
+    _tmpfs_mounts: &[RunTmpfsMount],
+    _context_dir: &Path,
+    _completed_stages: &[(Option<String>, PathBuf)],
+    _rootfs_dir: &Path,
+    _layers_dir: &Path,
+    _workdir: &str,
+    _env: &[(String, String)],
+    _shell: &[String],
+    _user: Option<&str>,
+    _layer_index: usize,
+    _quiet: bool,
+    _session: &super::BuildRunPoolSession,
+    _ignore: Option<&DockerIgnore>,
+) -> Result<Option<LayerInfo>> {
+    Err(BoxError::BuildError(format!(
+        "Dockerfile RUN warm-pool execution requires the runtime 'pool' feature: {}",
+        run_command_to_string(command)
+    )))
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
@@ -390,23 +543,43 @@ fn shell_quote(value: &str) -> String {
     out
 }
 
-#[cfg(any(target_os = "linux", test))]
+#[cfg_attr(all(not(feature = "pool"), not(target_os = "linux")), allow(dead_code))]
+fn normalized_run_workdir(workdir: &str) -> &str {
+    if workdir.trim().is_empty() {
+        "/"
+    } else {
+        workdir
+    }
+}
+
+fn run_command_to_string(command: &RunCommand) -> String {
+    match command {
+        RunCommand::Shell(command) => command.clone(),
+        RunCommand::Exec(exec) => serde_json::to_string(exec).unwrap_or_else(|_| {
+            exec.iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(" ")
+        }),
+    }
+}
+
 fn linux_run_shell_path(shell: &[String]) -> &str {
     shell.first().map(String::as_str).unwrap_or("/bin/sh")
 }
 
-#[cfg(any(target_os = "linux", test))]
-fn validate_linux_run_preconditions(
+fn validate_run_command_preconditions(
     rootfs_dir: &Path,
+    command: &RunCommand,
     shell: &[String],
-    effective_uid: u32,
 ) -> Result<()> {
-    if effective_uid != 0 {
-        return Err(BoxError::BuildError(
-            "Dockerfile RUN on Linux requires root privileges because the current isolated build path uses chroot. Re-run as root or build on a root-capable builder.".to_string(),
-        ));
+    match command {
+        RunCommand::Shell(_) => validate_run_shell_preconditions(rootfs_dir, shell),
+        RunCommand::Exec(exec) => validate_run_exec_preconditions(rootfs_dir, exec),
     }
+}
 
+fn validate_run_shell_preconditions(rootfs_dir: &Path, shell: &[String]) -> Result<()> {
     let shell_path = linux_run_shell_path(shell);
     if !shell_path.starts_with('/') {
         return Err(BoxError::BuildError(format!(
@@ -415,7 +588,7 @@ fn validate_linux_run_preconditions(
         )));
     }
     let shell_in_rootfs = rootfs_dir.join(shell_path.trim_start_matches('/'));
-    if !shell_in_rootfs.exists() {
+    if std::fs::symlink_metadata(&shell_in_rootfs).is_err() {
         return Err(BoxError::BuildError(format!(
             "Dockerfile RUN shell '{}' was not found in rootfs at {}; the base image must contain the configured shell",
             shell_path,
@@ -426,12 +599,54 @@ fn validate_linux_run_preconditions(
     Ok(())
 }
 
+fn validate_run_exec_preconditions(rootfs_dir: &Path, exec: &[String]) -> Result<()> {
+    let executable = exec.first().ok_or_else(|| {
+        BoxError::BuildError("Dockerfile RUN exec form requires at least one argument".to_string())
+    })?;
+    if executable.is_empty() {
+        return Err(BoxError::BuildError(
+            "Dockerfile RUN exec form executable cannot be empty".to_string(),
+        ));
+    }
+    if executable.starts_with('/') {
+        let executable_in_rootfs = rootfs_dir.join(executable.trim_start_matches('/'));
+        if std::fs::symlink_metadata(&executable_in_rootfs).is_err() {
+            return Err(BoxError::BuildError(format!(
+                "Dockerfile RUN exec form executable '{}' was not found in rootfs at {}",
+                executable,
+                executable_in_rootfs.display()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn validate_linux_run_preconditions(
+    rootfs_dir: &Path,
+    command: &RunCommand,
+    shell: &[String],
+    effective_uid: u32,
+) -> Result<()> {
+    if effective_uid != 0 {
+        return Err(BoxError::BuildError(
+            "Dockerfile RUN on Linux requires root privileges because the current isolated build path uses chroot. Re-run as root or build on a root-capable builder.".to_string(),
+        ));
+    }
+
+    validate_run_command_preconditions(rootfs_dir, command, shell)
+}
+
 #[cfg(target_os = "linux")]
 fn linux_effective_uid() -> u32 {
     unsafe { libc::geteuid() }
 }
 
-#[cfg(any(target_os = "linux", test))]
+#[cfg_attr(
+    all(not(feature = "pool"), not(target_os = "linux"), not(test)),
+    allow(dead_code)
+)]
 fn ensure_linux_run_workdir(rootfs_dir: &Path, workdir: &str) -> Result<PathBuf> {
     let workdir = if workdir.trim().is_empty() {
         "/"
@@ -456,9 +671,128 @@ fn ensure_linux_run_workdir(rootfs_dir: &Path, workdir: &str) -> Result<PathBuf>
     Ok(workdir_path)
 }
 
+#[cfg_attr(all(not(feature = "pool"), not(test)), allow(dead_code))]
+fn build_run_shell_cmd(shell: &[String], workdir: &str, command: &str) -> Vec<String> {
+    let run_command = shell_command_in_workdir(workdir, command);
+    if shell.len() >= 2 {
+        let mut cmd = shell.to_vec();
+        cmd.push(run_command);
+        cmd
+    } else if shell.len() == 1 {
+        vec![shell[0].clone(), run_command]
+    } else {
+        vec!["/bin/sh".to_string(), "-c".to_string(), run_command]
+    }
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn build_pool_run_cmd(command: &RunCommand, shell: &[String], workdir: &str) -> Vec<String> {
+    match command {
+        RunCommand::Shell(command) => build_run_shell_cmd(shell, workdir, command),
+        RunCommand::Exec(exec) => exec.to_vec(),
+    }
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn build_pool_run_workdir(command: &RunCommand, workdir: &str) -> Option<String> {
+    match command {
+        RunCommand::Shell(_) => Some("/".to_string()),
+        RunCommand::Exec(_) => Some(normalized_run_workdir(workdir).to_string()),
+    }
+}
+
+#[cfg_attr(all(not(feature = "pool"), not(test)), allow(dead_code))]
+fn run_env_entries(env: &[(String, String)]) -> Vec<String> {
+    let mut entries = vec![
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string(),
+        "HOME=/root".to_string(),
+    ];
+    entries.extend(env.iter().map(|(key, value)| format!("{key}={value}")));
+    entries
+}
+
+#[cfg(target_os = "linux")]
+fn execute_linux_run_command(
+    rootfs_dir: &Path,
+    command: &RunCommand,
+    workdir: &str,
+    env: &[(String, String)],
+    shell: &[String],
+) -> Result<std::process::Output> {
+    match command {
+        RunCommand::Shell(command) => {
+            let mut cmd = std::process::Command::new("chroot");
+            cmd.arg(rootfs_dir);
+            if shell.len() >= 2 {
+                cmd.arg(&shell[0]);
+                for arg in &shell[1..] {
+                    cmd.arg(arg);
+                }
+            } else if shell.len() == 1 {
+                cmd.arg(&shell[0]);
+            } else {
+                cmd.arg("/bin/sh");
+                cmd.arg("-c");
+            }
+            let run_command = shell_command_in_workdir(workdir, command);
+            cmd.arg(&run_command);
+            configure_run_command_env(&mut cmd, env);
+            cmd.output()
+                .map_err(|e| BoxError::BuildError(format!("Failed to execute RUN command: {}", e)))
+        }
+        RunCommand::Exec(exec) => execute_linux_run_exec_form(rootfs_dir, exec, workdir, env),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn execute_linux_run_exec_form(
+    rootfs_dir: &Path,
+    exec: &[String],
+    workdir: &str,
+    env: &[(String, String)],
+) -> Result<std::process::Output> {
+    use std::os::unix::process::CommandExt;
+
+    validate_run_exec_preconditions(rootfs_dir, exec)?;
+    let mut cmd = std::process::Command::new(&exec[0]);
+    cmd.args(&exec[1..]);
+    configure_run_command_env(&mut cmd, env);
+
+    let rootfs = path_cstring(rootfs_dir, "RUN rootfs")?;
+    let workdir = std::ffi::CString::new(normalized_run_workdir(workdir))
+        .map_err(|_| BoxError::BuildError("Dockerfile RUN workdir contains NUL".to_string()))?;
+    unsafe {
+        cmd.pre_exec(move || {
+            if libc::chroot(rootfs.as_ptr()) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::chdir(workdir.as_ptr()) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    cmd.output()
+        .map_err(|e| BoxError::BuildError(format!("Failed to execute RUN exec form: {}", e)))
+}
+
+#[cfg(target_os = "linux")]
+fn configure_run_command_env(cmd: &mut std::process::Command, env: &[(String, String)]) {
+    cmd.env_clear();
+    cmd.env(
+        "PATH",
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    );
+    cmd.env("HOME", "/root");
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+}
+
 fn ensure_run_cache_mount_targets(rootfs_dir: &Path, cache_mounts: &[RunCacheMount]) -> Result<()> {
     for mount in cache_mounts {
-        let target = rootfs_dir.join(mount.target.trim_start_matches('/'));
+        let target = run_cache_mount_target(rootfs_dir, mount)?;
         std::fs::create_dir_all(&target).map_err(|e| {
             BoxError::BuildError(format!(
                 "Failed to create RUN cache mount target {}: {}",
@@ -470,17 +804,1000 @@ fn ensure_run_cache_mount_targets(rootfs_dir: &Path, cache_mounts: &[RunCacheMou
     Ok(())
 }
 
+fn run_bind_mount_source(
+    source_root: &Path,
+    source_label: &str,
+    mount: &RunBindMount,
+    ignore: Option<&DockerIgnore>,
+) -> Result<(PathBuf, PathBuf)> {
+    reject_path_traversal(&mount.source)?;
+    let rel = normalized_context_rel(&mount.source);
+    let source_path = source_root.join(&rel);
+    if !source_path.exists() {
+        return Err(BoxError::BuildError(format!(
+            "RUN bind mount source not found: {} (in {})",
+            mount.source, source_label
+        )));
+    }
+    assert_within(source_root, &source_path)?;
+    if let Some(ign) = ignore {
+        if !rel.as_os_str().is_empty() && ign.is_excluded(&rel) {
+            return Err(BoxError::BuildError(format!(
+                "RUN bind mount source not found: {} (excluded by .dockerignore)",
+                mount.source
+            )));
+        }
+    }
+    Ok((source_path, rel))
+}
+
+fn run_bind_mount_target(
+    rootfs_dir: &Path,
+    workdir: &str,
+    mount: &RunBindMount,
+) -> Result<(PathBuf, PathBuf)> {
+    let resolved = resolve_path(normalized_run_workdir(workdir), &mount.target);
+    reject_path_traversal(&resolved)?;
+    let rel = normalized_rootfs_rel(&resolved);
+    if rel.as_os_str().is_empty() {
+        return Err(BoxError::BuildError(format!(
+            "RUN bind mount target '{}' resolves to /, which is not supported by the warm-pool build overlay",
+            mount.target
+        )));
+    }
+    let target = rootfs_dir.join(&rel);
+    assert_within(rootfs_dir, &target)?;
+    Ok((target, rel))
+}
+
+fn run_tmpfs_mount_target(
+    rootfs_dir: &Path,
+    workdir: &str,
+    mount: &RunTmpfsMount,
+) -> Result<(PathBuf, PathBuf)> {
+    let resolved = resolve_path(normalized_run_workdir(workdir), &mount.target);
+    reject_path_traversal(&resolved)?;
+    let rel = normalized_rootfs_rel(&resolved);
+    if rel.as_os_str().is_empty() {
+        return Err(BoxError::BuildError(format!(
+            "RUN tmpfs mount target '{}' resolves to /, which is not supported by the warm-pool build overlay",
+            mount.target
+        )));
+    }
+    let target = rootfs_dir.join(&rel);
+    assert_within(rootfs_dir, &target)?;
+    Ok((target, rel))
+}
+
+fn normalized_context_rel(path: &str) -> PathBuf {
+    let trimmed = path.trim_start_matches('/');
+    if trimmed == "." {
+        PathBuf::new()
+    } else {
+        normalize_rel_components(Path::new(trimmed))
+    }
+}
+
+fn normalized_rootfs_rel(path: &str) -> PathBuf {
+    normalize_rel_components(Path::new(path.trim_start_matches('/')))
+}
+
+fn normalize_rel_components(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        if let std::path::Component::Normal(part) = component {
+            out.push(part);
+        }
+    }
+    out
+}
+
+fn copy_run_bind_mount_source(
+    source: &Path,
+    source_rel: &Path,
+    target: &Path,
+    ignore: Option<&DockerIgnore>,
+) -> Result<()> {
+    let meta = std::fs::symlink_metadata(source).map_err(|e| {
+        BoxError::BuildError(format!(
+            "Failed to inspect RUN bind mount source {}: {}",
+            source.display(),
+            e
+        ))
+    })?;
+
+    if meta.is_dir() {
+        copy_dir_filtered(source, target, source_rel, ignore)?;
+        return Ok(());
+    }
+
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to create RUN bind mount target parent {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+
+    if meta.file_type().is_symlink() {
+        copy_symlink(source, target)
+    } else {
+        std::fs::copy(source, target).map(|_| ()).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to copy RUN bind mount source {} to {}: {}",
+                source.display(),
+                target.display(),
+                e
+            ))
+        })
+    }
+}
+
+fn copy_symlink(source: &Path, target: &Path) -> Result<()> {
+    let link_target = std::fs::read_link(source).map_err(|e| {
+        BoxError::BuildError(format!(
+            "Failed to read RUN bind mount symlink {}: {}",
+            source.display(),
+            e
+        ))
+    })?;
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&link_target, target).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to create RUN bind mount symlink {} -> {}: {}",
+                target.display(),
+                link_target.display(),
+                e
+            ))
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(target, Vec::new()).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to create RUN bind mount symlink placeholder {} -> {}: {}",
+                target.display(),
+                link_target.display(),
+                e
+            ))
+        })
+    }
+}
+
+fn run_cache_mount_target(rootfs_dir: &Path, mount: &RunCacheMount) -> Result<PathBuf> {
+    reject_path_traversal(&mount.target)?;
+    let target = rootfs_dir.join(mount.target.trim_start_matches('/'));
+    assert_within(rootfs_dir, &target)?;
+    Ok(target)
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn filter_run_mount_paths(
+    paths: Vec<PathBuf>,
+    cache_mounts: &[RunCacheMount],
+    bind_mounts: &[RunBindMount],
+    tmpfs_mounts: &[RunTmpfsMount],
+    workdir: &str,
+) -> Vec<PathBuf> {
+    if cache_mounts.is_empty() && bind_mounts.is_empty() && tmpfs_mounts.is_empty() {
+        return paths;
+    }
+
+    let mut exact_paths = Vec::new();
+    let mut subtree_paths = Vec::new();
+    for mount in cache_mounts {
+        let mount_path = PathBuf::from(mount.target.trim_start_matches('/'));
+        subtree_paths.push(mount_path.clone());
+        for ancestor in mount_path.ancestors() {
+            if !ancestor.as_os_str().is_empty() {
+                exact_paths.push(ancestor.to_path_buf());
+            }
+        }
+    }
+    for mount in bind_mounts {
+        let resolved = resolve_path(normalized_run_workdir(workdir), &mount.target);
+        let mount_path = normalized_rootfs_rel(&resolved);
+        subtree_paths.push(mount_path.clone());
+        for ancestor in mount_path.ancestors() {
+            if !ancestor.as_os_str().is_empty() {
+                exact_paths.push(ancestor.to_path_buf());
+            }
+        }
+    }
+    for mount in tmpfs_mounts {
+        let resolved = resolve_path(normalized_run_workdir(workdir), &mount.target);
+        let mount_path = normalized_rootfs_rel(&resolved);
+        subtree_paths.push(mount_path.clone());
+        for ancestor in mount_path.ancestors() {
+            if !ancestor.as_os_str().is_empty() {
+                exact_paths.push(ancestor.to_path_buf());
+            }
+        }
+    }
+    exact_paths.sort();
+    exact_paths.dedup();
+    subtree_paths.sort();
+    subtree_paths.dedup();
+    paths
+        .into_iter()
+        .filter(|path| {
+            !exact_paths.iter().any(|mount_path| path == mount_path)
+                && !subtree_paths
+                    .iter()
+                    .any(|mount_path| path == mount_path || path.starts_with(mount_path))
+        })
+        .collect()
+}
+
+fn run_cache_mount_dir(cache_root: &Path, mount: &RunCacheMount) -> PathBuf {
+    let id = mount.id.as_deref().unwrap_or(&mount.target);
+    cache_root.join(sha256_bytes(id.as_bytes()))
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn run_cache_mount_seed_source(
+    completed_stages: &[(Option<String>, PathBuf)],
+    mount: &RunCacheMount,
+) -> Result<Option<PathBuf>> {
+    let Some(from_ref) = mount.from.as_deref() else {
+        return Ok(None);
+    };
+
+    reject_path_traversal(&mount.source)?;
+    let rel = normalized_context_rel(&mount.source);
+    let source_root = resolve_stage_rootfs(from_ref, completed_stages)?;
+    let source = source_root.join(&rel);
+    if !source.exists() {
+        return Err(BoxError::BuildError(format!(
+            "RUN cache mount seed source not found: {} (in from={})",
+            mount.source, from_ref
+        )));
+    }
+    assert_within(source_root, &source)?;
+    if !source.is_dir() {
+        return Err(BoxError::BuildError(format!(
+            "RUN cache mount seed source must be a directory: {} (in from={})",
+            mount.source, from_ref
+        )));
+    }
+    Ok(Some(source))
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn seed_run_cache_mount(
+    cache_dir: &Path,
+    mount: &RunCacheMount,
+    completed_stages: &[(Option<String>, PathBuf)],
+) -> Result<()> {
+    if cache_dir.exists() {
+        return Ok(());
+    }
+
+    let Some(seed_source) = run_cache_mount_seed_source(completed_stages, mount)? else {
+        return Ok(());
+    };
+
+    let parent = cache_dir.parent().ok_or_else(|| {
+        BoxError::BuildError(format!(
+            "RUN cache directory has no parent: {}",
+            cache_dir.display()
+        ))
+    })?;
+    std::fs::create_dir_all(parent).map_err(|e| {
+        BoxError::BuildError(format!(
+            "Failed to create RUN cache parent {}: {}",
+            parent.display(),
+            e
+        ))
+    })?;
+    copy_run_cache_seed_to(&seed_source, cache_dir)
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn copy_run_cache_seed_to(seed_source: &Path, cache_dir: &Path) -> Result<()> {
+    crate::cache::layer_cache::copy_dir_recursive(seed_source, cache_dir).map_err(|e| {
+        BoxError::BuildError(format!(
+            "Failed to seed RUN cache mount {} from {}: {}",
+            cache_dir.display(),
+            seed_source.display(),
+            e
+        ))
+    })
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn hydrate_run_cache_mount(cache_dir: &Path, target: &Path) -> Result<()> {
+    if !cache_dir.exists() {
+        return Ok(());
+    }
+    if !cache_dir.is_dir() {
+        return Err(BoxError::BuildError(format!(
+            "RUN cache mount {} is not a directory",
+            cache_dir.display()
+        )));
+    }
+    remove_path_any(target)?;
+    crate::cache::layer_cache::copy_dir_recursive(cache_dir, target).map_err(|e| {
+        BoxError::BuildError(format!(
+            "Failed to hydrate RUN cache mount {} from {}: {}",
+            target.display(),
+            cache_dir.display(),
+            e
+        ))
+    })
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn sync_run_cache_mount(target: &Path, cache_dir: &Path) -> Result<()> {
+    let parent = cache_dir.parent().ok_or_else(|| {
+        BoxError::BuildError(format!(
+            "RUN cache directory has no parent: {}",
+            cache_dir.display()
+        ))
+    })?;
+    std::fs::create_dir_all(parent).map_err(|e| {
+        BoxError::BuildError(format!(
+            "Failed to create RUN cache parent {}: {}",
+            parent.display(),
+            e
+        ))
+    })?;
+
+    let staging = tempfile::Builder::new()
+        .prefix(".run-cache-staging-")
+        .tempdir_in(parent)
+        .map_err(|e| {
+            BoxError::BuildError(format!("Failed to create RUN cache staging dir: {e}"))
+        })?;
+    let staged = staging.path().join("cache");
+    if target.exists() {
+        crate::cache::layer_cache::copy_dir_recursive(target, &staged).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to stage RUN cache mount {} into {}: {}",
+                target.display(),
+                staged.display(),
+                e
+            ))
+        })?;
+    } else {
+        std::fs::create_dir_all(&staged).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to create empty RUN cache staging dir {}: {}",
+                staged.display(),
+                e
+            ))
+        })?;
+    }
+
+    remove_path_any(cache_dir)?;
+    std::fs::rename(&staged, cache_dir).map_err(|e| {
+        BoxError::BuildError(format!(
+            "Failed to publish RUN cache mount {}: {}",
+            cache_dir.display(),
+            e
+        ))
+    })
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+struct PoolRunCacheMounts {
+    staging_dir: Option<PathBuf>,
+    overlays: Vec<PoolRunCacheMountOverlay>,
+    restored: bool,
+    sync_cache: bool,
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+struct PoolRunCacheMountOverlay {
+    target: PathBuf,
+    backup: PathBuf,
+    cache_dir: PathBuf,
+    _lock: crate::file_lock::FileLock,
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+impl PoolRunCacheMounts {
+    fn activate_with_cache_root(
+        rootfs_dir: &Path,
+        cache_mounts: &[RunCacheMount],
+        cache_root: &Path,
+        completed_stages: &[(Option<String>, PathBuf)],
+    ) -> Result<Self> {
+        let mut mounts = Self {
+            staging_dir: None,
+            overlays: Vec::new(),
+            restored: false,
+            sync_cache: false,
+        };
+
+        if cache_mounts.is_empty() {
+            return Ok(mounts);
+        }
+
+        std::fs::create_dir_all(cache_root).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to create RUN cache root {}: {}",
+                cache_root.display(),
+                e
+            ))
+        })?;
+        let staging_dir = rootfs_dir
+            .join(".a3s-box-run-cache-overlays")
+            .join(uuid::Uuid::new_v4().to_string());
+        std::fs::create_dir_all(&staging_dir).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to create RUN cache mount staging dir {}: {}",
+                staging_dir.display(),
+                e
+            ))
+        })?;
+        mounts.staging_dir = Some(staging_dir.clone());
+
+        for (idx, mount) in cache_mounts.iter().enumerate() {
+            let target = run_cache_mount_target(rootfs_dir, mount)?;
+            let backup = staging_dir.join(format!("target-{idx}"));
+            let cache_dir = run_cache_mount_dir(cache_root, mount);
+            if mounts
+                .overlays
+                .iter()
+                .any(|overlay| overlay.cache_dir == cache_dir)
+            {
+                return Err(BoxError::BuildError(format!(
+                    "Duplicate RUN cache mount id/target for {}",
+                    mount.raw
+                )));
+            }
+            // The warm-pool cache mount is a host-side hydrate/publish overlay,
+            // not BuildKit's live shared directory, so even `sharing=shared`
+            // serializes one cache key to avoid losing concurrent writeback.
+            let lock = crate::file_lock::FileLock::acquire(&cache_dir).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to lock RUN cache mount {}: {}",
+                    cache_dir.display(),
+                    e
+                ))
+            })?;
+            seed_run_cache_mount(&cache_dir, mount, completed_stages)?;
+            std::fs::rename(&target, &backup).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to hide RUN cache mount target {}: {}",
+                    target.display(),
+                    e
+                ))
+            })?;
+            mounts.overlays.push(PoolRunCacheMountOverlay {
+                target: target.clone(),
+                backup,
+                cache_dir: cache_dir.clone(),
+                _lock: lock,
+            });
+            std::fs::create_dir_all(&target).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to activate RUN cache mount target {}: {}",
+                    target.display(),
+                    e
+                ))
+            })?;
+            hydrate_run_cache_mount(&cache_dir, &target)?;
+            apply_run_cache_mount_metadata(&target, mount)?;
+        }
+
+        mounts.sync_cache = true;
+        Ok(mounts)
+    }
+
+    fn restore(mut self) -> Result<()> {
+        let result = self.restore_inner();
+        if result.is_ok() {
+            self.restored = true;
+        }
+        result
+    }
+
+    fn restore_without_sync(mut self) -> Result<()> {
+        self.sync_cache = false;
+        let result = self.restore_inner();
+        if result.is_ok() {
+            self.restored = true;
+        }
+        result
+    }
+
+    fn restore_inner(&mut self) -> Result<()> {
+        if self.restored {
+            return Ok(());
+        }
+
+        let mut first_error = None;
+        for overlay in self.overlays.iter().rev() {
+            if self.sync_cache {
+                if let Err(error) = sync_run_cache_mount(&overlay.target, &overlay.cache_dir) {
+                    first_error.get_or_insert(error);
+                }
+            }
+            if let Err(error) = remove_path_any(&overlay.target) {
+                first_error.get_or_insert(error);
+                continue;
+            }
+            if let Err(error) = std::fs::rename(&overlay.backup, &overlay.target).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to restore RUN cache mount target {}: {}",
+                    overlay.target.display(),
+                    e
+                ))
+            }) {
+                first_error.get_or_insert(error);
+            }
+        }
+
+        if let Some(staging_dir) = &self.staging_dir {
+            if let Err(error) = std::fs::remove_dir_all(staging_dir).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to remove RUN cache mount staging dir {}: {}",
+                    staging_dir.display(),
+                    e
+                ))
+            }) {
+                first_error.get_or_insert(error);
+            }
+            if let Some(parent) = staging_dir.parent() {
+                match std::fs::remove_dir(parent) {
+                    Ok(()) => {}
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+                        ) => {}
+                    Err(err) => {
+                        first_error.get_or_insert(BoxError::BuildError(format!(
+                            "Failed to remove RUN cache mount staging parent {}: {}",
+                            parent.display(),
+                            err
+                        )));
+                    }
+                }
+            }
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => {
+                self.restored = true;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+impl Drop for PoolRunCacheMounts {
+    fn drop(&mut self) {
+        let _ = self.restore_inner();
+    }
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+struct RunBindMountOverlays {
+    staging_dir: Option<PathBuf>,
+    overlays: Vec<RunBindMountOverlay>,
+    restored: bool,
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+struct RunBindMountOverlay {
+    target: PathBuf,
+    backup: Option<PathBuf>,
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+impl RunBindMountOverlays {
+    #[cfg(test)]
+    fn activate_context(
+        rootfs_dir: &Path,
+        context_dir: &Path,
+        bind_mounts: &[RunBindMount],
+        workdir: &str,
+        ignore: Option<&DockerIgnore>,
+    ) -> Result<Self> {
+        Self::activate(rootfs_dir, context_dir, &[], bind_mounts, workdir, ignore)
+    }
+
+    fn activate(
+        rootfs_dir: &Path,
+        context_dir: &Path,
+        completed_stages: &[(Option<String>, PathBuf)],
+        bind_mounts: &[RunBindMount],
+        workdir: &str,
+        ignore: Option<&DockerIgnore>,
+    ) -> Result<Self> {
+        let mut mounts = Self {
+            staging_dir: None,
+            overlays: Vec::new(),
+            restored: false,
+        };
+
+        if bind_mounts.is_empty() {
+            return Ok(mounts);
+        }
+
+        let staging_dir = rootfs_dir
+            .join(".a3s-box-run-bind-overlays")
+            .join(uuid::Uuid::new_v4().to_string());
+        std::fs::create_dir_all(&staging_dir).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to create RUN bind mount staging dir {}: {}",
+                staging_dir.display(),
+                e
+            ))
+        })?;
+        mounts.staging_dir = Some(staging_dir.clone());
+
+        for (idx, mount) in bind_mounts.iter().enumerate() {
+            let (source_root, source_ignore, source_label) = match mount.from.as_deref() {
+                Some(from_ref) => {
+                    let rootfs = resolve_stage_rootfs(from_ref, completed_stages)?;
+                    (
+                        rootfs,
+                        None,
+                        format!("stage '{}' rootfs {}", from_ref, rootfs.display()),
+                    )
+                }
+                None => (
+                    context_dir,
+                    ignore,
+                    format!("build context {}", context_dir.display()),
+                ),
+            };
+            let (source, source_rel) =
+                run_bind_mount_source(source_root, &source_label, mount, source_ignore)?;
+            let (target, _target_rel) = run_bind_mount_target(rootfs_dir, workdir, mount)?;
+            let backup = if target.exists() {
+                let backup = staging_dir.join(format!("target-{idx}"));
+                std::fs::rename(&target, &backup).map_err(|e| {
+                    BoxError::BuildError(format!(
+                        "Failed to hide RUN bind mount target {}: {}",
+                        target.display(),
+                        e
+                    ))
+                })?;
+                Some(backup)
+            } else {
+                None
+            };
+
+            mounts.overlays.push(RunBindMountOverlay {
+                target: target.clone(),
+                backup,
+            });
+            copy_run_bind_mount_source(&source, &source_rel, &target, source_ignore)?;
+        }
+
+        Ok(mounts)
+    }
+
+    fn restore(mut self) -> Result<()> {
+        let result = self.restore_inner();
+        if result.is_ok() {
+            self.restored = true;
+        }
+        result
+    }
+
+    fn restore_inner(&mut self) -> Result<()> {
+        if self.restored {
+            return Ok(());
+        }
+
+        let mut first_error = None;
+        for overlay in self.overlays.iter().rev() {
+            if let Err(error) = remove_path_any(&overlay.target) {
+                first_error.get_or_insert(error);
+            }
+            if let Some(backup) = &overlay.backup {
+                if let Err(error) = std::fs::rename(backup, &overlay.target).map_err(|e| {
+                    BoxError::BuildError(format!(
+                        "Failed to restore RUN bind mount target {}: {}",
+                        overlay.target.display(),
+                        e
+                    ))
+                }) {
+                    first_error.get_or_insert(error);
+                }
+            }
+        }
+
+        if let Some(staging_dir) = &self.staging_dir {
+            if let Err(error) = std::fs::remove_dir_all(staging_dir).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to remove RUN bind mount staging dir {}: {}",
+                    staging_dir.display(),
+                    e
+                ))
+            }) {
+                first_error.get_or_insert(error);
+            }
+            if let Some(parent) = staging_dir.parent() {
+                match std::fs::remove_dir(parent) {
+                    Ok(()) => {}
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+                        ) => {}
+                    Err(err) => {
+                        first_error.get_or_insert(BoxError::BuildError(format!(
+                            "Failed to remove RUN bind mount staging parent {}: {}",
+                            parent.display(),
+                            err
+                        )));
+                    }
+                }
+            }
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => {
+                self.restored = true;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+impl Drop for RunBindMountOverlays {
+    fn drop(&mut self) {
+        let _ = self.restore_inner();
+    }
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+struct RunTmpfsMountOverlays {
+    staging_dir: Option<PathBuf>,
+    overlays: Vec<RunTmpfsMountOverlay>,
+    restored: bool,
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+struct RunTmpfsMountOverlay {
+    target: PathBuf,
+    backup: Option<PathBuf>,
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+impl RunTmpfsMountOverlays {
+    fn activate(rootfs_dir: &Path, tmpfs_mounts: &[RunTmpfsMount], workdir: &str) -> Result<Self> {
+        let mut mounts = Self {
+            staging_dir: None,
+            overlays: Vec::new(),
+            restored: false,
+        };
+
+        if tmpfs_mounts.is_empty() {
+            return Ok(mounts);
+        }
+
+        let staging_dir = rootfs_dir
+            .join(".a3s-box-run-tmpfs-overlays")
+            .join(uuid::Uuid::new_v4().to_string());
+        std::fs::create_dir_all(&staging_dir).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to create RUN tmpfs mount staging dir {}: {}",
+                staging_dir.display(),
+                e
+            ))
+        })?;
+        mounts.staging_dir = Some(staging_dir.clone());
+
+        for (idx, mount) in tmpfs_mounts.iter().enumerate() {
+            let (target, _target_rel) = run_tmpfs_mount_target(rootfs_dir, workdir, mount)?;
+            let backup = if target.exists() {
+                let backup = staging_dir.join(format!("target-{idx}"));
+                std::fs::rename(&target, &backup).map_err(|e| {
+                    BoxError::BuildError(format!(
+                        "Failed to hide RUN tmpfs mount target {}: {}",
+                        target.display(),
+                        e
+                    ))
+                })?;
+                Some(backup)
+            } else {
+                None
+            };
+
+            mounts.overlays.push(RunTmpfsMountOverlay {
+                target: target.clone(),
+                backup,
+            });
+            std::fs::create_dir_all(&target).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to activate RUN tmpfs mount target {}: {}",
+                    target.display(),
+                    e
+                ))
+            })?;
+        }
+
+        Ok(mounts)
+    }
+
+    fn restore(mut self) -> Result<()> {
+        let result = self.restore_inner();
+        if result.is_ok() {
+            self.restored = true;
+        }
+        result
+    }
+
+    fn restore_inner(&mut self) -> Result<()> {
+        if self.restored {
+            return Ok(());
+        }
+
+        let mut first_error = None;
+        for overlay in self.overlays.iter().rev() {
+            if let Err(error) = remove_path_any(&overlay.target) {
+                first_error.get_or_insert(error);
+            }
+            if let Some(backup) = &overlay.backup {
+                if let Err(error) = std::fs::rename(backup, &overlay.target).map_err(|e| {
+                    BoxError::BuildError(format!(
+                        "Failed to restore RUN tmpfs mount target {}: {}",
+                        overlay.target.display(),
+                        e
+                    ))
+                }) {
+                    first_error.get_or_insert(error);
+                }
+            }
+        }
+
+        if let Some(staging_dir) = &self.staging_dir {
+            if let Err(error) = std::fs::remove_dir_all(staging_dir).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to remove RUN tmpfs mount staging dir {}: {}",
+                    staging_dir.display(),
+                    e
+                ))
+            }) {
+                first_error.get_or_insert(error);
+            }
+            if let Some(parent) = staging_dir.parent() {
+                match std::fs::remove_dir(parent) {
+                    Ok(()) => {}
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+                        ) => {}
+                    Err(err) => {
+                        first_error.get_or_insert(BoxError::BuildError(format!(
+                            "Failed to remove RUN tmpfs mount staging parent {}: {}",
+                            parent.display(),
+                            err
+                        )));
+                    }
+                }
+            }
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => {
+                self.restored = true;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+impl Drop for RunTmpfsMountOverlays {
+    fn drop(&mut self) {
+        let _ = self.restore_inner();
+    }
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn remove_path_any(path: &Path) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.is_dir() && !meta.file_type().is_symlink() => {
+            std::fs::remove_dir_all(path)
+        }
+        Ok(_) => std::fs::remove_file(path),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(BoxError::BuildError(format!(
+                "Failed to inspect RUN cache mount target {}: {}",
+                path.display(),
+                err
+            )));
+        }
+    }
+    .map_err(|e| {
+        BoxError::BuildError(format!(
+            "Failed to remove RUN cache mount target {}: {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn apply_run_cache_mount_metadata(target: &Path, mount: &RunCacheMount) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        if let Some(mode) = mount.mode {
+            let mut permissions = std::fs::metadata(target)
+                .map_err(|e| {
+                    BoxError::BuildError(format!(
+                        "Failed to inspect RUN cache mount target {}: {}",
+                        target.display(),
+                        e
+                    ))
+                })?
+                .permissions();
+            permissions.set_mode(mode);
+            std::fs::set_permissions(target, permissions).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to set RUN cache mount mode {:o} on {}: {}",
+                    mode,
+                    target.display(),
+                    e
+                ))
+            })?;
+        }
+
+        if mount.uid.is_some() || mount.gid.is_some() {
+            let uid = mount.uid.map(|uid| uid as libc::uid_t).unwrap_or(!0);
+            let gid = mount.gid.map(|gid| gid as libc::gid_t).unwrap_or(!0);
+            let c_path = std::ffi::CString::new(target.as_os_str().as_bytes()).map_err(|_| {
+                BoxError::BuildError(format!(
+                    "RUN cache mount target contains NUL: {}",
+                    target.display()
+                ))
+            })?;
+            let ret = unsafe { libc::chown(c_path.as_ptr(), uid, gid) };
+            if ret != 0 {
+                return Err(BoxError::BuildError(format!(
+                    "Failed to set RUN cache mount ownership on {}: {}",
+                    target.display(),
+                    std::io::Error::last_os_error()
+                )));
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (target, mount);
+    }
+
+    Ok(())
+}
+
 fn print_run_output(output: &std::process::Output, quiet: bool) {
+    print_output_parts(&output.stdout, &output.stderr, quiet);
+}
+
+fn print_output_parts(stdout: &[u8], stderr: &[u8], quiet: bool) {
     if quiet {
         return;
     }
 
-    if !output.stdout.is_empty() {
-        print!("{}", String::from_utf8_lossy(&output.stdout));
+    if !stdout.is_empty() {
+        print!("{}", String::from_utf8_lossy(stdout));
     }
-    if !output.stderr.is_empty() {
+    if !stderr.is_empty() {
         use std::io::Write as _;
-        let _ = std::io::stderr().write_all(String::from_utf8_lossy(&output.stderr).as_bytes());
+        let _ = std::io::stderr().write_all(String::from_utf8_lossy(stderr).as_bytes());
     }
 }
 
@@ -490,16 +1807,75 @@ fn run_command_failed_error(command: &str, output: &std::process::Output) -> Box
         .code()
         .map(|code| code.to_string())
         .unwrap_or_else(|| "signal".to_string());
+    run_command_failed_error_message(command, exit, &output.stdout, &output.stderr)
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+fn run_command_failed_error_parts(
+    command: &str,
+    exit_code: i32,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> BoxError {
+    run_command_failed_error_message(command, exit_code.to_string(), stdout, stderr)
+}
+
+fn run_command_failed_error_message(
+    command: &str,
+    exit: String,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> BoxError {
     let mut message = format!("RUN command failed (exit {exit}): {command}");
 
-    append_output_context(&mut message, "stdout", &output.stdout);
-    append_output_context(&mut message, "stderr", &output.stderr);
+    append_output_context(&mut message, "stdout", stdout);
+    append_output_context(&mut message, "stderr", stderr);
 
-    if output.stdout.is_empty() && output.stderr.is_empty() {
+    if stdout.is_empty() && stderr.is_empty() {
         message.push_str("\n(no stdout or stderr captured)");
     }
 
     BoxError::BuildError(message)
+}
+
+#[cfg_attr(all(not(feature = "pool"), not(test)), allow(dead_code))]
+fn prepare_pool_run_filesystem(rootfs_dir: &Path) -> Result<()> {
+    for dir in ["dev", "proc", "sys", "tmp", "var/tmp", "etc"] {
+        std::fs::create_dir_all(rootfs_dir.join(dir)).map_err(|e| {
+            BoxError::BuildError(format!(
+                "Failed to prepare RUN directory {}: {}",
+                rootfs_dir.join(dir).display(),
+                e
+            ))
+        })?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for dir in ["tmp", "var/tmp"] {
+            let path = rootfs_dir.join(dir);
+            let mut perms = std::fs::metadata(&path)
+                .map_err(|e| {
+                    BoxError::BuildError(format!("Failed to inspect {}: {}", path.display(), e))
+                })?
+                .permissions();
+            perms.set_mode(0o1777);
+            std::fs::set_permissions(&path, perms).map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to set sticky tmp permissions on {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+        }
+        ensure_run_symlink(rootfs_dir.join("dev/fd"), "/proc/self/fd")?;
+        ensure_run_symlink(rootfs_dir.join("dev/stdin"), "/proc/self/fd/0")?;
+        ensure_run_symlink(rootfs_dir.join("dev/stdout"), "/proc/self/fd/1")?;
+        ensure_run_symlink(rootfs_dir.join("dev/stderr"), "/proc/self/fd/2")?;
+    }
+
+    ensure_run_resolv_conf(rootfs_dir)
 }
 
 fn append_output_context(message: &mut String, label: &str, bytes: &[u8]) {
@@ -571,17 +1947,21 @@ fn prepare_linux_run_filesystem(rootfs_dir: &Path) -> Result<()> {
         }
     }
 
-    ensure_linux_run_symlink(rootfs_dir.join("dev/fd"), "/proc/self/fd")?;
-    ensure_linux_run_symlink(rootfs_dir.join("dev/stdin"), "/proc/self/fd/0")?;
-    ensure_linux_run_symlink(rootfs_dir.join("dev/stdout"), "/proc/self/fd/1")?;
-    ensure_linux_run_symlink(rootfs_dir.join("dev/stderr"), "/proc/self/fd/2")?;
-    ensure_linux_resolv_conf(rootfs_dir)?;
+    ensure_run_symlink(rootfs_dir.join("dev/fd"), "/proc/self/fd")?;
+    ensure_run_symlink(rootfs_dir.join("dev/stdin"), "/proc/self/fd/0")?;
+    ensure_run_symlink(rootfs_dir.join("dev/stdout"), "/proc/self/fd/1")?;
+    ensure_run_symlink(rootfs_dir.join("dev/stderr"), "/proc/self/fd/2")?;
+    ensure_run_resolv_conf(rootfs_dir)?;
 
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
-fn ensure_linux_run_symlink(path: PathBuf, target: &str) -> Result<()> {
+#[cfg(unix)]
+#[cfg_attr(
+    all(not(feature = "pool"), not(target_os = "linux"), not(test)),
+    allow(dead_code)
+)]
+fn ensure_run_symlink(path: PathBuf, target: &str) -> Result<()> {
     match std::fs::symlink_metadata(&path) {
         Ok(meta) if meta.file_type().is_symlink() => return Ok(()),
         Ok(_) => return Ok(()),
@@ -605,8 +1985,11 @@ fn ensure_linux_run_symlink(path: PathBuf, target: &str) -> Result<()> {
     })
 }
 
-#[cfg(target_os = "linux")]
-fn ensure_linux_resolv_conf(rootfs_dir: &Path) -> Result<()> {
+#[cfg_attr(
+    all(not(feature = "pool"), not(target_os = "linux"), not(test)),
+    allow(dead_code)
+)]
+fn ensure_run_resolv_conf(rootfs_dir: &Path) -> Result<()> {
     let path = rootfs_dir.join("etc/resolv.conf");
     if std::fs::metadata(&path)
         .map(|m| m.len() > 0)
@@ -650,6 +2033,7 @@ impl LinuxRunMounts {
         mut self,
         rootfs_dir: &Path,
         cache_mounts: &[RunCacheMount],
+        completed_stages: &[(Option<String>, PathBuf)],
     ) -> Result<Self> {
         for mount in cache_mounts {
             let cache_dir = tempfile::Builder::new()
@@ -658,6 +2042,9 @@ impl LinuxRunMounts {
                 .map_err(|e| {
                     BoxError::BuildError(format!("Failed to create RUN cache mount: {}", e))
                 })?;
+            if let Some(seed_source) = run_cache_mount_seed_source(completed_stages, mount)? {
+                copy_run_cache_seed_to(&seed_source, cache_dir.path())?;
+            }
             let target = rootfs_dir.join(mount.target.trim_start_matches('/'));
             self.bind_mount(cache_dir.path().to_path_buf(), target)?;
             self.cache_dirs.push(cache_dir);
@@ -786,8 +2173,12 @@ fn unsafe_host_run_enabled() -> bool {
 #[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 fn handle_run_on_host_unsafe(
-    command: &str,
+    command: &RunCommand,
     cache_mounts: &[RunCacheMount],
+    bind_mounts: &[RunBindMount],
+    tmpfs_mounts: &[RunTmpfsMount],
+    context_dir: &Path,
+    completed_stages: &[(Option<String>, PathBuf)],
     rootfs_dir: &Path,
     layers_dir: &Path,
     workdir: &str,
@@ -795,8 +2186,15 @@ fn handle_run_on_host_unsafe(
     shell: &[String],
     layer_index: usize,
     quiet: bool,
+    ignore: Option<&DockerIgnore>,
 ) -> Result<Option<LayerInfo>> {
     use super::super::layer::DirSnapshot;
+
+    let RunCommand::Shell(command) = command else {
+        return Err(BoxError::BuildError(
+            "Dockerfile RUN exec form requires isolated Linux execution; use --run-pool or --builder=buildkit-vm on macOS".to_string(),
+        ));
+    };
 
     if !quiet {
         println!("→ Executing RUN command on host (unsafe)");
@@ -842,19 +2240,44 @@ fn handle_run_on_host_unsafe(
     for (key, value) in env {
         cmd.env(key, value);
     }
+    let bind_mount_guard = RunBindMountOverlays::activate(
+        rootfs_dir,
+        context_dir,
+        completed_stages,
+        bind_mounts,
+        workdir,
+        ignore,
+    )?;
+    let tmpfs_mount_guard = RunTmpfsMountOverlays::activate(rootfs_dir, tmpfs_mounts, workdir)?;
     let output = cmd
         .output()
         .map_err(|e| BoxError::BuildError(format!("Failed to execute command: {}", e)))?;
 
     if !output.status.success() {
+        tmpfs_mount_guard.restore()?;
+        bind_mount_guard.restore()?;
         return Err(run_command_failed_error(command, &output));
     }
+    tmpfs_mount_guard.restore()?;
+    bind_mount_guard.restore()?;
     print_run_output(&output, quiet);
 
     // Capture filesystem state after execution
     let after = DirSnapshot::capture(rootfs_dir)?;
-    let changed = before.diff(&after);
-    let deleted = before.deletions(&after);
+    let changed = filter_run_mount_paths(
+        before.diff(&after),
+        cache_mounts,
+        bind_mounts,
+        tmpfs_mounts,
+        workdir,
+    );
+    let deleted = filter_run_mount_paths(
+        before.deletions(&after),
+        cache_mounts,
+        bind_mounts,
+        tmpfs_mounts,
+        workdir,
+    );
 
     if changed.is_empty() && deleted.is_empty() {
         if !quiet {
@@ -1088,16 +2511,20 @@ pub(super) fn instruction_to_string(instr: &Instruction) -> String {
         Instruction::Run {
             command,
             cache_mounts,
+            bind_mounts,
+            tmpfs_mounts,
         } => {
             let flags = cache_mounts
                 .iter()
                 .map(|mount| mount.raw.as_str())
+                .chain(bind_mounts.iter().map(|mount| mount.raw.as_str()))
+                .chain(tmpfs_mounts.iter().map(|mount| mount.raw.as_str()))
                 .collect::<Vec<_>>()
                 .join(" ");
             if flags.is_empty() {
-                format!("RUN {}", command)
+                format!("RUN {}", run_command_to_string(command))
             } else {
-                format!("RUN {} {}", flags, command)
+                format!("RUN {} {}", flags, run_command_to_string(command))
             }
         }
         Instruction::Copy {
@@ -1253,7 +2680,9 @@ fn download_url(url: &str) -> std::result::Result<Vec<u8>, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::dockerfile::{Instruction, RunCacheMount};
+    use super::super::super::dockerfile::{
+        Instruction, RunBindMount, RunCacheMount, RunCacheSharing, RunCommand, RunTmpfsMount,
+    };
     use super::{
         execute_onbuild_trigger, expand_glob_sources, glob_segment_match, handle_add,
         instruction_to_string, run_command_failed_error, shell_command_in_workdir,
@@ -1262,6 +2691,10 @@ mod tests {
     use a3s_box_core::error::BoxError;
     use std::collections::HashMap;
     use std::path::PathBuf;
+
+    fn shell_run(command: &str) -> RunCommand {
+        RunCommand::Shell(command.to_string())
+    }
 
     #[test]
     fn test_glob_segment_match() {
@@ -1314,24 +2747,90 @@ mod tests {
     #[test]
     fn test_instruction_to_string_run() {
         let instr = Instruction::Run {
-            command: "echo hello".to_string(),
+            command: RunCommand::Shell("echo hello".to_string()),
             cache_mounts: vec![],
+            bind_mounts: vec![],
+            tmpfs_mounts: vec![],
         };
         assert_eq!(instruction_to_string(&instr), "RUN echo hello");
     }
 
     #[test]
+    fn test_instruction_to_string_run_exec_form() {
+        let instr = Instruction::Run {
+            command: RunCommand::Exec(vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "echo hello".to_string(),
+            ]),
+            cache_mounts: vec![],
+            bind_mounts: vec![],
+            tmpfs_mounts: vec![],
+        };
+        assert_eq!(
+            instruction_to_string(&instr),
+            r#"RUN ["/bin/sh","-c","echo hello"]"#
+        );
+    }
+
+    #[test]
     fn test_instruction_to_string_run_with_cache_mount() {
         let instr = Instruction::Run {
-            command: "pnpm install".to_string(),
+            command: RunCommand::Shell("pnpm install".to_string()),
             cache_mounts: vec![RunCacheMount {
-                raw: "--mount=type=cache,target=/root/.cache".to_string(),
+                raw: "--mount=type=cache,sharing=locked,target=/root/.cache".to_string(),
+                id: None,
+                from: None,
+                source: ".".to_string(),
+                sharing: RunCacheSharing::Locked,
+                mode: None,
+                uid: None,
+                gid: None,
                 target: "/root/.cache".to_string(),
+            }],
+            bind_mounts: vec![],
+            tmpfs_mounts: vec![],
+        };
+        assert_eq!(
+            instruction_to_string(&instr),
+            "RUN --mount=type=cache,sharing=locked,target=/root/.cache pnpm install"
+        );
+    }
+
+    #[test]
+    fn test_instruction_to_string_run_with_bind_mount() {
+        let instr = Instruction::Run {
+            command: RunCommand::Shell("go build ./...".to_string()),
+            cache_mounts: vec![],
+            bind_mounts: vec![RunBindMount {
+                from: None,
+                raw: "--mount=type=bind,source=.,target=.".to_string(),
+                source: ".".to_string(),
+                target: ".".to_string(),
+                read_write: false,
+            }],
+            tmpfs_mounts: vec![],
+        };
+        assert_eq!(
+            instruction_to_string(&instr),
+            "RUN --mount=type=bind,source=.,target=. go build ./..."
+        );
+    }
+
+    #[test]
+    fn test_instruction_to_string_run_with_tmpfs_mount() {
+        let instr = Instruction::Run {
+            command: RunCommand::Shell("make test".to_string()),
+            cache_mounts: vec![],
+            bind_mounts: vec![],
+            tmpfs_mounts: vec![RunTmpfsMount {
+                raw: "--mount=type=tmpfs,target=/tmp".to_string(),
+                target: "/tmp".to_string(),
             }],
         };
         assert_eq!(
             instruction_to_string(&instr),
-            "RUN --mount=type=cache,target=/root/.cache pnpm install"
+            "RUN --mount=type=tmpfs,target=/tmp make test"
         );
     }
 
@@ -1346,6 +2845,680 @@ mod tests {
             "cd '/app'\\''s dir' && pwd"
         );
         assert_eq!(shell_command_in_workdir("/", "pwd"), "pwd");
+    }
+
+    #[test]
+    fn test_build_run_shell_cmd_uses_configured_shell_and_workdir() {
+        let cmd = super::build_run_shell_cmd(
+            &["/bin/bash".to_string(), "-lc".to_string()],
+            "/app",
+            "echo hi",
+        );
+
+        assert_eq!(cmd, vec!["/bin/bash", "-lc", "cd '/app' && echo hi"]);
+    }
+
+    #[test]
+    fn test_run_env_entries_includes_defaults_and_build_env() {
+        let env = super::run_env_entries(&[("FOO".to_string(), "bar".to_string())]);
+
+        assert!(env
+            .iter()
+            .any(|entry| entry
+                == "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"));
+        assert!(env.iter().any(|entry| entry == "HOME=/root"));
+        assert!(env.iter().any(|entry| entry == "FOO=bar"));
+    }
+
+    #[test]
+    fn test_prepare_pool_run_filesystem_creates_support_paths() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+
+        super::prepare_pool_run_filesystem(&rootfs).unwrap();
+
+        assert!(rootfs.join("dev").is_dir());
+        assert!(rootfs.join("proc").is_dir());
+        assert!(rootfs.join("sys").is_dir());
+        assert!(rootfs.join("tmp").is_dir());
+        assert!(rootfs.join("etc/resolv.conf").is_file());
+    }
+
+    #[test]
+    fn test_run_bind_mount_overlays_context_and_restores_target() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = tmp.path().join("context");
+        let rootfs = tmp.path().join("rootfs");
+        let source = context.join("src");
+        let target = rootfs.join("work");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(source.join("input.txt"), "from-context").unwrap();
+        std::fs::write(target.join("original.txt"), "from-rootfs").unwrap();
+
+        let mounts = vec![RunBindMount {
+            from: None,
+            raw: "--mount=type=bind,source=src,target=.".to_string(),
+            source: "src".to_string(),
+            target: ".".to_string(),
+            read_write: true,
+        }];
+
+        let guard = super::RunBindMountOverlays::activate_context(
+            &rootfs, &context, &mounts, "/work", None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("input.txt")).unwrap(),
+            "from-context"
+        );
+        assert!(!target.join("original.txt").exists());
+        std::fs::write(target.join("generated.txt"), "discard me").unwrap();
+
+        guard.restore().unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("original.txt")).unwrap(),
+            "from-rootfs"
+        );
+        assert!(!target.join("input.txt").exists());
+        assert!(!target.join("generated.txt").exists());
+    }
+
+    #[test]
+    fn test_run_bind_mount_overlays_stage_source_and_restores_target() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = tmp.path().join("context");
+        let stage_rootfs = tmp.path().join("stage-rootfs");
+        let rootfs = tmp.path().join("rootfs");
+        let source = stage_rootfs.join("out");
+        let target = rootfs.join("work");
+        std::fs::create_dir_all(&context).unwrap();
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(source.join("artifact.txt"), "from-stage").unwrap();
+        std::fs::write(target.join("original.txt"), "from-rootfs").unwrap();
+
+        let mounts = vec![RunBindMount {
+            from: Some("builder".to_string()),
+            raw: "--mount=type=bind,from=builder,source=/out,target=.".to_string(),
+            source: "/out".to_string(),
+            target: ".".to_string(),
+            read_write: false,
+        }];
+        let completed_stages = vec![(Some("builder".to_string()), stage_rootfs)];
+
+        let guard = super::RunBindMountOverlays::activate(
+            &rootfs,
+            &context,
+            &completed_stages,
+            &mounts,
+            "/work",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("artifact.txt")).unwrap(),
+            "from-stage"
+        );
+        assert!(!target.join("original.txt").exists());
+        std::fs::write(target.join("generated.txt"), "discard me").unwrap();
+
+        guard.restore().unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("original.txt")).unwrap(),
+            "from-rootfs"
+        );
+        assert!(!target.join("artifact.txt").exists());
+        assert!(!target.join("generated.txt").exists());
+    }
+
+    #[test]
+    fn test_filter_run_mount_paths_excludes_bind_target() {
+        let mounts = vec![RunBindMount {
+            from: None,
+            raw: "--mount=type=bind,source=src,target=.".to_string(),
+            source: "src".to_string(),
+            target: ".".to_string(),
+            read_write: false,
+        }];
+        let paths = vec![
+            PathBuf::from("work/input.txt"),
+            PathBuf::from("work/generated.txt"),
+            PathBuf::from("out.txt"),
+        ];
+
+        let filtered = super::filter_run_mount_paths(paths, &[], &mounts, &[], "/work");
+
+        assert_eq!(filtered, vec![PathBuf::from("out.txt")]);
+    }
+
+    #[test]
+    fn test_filter_run_mount_paths_keeps_siblings_under_mount_ancestor() {
+        let mounts = vec![RunCacheMount {
+            raw: "--mount=type=cache,target=/root/.cache".to_string(),
+            id: None,
+            from: None,
+            source: ".".to_string(),
+            sharing: RunCacheSharing::Shared,
+            mode: None,
+            uid: None,
+            gid: None,
+            target: "/root/.cache".to_string(),
+        }];
+        let paths = vec![
+            PathBuf::from("root"),
+            PathBuf::from("root/.cache/pkg"),
+            PathBuf::from("root/.profile"),
+        ];
+
+        let filtered = super::filter_run_mount_paths(paths, &mounts, &[], &[], "/");
+
+        assert_eq!(filtered, vec![PathBuf::from("root/.profile")]);
+    }
+
+    #[test]
+    fn test_run_tmpfs_mount_overlays_empty_dir_and_restores_target() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        let target = rootfs.join("work/tmp");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("original.txt"), "from-rootfs").unwrap();
+
+        let mounts = vec![RunTmpfsMount {
+            raw: "--mount=type=tmpfs,target=tmp".to_string(),
+            target: "tmp".to_string(),
+        }];
+
+        let guard = super::RunTmpfsMountOverlays::activate(&rootfs, &mounts, "/work").unwrap();
+
+        assert!(target.is_dir());
+        assert!(!target.join("original.txt").exists());
+        std::fs::write(target.join("generated.txt"), "discard me").unwrap();
+
+        guard.restore().unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("original.txt")).unwrap(),
+            "from-rootfs"
+        );
+        assert!(!target.join("generated.txt").exists());
+    }
+
+    #[test]
+    fn test_filter_run_mount_paths_excludes_tmpfs_target() {
+        let mounts = vec![RunTmpfsMount {
+            raw: "--mount=type=tmpfs,target=/tmp".to_string(),
+            target: "/tmp".to_string(),
+        }];
+        let paths = vec![
+            PathBuf::from("tmp/generated.txt"),
+            PathBuf::from("var/output.txt"),
+        ];
+
+        let filtered = super::filter_run_mount_paths(paths, &[], &[], &mounts, "/");
+
+        assert_eq!(filtered, vec![PathBuf::from("var/output.txt")]);
+    }
+
+    #[test]
+    fn test_pool_run_cache_mounts_restore_original_target() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        let target = rootfs.join("root/.cache");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("original.txt"), "original").unwrap();
+        let mounts = vec![RunCacheMount {
+            raw: "--mount=type=cache,sharing=locked,target=/root/.cache".to_string(),
+            id: None,
+            from: None,
+            source: ".".to_string(),
+            sharing: RunCacheSharing::Locked,
+            mode: None,
+            uid: None,
+            gid: None,
+            target: "/root/.cache".to_string(),
+        }];
+
+        super::ensure_run_cache_mount_targets(&rootfs, &mounts).unwrap();
+        let guard =
+            super::PoolRunCacheMounts::activate_with_cache_root(&rootfs, &mounts, &cache_root, &[])
+                .unwrap();
+
+        assert!(!target.join("original.txt").exists());
+        std::fs::write(target.join("cache-only.txt"), "cache").unwrap();
+
+        guard.restore().unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("original.txt")).unwrap(),
+            "original"
+        );
+        assert!(!target.join("cache-only.txt").exists());
+    }
+
+    #[test]
+    fn test_pool_run_cache_mounts_persist_by_id() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        let target = rootfs.join("root/.cache");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&rootfs).unwrap();
+        let mounts = vec![RunCacheMount {
+            raw: "--mount=type=cache,id=shared,sharing=locked,target=/root/.cache".to_string(),
+            id: Some("shared".to_string()),
+            from: None,
+            source: ".".to_string(),
+            sharing: RunCacheSharing::Locked,
+            mode: None,
+            uid: None,
+            gid: None,
+            target: "/root/.cache".to_string(),
+        }];
+
+        super::ensure_run_cache_mount_targets(&rootfs, &mounts).unwrap();
+        let guard =
+            super::PoolRunCacheMounts::activate_with_cache_root(&rootfs, &mounts, &cache_root, &[])
+                .unwrap();
+        std::fs::write(target.join("cache-only.txt"), "cache").unwrap();
+        guard.restore().unwrap();
+        let cache_dir = super::run_cache_mount_dir(&cache_root, &mounts[0]);
+        assert_eq!(
+            std::fs::read_to_string(cache_dir.join("cache-only.txt")).unwrap(),
+            "cache"
+        );
+
+        let guard =
+            super::PoolRunCacheMounts::activate_with_cache_root(&rootfs, &mounts, &cache_root, &[])
+                .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(target.join("cache-only.txt")).unwrap(),
+            "cache"
+        );
+        guard.restore().unwrap();
+    }
+
+    #[test]
+    fn test_pool_run_cache_mounts_seed_from_stage_once() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let stage_rootfs = tmp.path().join("stage-rootfs");
+        let seed_dir = stage_rootfs.join("seed-cache");
+        let rootfs = tmp.path().join("rootfs");
+        let target = rootfs.join("root/.cache");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&seed_dir).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(seed_dir.join("seed.txt"), "seed-v1").unwrap();
+        std::fs::write(target.join("original.txt"), "original").unwrap();
+        let mounts = vec![RunCacheMount {
+            raw: "--mount=type=cache,id=seeded,sharing=locked,from=builder,source=/seed-cache,target=/root/.cache".to_string(),
+            id: Some("seeded".to_string()),
+            from: Some("builder".to_string()),
+            source: "/seed-cache".to_string(),
+            sharing: RunCacheSharing::Locked,
+            mode: None,
+            uid: None,
+            gid: None,
+            target: "/root/.cache".to_string(),
+        }];
+        let completed_stages = vec![(Some("builder".to_string()), stage_rootfs)];
+
+        super::ensure_run_cache_mount_targets(&rootfs, &mounts).unwrap();
+        let guard = super::PoolRunCacheMounts::activate_with_cache_root(
+            &rootfs,
+            &mounts,
+            &cache_root,
+            &completed_stages,
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(target.join("seed.txt")).unwrap(),
+            "seed-v1"
+        );
+        assert!(!target.join("original.txt").exists());
+        std::fs::write(target.join("generated.txt"), "persisted").unwrap();
+        guard.restore().unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("original.txt")).unwrap(),
+            "original"
+        );
+        assert!(!target.join("seed.txt").exists());
+        let cache_dir = super::run_cache_mount_dir(&cache_root, &mounts[0]);
+        assert_eq!(
+            std::fs::read_to_string(cache_dir.join("seed.txt")).unwrap(),
+            "seed-v1"
+        );
+        assert_eq!(
+            std::fs::read_to_string(cache_dir.join("generated.txt")).unwrap(),
+            "persisted"
+        );
+
+        std::fs::write(seed_dir.join("seed.txt"), "seed-v2").unwrap();
+        let guard = super::PoolRunCacheMounts::activate_with_cache_root(
+            &rootfs,
+            &mounts,
+            &cache_root,
+            &completed_stages,
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(target.join("seed.txt")).unwrap(),
+            "seed-v1",
+            "existing persistent cache should not be re-seeded"
+        );
+        guard.restore().unwrap();
+    }
+
+    #[test]
+    fn test_pool_run_cache_mounts_reject_missing_seed_source() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let stage_rootfs = tmp.path().join("stage-rootfs");
+        let rootfs = tmp.path().join("rootfs");
+        let target = rootfs.join("root/.cache");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&stage_rootfs).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("original.txt"), "original").unwrap();
+        let mounts = vec![RunCacheMount {
+            raw: "--mount=type=cache,id=seeded,sharing=locked,from=builder,source=/missing,target=/root/.cache".to_string(),
+            id: Some("seeded".to_string()),
+            from: Some("builder".to_string()),
+            source: "/missing".to_string(),
+            sharing: RunCacheSharing::Locked,
+            mode: None,
+            uid: None,
+            gid: None,
+            target: "/root/.cache".to_string(),
+        }];
+        let completed_stages = vec![(Some("builder".to_string()), stage_rootfs)];
+
+        let err = match super::PoolRunCacheMounts::activate_with_cache_root(
+            &rootfs,
+            &mounts,
+            &cache_root,
+            &completed_stages,
+        ) {
+            Ok(_) => panic!("missing RUN cache seed source should fail"),
+            Err(err) => err.to_string(),
+        };
+
+        assert!(err.contains("RUN cache mount seed source not found"));
+        assert_eq!(
+            std::fs::read_to_string(target.join("original.txt")).unwrap(),
+            "original"
+        );
+    }
+
+    #[test]
+    fn test_pool_run_cache_mounts_reject_file_seed_source() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let stage_rootfs = tmp.path().join("stage-rootfs");
+        let rootfs = tmp.path().join("rootfs");
+        let target = rootfs.join("root/.cache");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&stage_rootfs).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(stage_rootfs.join("seed-cache"), "not a directory").unwrap();
+        std::fs::write(target.join("original.txt"), "original").unwrap();
+        let mounts = vec![RunCacheMount {
+            raw: "--mount=type=cache,id=seeded,sharing=locked,from=builder,source=/seed-cache,target=/root/.cache".to_string(),
+            id: Some("seeded".to_string()),
+            from: Some("builder".to_string()),
+            source: "/seed-cache".to_string(),
+            sharing: RunCacheSharing::Locked,
+            mode: None,
+            uid: None,
+            gid: None,
+            target: "/root/.cache".to_string(),
+        }];
+        let completed_stages = vec![(Some("builder".to_string()), stage_rootfs)];
+
+        let err = match super::PoolRunCacheMounts::activate_with_cache_root(
+            &rootfs,
+            &mounts,
+            &cache_root,
+            &completed_stages,
+        ) {
+            Ok(_) => panic!("file RUN cache seed source should fail"),
+            Err(err) => err.to_string(),
+        };
+
+        assert!(err.contains("RUN cache mount seed source must be a directory"));
+        assert_eq!(
+            std::fs::read_to_string(target.join("original.txt")).unwrap(),
+            "original"
+        );
+    }
+
+    #[test]
+    fn test_pool_run_cache_mounts_restore_without_sync_discards_failed_run_cache() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        let target = rootfs.join("root/.cache");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("original.txt"), "original").unwrap();
+        let mounts = vec![RunCacheMount {
+            raw: "--mount=type=cache,id=failed,sharing=locked,target=/root/.cache".to_string(),
+            id: Some("failed".to_string()),
+            from: None,
+            source: ".".to_string(),
+            sharing: RunCacheSharing::Locked,
+            mode: None,
+            uid: None,
+            gid: None,
+            target: "/root/.cache".to_string(),
+        }];
+
+        super::ensure_run_cache_mount_targets(&rootfs, &mounts).unwrap();
+        let guard =
+            super::PoolRunCacheMounts::activate_with_cache_root(&rootfs, &mounts, &cache_root, &[])
+                .unwrap();
+        std::fs::write(target.join("partial.txt"), "partial").unwrap();
+        guard.restore_without_sync().unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("original.txt")).unwrap(),
+            "original"
+        );
+        assert!(!target.join("partial.txt").exists());
+        let cache_dir = super::run_cache_mount_dir(&cache_root, &mounts[0]);
+        assert!(
+            !cache_dir.join("partial.txt").exists(),
+            "failed RUN cache contents must not be persisted"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_pool_run_cache_mounts_apply_root_metadata() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        let target = rootfs.join("var/cache/apt");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&rootfs).unwrap();
+        let uid = unsafe { libc::geteuid() };
+        let gid = unsafe { libc::getegid() };
+        let mounts = vec![RunCacheMount {
+            raw: format!(
+                "--mount=type=cache,id=apt,sharing=locked,mode=0750,uid={uid},gid={gid},target=/var/cache/apt"
+            ),
+            id: Some("apt".to_string()),
+            from: None,
+            source: ".".to_string(),
+            sharing: RunCacheSharing::Locked,
+            mode: Some(0o750),
+            uid: Some(uid),
+            gid: Some(gid),
+            target: "/var/cache/apt".to_string(),
+        }];
+
+        super::ensure_run_cache_mount_targets(&rootfs, &mounts).unwrap();
+        let guard =
+            super::PoolRunCacheMounts::activate_with_cache_root(&rootfs, &mounts, &cache_root, &[])
+                .unwrap();
+        let metadata = std::fs::metadata(&target).unwrap();
+        assert_eq!(metadata.permissions().mode() & 0o7777, 0o750);
+        assert_eq!(metadata.uid(), uid);
+        assert_eq!(metadata.gid(), gid);
+        guard.restore().unwrap();
+    }
+
+    #[test]
+    fn test_pool_run_cache_mounts_reject_duplicate_cache_key() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(rootfs.join("a")).unwrap();
+        std::fs::create_dir_all(rootfs.join("b")).unwrap();
+        let mounts = vec![
+            RunCacheMount {
+                raw: "--mount=type=cache,id=shared,sharing=locked,target=/a".to_string(),
+                id: Some("shared".to_string()),
+                from: None,
+                source: ".".to_string(),
+                sharing: RunCacheSharing::Locked,
+                mode: None,
+                uid: None,
+                gid: None,
+                target: "/a".to_string(),
+            },
+            RunCacheMount {
+                raw: "--mount=type=cache,id=shared,sharing=locked,target=/b".to_string(),
+                id: Some("shared".to_string()),
+                from: None,
+                source: ".".to_string(),
+                sharing: RunCacheSharing::Locked,
+                mode: None,
+                uid: None,
+                gid: None,
+                target: "/b".to_string(),
+            },
+        ];
+
+        let err = match super::PoolRunCacheMounts::activate_with_cache_root(
+            &rootfs,
+            &mounts,
+            &cache_root,
+            &[],
+        ) {
+            Ok(_) => panic!("duplicate RUN cache mount key should fail"),
+            Err(err) => err.to_string(),
+        };
+
+        assert!(err.contains("Duplicate RUN cache mount"));
+        assert!(rootfs.join("a").is_dir());
+        assert!(rootfs.join("b").is_dir());
+    }
+
+    #[test]
+    fn test_pool_run_cache_mount_hydrate_failure_does_not_sync_partial_cache() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        let target = rootfs.join("root/.cache");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("original.txt"), "original").unwrap();
+        let mounts = vec![RunCacheMount {
+            raw: "--mount=type=cache,id=broken,sharing=locked,target=/root/.cache".to_string(),
+            id: Some("broken".to_string()),
+            from: None,
+            source: ".".to_string(),
+            sharing: RunCacheSharing::Locked,
+            mode: None,
+            uid: None,
+            gid: None,
+            target: "/root/.cache".to_string(),
+        }];
+        let cache_dir = super::run_cache_mount_dir(&cache_root, &mounts[0]);
+        std::fs::create_dir_all(cache_dir.parent().unwrap()).unwrap();
+        std::fs::write(&cache_dir, "not a directory").unwrap();
+
+        let err = match super::PoolRunCacheMounts::activate_with_cache_root(
+            &rootfs,
+            &mounts,
+            &cache_root,
+            &[],
+        ) {
+            Ok(_) => panic!("file cache entry should fail to hydrate"),
+            Err(err) => err.to_string(),
+        };
+
+        assert!(err.contains("is not a directory"));
+        assert_eq!(
+            std::fs::read_to_string(target.join("original.txt")).unwrap(),
+            "original"
+        );
+        assert!(cache_dir.is_file());
+        assert_eq!(
+            std::fs::read_to_string(cache_dir).unwrap(),
+            "not a directory"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_pool_run_cache_mount_lock_blocks_same_cache_key() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs-a");
+        let cache_root = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&rootfs).unwrap();
+        let mounts = vec![RunCacheMount {
+            raw: "--mount=type=cache,id=shared,sharing=locked,target=/root/.cache".to_string(),
+            id: Some("shared".to_string()),
+            from: None,
+            source: ".".to_string(),
+            sharing: RunCacheSharing::Locked,
+            mode: None,
+            uid: None,
+            gid: None,
+            target: "/root/.cache".to_string(),
+        }];
+        super::ensure_run_cache_mount_targets(&rootfs, &mounts).unwrap();
+        let guard =
+            super::PoolRunCacheMounts::activate_with_cache_root(&rootfs, &mounts, &cache_root, &[])
+                .unwrap();
+
+        let rootfs_b = tmp.path().join("rootfs-b");
+        std::fs::create_dir_all(&rootfs_b).unwrap();
+        super::ensure_run_cache_mount_targets(&rootfs_b, &mounts).unwrap();
+        let thread_mounts = mounts.clone();
+        let thread_cache_root = cache_root.clone();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let guard = super::PoolRunCacheMounts::activate_with_cache_root(
+                &rootfs_b,
+                &thread_mounts,
+                &thread_cache_root,
+                &[],
+            )
+            .unwrap();
+            done_tx.send(()).unwrap();
+            guard.restore().unwrap();
+        });
+
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "same RUN cache key should remain locked while the first mount is active"
+        );
+
+        guard.restore().unwrap();
+        done_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        waiter.join().unwrap();
     }
 
     #[test]
@@ -1561,8 +3734,10 @@ mod tests {
     #[test]
     fn test_instruction_to_string_onbuild() {
         let inner = Instruction::Run {
-            command: "echo triggered".to_string(),
+            command: RunCommand::Shell("echo triggered".to_string()),
             cache_mounts: vec![],
+            bind_mounts: vec![],
+            tmpfs_mounts: vec![],
         };
         let instr = Instruction::OnBuild {
             instruction: Box::new(inner),
@@ -1614,6 +3789,7 @@ mod tests {
             target: None,
             no_cache: false,
             metrics: None,
+            run_pool: None,
         };
         let tmp = tempfile::TempDir::new().unwrap();
 
@@ -1648,7 +3824,7 @@ mod tests {
         std::fs::create_dir_all(rootfs.join("bin")).unwrap();
         std::fs::write(rootfs.join("bin/sh"), "fake shell").unwrap();
 
-        let err = super::validate_linux_run_preconditions(&rootfs, &[], 1000)
+        let err = super::validate_linux_run_preconditions(&rootfs, &shell_run("true"), &[], 1000)
             .unwrap_err()
             .to_string();
 
@@ -1661,11 +3837,23 @@ mod tests {
         let rootfs = tmp.path().join("rootfs");
         std::fs::create_dir_all(&rootfs).unwrap();
 
-        let err = super::validate_linux_run_preconditions(&rootfs, &[], 0)
+        let err = super::validate_linux_run_preconditions(&rootfs, &shell_run("true"), &[], 0)
             .unwrap_err()
             .to_string();
 
         assert!(err.contains("was not found in rootfs"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_linux_run_preconditions_accept_absolute_shell_symlink() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        std::fs::create_dir_all(rootfs.join("bin")).unwrap();
+        std::fs::write(rootfs.join("bin/busybox"), "fake busybox").unwrap();
+        std::os::unix::fs::symlink("/bin/busybox", rootfs.join("bin/sh")).unwrap();
+
+        super::validate_linux_run_preconditions(&rootfs, &shell_run("true"), &[], 0).unwrap();
     }
 
     #[test]
@@ -1674,11 +3862,39 @@ mod tests {
         let rootfs = tmp.path().join("rootfs");
         std::fs::create_dir_all(&rootfs).unwrap();
 
-        let err = super::validate_linux_run_preconditions(&rootfs, &["sh".to_string()], 0)
+        let err = super::validate_linux_run_preconditions(
+            &rootfs,
+            &shell_run("true"),
+            &["sh".to_string()],
+            0,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("is not absolute"));
+    }
+
+    #[test]
+    fn test_run_exec_preconditions_accept_absolute_executable() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        std::fs::create_dir_all(rootfs.join("bin")).unwrap();
+        std::fs::write(rootfs.join("bin/echo"), "fake echo").unwrap();
+
+        super::validate_run_exec_preconditions(&rootfs, &["/bin/echo".to_string()]).unwrap();
+    }
+
+    #[test]
+    fn test_run_exec_preconditions_reject_missing_absolute_executable() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rootfs = tmp.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+
+        let err = super::validate_run_exec_preconditions(&rootfs, &["/bin/missing".to_string()])
             .unwrap_err()
             .to_string();
 
-        assert!(err.contains("is not absolute"));
+        assert!(err.contains("was not found in rootfs"));
     }
 
     #[test]
@@ -1717,8 +3933,23 @@ mod tests {
         std::fs::create_dir_all(&rootfs).unwrap();
         std::fs::create_dir_all(&layers).unwrap();
 
-        let result =
-            super::handle_run("echo unsafe", &[], &rootfs, &layers, "/", &[], &[], 0, true);
+        let command = shell_run("echo unsafe");
+        let result = super::handle_run(
+            &command,
+            &[],
+            &[],
+            &[],
+            tmp.path(),
+            &[],
+            &rootfs,
+            &layers,
+            "/",
+            &[],
+            &[],
+            0,
+            true,
+            None,
+        );
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Dockerfile RUN is not supported on macOS yet"));
         assert!(err.contains("--builder=buildkit-vm"));

--- a/src/runtime/src/oci/build/engine/mod.rs
+++ b/src/runtime/src/oci/build/engine/mod.rs
@@ -12,7 +12,7 @@ use a3s_box_core::error::{BoxError, Result};
 use a3s_box_core::platform::Platform;
 
 use super::cache::{hash_context_sources, BuildCache};
-use super::dockerfile::{Dockerfile, Instruction};
+use super::dockerfile::{Dockerfile, Instruction, RunBindMount, RunCacheMount};
 use super::dockerignore::DockerIgnore;
 use super::layer::{sha256_bytes, sha256_file, LayerInfo};
 use crate::oci::image::OciImageConfig;
@@ -29,7 +29,7 @@ mod tests;
 
 use handlers::{
     apply_base_config, execute_onbuild_trigger, handle_add, handle_copy, handle_run,
-    instruction_to_string,
+    handle_run_with_pool, instruction_to_string,
 };
 use stages::{global_arg_decls, resolve_stage_rootfs, split_into_stages};
 use utils::{compute_diff_id, expand_args, format_size, resolve_path};
@@ -57,6 +57,27 @@ pub struct BuildConfig {
     pub no_cache: bool,
     /// Prometheus metrics (optional).
     pub metrics: Option<crate::prom::RuntimeMetrics>,
+    /// Execute Dockerfile RUN instructions through a warm-pool daemon lease.
+    pub run_pool: Option<BuildRunPoolConfig>,
+}
+
+/// Configuration for executing Dockerfile RUN instructions in a warm-pool VM.
+#[derive(Debug, Clone)]
+pub struct BuildRunPoolConfig {
+    /// Pool daemon Unix socket.
+    pub socket: String,
+    /// Helper VM image. `None` uses the daemon's default image.
+    pub image: Option<String>,
+    /// Helper VM vCPU count for lazily-created pools.
+    pub vcpus: u32,
+    /// Helper VM memory in MiB for lazily-created pools.
+    pub memory_mb: u32,
+    /// Guest path where the stage rootfs is mounted.
+    pub guest_rootfs: String,
+    /// RUN exec timeout in nanoseconds.
+    pub timeout_ns: u64,
+    /// Persistent cache directory for `RUN --mount=type=cache`.
+    pub run_cache_dir: PathBuf,
 }
 
 /// Result of a successful build.
@@ -70,6 +91,235 @@ pub struct BuildResult {
     pub size: u64,
     /// Number of layers
     pub layer_count: usize,
+}
+
+#[cfg_attr(not(feature = "pool"), allow(dead_code))]
+struct BuildRunPoolSession {
+    guest_rootfs: String,
+    timeout_ns: u64,
+    run_cache_dir: PathBuf,
+    #[cfg(feature = "pool")]
+    lease: crate::pool::PoolLeaseClient,
+}
+
+impl BuildRunPoolSession {
+    async fn acquire(config: &BuildRunPoolConfig, rootfs_dir: &Path) -> Result<Self> {
+        #[cfg(feature = "pool")]
+        {
+            let rootfs_dir = rootfs_dir.canonicalize().map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to canonicalize build RUN rootfs {}: {}",
+                    rootfs_dir.display(),
+                    e
+                ))
+            })?;
+            let volume = format!("{}:{}:rw", rootfs_dir.display(), config.guest_rootfs);
+            let lease = crate::pool::PoolLeaseClient::acquire(crate::pool::PoolClientLease {
+                socket: config.socket.clone(),
+                image: config.image.clone(),
+                volumes: vec![volume],
+                vcpus: config.vcpus,
+                memory_mb: config.memory_mb,
+            })
+            .await
+            .map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to lease warm-pool VM for Dockerfile RUN: {}",
+                    e
+                ))
+            })?;
+            Ok(Self {
+                guest_rootfs: config.guest_rootfs.clone(),
+                timeout_ns: config.timeout_ns,
+                run_cache_dir: config.run_cache_dir.clone(),
+                lease,
+            })
+        }
+
+        #[cfg(not(feature = "pool"))]
+        {
+            let _ = (config, rootfs_dir);
+            Err(BoxError::BuildError(
+                "Dockerfile RUN warm-pool execution requires the runtime 'pool' feature"
+                    .to_string(),
+            ))
+        }
+    }
+
+    async fn release(self) -> Result<()> {
+        #[cfg(feature = "pool")]
+        {
+            self.lease.release().await.map_err(|e| {
+                BoxError::BuildError(format!(
+                    "Failed to release warm-pool Dockerfile RUN lease: {}",
+                    e
+                ))
+            })
+        }
+
+        #[cfg(not(feature = "pool"))]
+        {
+            Ok(())
+        }
+    }
+}
+
+fn run_bind_mount_input_hash(
+    context_dir: &Path,
+    completed_stages: &[(Option<String>, PathBuf)],
+    bind_mounts: &[RunBindMount],
+) -> Option<String> {
+    let mut input = String::new();
+
+    for mount in bind_mounts {
+        if has_parent_component(&mount.source) {
+            return None;
+        }
+
+        let source = if mount.source.is_empty() {
+            "."
+        } else {
+            mount.source.as_str()
+        };
+        let (origin, source_root) = match mount.from.as_deref() {
+            Some(from_ref) => (
+                format!("stage:{from_ref}"),
+                resolve_stage_rootfs(from_ref, completed_stages).ok()?,
+            ),
+            None => ("context".to_string(), context_dir),
+        };
+
+        let source_hash = hash_context_sources(source_root, &[source.to_string()])?;
+        input.push_str(&origin);
+        input.push('\0');
+        input.push_str(source);
+        input.push('\0');
+        input.push_str(&source_hash);
+        input.push('\0');
+
+        if mount.from.is_none() {
+            let dockerignore = context_dir.join(".dockerignore");
+            if let Ok(bytes) = std::fs::read(&dockerignore) {
+                input.push_str(".dockerignore");
+                input.push('\0');
+                input.push_str(&sha256_bytes(&bytes));
+                input.push('\0');
+            }
+        }
+    }
+
+    Some(sha256_bytes(input.as_bytes()))
+}
+
+fn run_cache_mount_input_hash(
+    completed_stages: &[(Option<String>, PathBuf)],
+    cache_mounts: &[RunCacheMount],
+) -> Option<String> {
+    let mut input = String::new();
+    let mut saw_seeded_cache = false;
+
+    for mount in cache_mounts {
+        let Some(from_ref) = mount.from.as_deref() else {
+            continue;
+        };
+        if has_parent_component(&mount.source) {
+            return None;
+        }
+
+        saw_seeded_cache = true;
+        let source = if mount.source.is_empty() {
+            "."
+        } else {
+            mount.source.as_str()
+        };
+        let source_root = resolve_stage_rootfs(from_ref, completed_stages).ok()?;
+        let source_hash = hash_context_sources(source_root, &[source.to_string()])?;
+        input.push_str("cache-seed:");
+        input.push_str(from_ref);
+        input.push('\0');
+        input.push_str(source);
+        input.push('\0');
+        input.push_str(&source_hash);
+        input.push('\0');
+    }
+
+    saw_seeded_cache.then(|| sha256_bytes(input.as_bytes()))
+}
+
+fn run_mount_input_hash(
+    context_dir: &Path,
+    completed_stages: &[(Option<String>, PathBuf)],
+    cache_mounts: &[RunCacheMount],
+    bind_mounts: &[RunBindMount],
+) -> Option<String> {
+    let bind_hash = if bind_mounts.is_empty() {
+        None
+    } else {
+        run_bind_mount_input_hash(context_dir, completed_stages, bind_mounts)
+    };
+    let cache_hash = run_cache_mount_input_hash(completed_stages, cache_mounts);
+
+    match (bind_hash, cache_hash) {
+        (None, None) => None,
+        (Some(hash), None) | (None, Some(hash)) => Some(hash),
+        (Some(bind_hash), Some(cache_hash)) => Some(sha256_bytes(
+            format!("bind\0{bind_hash}\0cache\0{cache_hash}").as_bytes(),
+        )),
+    }
+}
+
+fn has_parent_component(path: &str) -> bool {
+    Path::new(path)
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+}
+
+async fn resolve_run_mount_source_roots(
+    completed_stages: &[(Option<String>, PathBuf)],
+    bind_mounts: &[RunBindMount],
+    cache_mounts: &[RunCacheMount],
+    store: &Arc<ImageStore>,
+    build_dir: &Path,
+    external_from_rootfs: &mut HashMap<String, PathBuf>,
+) -> Result<Option<Vec<(Option<String>, PathBuf)>>> {
+    let mut roots: Option<Vec<(Option<String>, PathBuf)>> = None;
+    let mut external_refs = HashSet::new();
+
+    let mut from_refs: Vec<&str> = Vec::new();
+    from_refs.extend(bind_mounts.iter().filter_map(|mount| mount.from.as_deref()));
+    from_refs.extend(
+        cache_mounts
+            .iter()
+            .filter_map(|mount| mount.from.as_deref()),
+    );
+
+    for from_ref in from_refs {
+        if resolve_stage_rootfs(from_ref, completed_stages).is_ok()
+            || roots
+                .as_deref()
+                .is_some_and(|resolved| resolve_stage_rootfs(from_ref, resolved).is_ok())
+        {
+            continue;
+        }
+
+        if !external_refs.insert(from_ref.to_string()) {
+            continue;
+        }
+
+        let rootfs = resolve_external_from_rootfs(
+            from_ref,
+            "RUN bind mount",
+            store,
+            build_dir,
+            external_from_rootfs,
+        )
+        .await?;
+        roots
+            .get_or_insert_with(|| completed_stages.to_vec())
+            .push((Some(from_ref.to_string()), rootfs));
+    }
+
+    Ok(roots)
 }
 
 /// Mutable state accumulated during the build.
@@ -246,7 +496,7 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
     // Track completed stages: (alias, rootfs_path)
     let mut completed_stages: Vec<(Option<String>, PathBuf)> = Vec::new();
     // Cache external images already pulled+extracted for `COPY --from=<image>`
-    // (keyed by image ref) so multiple copies from one image pull once.
+    // and RUN mount `from=<image>` sources so repeated references pull once.
     let mut external_from_rootfs: HashMap<String, PathBuf> = HashMap::new();
 
     // Create temp directory for build workspace
@@ -283,6 +533,7 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
         }
         let mut base_layers: Vec<LayerInfo> = Vec::new();
         let mut base_diff_ids: Vec<String> = Vec::new();
+        let mut run_pool_session: Option<BuildRunPoolSession> = None;
 
         // Layer-level build cache (best-effort; None disables caching).
         let cache = if config.no_cache {
@@ -298,6 +549,24 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
         for instruction in &stage.instructions {
             global_step += 1;
             let step = global_step;
+            let run_mount_source_roots = if let Instruction::Run {
+                bind_mounts,
+                cache_mounts,
+                ..
+            } = instruction
+            {
+                resolve_run_mount_source_roots(
+                    &completed_stages,
+                    bind_mounts,
+                    cache_mounts,
+                    &store,
+                    build_dir.path(),
+                    &mut external_from_rootfs,
+                )
+                .await?
+            } else {
+                None
+            };
 
             // Advance the chain key BEFORE the match so a cache-hit `continue`
             // does not skip it. FROM resets the key (keyed on base content below);
@@ -351,6 +620,18 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
                             .and_then(|rootfs| hash_context_sources(rootfs, src))
                     }
                     Instruction::Add { src, .. } => hash_context_sources(&config.context_dir, src),
+                    Instruction::Run {
+                        cache_mounts,
+                        bind_mounts,
+                        ..
+                    } => run_mount_input_hash(
+                        &config.context_dir,
+                        run_mount_source_roots
+                            .as_deref()
+                            .unwrap_or(&completed_stages),
+                        cache_mounts,
+                        bind_mounts,
+                    ),
                     _ => None,
                 };
                 chain_key = BuildCache::chain(&chain_key, &repr, input_hash.as_deref());
@@ -476,8 +757,9 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
                             match resolve_stage_rootfs(from_ref, &completed_stages) {
                                 Ok(stage_rootfs) => stage_rootfs.to_path_buf(),
                                 Err(_) => {
-                                    resolve_external_image_rootfs(
+                                    resolve_external_from_rootfs(
                                         from_ref,
+                                        "COPY --from",
                                         &store,
                                         build_dir.path(),
                                         &mut external_from_rootfs,
@@ -608,6 +890,8 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
                 Instruction::Run {
                     command,
                     cache_mounts,
+                    bind_mounts,
+                    tmpfs_mounts,
                 } => {
                     let created_by = instruction_to_string(instruction);
                     if try_reuse_cached_layer(
@@ -637,17 +921,55 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
                     if !config.quiet {
                         println!("Step {}/{}: {}", step, total_instructions, created_by);
                     }
-                    let layer_opt = handle_run(
-                        command,
-                        cache_mounts,
-                        &rootfs_dir,
-                        &layers_dir,
-                        &state.workdir,
-                        &state.run_env(),
-                        &state.shell,
-                        state.layers.len() + base_layers.len(),
-                        config.quiet,
-                    )?;
+                    let layer_opt = if let Some(pool_config) = &config.run_pool {
+                        if run_pool_session.is_none() {
+                            run_pool_session =
+                                Some(BuildRunPoolSession::acquire(pool_config, &rootfs_dir).await?);
+                        }
+                        let session = run_pool_session
+                            .as_ref()
+                            .expect("run pool session was just initialized");
+                        handle_run_with_pool(
+                            command,
+                            cache_mounts,
+                            bind_mounts,
+                            tmpfs_mounts,
+                            &config.context_dir,
+                            run_mount_source_roots
+                                .as_deref()
+                                .unwrap_or(&completed_stages),
+                            &rootfs_dir,
+                            &layers_dir,
+                            &state.workdir,
+                            &state.run_env(),
+                            &state.shell,
+                            state.user.as_deref(),
+                            state.layers.len() + base_layers.len(),
+                            config.quiet,
+                            session,
+                            Some(&dockerignore),
+                        )
+                        .await?
+                    } else {
+                        handle_run(
+                            command,
+                            cache_mounts,
+                            bind_mounts,
+                            tmpfs_mounts,
+                            &config.context_dir,
+                            run_mount_source_roots
+                                .as_deref()
+                                .unwrap_or(&completed_stages),
+                            &rootfs_dir,
+                            &layers_dir,
+                            &state.workdir,
+                            &state.run_env(),
+                            &state.shell,
+                            state.layers.len() + base_layers.len(),
+                            config.quiet,
+                            Some(&dockerignore),
+                        )?
+                    };
                     if let Some(layer_info) = layer_opt {
                         let diff_id = compute_diff_id(&layer_info.path)?;
                         if let Some(c) = &cache {
@@ -887,6 +1209,10 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
             }
         }
 
+        if let Some(session) = run_pool_session.take() {
+            session.release().await?;
+        }
+
         // Store completed stage rootfs for COPY --from
         completed_stages.push((stage.alias.clone(), rootfs_dir.clone()));
 
@@ -1056,11 +1382,12 @@ async fn handle_from(
     Ok((base_layers, base_diff_ids, config))
 }
 
-/// Resolve `COPY --from=<image>` when `<image>` is not a build stage: pull the
-/// external image and extract it to a temp rootfs to copy from (Docker behavior).
-/// Memoized per build so several copies from one image pull only once.
-async fn resolve_external_image_rootfs(
+/// Resolve an external image source when `from=<image>` is not a build stage:
+/// pull the image and extract it to a temp rootfs (Docker behavior). Memoized
+/// per build so several copies or RUN bind mounts from one image pull only once.
+async fn resolve_external_from_rootfs(
     image_ref: &str,
+    operation: &str,
     store: &Arc<ImageStore>,
     build_dir: &Path,
     cache: &mut HashMap<String, PathBuf>,
@@ -1072,7 +1399,7 @@ async fn resolve_external_image_rootfs(
     let dir = build_dir.join(format!("copyfrom_{}", cache.len()));
     std::fs::create_dir_all(&dir).map_err(|e| {
         BoxError::BuildError(format!(
-            "Failed to create COPY --from image rootfs {}: {}",
+            "Failed to create {operation} image rootfs {}: {}",
             dir.display(),
             e
         ))
@@ -1081,7 +1408,7 @@ async fn resolve_external_image_rootfs(
     let puller = ImagePuller::new(store.clone(), RegistryAuth::from_env());
     let oci_image = puller.pull(image_ref).await.map_err(|e| {
         BoxError::BuildError(format!(
-            "COPY --from={}: not a build stage and could not be pulled as an image: {}",
+            "{operation} from={}: not a build stage and could not be pulled as an image: {}",
             image_ref, e
         ))
     })?;

--- a/src/runtime/src/oci/build/engine/stages.rs
+++ b/src/runtime/src/oci/build/engine/stages.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 use a3s_box_core::error::{BoxError, Result};
 
 use super::super::dockerfile::Instruction;
+#[cfg(test)]
+use super::super::dockerfile::RunCommand;
 
 /// A build stage: a FROM instruction followed by its body instructions.
 pub(super) struct BuildStage {
@@ -115,8 +117,10 @@ mod tests {
 
     fn make_run(cmd: &str) -> Instruction {
         Instruction::Run {
-            command: cmd.to_string(),
+            command: RunCommand::Shell(cmd.to_string()),
             cache_mounts: vec![],
+            bind_mounts: vec![],
+            tmpfs_mounts: vec![],
         }
     }
 

--- a/src/runtime/src/oci/build/engine/tests.rs
+++ b/src/runtime/src/oci/build/engine/tests.rs
@@ -93,7 +93,56 @@ mod tests {
             target: None,
             no_cache: false,
             metrics: None,
+            run_pool: None,
         }
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    fn parse_pool_volume_spec(spec: &str) -> (PathBuf, String, String) {
+        let parts = spec.rsplitn(3, ':').collect::<Vec<_>>();
+        assert_eq!(parts.len(), 3, "expected host:guest:mode volume spec");
+        (
+            PathBuf::from(parts[2]),
+            parts[1].to_string(),
+            parts[0].to_string(),
+        )
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    fn image_layer_files(image: &OciImage) -> Vec<String> {
+        let mut names = Vec::new();
+        for layer in image.layer_paths() {
+            let file = std::fs::File::open(layer).unwrap();
+            let dec = flate2::read::GzDecoder::new(file);
+            let mut ar = tar::Archive::new(dec);
+            names.extend(
+                ar.entries()
+                    .unwrap()
+                    .filter_map(|entry| entry.ok())
+                    .filter(|entry| entry.header().entry_type().is_file())
+                    .map(|entry| entry.path().unwrap().to_string_lossy().to_string()),
+            );
+        }
+        names.sort();
+        names
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    fn tree_contains_file_named(root: &std::path::Path, file_name: &str) -> bool {
+        let Ok(entries) = std::fs::read_dir(root) else {
+            return false;
+        };
+        for entry in entries.filter_map(|entry| entry.ok()) {
+            let path = entry.path();
+            if path.is_file() && path.file_name().and_then(|name| name.to_str()) == Some(file_name)
+            {
+                return true;
+            }
+            if path.is_dir() && tree_contains_file_named(&path, file_name) {
+                return true;
+            }
+        }
+        false
     }
 
     #[test]
@@ -155,6 +204,7 @@ LABEL org.opencontainers.image.title="scratch-smoke"
                 target: None,
                 no_cache: false,
                 metrics: None,
+                run_pool: None,
             },
             store.clone(),
         )
@@ -174,6 +224,1303 @@ LABEL org.opencontainers.image.title="scratch-smoke"
             image.label("org.opencontainers.image.title"),
             Some("scratch-smoke")
         );
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    #[tokio::test]
+    async fn test_build_run_pool_reuses_stage_lease_and_captures_rootfs_diff() {
+        use super::super::BuildRunPoolConfig;
+        use crate::pool::client::{read_frame, write_frame};
+        use crate::pool::{
+            PoolLeaseReleaseResponse, PoolLeaseResponse, PoolRequest, PoolRunResponse,
+        };
+        use std::time::Duration;
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = tmp.path().join("context");
+        let store_dir = tmp.path().join("images");
+        let socket = tmp.path().join("pool.sock");
+        let run_cache_dir = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&context).unwrap();
+        std::fs::write(context.join("sh"), "fake shell").unwrap();
+        std::fs::write(
+            context.join("Dockerfile"),
+            r#"FROM scratch
+COPY sh /bin/sh
+WORKDIR /app
+ENV HELLO=warm
+USER 1000:1001
+RUN echo "$HELLO" > out.txt
+RUN cat out.txt > copied.txt
+RUN ["/bin/sh", "-c", "printf exec > exec.txt"]
+CMD ["cat", "/app/copied.txt"]
+"#,
+        )
+        .unwrap();
+
+        let listener = UnixListener::bind(&socket).unwrap();
+        let daemon = tokio::spawn(async move {
+            let mut lease_count = 0usize;
+            let mut exec_count = 0usize;
+            let mut release_count = 0usize;
+            let mut rootfs_host: Option<PathBuf> = None;
+
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let req: PoolRequest =
+                    serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+
+                match req {
+                    PoolRequest::Lease(req) => {
+                        lease_count += 1;
+                        assert_eq!(lease_count, 1, "stage should lease exactly one VM");
+                        assert_eq!(req.image.as_deref(), Some("helper:latest"));
+                        assert_eq!(req.vcpus, Some(3));
+                        assert_eq!(req.memory_mb, Some(768));
+                        assert_eq!(req.volumes.len(), 1);
+
+                        let (host, guest, mode) = parse_pool_volume_spec(&req.volumes[0]);
+                        assert_eq!(guest, "/run/a3s/test-rootfs");
+                        assert_eq!(mode, "rw");
+                        rootfs_host = Some(host);
+
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseResponse {
+                                lease_id: Some("lease-1".to_string()),
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Exec(req) => {
+                        exec_count += 1;
+                        assert_eq!(req.lease_id, "lease-1");
+                        assert_eq!(req.rootfs.as_deref(), Some("/run/a3s/test-rootfs"));
+                        assert_eq!(req.timeout_ns, Some(12_000_000_000));
+                        assert_eq!(req.user.as_deref(), Some("1000:1001"));
+                        assert!(req.env.iter().any(|entry| entry == "HELLO=warm"));
+
+                        let rootfs = rootfs_host.as_ref().expect("lease records rootfs host");
+                        match exec_count {
+                            1 => {
+                                assert_eq!(req.working_dir.as_deref(), Some("/"));
+                                assert_eq!(
+                                    req.cmd,
+                                    vec![
+                                        "/bin/sh".to_string(),
+                                        "-c".to_string(),
+                                        "cd '/app' && echo \"$HELLO\" > out.txt".to_string(),
+                                    ]
+                                );
+                                std::fs::write(rootfs.join("app/out.txt"), "warm\n").unwrap();
+                            }
+                            2 => {
+                                assert_eq!(req.working_dir.as_deref(), Some("/"));
+                                assert_eq!(
+                                    req.cmd,
+                                    vec![
+                                        "/bin/sh".to_string(),
+                                        "-c".to_string(),
+                                        "cd '/app' && cat out.txt > copied.txt".to_string(),
+                                    ]
+                                );
+                                let content = std::fs::read_to_string(rootfs.join("app/out.txt"))
+                                    .expect("second RUN sees first RUN output in the same rootfs");
+                                std::fs::write(rootfs.join("app/copied.txt"), content).unwrap();
+                            }
+                            3 => {
+                                assert_eq!(req.working_dir.as_deref(), Some("/app"));
+                                assert_eq!(
+                                    req.cmd,
+                                    vec![
+                                        "/bin/sh".to_string(),
+                                        "-c".to_string(),
+                                        "printf exec > exec.txt".to_string(),
+                                    ]
+                                );
+                                std::fs::write(rootfs.join("app/exec.txt"), "exec").unwrap();
+                            }
+                            other => panic!("unexpected exec request {other}"),
+                        }
+
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolRunResponse {
+                                stdout: Vec::new(),
+                                stderr: Vec::new(),
+                                exit_code: 0,
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Release(req) => {
+                        release_count += 1;
+                        assert_eq!(req.lease_id, "lease-1");
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseReleaseResponse { error: None }).unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                        break;
+                    }
+                    other => panic!(
+                        "unexpected pool request: {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }
+            }
+
+            assert_eq!(lease_count, 1);
+            assert_eq!(exec_count, 3);
+            assert_eq!(release_count, 1);
+        });
+
+        let store = Arc::new(ImageStore::new(&store_dir, 1024 * 1024 * 100).unwrap());
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            build(
+                BuildConfig {
+                    context_dir: context.clone(),
+                    dockerfile_path: context.join("Dockerfile"),
+                    tag: Some("run-pool:latest".to_string()),
+                    build_args: HashMap::new(),
+                    quiet: true,
+                    platforms: vec![],
+                    target: None,
+                    no_cache: true,
+                    metrics: None,
+                    run_pool: Some(BuildRunPoolConfig {
+                        socket: socket.to_string_lossy().to_string(),
+                        image: Some("helper:latest".to_string()),
+                        vcpus: 3,
+                        memory_mb: 768,
+                        guest_rootfs: "/run/a3s/test-rootfs".to_string(),
+                        timeout_ns: 12_000_000_000,
+                        run_cache_dir: run_cache_dir.clone(),
+                    }),
+                },
+                store.clone(),
+            ),
+        )
+        .await
+        .expect("build should not hang")
+        .unwrap();
+
+        daemon.await.unwrap();
+        assert_eq!(result.layer_count, 4);
+
+        let stored = store.get("run-pool:latest").await.unwrap();
+        let image = OciImage::from_path(&stored.path).unwrap();
+        let files = image_layer_files(&image);
+        assert_eq!(image.config().user.as_deref(), Some("1000:1001"));
+        assert!(files.iter().any(|path| path == "bin/sh"));
+        assert!(files.iter().any(|path| path == "app/out.txt"));
+        assert!(files.iter().any(|path| path == "app/copied.txt"));
+        assert!(files.iter().any(|path| path == "app/exec.txt"));
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    #[tokio::test]
+    async fn test_build_run_pool_bind_mount_context_is_not_committed() {
+        use super::super::BuildRunPoolConfig;
+        use crate::pool::client::{read_frame, write_frame};
+        use crate::pool::{
+            PoolLeaseReleaseResponse, PoolLeaseResponse, PoolRequest, PoolRunResponse,
+        };
+        use std::time::Duration;
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = tmp.path().join("context");
+        let store_dir = tmp.path().join("images");
+        let socket = tmp.path().join("pool.sock");
+        let run_cache_dir = tmp.path().join("run-cache");
+        std::fs::create_dir_all(context.join("src")).unwrap();
+        std::fs::write(context.join("sh"), "fake shell").unwrap();
+        std::fs::write(context.join("src/input.txt"), "from-bind\n").unwrap();
+        std::fs::write(
+            context.join("Dockerfile"),
+            r#"FROM scratch
+COPY sh /bin/sh
+WORKDIR /work
+RUN --mount=type=bind,source=src,target=. cat input.txt > /out.txt
+"#,
+        )
+        .unwrap();
+
+        let listener = UnixListener::bind(&socket).unwrap();
+        let daemon = tokio::spawn(async move {
+            let mut rootfs_host: Option<PathBuf> = None;
+
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let req: PoolRequest =
+                    serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+
+                match req {
+                    PoolRequest::Lease(req) => {
+                        let (host, guest, mode) = parse_pool_volume_spec(&req.volumes[0]);
+                        assert_eq!(guest, "/run/a3s/test-rootfs");
+                        assert_eq!(mode, "rw");
+                        rootfs_host = Some(host);
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseResponse {
+                                lease_id: Some("lease-bind".to_string()),
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Exec(req) => {
+                        assert_eq!(req.lease_id, "lease-bind");
+                        assert_eq!(
+                            req.cmd,
+                            vec![
+                                "/bin/sh".to_string(),
+                                "-c".to_string(),
+                                "cd '/work' && cat input.txt > /out.txt".to_string(),
+                            ]
+                        );
+                        let rootfs = rootfs_host.as_ref().expect("lease records rootfs host");
+                        assert_eq!(
+                            std::fs::read_to_string(rootfs.join("work/input.txt")).unwrap(),
+                            "from-bind\n"
+                        );
+                        std::fs::write(rootfs.join("out.txt"), "from-bind\n").unwrap();
+                        std::fs::write(rootfs.join("work/generated.txt"), "discarded\n").unwrap();
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolRunResponse {
+                                stdout: Vec::new(),
+                                stderr: Vec::new(),
+                                exit_code: 0,
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Release(req) => {
+                        assert_eq!(req.lease_id, "lease-bind");
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseReleaseResponse { error: None }).unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                        break;
+                    }
+                    other => panic!(
+                        "unexpected pool request: {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }
+            }
+        });
+
+        let store = Arc::new(ImageStore::new(&store_dir, 1024 * 1024 * 100).unwrap());
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            build(
+                BuildConfig {
+                    context_dir: context.clone(),
+                    dockerfile_path: context.join("Dockerfile"),
+                    tag: Some("run-pool-bind:latest".to_string()),
+                    build_args: HashMap::new(),
+                    quiet: true,
+                    platforms: vec![],
+                    target: None,
+                    no_cache: true,
+                    metrics: None,
+                    run_pool: Some(BuildRunPoolConfig {
+                        socket: socket.to_string_lossy().to_string(),
+                        image: Some("helper:latest".to_string()),
+                        vcpus: 2,
+                        memory_mb: 512,
+                        guest_rootfs: "/run/a3s/test-rootfs".to_string(),
+                        timeout_ns: 12_000_000_000,
+                        run_cache_dir: run_cache_dir.clone(),
+                    }),
+                },
+                store.clone(),
+            ),
+        )
+        .await
+        .expect("build should not hang")
+        .unwrap();
+
+        daemon.await.unwrap();
+        assert_eq!(result.layer_count, 2);
+
+        let stored = store.get("run-pool-bind:latest").await.unwrap();
+        let image = OciImage::from_path(&stored.path).unwrap();
+        let files = image_layer_files(&image);
+        assert!(files.iter().any(|path| path == "out.txt"));
+        assert!(!files.iter().any(|path| path == "work/input.txt"));
+        assert!(!files.iter().any(|path| path == "work/generated.txt"));
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    #[tokio::test]
+    async fn test_build_run_pool_bind_mount_from_stage_is_not_committed() {
+        use super::super::BuildRunPoolConfig;
+        use crate::pool::client::{read_frame, write_frame};
+        use crate::pool::{
+            PoolLeaseReleaseResponse, PoolLeaseResponse, PoolRequest, PoolRunResponse,
+        };
+        use std::collections::HashMap;
+        use std::time::Duration;
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = tmp.path().join("context");
+        let store_dir = tmp.path().join("images");
+        let socket = tmp.path().join("pool.sock");
+        let run_cache_dir = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&context).unwrap();
+        std::fs::write(context.join("sh"), "fake shell").unwrap();
+        std::fs::write(
+            context.join("Dockerfile"),
+            r#"FROM scratch AS builder
+COPY sh /bin/sh
+RUN printf built > /artifact.txt
+
+FROM scratch
+COPY sh /bin/sh
+WORKDIR /work
+RUN --mount=type=bind,from=builder,source=/artifact.txt,target=artifact.txt cat artifact.txt > /out.txt
+"#,
+        )
+        .unwrap();
+
+        let listener = UnixListener::bind(&socket).unwrap();
+        let daemon = tokio::spawn(async move {
+            let mut lease_count = 0usize;
+            let mut exec_count = 0usize;
+            let mut release_count = 0usize;
+            let mut rootfs_hosts: HashMap<String, PathBuf> = HashMap::new();
+
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let req: PoolRequest =
+                    serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+
+                match req {
+                    PoolRequest::Lease(req) => {
+                        lease_count += 1;
+                        assert_eq!(req.volumes.len(), 1);
+                        let (host, guest, mode) = parse_pool_volume_spec(&req.volumes[0]);
+                        assert_eq!(guest, "/run/a3s/test-rootfs");
+                        assert_eq!(mode, "rw");
+                        let lease_id = format!("lease-{lease_count}");
+                        rootfs_hosts.insert(lease_id.clone(), host);
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseResponse {
+                                lease_id: Some(lease_id),
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Exec(req) => {
+                        exec_count += 1;
+                        let rootfs = rootfs_hosts
+                            .get(&req.lease_id)
+                            .expect("lease records rootfs host");
+                        match req.lease_id.as_str() {
+                            "lease-1" => {
+                                assert_eq!(
+                                    req.cmd,
+                                    vec![
+                                        "/bin/sh".to_string(),
+                                        "-c".to_string(),
+                                        "printf built > /artifact.txt".to_string(),
+                                    ]
+                                );
+                                std::fs::write(rootfs.join("artifact.txt"), "built").unwrap();
+                            }
+                            "lease-2" => {
+                                assert_eq!(
+                                    req.cmd,
+                                    vec![
+                                        "/bin/sh".to_string(),
+                                        "-c".to_string(),
+                                        "cd '/work' && cat artifact.txt > /out.txt".to_string(),
+                                    ]
+                                );
+                                assert_eq!(
+                                    std::fs::read_to_string(rootfs.join("work/artifact.txt"))
+                                        .unwrap(),
+                                    "built"
+                                );
+                                std::fs::write(rootfs.join("out.txt"), "built").unwrap();
+                                std::fs::write(rootfs.join("work/artifact.txt"), "discarded")
+                                    .unwrap();
+                            }
+                            other => panic!("unexpected lease id {other}"),
+                        }
+
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolRunResponse {
+                                stdout: Vec::new(),
+                                stderr: Vec::new(),
+                                exit_code: 0,
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Release(req) => {
+                        release_count += 1;
+                        assert!(matches!(req.lease_id.as_str(), "lease-1" | "lease-2"));
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseReleaseResponse { error: None }).unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                        if release_count == 2 {
+                            break;
+                        }
+                    }
+                    other => panic!(
+                        "unexpected pool request: {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }
+            }
+
+            assert_eq!(lease_count, 2);
+            assert_eq!(exec_count, 2);
+            assert_eq!(release_count, 2);
+        });
+
+        let store = Arc::new(ImageStore::new(&store_dir, 1024 * 1024 * 100).unwrap());
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            build(
+                BuildConfig {
+                    context_dir: context.clone(),
+                    dockerfile_path: context.join("Dockerfile"),
+                    tag: Some("run-pool-stage-bind:latest".to_string()),
+                    build_args: HashMap::new(),
+                    quiet: true,
+                    platforms: vec![],
+                    target: None,
+                    no_cache: true,
+                    metrics: None,
+                    run_pool: Some(BuildRunPoolConfig {
+                        socket: socket.to_string_lossy().to_string(),
+                        image: Some("helper:latest".to_string()),
+                        vcpus: 2,
+                        memory_mb: 512,
+                        guest_rootfs: "/run/a3s/test-rootfs".to_string(),
+                        timeout_ns: 12_000_000_000,
+                        run_cache_dir: run_cache_dir.clone(),
+                    }),
+                },
+                store.clone(),
+            ),
+        )
+        .await
+        .expect("build should not hang")
+        .unwrap();
+
+        daemon.await.unwrap();
+        assert_eq!(result.layer_count, 2);
+
+        let stored = store.get("run-pool-stage-bind:latest").await.unwrap();
+        let image = OciImage::from_path(&stored.path).unwrap();
+        let files = image_layer_files(&image);
+        assert!(files.iter().any(|path| path == "bin/sh"));
+        assert!(files.iter().any(|path| path == "out.txt"));
+        assert!(!files.iter().any(|path| path == "work/artifact.txt"));
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    #[tokio::test]
+    async fn test_build_run_pool_bind_mount_from_external_image_is_not_committed() {
+        use super::super::BuildRunPoolConfig;
+        use crate::pool::client::{read_frame, write_frame};
+        use crate::pool::{
+            PoolLeaseReleaseResponse, PoolLeaseResponse, PoolRequest, PoolRunResponse,
+        };
+        use std::time::Duration;
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let source_context = tmp.path().join("source-context");
+        let target_context = tmp.path().join("target-context");
+        let store_dir = tmp.path().join("images");
+        let socket = tmp.path().join("pool.sock");
+        let run_cache_dir = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&source_context).unwrap();
+        std::fs::create_dir_all(&target_context).unwrap();
+        std::fs::write(source_context.join("artifact.txt"), "from-external").unwrap();
+        std::fs::write(
+            source_context.join("Dockerfile"),
+            r#"FROM scratch
+COPY artifact.txt /artifact.txt
+"#,
+        )
+        .unwrap();
+        std::fs::write(target_context.join("sh"), "fake shell").unwrap();
+        std::fs::write(
+            target_context.join("Dockerfile"),
+            r#"FROM scratch
+COPY sh /bin/sh
+WORKDIR /work
+RUN --mount=type=bind,from=external-bind-source:latest,source=/artifact.txt,target=artifact.txt cat artifact.txt > /out.txt
+"#,
+        )
+        .unwrap();
+
+        let store = Arc::new(ImageStore::new(&store_dir, 1024 * 1024 * 100).unwrap());
+        build(
+            BuildConfig {
+                context_dir: source_context.clone(),
+                dockerfile_path: source_context.join("Dockerfile"),
+                tag: Some("external-bind-source:latest".to_string()),
+                build_args: HashMap::new(),
+                quiet: true,
+                platforms: vec![],
+                target: None,
+                no_cache: true,
+                metrics: None,
+                run_pool: None,
+            },
+            store.clone(),
+        )
+        .await
+        .expect("source image should build into the local store");
+
+        let listener = UnixListener::bind(&socket).unwrap();
+        let daemon = tokio::spawn(async move {
+            let mut rootfs_host: Option<PathBuf> = None;
+
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let req: PoolRequest =
+                    serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+
+                match req {
+                    PoolRequest::Lease(req) => {
+                        assert_eq!(req.volumes.len(), 1);
+                        let (host, guest, mode) = parse_pool_volume_spec(&req.volumes[0]);
+                        assert_eq!(guest, "/run/a3s/test-rootfs");
+                        assert_eq!(mode, "rw");
+                        rootfs_host = Some(host);
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseResponse {
+                                lease_id: Some("lease-external-bind".to_string()),
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Exec(req) => {
+                        assert_eq!(req.lease_id, "lease-external-bind");
+                        assert_eq!(
+                            req.cmd,
+                            vec![
+                                "/bin/sh".to_string(),
+                                "-c".to_string(),
+                                "cd '/work' && cat artifact.txt > /out.txt".to_string(),
+                            ]
+                        );
+                        let rootfs = rootfs_host.as_ref().expect("lease records rootfs host");
+                        assert_eq!(
+                            std::fs::read_to_string(rootfs.join("work/artifact.txt")).unwrap(),
+                            "from-external"
+                        );
+                        std::fs::write(rootfs.join("out.txt"), "from-external").unwrap();
+                        std::fs::write(rootfs.join("work/artifact.txt"), "discarded").unwrap();
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolRunResponse {
+                                stdout: Vec::new(),
+                                stderr: Vec::new(),
+                                exit_code: 0,
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Release(req) => {
+                        assert_eq!(req.lease_id, "lease-external-bind");
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseReleaseResponse { error: None }).unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                        break;
+                    }
+                    other => panic!(
+                        "unexpected pool request: {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }
+            }
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            build(
+                BuildConfig {
+                    context_dir: target_context.clone(),
+                    dockerfile_path: target_context.join("Dockerfile"),
+                    tag: Some("run-pool-external-bind:latest".to_string()),
+                    build_args: HashMap::new(),
+                    quiet: true,
+                    platforms: vec![],
+                    target: None,
+                    no_cache: true,
+                    metrics: None,
+                    run_pool: Some(BuildRunPoolConfig {
+                        socket: socket.to_string_lossy().to_string(),
+                        image: Some("helper:latest".to_string()),
+                        vcpus: 2,
+                        memory_mb: 512,
+                        guest_rootfs: "/run/a3s/test-rootfs".to_string(),
+                        timeout_ns: 12_000_000_000,
+                        run_cache_dir: run_cache_dir.clone(),
+                    }),
+                },
+                store.clone(),
+            ),
+        )
+        .await
+        .expect("build should not hang")
+        .unwrap();
+
+        daemon.await.unwrap();
+        assert_eq!(result.layer_count, 2);
+
+        let stored = store.get("run-pool-external-bind:latest").await.unwrap();
+        let image = OciImage::from_path(&stored.path).unwrap();
+        let files = image_layer_files(&image);
+        assert!(files.iter().any(|path| path == "bin/sh"));
+        assert!(files.iter().any(|path| path == "out.txt"));
+        assert!(!files.iter().any(|path| path == "work/artifact.txt"));
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    #[tokio::test]
+    async fn test_build_run_pool_tmpfs_mount_is_not_committed() {
+        use super::super::BuildRunPoolConfig;
+        use crate::pool::client::{read_frame, write_frame};
+        use crate::pool::{
+            PoolLeaseReleaseResponse, PoolLeaseResponse, PoolRequest, PoolRunResponse,
+        };
+        use std::time::Duration;
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = tmp.path().join("context");
+        let store_dir = tmp.path().join("images");
+        let socket = tmp.path().join("pool.sock");
+        let run_cache_dir = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&context).unwrap();
+        std::fs::write(context.join("sh"), "fake shell").unwrap();
+        std::fs::write(context.join("original.txt"), "from-rootfs\n").unwrap();
+        std::fs::write(
+            context.join("Dockerfile"),
+            r#"FROM scratch
+COPY sh /bin/sh
+WORKDIR /work
+COPY original.txt tmp/original.txt
+RUN --mount=type=tmpfs,target=tmp printf ok > /out.txt
+"#,
+        )
+        .unwrap();
+
+        let listener = UnixListener::bind(&socket).unwrap();
+        let daemon = tokio::spawn(async move {
+            let mut rootfs_host: Option<PathBuf> = None;
+
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let req: PoolRequest =
+                    serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+
+                match req {
+                    PoolRequest::Lease(req) => {
+                        let (host, guest, mode) = parse_pool_volume_spec(&req.volumes[0]);
+                        assert_eq!(guest, "/run/a3s/test-rootfs");
+                        assert_eq!(mode, "rw");
+                        rootfs_host = Some(host);
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseResponse {
+                                lease_id: Some("lease-tmpfs".to_string()),
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Exec(req) => {
+                        assert_eq!(req.lease_id, "lease-tmpfs");
+                        assert_eq!(
+                            req.cmd,
+                            vec![
+                                "/bin/sh".to_string(),
+                                "-c".to_string(),
+                                "cd '/work' && printf ok > /out.txt".to_string(),
+                            ]
+                        );
+                        let rootfs = rootfs_host.as_ref().expect("lease records rootfs host");
+                        assert!(rootfs.join("work/tmp").is_dir());
+                        assert!(
+                            !rootfs.join("work/tmp/original.txt").exists(),
+                            "tmpfs mount should hide the original target during RUN"
+                        );
+                        std::fs::write(rootfs.join("out.txt"), "ok").unwrap();
+                        std::fs::write(rootfs.join("work/tmp/transient.txt"), "discarded").unwrap();
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolRunResponse {
+                                stdout: Vec::new(),
+                                stderr: Vec::new(),
+                                exit_code: 0,
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Release(req) => {
+                        assert_eq!(req.lease_id, "lease-tmpfs");
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseReleaseResponse { error: None }).unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                        break;
+                    }
+                    other => panic!(
+                        "unexpected pool request: {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }
+            }
+        });
+
+        let store = Arc::new(ImageStore::new(&store_dir, 1024 * 1024 * 100).unwrap());
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            build(
+                BuildConfig {
+                    context_dir: context.clone(),
+                    dockerfile_path: context.join("Dockerfile"),
+                    tag: Some("run-pool-tmpfs:latest".to_string()),
+                    build_args: HashMap::new(),
+                    quiet: true,
+                    platforms: vec![],
+                    target: None,
+                    no_cache: true,
+                    metrics: None,
+                    run_pool: Some(BuildRunPoolConfig {
+                        socket: socket.to_string_lossy().to_string(),
+                        image: Some("helper:latest".to_string()),
+                        vcpus: 2,
+                        memory_mb: 512,
+                        guest_rootfs: "/run/a3s/test-rootfs".to_string(),
+                        timeout_ns: 12_000_000_000,
+                        run_cache_dir: run_cache_dir.clone(),
+                    }),
+                },
+                store.clone(),
+            ),
+        )
+        .await
+        .expect("build should not hang")
+        .unwrap();
+
+        daemon.await.unwrap();
+        assert_eq!(result.layer_count, 3);
+
+        let stored = store.get("run-pool-tmpfs:latest").await.unwrap();
+        let image = OciImage::from_path(&stored.path).unwrap();
+        let files = image_layer_files(&image);
+        assert!(files.iter().any(|path| path == "out.txt"));
+        assert!(files.iter().any(|path| path == "work/tmp/original.txt"));
+        assert!(!files.iter().any(|path| path == "work/tmp/transient.txt"));
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    #[tokio::test]
+    async fn test_build_run_pool_releases_stage_lease_after_run_failure() {
+        use super::super::BuildRunPoolConfig;
+        use crate::pool::client::{read_frame, write_frame};
+        use crate::pool::{
+            PoolLeaseReleaseResponse, PoolLeaseResponse, PoolRequest, PoolRunResponse,
+        };
+        use std::time::Duration;
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = tmp.path().join("context");
+        let store_dir = tmp.path().join("images");
+        let socket = tmp.path().join("pool.sock");
+        let run_cache_dir = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&context).unwrap();
+        std::fs::write(context.join("sh"), "fake shell").unwrap();
+        std::fs::write(context.join("cache-marker"), "original\n").unwrap();
+        std::fs::write(
+            context.join("Dockerfile"),
+            r#"FROM scratch
+COPY sh /bin/sh
+COPY cache-marker /root/.cache/original.txt
+RUN --mount=type=cache,id=failed,target=/root/.cache echo before-failure > /root/.cache/failed.txt && false
+"#,
+        )
+        .unwrap();
+
+        let listener = UnixListener::bind(&socket).unwrap();
+        let daemon = tokio::spawn(async move {
+            let mut lease_count = 0usize;
+            let mut exec_count = 0usize;
+            let mut release_count = 0usize;
+            let mut rootfs_host: Option<PathBuf> = None;
+
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let req: PoolRequest =
+                    serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+
+                match req {
+                    PoolRequest::Lease(req) => {
+                        lease_count += 1;
+                        assert_eq!(req.volumes.len(), 1);
+                        let (host, guest, mode) = parse_pool_volume_spec(&req.volumes[0]);
+                        assert_eq!(guest, "/run/a3s/test-rootfs");
+                        assert_eq!(mode, "rw");
+                        rootfs_host = Some(host);
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseResponse {
+                                lease_id: Some("lease-fail".to_string()),
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Exec(req) => {
+                        exec_count += 1;
+                        assert_eq!(req.lease_id, "lease-fail");
+                        let rootfs = rootfs_host.as_ref().expect("lease records rootfs host");
+                        std::fs::write(rootfs.join("root/.cache/failed.txt"), "failed\n").unwrap();
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolRunResponse {
+                                stdout: b"before-failure\n".to_vec(),
+                                stderr: b"boom\n".to_vec(),
+                                exit_code: 42,
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Release(req) => {
+                        release_count += 1;
+                        assert_eq!(req.lease_id, "lease-fail");
+                        let response =
+                            serde_json::to_vec(&PoolLeaseReleaseResponse { error: None }).unwrap();
+                        let _ = write_frame(&mut stream, &response).await;
+                        break;
+                    }
+                    other => panic!(
+                        "unexpected pool request: {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }
+            }
+
+            assert_eq!(lease_count, 1);
+            assert_eq!(exec_count, 1);
+            assert_eq!(release_count, 1);
+        });
+
+        let store = Arc::new(ImageStore::new(&store_dir, 1024 * 1024 * 100).unwrap());
+        let error = tokio::time::timeout(
+            Duration::from_secs(10),
+            build(
+                BuildConfig {
+                    context_dir: context.clone(),
+                    dockerfile_path: context.join("Dockerfile"),
+                    tag: Some("run-pool-failure:latest".to_string()),
+                    build_args: HashMap::new(),
+                    quiet: true,
+                    platforms: vec![],
+                    target: None,
+                    no_cache: true,
+                    metrics: None,
+                    run_pool: Some(BuildRunPoolConfig {
+                        socket: socket.to_string_lossy().to_string(),
+                        image: Some("helper:latest".to_string()),
+                        vcpus: 2,
+                        memory_mb: 512,
+                        guest_rootfs: "/run/a3s/test-rootfs".to_string(),
+                        timeout_ns: 12_000_000_000,
+                        run_cache_dir: run_cache_dir.clone(),
+                    }),
+                },
+                store,
+            ),
+        )
+        .await
+        .expect("build should not hang")
+        .expect_err("RUN failure should fail the build");
+
+        assert!(error.to_string().contains("exit 42"));
+        assert!(error.to_string().contains("boom"));
+        daemon.await.unwrap();
+        assert!(
+            !tree_contains_file_named(&run_cache_dir, "failed.txt"),
+            "failed RUN cache mount contents must not be persisted"
+        );
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    #[tokio::test]
+    async fn test_build_run_pool_cache_mount_is_not_committed_to_layer() {
+        use super::super::BuildRunPoolConfig;
+        use crate::pool::client::{read_frame, write_frame};
+        use crate::pool::{
+            PoolLeaseReleaseResponse, PoolLeaseResponse, PoolRequest, PoolRunResponse,
+        };
+        use std::time::Duration;
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = tmp.path().join("context");
+        let store_dir = tmp.path().join("images");
+        let socket = tmp.path().join("pool.sock");
+        let run_cache_dir = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&context).unwrap();
+        std::fs::write(context.join("sh"), "fake shell").unwrap();
+        std::fs::write(context.join("cache-marker"), "original\n").unwrap();
+        std::fs::write(
+            context.join("Dockerfile"),
+            r#"FROM scratch
+COPY sh /bin/sh
+COPY cache-marker /root/.cache/original.txt
+RUN --mount=type=cache,id=warm,target=/root/.cache echo warm > /root/.cache/cache-only.txt
+RUN --mount=type=cache,id=warm,target=/root/.cache cat /root/.cache/cache-only.txt > /result.txt
+"#,
+        )
+        .unwrap();
+
+        let listener = UnixListener::bind(&socket).unwrap();
+        let daemon = tokio::spawn(async move {
+            let mut rootfs_host: Option<PathBuf> = None;
+            let mut exec_count = 0usize;
+
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let req: PoolRequest =
+                    serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+
+                match req {
+                    PoolRequest::Lease(req) => {
+                        let (host, guest, mode) = parse_pool_volume_spec(&req.volumes[0]);
+                        assert_eq!(guest, "/run/a3s/test-rootfs");
+                        assert_eq!(mode, "rw");
+                        rootfs_host = Some(host);
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseResponse {
+                                lease_id: Some("lease-cache".to_string()),
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Exec(req) => {
+                        exec_count += 1;
+                        assert_eq!(req.lease_id, "lease-cache");
+                        assert_eq!(req.rootfs.as_deref(), Some("/run/a3s/test-rootfs"));
+                        let rootfs = rootfs_host.as_ref().expect("lease records rootfs host");
+
+                        assert!(
+                            !rootfs.join("root/.cache/original.txt").exists(),
+                            "cache mount should hide original target contents during RUN"
+                        );
+                        match exec_count {
+                            1 => {
+                                std::fs::write(rootfs.join("root/.cache/cache-only.txt"), "warm\n")
+                                    .unwrap();
+                            }
+                            2 => {
+                                let cached = std::fs::read_to_string(
+                                    rootfs.join("root/.cache/cache-only.txt"),
+                                )
+                                .expect("second RUN sees persistent cache mount content");
+                                std::fs::write(rootfs.join("result.txt"), cached).unwrap();
+                            }
+                            other => panic!("unexpected exec request {other}"),
+                        }
+
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolRunResponse {
+                                stdout: Vec::new(),
+                                stderr: Vec::new(),
+                                exit_code: 0,
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Release(req) => {
+                        assert_eq!(req.lease_id, "lease-cache");
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseReleaseResponse { error: None }).unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                        assert_eq!(exec_count, 2);
+                        break;
+                    }
+                    other => panic!(
+                        "unexpected pool request: {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }
+            }
+        });
+
+        let store = Arc::new(ImageStore::new(&store_dir, 1024 * 1024 * 100).unwrap());
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            build(
+                BuildConfig {
+                    context_dir: context.clone(),
+                    dockerfile_path: context.join("Dockerfile"),
+                    tag: Some("run-pool-cache:latest".to_string()),
+                    build_args: HashMap::new(),
+                    quiet: true,
+                    platforms: vec![],
+                    target: None,
+                    no_cache: true,
+                    metrics: None,
+                    run_pool: Some(BuildRunPoolConfig {
+                        socket: socket.to_string_lossy().to_string(),
+                        image: Some("helper:latest".to_string()),
+                        vcpus: 2,
+                        memory_mb: 512,
+                        guest_rootfs: "/run/a3s/test-rootfs".to_string(),
+                        timeout_ns: 60_000_000_000,
+                        run_cache_dir,
+                    }),
+                },
+                store.clone(),
+            ),
+        )
+        .await
+        .expect("build should not hang")
+        .unwrap();
+
+        daemon.await.unwrap();
+
+        let stored = store.get("run-pool-cache:latest").await.unwrap();
+        let image = OciImage::from_path(&stored.path).unwrap();
+        let files = image_layer_files(&image);
+        assert_eq!(result.layer_count, 3);
+        assert!(files.iter().any(|path| path == "root/.cache/original.txt"));
+        assert!(files.iter().any(|path| path == "result.txt"));
+        assert!(!files
+            .iter()
+            .any(|path| path == "root/.cache/cache-only.txt"));
+    }
+
+    #[cfg(all(feature = "pool", not(windows)))]
+    #[tokio::test]
+    async fn test_build_run_pool_cache_mount_from_stage_seeds_cache() {
+        use super::super::BuildRunPoolConfig;
+        use crate::pool::client::{read_frame, write_frame};
+        use crate::pool::{
+            PoolLeaseReleaseResponse, PoolLeaseResponse, PoolRequest, PoolRunResponse,
+        };
+        use std::time::Duration;
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = tmp.path().join("context");
+        let store_dir = tmp.path().join("images");
+        let socket = tmp.path().join("pool.sock");
+        let run_cache_dir = tmp.path().join("run-cache");
+        std::fs::create_dir_all(&context).unwrap();
+        std::fs::write(context.join("sh"), "fake shell").unwrap();
+        std::fs::write(context.join("seed.txt"), "seeded\n").unwrap();
+        std::fs::write(
+            context.join("Dockerfile"),
+            r#"FROM scratch AS builder
+COPY seed.txt /seed-cache/seed.txt
+
+FROM scratch
+COPY sh /bin/sh
+RUN --mount=type=cache,id=seeded,sharing=locked,from=builder,source=/seed-cache,target=/root/.cache cat /root/.cache/seed.txt > /out.txt
+"#,
+        )
+        .unwrap();
+
+        let listener = UnixListener::bind(&socket).unwrap();
+        let daemon = tokio::spawn(async move {
+            let mut rootfs_host: Option<PathBuf> = None;
+
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let req: PoolRequest =
+                    serde_json::from_slice(&read_frame(&mut stream).await.unwrap()).unwrap();
+
+                match req {
+                    PoolRequest::Lease(req) => {
+                        assert_eq!(req.volumes.len(), 1);
+                        let (host, guest, mode) = parse_pool_volume_spec(&req.volumes[0]);
+                        assert_eq!(guest, "/run/a3s/test-rootfs");
+                        assert_eq!(mode, "rw");
+                        rootfs_host = Some(host);
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseResponse {
+                                lease_id: Some("lease-cache-seed".to_string()),
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Exec(req) => {
+                        assert_eq!(req.lease_id, "lease-cache-seed");
+                        assert_eq!(
+                            req.cmd,
+                            vec![
+                                "/bin/sh".to_string(),
+                                "-c".to_string(),
+                                "cat /root/.cache/seed.txt > /out.txt".to_string(),
+                            ]
+                        );
+                        let rootfs = rootfs_host.as_ref().expect("lease records rootfs host");
+                        assert_eq!(
+                            std::fs::read_to_string(rootfs.join("root/.cache/seed.txt")).unwrap(),
+                            "seeded\n"
+                        );
+                        std::fs::write(rootfs.join("out.txt"), "seeded\n").unwrap();
+                        std::fs::write(rootfs.join("root/.cache/generated.txt"), "persisted")
+                            .unwrap();
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolRunResponse {
+                                stdout: Vec::new(),
+                                stderr: Vec::new(),
+                                exit_code: 0,
+                                error: None,
+                            })
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    }
+                    PoolRequest::Release(req) => {
+                        assert_eq!(req.lease_id, "lease-cache-seed");
+                        write_frame(
+                            &mut stream,
+                            &serde_json::to_vec(&PoolLeaseReleaseResponse { error: None }).unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                        break;
+                    }
+                    other => panic!(
+                        "unexpected pool request: {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }
+            }
+        });
+
+        let store = Arc::new(ImageStore::new(&store_dir, 1024 * 1024 * 100).unwrap());
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            build(
+                BuildConfig {
+                    context_dir: context.clone(),
+                    dockerfile_path: context.join("Dockerfile"),
+                    tag: Some("run-pool-cache-seed:latest".to_string()),
+                    build_args: HashMap::new(),
+                    quiet: true,
+                    platforms: vec![],
+                    target: None,
+                    no_cache: true,
+                    metrics: None,
+                    run_pool: Some(BuildRunPoolConfig {
+                        socket: socket.to_string_lossy().to_string(),
+                        image: Some("helper:latest".to_string()),
+                        vcpus: 2,
+                        memory_mb: 512,
+                        guest_rootfs: "/run/a3s/test-rootfs".to_string(),
+                        timeout_ns: 60_000_000_000,
+                        run_cache_dir: run_cache_dir.clone(),
+                    }),
+                },
+                store.clone(),
+            ),
+        )
+        .await
+        .expect("build should not hang")
+        .unwrap();
+
+        daemon.await.unwrap();
+        assert_eq!(result.layer_count, 2);
+
+        let stored = store.get("run-pool-cache-seed:latest").await.unwrap();
+        let image = OciImage::from_path(&stored.path).unwrap();
+        let files = image_layer_files(&image);
+        assert!(files.iter().any(|path| path == "bin/sh"));
+        assert!(files.iter().any(|path| path == "out.txt"));
+        assert!(!files.iter().any(|path| path == "root/.cache/seed.txt"));
+        assert!(!files.iter().any(|path| path == "root/.cache/generated.txt"));
+        assert!(tree_contains_file_named(&run_cache_dir, "seed.txt"));
+        assert!(tree_contains_file_named(&run_cache_dir, "generated.txt"));
     }
 
     /// Regression: a multi-stage `COPY --from=<stage> /abs/path` must resolve
@@ -209,6 +1556,7 @@ LABEL org.opencontainers.image.title="scratch-smoke"
                 target: Some("builder".to_string()),
                 no_cache: false,
                 metrics: None,
+                run_pool: None,
             },
             store.clone(),
         )
@@ -234,6 +1582,7 @@ LABEL org.opencontainers.image.title="scratch-smoke"
                 target: Some("nope".to_string()),
                 no_cache: false,
                 metrics: None,
+                run_pool: None,
             },
             store.clone(),
         )
@@ -276,6 +1625,7 @@ LABEL org.opencontainers.image.title="scratch-smoke"
                 target: None,
                 no_cache: false,
                 metrics: None,
+                run_pool: None,
             },
             store.clone(),
         )
@@ -344,6 +1694,7 @@ CMD ["/work/run.sh"]
                 target: None,
                 no_cache: false,
                 metrics: None,
+                run_pool: None,
             },
             store.clone(),
         )

--- a/src/runtime/src/oci/build/mod.rs
+++ b/src/runtime/src/oci/build/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! # Supported Instructions
 //!
-//! FROM, shell-form RUN, shell-form COPY/ADD, WORKDIR, ENV, ENTRYPOINT, CMD,
+//! FROM, shell/exec-form RUN, shell-form COPY/ADD, WORKDIR, ENV, ENTRYPOINT, CMD,
 //! EXPOSE, LABEL, USER, ARG, SHELL, STOPSIGNAL, HEALTHCHECK, ONBUILD metadata
 //! triggers, VOLUME.
 //!
@@ -25,5 +25,5 @@ pub mod engine;
 pub mod layer;
 
 pub use dockerfile::{Dockerfile, Instruction};
-pub use engine::{build, BuildConfig, BuildResult};
+pub use engine::{build, BuildConfig, BuildResult, BuildRunPoolConfig};
 pub use layer::{DirSnapshot, LayerInfo};

--- a/src/runtime/src/oci/layers.rs
+++ b/src/runtime/src/oci/layers.rs
@@ -300,8 +300,6 @@ fn metadata_from_header<R: Read>(
     entry: &tar::Entry<'_, R>,
     path: &Path,
 ) -> Result<RootfsMetadataEntry> {
-    use std::os::unix::ffi::OsStrExt;
-
     let entry_type = entry.header().entry_type();
     let (kind, link_target_base64) = if entry_type.is_dir() {
         (RootfsEntryKind::Directory, None)
@@ -312,7 +310,10 @@ fn metadata_from_header<R: Read>(
             .ok_or_else(|| BoxError::OciImageError("Missing symlink target".to_string()))?;
         (
             RootfsEntryKind::Symlink,
-            Some(base64::engine::general_purpose::STANDARD.encode(target.as_os_str().as_bytes())),
+            Some(
+                base64::engine::general_purpose::STANDARD
+                    .encode(target.as_os_str().as_encoded_bytes()),
+            ),
         )
     } else if entry_type.is_file() || entry_type.is_hard_link() {
         (RootfsEntryKind::Regular, None)
@@ -323,7 +324,7 @@ fn metadata_from_header<R: Read>(
         )));
     };
     let path_base64 = base64::engine::general_purpose::STANDARD
-        .encode(archive_metadata_path(path).as_os_str().as_bytes());
+        .encode(archive_metadata_path(path).as_os_str().as_encoded_bytes());
     Ok(RootfsMetadataEntry {
         path_base64,
         kind,
@@ -365,8 +366,6 @@ fn remove_metadata_descendants(
 }
 
 fn load_image_metadata(target_dir: &Path) -> Result<BTreeMap<PathBuf, RootfsMetadataEntry>> {
-    use std::os::unix::ffi::OsStringExt;
-
     let path = target_dir.join(image_metadata_relative_path());
     let bytes = match std::fs::read(&path) {
         Ok(bytes) => bytes,
@@ -390,7 +389,7 @@ fn load_image_metadata(target_dir: &Path) -> Result<BTreeMap<PathBuf, RootfsMeta
         let raw = base64::engine::general_purpose::STANDARD
             .decode(&entry.path_base64)
             .map_err(|error| BoxError::OciImageError(format!("Invalid metadata path: {error}")))?;
-        let archive_path = PathBuf::from(std::ffi::OsString::from_vec(raw));
+        let archive_path = PathBuf::from(os_string_from_encoded_bytes(raw));
         let relative = normalize_layer_path(&archive_path)
             .ok_or_else(|| BoxError::OciImageError("Unsafe path in image metadata".to_string()))?;
         if relative == image_metadata_relative_path() || result.insert(relative, entry).is_some() {
@@ -492,11 +491,17 @@ fn finalize_image_metadata(
 }
 
 fn decode_metadata_key(entry: &RootfsMetadataEntry) -> Option<PathBuf> {
-    use std::os::unix::ffi::OsStringExt;
     let raw = base64::engine::general_purpose::STANDARD
         .decode(&entry.path_base64)
         .ok()?;
-    normalize_layer_path(Path::new(&std::ffi::OsString::from_vec(raw)))
+    normalize_layer_path(Path::new(&os_string_from_encoded_bytes(raw)))
+}
+
+fn os_string_from_encoded_bytes(raw: Vec<u8>) -> std::ffi::OsString {
+    // Every metadata manifest is produced and consumed on the same host. The
+    // bytes therefore use this platform's `OsStr` encoding and can be restored
+    // losslessly, including non-UTF-8 Unix paths and Windows WTF-8 paths.
+    unsafe { std::ffi::OsString::from_encoded_bytes_unchecked(raw) }
 }
 
 fn collect_final_metadata(
@@ -506,9 +511,6 @@ fn collect_final_metadata(
     desired: &BTreeMap<PathBuf, RootfsMetadataEntry>,
     output: &mut BTreeMap<PathBuf, RootfsMetadataEntry>,
 ) -> Result<()> {
-    use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::MetadataExt;
-
     if relative == image_metadata_relative_path()
         || relative == Path::new(".a3s_image_metadata_v1.json.tmp")
     {
@@ -528,21 +530,46 @@ fn collect_final_metadata(
         })?;
         (
             RootfsEntryKind::Symlink,
-            Some(base64::engine::general_purpose::STANDARD.encode(target.as_os_str().as_bytes())),
+            Some(
+                base64::engine::general_purpose::STANDARD
+                    .encode(target.as_os_str().as_encoded_bytes()),
+            ),
         )
     } else {
         return Ok(());
     };
     let previous = desired.get(relative);
+    #[cfg(unix)]
+    let (mode, mtime, size) = {
+        use std::os::unix::fs::MetadataExt;
+        (
+            filesystem.mode(),
+            filesystem.mtime().max(0) as u64,
+            filesystem.size(),
+        )
+    };
+    #[cfg(not(unix))]
+    let (mode, mtime, size) = previous
+        .map(|entry| (entry.mode, entry.mtime, entry.size))
+        .unwrap_or_else(|| {
+            (
+                if file_type.is_dir() { 0o755 } else { 0o644 },
+                0,
+                filesystem.len(),
+            )
+        });
     let entry = RootfsMetadataEntry {
-        path_base64: base64::engine::general_purpose::STANDARD
-            .encode(archive_metadata_path(relative).as_os_str().as_bytes()),
+        path_base64: base64::engine::general_purpose::STANDARD.encode(
+            archive_metadata_path(relative)
+                .as_os_str()
+                .as_encoded_bytes(),
+        ),
         kind,
-        mode: filesystem.mode(),
+        mode,
         uid: previous.map_or(0, |entry| entry.uid),
         gid: previous.map_or(0, |entry| entry.gid),
-        mtime: filesystem.mtime().max(0) as u64,
-        size: filesystem.size(),
+        mtime,
+        size,
         link_target_base64,
     };
     output.insert(relative.to_path_buf(), entry);

--- a/src/runtime/src/oci/layers.rs
+++ b/src/runtime/src/oci/layers.rs
@@ -3,7 +3,12 @@
 //! Handles extraction of OCI image layers (gzip, zstd, or uncompressed tar).
 
 use a3s_box_core::error::{BoxError, Result};
+use a3s_box_core::rootfs_metadata::{
+    RootfsEntryKind, RootfsMetadataEntry, RootfsMetadataManifest, IMAGE_ROOTFS_METADATA_PATH,
+};
+use base64::Engine;
 use flate2::read::GzDecoder;
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -29,13 +34,25 @@ pub fn extract_layer(layer_path: &Path, target_dir: &Path) -> Result<()> {
     // Generous default; tune with A3S_BOX_MAX_LAYER_BYTES.
     let max_layer_bytes =
         super::limited_reader::cap_from_env("A3S_BOX_MAX_LAYER_BYTES", 16 * 1024 * 1024 * 1024);
-    extract_layer_with_cap(layer_path, target_dir, max_layer_bytes)
+    extract_layer_with_cap(layer_path, target_dir, max_layer_bytes, false)
+}
+
+/// Extract a layer and retain the Linux ownership encoded in its tar headers.
+///
+/// Rootless macOS extraction cannot apply arbitrary uid/gid values to APFS.
+/// The generated rootfs-private manifest is replayed by guest-init before any
+/// nested filesystems are mounted.
+pub(crate) fn extract_layer_with_metadata(layer_path: &Path, target_dir: &Path) -> Result<()> {
+    let max_layer_bytes =
+        super::limited_reader::cap_from_env("A3S_BOX_MAX_LAYER_BYTES", 16 * 1024 * 1024 * 1024);
+    extract_layer_with_cap(layer_path, target_dir, max_layer_bytes, true)
 }
 
 fn extract_layer_with_cap(
     layer_path: &Path,
     target_dir: &Path,
     max_layer_bytes: u64,
+    track_metadata: bool,
 ) -> Result<()> {
     // Validate layer exists
     if !layer_path.exists() {
@@ -121,6 +138,12 @@ fn extract_layer_with_cap(
         }
     }
 
+    let mut metadata = if track_metadata {
+        load_image_metadata(target_dir)?
+    } else {
+        BTreeMap::new()
+    };
+
     let entries = archive
         .entries()
         .map_err(|e| BoxError::OciImageError(format!("Failed to read layer entries: {e}")))?;
@@ -142,6 +165,16 @@ fn extract_layer_with_cap(
             continue;
         }
 
+        let normalized = normalize_layer_path(&path).ok_or_else(|| {
+            BoxError::OciImageError(format!("Invalid layer entry path: {}", path.display()))
+        })?;
+        if track_metadata && normalized == image_metadata_relative_path() {
+            return Err(BoxError::OciImageError(format!(
+                "OCI layer contains reserved internal path {}",
+                IMAGE_ROOTFS_METADATA_PATH
+            )));
+        }
+
         let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
         if file_name == ".wh..wh..opq" {
@@ -161,10 +194,30 @@ fn extract_layer_with_cap(
                     tracing::warn!(parent = %parent.display(), "Skipping opaque whiteout: parent escapes the rootfs");
                 }
             }
+            if track_metadata {
+                let parent = normalize_layer_path(path.parent().unwrap_or_else(|| Path::new("")))
+                    .ok_or_else(|| {
+                    BoxError::OciImageError("Invalid opaque whiteout path".to_string())
+                })?;
+                remove_metadata_descendants(&mut metadata, &parent, false);
+            }
             continue;
         }
 
         if let Some(victim_name) = file_name.strip_prefix(".wh.") {
+            let victim = normalize_layer_path(
+                &path
+                    .parent()
+                    .unwrap_or_else(|| Path::new(""))
+                    .join(victim_name),
+            )
+            .ok_or_else(|| BoxError::OciImageError("Invalid whiteout path".to_string()))?;
+            if track_metadata && victim == image_metadata_relative_path() {
+                return Err(BoxError::OciImageError(format!(
+                    "OCI layer whiteouts reserved internal path {}",
+                    IMAGE_ROOTFS_METADATA_PATH
+                )));
+            }
             // Whiteout marker: remove the named sibling from a lower layer. Resolve
             // the parent within the rootfs so a symlinked parent cannot redirect the
             // deletion to a host file outside the extraction target.
@@ -175,6 +228,9 @@ fn extract_layer_with_cap(
                     tracing::warn!(parent = %parent.display(), "Skipping whiteout: parent escapes the rootfs");
                 }
             }
+            if track_metadata {
+                remove_metadata_descendants(&mut metadata, &victim, true);
+            }
             continue;
         }
 
@@ -182,7 +238,12 @@ fn extract_layer_with_cap(
             prepare_symlink_destination(target_dir, &path)?;
         }
 
-        entry.unpack_in(target_dir).map_err(|e| {
+        let desired = if track_metadata {
+            Some(metadata_from_header(&entry, &normalized)?)
+        } else {
+            None
+        };
+        let unpacked = entry.unpack_in(target_dir).map_err(|e| {
             // Surface the underlying cause (e.g. the LimitedReader's size-cap
             // error) — tar's wrapper Display alone would just say "failed to
             // unpack <path>" and hide a decompression-bomb abort from the operator.
@@ -194,6 +255,18 @@ fn extract_layer_with_cap(
                 target_dir.display(),
             ))
         })?;
+        if track_metadata && unpacked {
+            if let Some(desired) = desired {
+                if desired.kind != RootfsEntryKind::Directory {
+                    remove_metadata_descendants(&mut metadata, &normalized, false);
+                }
+                metadata.insert(normalized, desired);
+            }
+        }
+    }
+
+    if track_metadata {
+        finalize_image_metadata(target_dir, &mut metadata)?;
     }
 
     tracing::debug!(
@@ -202,6 +275,296 @@ fn extract_layer_with_cap(
         "Extracted OCI layer"
     );
 
+    Ok(())
+}
+
+fn image_metadata_relative_path() -> PathBuf {
+    PathBuf::from(IMAGE_ROOTFS_METADATA_PATH.trim_start_matches('/'))
+}
+
+fn normalize_layer_path(path: &Path) -> Option<PathBuf> {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(name) => normalized.push(name),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(normalized)
+}
+
+fn metadata_from_header<R: Read>(
+    entry: &tar::Entry<'_, R>,
+    path: &Path,
+) -> Result<RootfsMetadataEntry> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let entry_type = entry.header().entry_type();
+    let (kind, link_target_base64) = if entry_type.is_dir() {
+        (RootfsEntryKind::Directory, None)
+    } else if entry_type.is_symlink() {
+        let target = entry
+            .link_name()
+            .map_err(|error| BoxError::OciImageError(format!("Invalid symlink target: {error}")))?
+            .ok_or_else(|| BoxError::OciImageError("Missing symlink target".to_string()))?;
+        (
+            RootfsEntryKind::Symlink,
+            Some(base64::engine::general_purpose::STANDARD.encode(target.as_os_str().as_bytes())),
+        )
+    } else if entry_type.is_file() || entry_type.is_hard_link() {
+        (RootfsEntryKind::Regular, None)
+    } else {
+        return Err(BoxError::OciImageError(format!(
+            "Unsupported OCI layer entry type at {}",
+            path.display()
+        )));
+    };
+    let path_base64 = base64::engine::general_purpose::STANDARD
+        .encode(archive_metadata_path(path).as_os_str().as_bytes());
+    Ok(RootfsMetadataEntry {
+        path_base64,
+        kind,
+        mode: entry.header().mode().map_err(|error| {
+            BoxError::OciImageError(format!("Invalid mode at {}: {error}", path.display()))
+        })?,
+        uid: entry.header().uid().map_err(|error| {
+            BoxError::OciImageError(format!("Invalid uid at {}: {error}", path.display()))
+        })?,
+        gid: entry.header().gid().map_err(|error| {
+            BoxError::OciImageError(format!("Invalid gid at {}: {error}", path.display()))
+        })?,
+        mtime: entry.header().mtime().map_err(|error| {
+            BoxError::OciImageError(format!("Invalid mtime at {}: {error}", path.display()))
+        })?,
+        size: entry.header().size().map_err(|error| {
+            BoxError::OciImageError(format!("Invalid size at {}: {error}", path.display()))
+        })?,
+        link_target_base64,
+    })
+}
+
+fn archive_metadata_path(path: &Path) -> PathBuf {
+    if path.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        Path::new(".").join(path)
+    }
+}
+
+fn remove_metadata_descendants(
+    metadata: &mut BTreeMap<PathBuf, RootfsMetadataEntry>,
+    path: &Path,
+    include_path: bool,
+) {
+    metadata.retain(|candidate, _| {
+        !(candidate.starts_with(path) && (include_path || candidate != path))
+    });
+}
+
+fn load_image_metadata(target_dir: &Path) -> Result<BTreeMap<PathBuf, RootfsMetadataEntry>> {
+    use std::os::unix::ffi::OsStringExt;
+
+    let path = target_dir.join(image_metadata_relative_path());
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(error) => {
+            return Err(BoxError::OciImageError(format!(
+                "Failed to read image metadata {}: {error}",
+                path.display()
+            )))
+        }
+    };
+    let manifest: RootfsMetadataManifest = serde_json::from_slice(&bytes).map_err(|error| {
+        BoxError::OciImageError(format!(
+            "Invalid image metadata {}: {error}",
+            path.display()
+        ))
+    })?;
+    manifest.validate().map_err(BoxError::OciImageError)?;
+    let mut result = BTreeMap::new();
+    for entry in manifest.entries {
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(&entry.path_base64)
+            .map_err(|error| BoxError::OciImageError(format!("Invalid metadata path: {error}")))?;
+        let archive_path = PathBuf::from(std::ffi::OsString::from_vec(raw));
+        let relative = normalize_layer_path(&archive_path)
+            .ok_or_else(|| BoxError::OciImageError("Unsafe path in image metadata".to_string()))?;
+        if relative == image_metadata_relative_path() || result.insert(relative, entry).is_some() {
+            return Err(BoxError::OciImageError(
+                "Duplicate or reserved path in image metadata".to_string(),
+            ));
+        }
+    }
+    Ok(result)
+}
+
+pub(crate) fn finalize_rootfs_metadata(target_dir: &Path) -> Result<()> {
+    let mut metadata = load_image_metadata(target_dir)?;
+    finalize_image_metadata(target_dir, &mut metadata)?;
+    prepare_rootless_metadata_replay(target_dir, &metadata)
+}
+
+fn prepare_rootless_metadata_replay(
+    target_dir: &Path,
+    metadata: &BTreeMap<PathBuf, RootfsMetadataEntry>,
+) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        if unsafe { libc::geteuid() } == 0 {
+            return Ok(());
+        }
+        // virtiofs stores synthetic uid/gid as filesystem metadata. A guest
+        // cannot update it on a 0444/0555 host-owned inode, so make only the
+        // owner's write bit temporarily available. Guest-init restores the
+        // exact manifest mode before launching any container process.
+        for (relative, entry) in metadata {
+            if entry.kind == RootfsEntryKind::Symlink || entry.mode & 0o200 != 0 {
+                continue;
+            }
+            let target = target_dir.join(relative);
+            let current = std::fs::symlink_metadata(&target).map_err(|error| {
+                BoxError::OciImageError(format!(
+                    "Failed to prepare metadata replay for {}: {error}",
+                    target.display()
+                ))
+            })?;
+            std::fs::set_permissions(
+                &target,
+                std::fs::Permissions::from_mode((current.mode() & 0o7777) | 0o200),
+            )
+            .map_err(|error| {
+                BoxError::OciImageError(format!(
+                    "Failed to prepare metadata replay for {}: {error}",
+                    target.display()
+                ))
+            })?;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (target_dir, metadata);
+    }
+    Ok(())
+}
+
+fn finalize_image_metadata(
+    target_dir: &Path,
+    metadata: &mut BTreeMap<PathBuf, RootfsMetadataEntry>,
+) -> Result<()> {
+    let mut final_entries = BTreeMap::new();
+    collect_final_metadata(
+        target_dir,
+        target_dir,
+        Path::new(""),
+        metadata,
+        &mut final_entries,
+    )?;
+    let manifest = RootfsMetadataManifest::new(final_entries.into_values().collect());
+    let destination = target_dir.join(image_metadata_relative_path());
+    let temporary = destination.with_extension("json.tmp");
+    let bytes = serde_json::to_vec(&manifest).map_err(|error| {
+        BoxError::OciImageError(format!("Failed to encode image metadata: {error}"))
+    })?;
+    std::fs::write(&temporary, bytes).map_err(|error| {
+        BoxError::OciImageError(format!(
+            "Failed to write image metadata {}: {error}",
+            temporary.display()
+        ))
+    })?;
+    std::fs::rename(&temporary, &destination).map_err(|error| {
+        BoxError::OciImageError(format!(
+            "Failed to activate image metadata {}: {error}",
+            destination.display()
+        ))
+    })?;
+    *metadata = manifest
+        .entries
+        .into_iter()
+        .filter_map(|entry| decode_metadata_key(&entry).map(|key| (key, entry)))
+        .collect();
+    Ok(())
+}
+
+fn decode_metadata_key(entry: &RootfsMetadataEntry) -> Option<PathBuf> {
+    use std::os::unix::ffi::OsStringExt;
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(&entry.path_base64)
+        .ok()?;
+    normalize_layer_path(Path::new(&std::ffi::OsString::from_vec(raw)))
+}
+
+fn collect_final_metadata(
+    root: &Path,
+    source: &Path,
+    relative: &Path,
+    desired: &BTreeMap<PathBuf, RootfsMetadataEntry>,
+    output: &mut BTreeMap<PathBuf, RootfsMetadataEntry>,
+) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
+
+    if relative == image_metadata_relative_path()
+        || relative == Path::new(".a3s_image_metadata_v1.json.tmp")
+    {
+        return Ok(());
+    }
+    let filesystem = std::fs::symlink_metadata(source).map_err(|error| {
+        BoxError::OciImageError(format!("Failed to inspect {}: {error}", source.display()))
+    })?;
+    let file_type = filesystem.file_type();
+    let (kind, link_target_base64) = if file_type.is_dir() {
+        (RootfsEntryKind::Directory, None)
+    } else if file_type.is_file() {
+        (RootfsEntryKind::Regular, None)
+    } else if file_type.is_symlink() {
+        let target = std::fs::read_link(source).map_err(|error| {
+            BoxError::OciImageError(format!("Failed to read {}: {error}", source.display()))
+        })?;
+        (
+            RootfsEntryKind::Symlink,
+            Some(base64::engine::general_purpose::STANDARD.encode(target.as_os_str().as_bytes())),
+        )
+    } else {
+        return Ok(());
+    };
+    let previous = desired.get(relative);
+    let entry = RootfsMetadataEntry {
+        path_base64: base64::engine::general_purpose::STANDARD
+            .encode(archive_metadata_path(relative).as_os_str().as_bytes()),
+        kind,
+        mode: filesystem.mode(),
+        uid: previous.map_or(0, |entry| entry.uid),
+        gid: previous.map_or(0, |entry| entry.gid),
+        mtime: filesystem.mtime().max(0) as u64,
+        size: filesystem.size(),
+        link_target_base64,
+    };
+    output.insert(relative.to_path_buf(), entry);
+    if file_type.is_dir() {
+        let mut children: Vec<_> = std::fs::read_dir(source)
+            .map_err(|error| {
+                BoxError::OciImageError(format!("Failed to read {}: {error}", source.display()))
+            })?
+            .collect::<std::result::Result<_, _>>()
+            .map_err(|error| BoxError::OciImageError(format!("Failed to read entry: {error}")))?;
+        children.sort_by_key(|entry| entry.file_name());
+        for child in children {
+            collect_final_metadata(
+                root,
+                &child.path(),
+                &relative.join(child.file_name()),
+                desired,
+                output,
+            )?;
+        }
+    }
+    let _ = root;
     Ok(())
 }
 
@@ -431,6 +794,51 @@ mod tests {
     }
 
     #[test]
+    fn tracked_metadata_preserves_header_ownership_and_whiteouts() {
+        let temp_dir = TempDir::new().unwrap();
+        let layer1 = temp_dir.path().join("metadata-1.tar.gz");
+        let layer2 = temp_dir.path().join("metadata-2.tar.gz");
+        let target = temp_dir.path().join("rootfs");
+        create_owned_test_layer(&layer1, "dir/owned", b"payload", 123, 456, 0o750);
+        create_test_layer(&layer2, &[("dir/.wh.owned", b"")]);
+
+        extract_layer_with_metadata(&layer1, &target).unwrap();
+        let manifest = read_image_manifest(&target);
+        let owned = manifest
+            .entries
+            .iter()
+            .find(|entry| {
+                base64::engine::general_purpose::STANDARD
+                    .decode(&entry.path_base64)
+                    .is_ok_and(|raw| raw == b"./dir/owned")
+            })
+            .unwrap();
+        assert_eq!(
+            (owned.uid, owned.gid, owned.mode & 0o7777),
+            (123, 456, 0o750)
+        );
+
+        extract_layer_with_metadata(&layer2, &target).unwrap();
+        let manifest = read_image_manifest(&target);
+        assert!(!manifest.entries.iter().any(|entry| {
+            base64::engine::general_purpose::STANDARD
+                .decode(&entry.path_base64)
+                .is_ok_and(|raw| raw.ends_with(b"dir/owned"))
+        }));
+    }
+
+    #[test]
+    fn tracked_metadata_rejects_reserved_image_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let layer = temp_dir.path().join("reserved.tar.gz");
+        let target = temp_dir.path().join("rootfs");
+        create_test_layer(&layer, &[(".a3s_image_metadata_v1.json", b"forged")]);
+
+        let error = extract_layer_with_metadata(&layer, &target).unwrap_err();
+        assert!(error.to_string().contains("reserved internal path"));
+    }
+
+    #[test]
     fn extract_layer_rejects_decompression_bomb_past_cap() {
         let temp_dir = TempDir::new().unwrap();
         let layer = temp_dir.path().join("bomb.tar.gz");
@@ -441,7 +849,7 @@ mod tests {
         create_test_layer(&layer, &[("big", &big)]);
 
         // A 4 KiB cap must abort the extraction...
-        let result = extract_layer_with_cap(&layer, &target, 4 * 1024);
+        let result = extract_layer_with_cap(&layer, &target, 4 * 1024, false);
         assert!(
             result.is_err(),
             "the cap must abort an oversized (bomb) layer, got: {result:?}"
@@ -463,7 +871,7 @@ mod tests {
         let target = temp_dir.path().join("out");
         create_test_layer(&layer, &[("file.txt", b"hello")]);
         // A generous cap must not regress a normal small layer.
-        extract_layer_with_cap(&layer, &target, 16 * 1024 * 1024).unwrap();
+        extract_layer_with_cap(&layer, &target, 16 * 1024 * 1024, false).unwrap();
         assert!(target.join("file.txt").exists());
     }
 
@@ -493,6 +901,37 @@ mod tests {
         }
 
         builder.finish().unwrap();
+    }
+
+    fn create_owned_test_layer(
+        path: &Path,
+        name: &str,
+        content: &[u8],
+        uid: u64,
+        gid: u64,
+        mode: u32,
+    ) {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use tar::Builder;
+
+        let file = File::create(path).unwrap();
+        let encoder = GzEncoder::new(file, Compression::default());
+        let mut builder = Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(mode);
+        header.set_uid(uid);
+        header.set_gid(gid);
+        header.set_cksum();
+        builder.append_data(&mut header, name, content).unwrap();
+        builder.finish().unwrap();
+    }
+
+    fn read_image_manifest(target: &Path) -> RootfsMetadataManifest {
+        let bytes =
+            std::fs::read(target.join(IMAGE_ROOTFS_METADATA_PATH.trim_start_matches('/'))).unwrap();
+        serde_json::from_slice(&bytes).unwrap()
     }
 
     fn write_test_tar<W: std::io::Write>(writer: W, files: &[(&str, &[u8])]) {

--- a/src/runtime/src/oci/mod.rs
+++ b/src/runtime/src/oci/mod.rs
@@ -38,7 +38,7 @@ pub mod signing;
 pub mod store;
 
 #[cfg(feature = "build")]
-pub use build::{BuildConfig, BuildResult, Dockerfile, Instruction};
+pub use build::{BuildConfig, BuildResult, BuildRunPoolConfig, Dockerfile, Instruction};
 pub use credentials::CredentialStore;
 pub use image::{OciHealthCheck, OciImage, OciImageConfig};
 pub use layers::extract_layer;

--- a/src/runtime/src/oci/rootfs.rs
+++ b/src/runtime/src/oci/rootfs.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::path::{Component, Path};
 
 use super::image::OciImage;
-use super::layers::extract_layer;
+use super::layers::{extract_layer_with_metadata, finalize_rootfs_metadata};
 
 /// Builder for creating a guest rootfs from an OCI image.
 ///
@@ -95,6 +95,7 @@ impl OciRootfsBuilder {
         }
 
         self.create_essential_files()?;
+        finalize_rootfs_metadata(&self.rootfs_path)?;
 
         tracing::info!("OCI rootfs built successfully");
         Ok(())
@@ -150,7 +151,7 @@ impl OciRootfsBuilder {
         );
 
         for layer_path in image.layer_paths() {
-            extract_layer(layer_path, &self.rootfs_path)?;
+            extract_layer_with_metadata(layer_path, &self.rootfs_path)?;
         }
 
         Ok(())

--- a/src/runtime/src/pool/client.rs
+++ b/src/runtime/src/pool/client.rs
@@ -347,6 +347,13 @@ async fn lease_client(req: &PoolClientLease) -> Result<PoolLeaseResponse> {
     Ok(resp)
 }
 
+#[cfg(windows)]
+async fn lease_client(_req: &PoolClientLease) -> Result<PoolLeaseResponse> {
+    Err(BoxError::PoolError(
+        "warm-pool leases are not supported on Windows".to_string(),
+    ))
+}
+
 #[cfg(not(windows))]
 async fn lease_exec_client(socket: &str, req: PoolLeaseExecRequest) -> Result<PoolClientOutput> {
     use tokio::net::UnixStream;
@@ -364,6 +371,13 @@ async fn lease_exec_client(socket: &str, req: PoolLeaseExecRequest) -> Result<Po
         stderr: resp.stderr,
         exit_code: resp.exit_code,
     })
+}
+
+#[cfg(windows)]
+async fn lease_exec_client(_socket: &str, _req: PoolLeaseExecRequest) -> Result<PoolClientOutput> {
+    Err(BoxError::PoolError(
+        "warm-pool leases are not supported on Windows".to_string(),
+    ))
 }
 
 #[cfg(not(windows))]
@@ -385,6 +399,13 @@ async fn release_client(socket: &str, lease_id: &str) -> Result<()> {
         return Err(BoxError::PoolError(error));
     }
     Ok(())
+}
+
+#[cfg(windows)]
+async fn release_client(_socket: &str, _lease_id: &str) -> Result<()> {
+    Err(BoxError::PoolError(
+        "warm-pool leases are not supported on Windows".to_string(),
+    ))
 }
 
 #[cfg(not(windows))]

--- a/src/runtime/src/pool/client.rs
+++ b/src/runtime/src/pool/client.rs
@@ -1,0 +1,477 @@
+//! Socket protocol and client helpers for the warm-pool daemon.
+
+use a3s_box_core::error::{BoxError, Result};
+use serde::{Deserialize, Serialize};
+
+/// Wire protocol for the `pool` Unix socket.
+///
+/// Client→daemon request: run a one-shot command, query status, stop the
+/// daemon, or manage a short-lived leased VM session.
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum PoolRequest {
+    Run(PoolRunRequest),
+    Status,
+    Stop,
+    Lease(PoolLeaseRequest),
+    Exec(PoolLeaseExecRequest),
+    Release(PoolLeaseReleaseRequest),
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolRunRequest {
+    /// Image to run in; `None` means use the daemon's default image.
+    #[serde(default)]
+    pub image: Option<String>,
+    /// User to run as (uid[:gid] or name); `None` runs as the image default.
+    #[serde(default)]
+    pub user: Option<String>,
+    /// Working directory inside the sandbox.
+    #[serde(default)]
+    pub workdir: Option<String>,
+    /// Optional guest-visible rootfs to chroot into before executing.
+    #[serde(default)]
+    pub rootfs: Option<String>,
+    /// Extra KEY=VALUE environment entries.
+    #[serde(default)]
+    pub env: Vec<String>,
+    /// Boot-time volume specs for this sandbox pool.
+    #[serde(default)]
+    pub volumes: Vec<String>,
+    /// Boot-time vCPU count for lazily-created pools.
+    #[serde(default)]
+    pub vcpus: Option<u32>,
+    /// Boot-time memory size for lazily-created pools.
+    #[serde(default)]
+    pub memory_mb: Option<u32>,
+    /// Force exec mode for this request.
+    #[serde(default)]
+    pub exec: bool,
+    /// Guest-side execution timeout in nanoseconds.
+    #[serde(default)]
+    pub timeout_ns: Option<u64>,
+    pub cmd: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolRunResponse {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub exit_code: i32,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolLeaseRequest {
+    /// Image for the helper VM; `None` means use the daemon's default image.
+    #[serde(default)]
+    pub image: Option<String>,
+    /// Boot-time volume specs for this leased VM.
+    #[serde(default)]
+    pub volumes: Vec<String>,
+    /// Boot-time vCPU count.
+    #[serde(default)]
+    pub vcpus: Option<u32>,
+    /// Boot-time memory size.
+    #[serde(default)]
+    pub memory_mb: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolLeaseResponse {
+    pub lease_id: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolLeaseExecRequest {
+    pub lease_id: String,
+    pub cmd: Vec<String>,
+    #[serde(default)]
+    pub timeout_ns: Option<u64>,
+    #[serde(default)]
+    pub env: Vec<String>,
+    #[serde(default)]
+    pub working_dir: Option<String>,
+    #[serde(default)]
+    pub rootfs: Option<String>,
+    #[serde(default)]
+    pub stdin: Option<Vec<u8>>,
+    #[serde(default)]
+    pub user: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolLeaseReleaseRequest {
+    pub lease_id: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolLeaseReleaseResponse {
+    pub error: Option<String>,
+}
+
+/// Live stats for one image's warm pool.
+#[derive(Serialize, Deserialize)]
+pub struct PoolImageStat {
+    pub image: String,
+    pub pool: String,
+    /// Maximum concurrent sandboxes for this pool key.
+    #[serde(default)]
+    pub max: usize,
+    pub idle: usize,
+    /// Sandboxes currently checked out by one-shot runs or leases.
+    #[serde(default)]
+    pub active: usize,
+    /// Active sandboxes held by lease clients.
+    #[serde(default)]
+    pub leased: usize,
+    pub total_created: u64,
+    pub total_acquired: u64,
+    pub total_evicted: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolStatusResponse {
+    pub images: Vec<PoolImageStat>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolStopResponse {
+    pub error: Option<String>,
+}
+
+pub struct PoolClientRun {
+    pub socket: String,
+    pub image: Option<String>,
+    pub user: Option<String>,
+    pub workdir: Option<String>,
+    pub rootfs: Option<String>,
+    pub env: Vec<String>,
+    pub volumes: Vec<String>,
+    pub vcpus: u32,
+    pub memory_mb: u32,
+    pub exec: bool,
+    pub timeout_ns: Option<u64>,
+    pub cmd: Vec<String>,
+}
+
+pub struct PoolClientOutput {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub exit_code: i32,
+}
+
+pub struct PoolLeaseClient {
+    socket: String,
+    lease_id: String,
+    released: bool,
+}
+
+impl PoolLeaseClient {
+    pub fn lease_id(&self) -> &str {
+        &self.lease_id
+    }
+
+    pub async fn acquire(req: PoolClientLease) -> Result<Self> {
+        let response = lease_client(&req).await?;
+        let lease_id = response.lease_id.ok_or_else(|| {
+            BoxError::PoolError("pool lease response did not include a lease id".to_string())
+        })?;
+        Ok(Self {
+            socket: req.socket,
+            lease_id,
+            released: false,
+        })
+    }
+
+    pub async fn exec(&self, req: PoolLeaseExec) -> Result<PoolClientOutput> {
+        lease_exec_client(
+            &self.socket,
+            PoolLeaseExecRequest {
+                lease_id: self.lease_id.clone(),
+                cmd: req.cmd,
+                timeout_ns: req.timeout_ns,
+                env: req.env,
+                working_dir: req.working_dir,
+                rootfs: req.rootfs,
+                stdin: req.stdin,
+                user: req.user,
+            },
+        )
+        .await
+    }
+
+    pub async fn release(mut self) -> Result<()> {
+        let result = release_client(&self.socket, &self.lease_id).await;
+        if result.is_ok() {
+            self.released = true;
+        }
+        result
+    }
+}
+
+impl Drop for PoolLeaseClient {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        #[cfg(not(windows))]
+        release_client_blocking_best_effort(&self.socket, &self.lease_id);
+    }
+}
+
+pub struct PoolClientLease {
+    pub socket: String,
+    pub image: Option<String>,
+    pub volumes: Vec<String>,
+    pub vcpus: u32,
+    pub memory_mb: u32,
+}
+
+pub struct PoolLeaseExec {
+    pub cmd: Vec<String>,
+    pub timeout_ns: Option<u64>,
+    pub env: Vec<String>,
+    pub working_dir: Option<String>,
+    pub rootfs: Option<String>,
+    pub stdin: Option<Vec<u8>>,
+    pub user: Option<String>,
+}
+
+#[cfg(not(windows))]
+pub async fn run_client(req: PoolClientRun) -> Result<PoolClientOutput> {
+    use tokio::net::UnixStream;
+
+    let mut stream = UnixStream::connect(&req.socket).await.map_err(|e| {
+        BoxError::PoolError(format!(
+            "Failed to connect to pool daemon at {} ({}). Is `a3s-box pool start` running?",
+            req.socket, e
+        ))
+    })?;
+
+    write_frame(
+        &mut stream,
+        &serde_json::to_vec(&PoolRequest::Run(PoolRunRequest {
+            image: req.image,
+            user: req.user,
+            workdir: req.workdir,
+            rootfs: req.rootfs,
+            env: req.env,
+            volumes: req.volumes,
+            vcpus: Some(req.vcpus),
+            memory_mb: Some(req.memory_mb),
+            exec: req.exec,
+            timeout_ns: req.timeout_ns,
+            cmd: req.cmd,
+        }))?,
+    )
+    .await?;
+    let resp: PoolRunResponse = serde_json::from_slice(&read_frame(&mut stream).await?)?;
+
+    if let Some(err) = resp.error {
+        return Err(BoxError::PoolError(err));
+    }
+
+    Ok(PoolClientOutput {
+        stdout: resp.stdout,
+        stderr: resp.stderr,
+        exit_code: resp.exit_code,
+    })
+}
+
+#[cfg(windows)]
+pub async fn run_client(_req: PoolClientRun) -> Result<PoolClientOutput> {
+    Err(BoxError::PoolError(
+        "`pool run` is not supported on Windows".to_string(),
+    ))
+}
+
+#[cfg(not(windows))]
+pub async fn status_client(socket: &str) -> Result<PoolStatusResponse> {
+    use tokio::net::UnixStream;
+
+    let mut stream = UnixStream::connect(socket).await.map_err(|e| {
+        BoxError::PoolError(format!("Failed to connect to pool daemon at {socket}: {e}"))
+    })?;
+    write_frame(&mut stream, &serde_json::to_vec(&PoolRequest::Status)?).await?;
+    Ok(serde_json::from_slice(&read_frame(&mut stream).await?)?)
+}
+
+#[cfg(not(windows))]
+pub async fn stop_client(socket: &str) -> Result<()> {
+    use tokio::net::UnixStream;
+
+    let mut stream = UnixStream::connect(socket).await.map_err(|e| {
+        BoxError::PoolError(format!("Failed to connect to pool daemon at {socket}: {e}"))
+    })?;
+    write_frame(&mut stream, &serde_json::to_vec(&PoolRequest::Stop)?).await?;
+    let resp: PoolStopResponse = serde_json::from_slice(&read_frame(&mut stream).await?)?;
+    if let Some(error) = resp.error {
+        return Err(BoxError::PoolError(error));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+pub async fn stop_client(_socket: &str) -> Result<()> {
+    Err(BoxError::PoolError(
+        "`pool stop` is not supported on Windows".to_string(),
+    ))
+}
+
+#[cfg(not(windows))]
+async fn lease_client(req: &PoolClientLease) -> Result<PoolLeaseResponse> {
+    use tokio::net::UnixStream;
+
+    let mut stream = UnixStream::connect(&req.socket).await.map_err(|e| {
+        BoxError::PoolError(format!(
+            "Failed to connect to pool daemon at {} ({}). Is `a3s-box pool start` running?",
+            req.socket, e
+        ))
+    })?;
+    write_frame(
+        &mut stream,
+        &serde_json::to_vec(&PoolRequest::Lease(PoolLeaseRequest {
+            image: req.image.clone(),
+            volumes: req.volumes.clone(),
+            vcpus: Some(req.vcpus),
+            memory_mb: Some(req.memory_mb),
+        }))?,
+    )
+    .await?;
+    let resp: PoolLeaseResponse = serde_json::from_slice(&read_frame(&mut stream).await?)?;
+    if let Some(error) = resp.error.as_ref() {
+        return Err(BoxError::PoolError(error.clone()));
+    }
+    Ok(resp)
+}
+
+#[cfg(not(windows))]
+async fn lease_exec_client(socket: &str, req: PoolLeaseExecRequest) -> Result<PoolClientOutput> {
+    use tokio::net::UnixStream;
+
+    let mut stream = UnixStream::connect(socket).await.map_err(|e| {
+        BoxError::PoolError(format!("Failed to connect to pool daemon at {socket}: {e}"))
+    })?;
+    write_frame(&mut stream, &serde_json::to_vec(&PoolRequest::Exec(req))?).await?;
+    let resp: PoolRunResponse = serde_json::from_slice(&read_frame(&mut stream).await?)?;
+    if let Some(error) = resp.error {
+        return Err(BoxError::PoolError(error));
+    }
+    Ok(PoolClientOutput {
+        stdout: resp.stdout,
+        stderr: resp.stderr,
+        exit_code: resp.exit_code,
+    })
+}
+
+#[cfg(not(windows))]
+async fn release_client(socket: &str, lease_id: &str) -> Result<()> {
+    use tokio::net::UnixStream;
+
+    let mut stream = UnixStream::connect(socket).await.map_err(|e| {
+        BoxError::PoolError(format!("Failed to connect to pool daemon at {socket}: {e}"))
+    })?;
+    write_frame(
+        &mut stream,
+        &serde_json::to_vec(&PoolRequest::Release(PoolLeaseReleaseRequest {
+            lease_id: lease_id.to_string(),
+        }))?,
+    )
+    .await?;
+    let resp: PoolLeaseReleaseResponse = serde_json::from_slice(&read_frame(&mut stream).await?)?;
+    if let Some(error) = resp.error {
+        return Err(BoxError::PoolError(error));
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn release_client_blocking_best_effort(socket: &str, lease_id: &str) {
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+    use std::time::Duration;
+
+    let Ok(mut stream) = UnixStream::connect(socket) else {
+        return;
+    };
+    let timeout = Some(Duration::from_millis(500));
+    let _ = stream.set_read_timeout(timeout);
+    let _ = stream.set_write_timeout(timeout);
+
+    let Ok(payload) = serde_json::to_vec(&PoolRequest::Release(PoolLeaseReleaseRequest {
+        lease_id: lease_id.to_string(),
+    })) else {
+        return;
+    };
+    let _ = stream
+        .write_all(&(payload.len() as u32).to_le_bytes())
+        .and_then(|_| stream.write_all(&payload))
+        .and_then(|_| stream.flush());
+}
+
+/// Length-prefixed (u32 LE) framing for the pool Unix-socket protocol.
+#[cfg(not(windows))]
+pub async fn write_frame<W>(w: &mut W, data: &[u8]) -> std::io::Result<()>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::AsyncWriteExt;
+
+    w.write_all(&(data.len() as u32).to_le_bytes()).await?;
+    w.write_all(data).await?;
+    w.flush().await
+}
+
+#[cfg(not(windows))]
+pub async fn read_frame<R>(r: &mut R) -> std::io::Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt;
+
+    let mut len = [0u8; 4];
+    r.read_exact(&mut len).await?;
+    let mut buf = vec![0u8; u32::from_le_bytes(len) as usize];
+    r.read_exact(&mut buf).await?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(windows))]
+    #[test]
+    fn lease_drop_releases_synchronously() {
+        use super::*;
+        use std::io::Read;
+        use std::os::unix::net::UnixListener;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let socket = tmp.path().join("pool.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let socket_arg = socket.to_string_lossy().to_string();
+
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut len = [0_u8; 4];
+            stream.read_exact(&mut len).unwrap();
+            let mut request = vec![0_u8; u32::from_le_bytes(len) as usize];
+            stream.read_exact(&mut request).unwrap();
+            let request: PoolRequest = serde_json::from_slice(&request).unwrap();
+            match request {
+                PoolRequest::Release(req) => assert_eq!(req.lease_id, "lease-drop"),
+                _ => panic!("drop should send release request"),
+            }
+        });
+
+        let lease = PoolLeaseClient {
+            socket: socket_arg,
+            lease_id: "lease-drop".to_string(),
+            released: false,
+        };
+        drop(lease);
+
+        server.join().unwrap();
+    }
+}

--- a/src/runtime/src/pool/mod.rs
+++ b/src/runtime/src/pool/mod.rs
@@ -3,8 +3,15 @@
 //! Pre-boots MicroVMs so that `acquire()` returns an already-ready VM
 //! instead of waiting for the full boot sequence.
 
+pub mod client;
 pub mod scaler;
 pub mod warm_pool;
 
+pub use client::{
+    PoolClientLease, PoolClientOutput, PoolClientRun, PoolImageStat, PoolLeaseClient,
+    PoolLeaseExec, PoolLeaseExecRequest, PoolLeaseReleaseRequest, PoolLeaseReleaseResponse,
+    PoolLeaseRequest, PoolLeaseResponse, PoolRequest, PoolRunRequest, PoolRunResponse,
+    PoolStatusResponse, PoolStopResponse,
+};
 pub use scaler::{PoolScaler, ScaleDecision};
 pub use warm_pool::{PoolStats, WarmPool};

--- a/src/runtime/src/pool/warm_pool.rs
+++ b/src/runtime/src/pool/warm_pool.rs
@@ -484,6 +484,8 @@ impl WarmPool {
                     cfg.snapshot_sock = None;
                     let mut vm = VmManager::new(cfg, event_emitter.clone());
                     vm.boot().await?;
+                    vm.wait_for_exec_available(std::time::Duration::from_secs(120))
+                        .await?;
                     return Ok(vm);
                 }
                 Err(error) => {
@@ -493,6 +495,8 @@ impl WarmPool {
         }
         let mut vm = VmManager::new(box_config.clone(), event_emitter.clone());
         vm.boot().await?;
+        vm.wait_for_exec_available(std::time::Duration::from_secs(120))
+            .await?;
         Ok(vm)
     }
 

--- a/src/runtime/src/rootfs/mod.rs
+++ b/src/runtime/src/rootfs/mod.rs
@@ -18,6 +18,59 @@ pub use provider::{default_provider, CopyProvider, OverlayProvider, RootfsProvid
 
 use std::path::Path;
 
+/// A temporarily attached persistent rootfs.
+///
+/// Dropping this guard detaches only mounts created by
+/// [`attach_persistent_rootfs`]. An already mounted rootfs is left untouched.
+pub struct AttachedRootfs {
+    path: std::path::PathBuf,
+    detach_on_drop: bool,
+}
+
+impl AttachedRootfs {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for AttachedRootfs {
+    fn drop(&mut self) {
+        if self.detach_on_drop {
+            unmount_box_rootfs(&self.path);
+        }
+    }
+}
+
+/// Attach an existing platform-backed persistent rootfs for offline access.
+///
+/// Returns `None` when the box has no platform-specific backing image. This
+/// never creates a new image, so callers cannot accidentally commit an empty
+/// filesystem when a backing image is missing.
+pub fn attach_persistent_rootfs(
+    box_dir: &Path,
+) -> a3s_box_core::error::Result<Option<AttachedRootfs>> {
+    #[cfg(target_os = "macos")]
+    {
+        let image = box_dir.join("rootfs-apfs-v2.sparseimage");
+        if !image.is_file() {
+            return Ok(None);
+        }
+        let rootfs = box_dir.join("rootfs");
+        let was_mounted = is_mountpoint(&rootfs);
+        let path = provider::CaseSensitiveApfsProvider.prepare_empty(box_dir)?;
+        Ok(Some(AttachedRootfs {
+            path,
+            detach_on_drop: !was_mounted,
+        }))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = box_dir;
+        Ok(None)
+    }
+}
+
 /// Unmount a box's overlayfs `merged` view — best-effort and idempotent.
 ///
 /// Box teardown must release this mount BEFORE removing the box dir, or
@@ -37,7 +90,7 @@ pub fn unmount_box_overlay(merged: &Path) {
 }
 
 /// True if `path` is a mountpoint (its device id differs from its parent's).
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 pub(crate) fn is_mountpoint(path: &Path) -> bool {
     use std::os::unix::fs::MetadataExt;
     match (std::fs::metadata(path), std::fs::metadata(path.join(".."))) {
@@ -46,9 +99,48 @@ pub(crate) fn is_mountpoint(path: &Path) -> bool {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(unix))]
 pub(crate) fn is_mountpoint(_path: &Path) -> bool {
     false
+}
+
+/// Unmount a platform-specific writable rootfs mount.
+pub fn unmount_box_rootfs(rootfs: &Path) {
+    #[cfg(target_os = "macos")]
+    {
+        // The case-sensitive provider returns `<mount>/.a3s-rootfs`, keeping
+        // APFS-created volume metadata outside the Linux tree. Accept either
+        // that data path or the mountpoint itself at cleanup call sites.
+        let mountpoint = if rootfs.file_name().is_some_and(|name| name == ".a3s-rootfs") {
+            rootfs.parent().unwrap_or(rootfs)
+        } else {
+            rootfs
+        };
+        if !is_mountpoint(mountpoint) {
+            return;
+        }
+        match std::process::Command::new("hdiutil")
+            .arg("detach")
+            .arg("-quiet")
+            .arg(mountpoint)
+            .status()
+        {
+            Ok(status) if status.success() => {}
+            Ok(status) => tracing::warn!(
+                path = %mountpoint.display(),
+                ?status,
+                "Failed to detach case-sensitive rootfs image"
+            ),
+            Err(error) => tracing::warn!(
+                path = %mountpoint.display(),
+                %error,
+                "Failed to run hdiutil detach"
+            ),
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = rootfs;
 }
 
 #[cfg(test)]

--- a/src/runtime/src/rootfs/overlay.rs
+++ b/src/runtime/src/rootfs/overlay.rs
@@ -192,6 +192,7 @@ pub(crate) fn is_overlay_supported() -> bool {
 ///
 /// Always returns `false` on non-Linux platforms.
 #[cfg(not(target_os = "linux"))]
+#[allow(dead_code)]
 pub(crate) fn is_overlay_supported() -> bool {
     false
 }

--- a/src/runtime/src/rootfs/provider.rs
+++ b/src/runtime/src/rootfs/provider.rs
@@ -14,6 +14,18 @@ pub trait RootfsProvider: Send + Sync {
     /// Returns the path to use as `InstanceSpec.rootfs_path`.
     fn prepare(&self, box_dir: &Path, cache_dir: &Path) -> Result<PathBuf>;
 
+    /// Prepare an empty writable rootfs for an OCI cache miss.
+    fn prepare_empty(&self, box_dir: &Path) -> Result<PathBuf> {
+        let rootfs = box_dir.join("rootfs");
+        std::fs::create_dir_all(&rootfs).map_err(|error| {
+            BoxError::BuildError(format!(
+                "Failed to create rootfs {}: {error}",
+                rootfs.display()
+            ))
+        })?;
+        Ok(rootfs)
+    }
+
     /// Cleanup after box stops.
     ///
     /// When `persistent` is true, the writable layer (overlay upper dir or copy
@@ -63,6 +75,185 @@ impl RootfsProvider for CopyProvider {
 
     fn name(&self) -> &'static str {
         "copy"
+    }
+}
+
+/// A copy provider backed by a case-sensitive APFS sparse image.
+///
+/// macOS commonly stores `~/.a3s` on case-insensitive APFS. Passing a normal
+/// host directory to libkrun as the guest root would then make Linux paths such
+/// as `/bin` and `/BIN` aliases. Each box therefore owns a sparse, dynamically
+/// allocated case-sensitive APFS image and exposes its mountpoint via virtiofs.
+#[cfg(target_os = "macos")]
+pub struct CaseSensitiveApfsProvider;
+
+#[cfg(target_os = "macos")]
+impl CaseSensitiveApfsProvider {
+    // v2 stores the Linux tree below a private directory inside the volume.
+    // APFS creates volume-management entries such as `.fseventsd` at the
+    // volume root; exposing that root to the guest both leaks host artifacts
+    // and can make recursive rootfs walks fail with EACCES.
+    const IMAGE_STEM: &'static str = "rootfs-apfs-v2";
+    const IMAGE_NAME: &'static str = "rootfs-apfs-v2.sparseimage";
+    const DATA_DIR: &'static str = ".a3s-rootfs";
+
+    fn clone_image(source: &Path, destination: &Path) -> Result<()> {
+        let output = std::process::Command::new("cp")
+            .arg("-c")
+            .arg(source)
+            .arg(destination)
+            .output()
+            .map_err(|error| {
+                BoxError::BuildError(format!("Failed to start APFS clone: {error}"))
+            })?;
+        if !output.status.success() {
+            return Err(BoxError::BuildError(format!(
+                "Failed to clone cached APFS rootfs {}: {}",
+                source.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        Ok(())
+    }
+
+    fn mount(&self, box_dir: &Path) -> Result<PathBuf> {
+        use std::process::Command;
+
+        std::fs::create_dir_all(box_dir).map_err(|error| {
+            BoxError::BuildError(format!(
+                "Failed to create box directory {}: {error}",
+                box_dir.display()
+            ))
+        })?;
+        let rootfs = box_dir.join("rootfs");
+        std::fs::create_dir_all(&rootfs).map_err(|error| {
+            BoxError::BuildError(format!(
+                "Failed to create APFS mountpoint {}: {error}",
+                rootfs.display()
+            ))
+        })?;
+        if super::is_mountpoint(&rootfs) {
+            return Self::data_dir(&rootfs);
+        }
+
+        let image = box_dir.join(Self::IMAGE_NAME);
+        if !image.exists() {
+            let stem = box_dir.join(Self::IMAGE_STEM);
+            let output = Command::new("hdiutil")
+                .args([
+                    "create",
+                    "-quiet",
+                    "-size",
+                    "64g",
+                    "-type",
+                    "SPARSE",
+                    "-fs",
+                    "Case-sensitive APFS",
+                    "-volname",
+                    "A3SRootfs",
+                ])
+                .arg(&stem)
+                .output()
+                .map_err(|error| {
+                    BoxError::BuildError(format!("Failed to start hdiutil create: {error}"))
+                })?;
+            if !output.status.success() {
+                return Err(BoxError::BuildError(format!(
+                    "Failed to create case-sensitive APFS rootfs image: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                )));
+            }
+        }
+
+        let output = Command::new("hdiutil")
+            .args([
+                "attach",
+                "-quiet",
+                "-nobrowse",
+                "-owners",
+                "on",
+                "-mountpoint",
+            ])
+            .arg(&rootfs)
+            .arg(&image)
+            .output()
+            .map_err(|error| {
+                BoxError::BuildError(format!("Failed to start hdiutil attach: {error}"))
+            })?;
+        if !output.status.success() {
+            return Err(BoxError::BuildError(format!(
+                "Failed to mount case-sensitive APFS rootfs image {}: {}",
+                image.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        if !super::is_mountpoint(&rootfs) {
+            return Err(BoxError::BuildError(format!(
+                "hdiutil did not mount the rootfs image at {}",
+                rootfs.display()
+            )));
+        }
+        Self::data_dir(&rootfs)
+    }
+
+    fn data_dir(mountpoint: &Path) -> Result<PathBuf> {
+        let data = mountpoint.join(Self::DATA_DIR);
+        std::fs::create_dir_all(&data).map_err(|error| {
+            BoxError::BuildError(format!(
+                "Failed to create APFS rootfs data directory {}: {error}",
+                data.display()
+            ))
+        })?;
+        Ok(data)
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl RootfsProvider for CaseSensitiveApfsProvider {
+    fn prepare(&self, box_dir: &Path, cache_dir: &Path) -> Result<PathBuf> {
+        let image = box_dir.join(Self::IMAGE_NAME);
+        if cache_dir.is_file() && !image.exists() {
+            std::fs::create_dir_all(box_dir).map_err(BoxError::IoError)?;
+            Self::clone_image(cache_dir, &image)?;
+        }
+        let rootfs = self.mount(box_dir)?;
+        if cache_dir.is_file() {
+            return Ok(rootfs);
+        }
+        if std::fs::read_dir(&rootfs)
+            .map_err(|error| BoxError::BuildError(error.to_string()))?
+            .next()
+            .is_none()
+        {
+            crate::cache::layer_cache::copy_dir_recursive(cache_dir, &rootfs)?;
+        } else {
+            tracing::info!(path = %rootfs.display(), "Reusing persistent APFS rootfs");
+        }
+        Ok(rootfs)
+    }
+
+    fn prepare_empty(&self, box_dir: &Path) -> Result<PathBuf> {
+        self.mount(box_dir)
+    }
+
+    fn cleanup(&self, box_dir: &Path, persistent: bool) -> Result<()> {
+        super::unmount_box_rootfs(&box_dir.join("rootfs"));
+        if !persistent {
+            let image = box_dir.join(Self::IMAGE_NAME);
+            if image.exists() {
+                std::fs::remove_file(&image).map_err(|error| {
+                    BoxError::BuildError(format!(
+                        "Failed to remove rootfs image {}: {error}",
+                        image.display()
+                    ))
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "case-sensitive-apfs"
     }
 }
 
@@ -156,13 +347,22 @@ impl RootfsProvider for OverlayProvider {
 
 /// Auto-detect the best available rootfs provider for the current platform.
 pub fn default_provider() -> Box<dyn RootfsProvider> {
-    if super::overlay::is_overlay_supported() {
-        tracing::info!("Using overlayfs rootfs provider");
-        return Box::new(OverlayProvider);
+    #[cfg(target_os = "macos")]
+    {
+        tracing::info!("Using case-sensitive APFS rootfs provider");
+        Box::new(CaseSensitiveApfsProvider)
     }
 
-    tracing::info!("Overlayfs not available, using copy provider");
-    Box::new(CopyProvider)
+    #[cfg(not(target_os = "macos"))]
+    {
+        if super::overlay::is_overlay_supported() {
+            tracing::info!("Using overlayfs rootfs provider");
+            return Box::new(OverlayProvider);
+        }
+
+        tracing::info!("Overlayfs not available, using copy provider");
+        Box::new(CopyProvider)
+    }
 }
 
 #[cfg(test)]
@@ -316,6 +516,35 @@ mod tests {
         let provider = default_provider();
         // On any platform, we should get a provider
         assert!(!provider.name().is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn case_sensitive_apfs_provider_preserves_distinct_names() {
+        use std::os::unix::fs::MetadataExt;
+
+        let tmp = TempDir::new().unwrap();
+        let box_dir = tmp.path().join("box");
+        let provider = CaseSensitiveApfsProvider;
+        let rootfs = provider.prepare_empty(&box_dir).unwrap();
+        std::fs::write(rootfs.join("Foo"), "upper").unwrap();
+        std::fs::write(rootfs.join("foo"), "lower").unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(rootfs.join("Foo")).unwrap(),
+            "upper"
+        );
+        assert_eq!(
+            std::fs::read_to_string(rootfs.join("foo")).unwrap(),
+            "lower"
+        );
+        assert_ne!(
+            std::fs::metadata(rootfs.join("Foo")).unwrap().ino(),
+            std::fs::metadata(rootfs.join("foo")).unwrap().ino()
+        );
+
+        provider.cleanup(&box_dir, false).unwrap();
+        assert!(!box_dir.join(CaseSensitiveApfsProvider::IMAGE_NAME).exists());
     }
 
     #[cfg(target_os = "linux")]

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -232,30 +232,52 @@ impl VmManager {
                     prom.rootfs_cache_misses.inc();
                 }
 
-                let rootfs_path = box_dir.join("rootfs");
+                let rootfs_path = self.rootfs_provider.prepare_empty(&box_dir)?;
+                let rootfs_populated = std::fs::read_dir(&rootfs_path)
+                    .map(|mut entries| entries.next().is_some())
+                    .map_err(|error| {
+                        BoxError::BuildError(format!(
+                            "Failed to inspect rootfs {}: {error}",
+                            rootfs_path.display()
+                        ))
+                    })?;
                 let mut builder = OciRootfsBuilder::new(&rootfs_path).with_image(&image_path);
 
-                // Install guest init if available (runs as PID 1, mounts virtiofs shares,
-                // then execs the container entrypoint)
-                if let Ok(guest_init_path) = Self::find_guest_init() {
+                // A persistent copy/APFS provider already contains the prior
+                // terminal rootfs generation. Re-extracting the image would
+                // overwrite guest changes and fails on existing layer
+                // hardlinks. The image config remains immutable OCI metadata,
+                // so read it without rebuilding the filesystem.
+                if rootfs_populated {
                     tracing::info!(
-                        guest_init = %guest_init_path.display(),
-                        "Installing guest init"
+                        rootfs = %rootfs_path.display(),
+                        "Reusing populated persistent rootfs"
                     );
-                    builder = builder.with_guest_init(guest_init_path);
+                    let config = builder.image_config()?;
+                    (rootfs_path, Some(config))
                 } else {
-                    tracing::warn!(
-                        "Guest init binary not found; container entrypoint will run as PID 1"
-                    );
+                    // Install guest init if available (runs as PID 1, mounts virtiofs shares,
+                    // then execs the container entrypoint)
+                    if let Ok(guest_init_path) = Self::find_guest_init() {
+                        tracing::info!(
+                            guest_init = %guest_init_path.display(),
+                            "Installing guest init"
+                        );
+                        builder = builder.with_guest_init(guest_init_path);
+                    } else {
+                        tracing::warn!(
+                            "Guest init binary not found; container entrypoint will run as PID 1"
+                        );
+                    }
+
+                    builder.build()?;
+                    let config = builder.image_config()?;
+
+                    // Store in cache for next time
+                    self.store_rootfs_cache(&cache_key, &rootfs_path, reference);
+
+                    (rootfs_path, Some(config))
                 }
-
-                builder.build()?;
-                let config = builder.image_config()?;
-
-                // Store in cache for next time
-                self.store_rootfs_cache(&cache_key, &rootfs_path, reference);
-
-                (rootfs_path, Some(config))
             };
 
         // Generate TEE configuration if enabled
@@ -338,20 +360,48 @@ impl VmManager {
     /// Returns `Some(cached_path)` if cache hit, `None` if cache miss.
     /// The caller is responsible for preparing the rootfs via `RootfsProvider`.
     pub(crate) fn try_rootfs_cache_path(&self, cache_key: &str) -> Result<Option<PathBuf>> {
-        if !self.config.cache.enabled {
-            return Ok(None);
-        }
-
-        let cache_dir = self.resolve_cache_dir().join("rootfs");
-        let cache = match RootfsCache::new(&cache_dir) {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to open rootfs cache, skipping");
+        #[cfg(target_os = "macos")]
+        {
+            if !self.config.cache.enabled {
                 return Ok(None);
             }
-        };
+            let image = self
+                .resolve_cache_dir()
+                .join("rootfs-apfs-v2")
+                .join(format!("{cache_key}.sparseimage"));
+            if image.is_file() {
+                // Cache pruning is LRU. Refresh both timestamps without changing
+                // sparse-image contents so frequently used images remain hot.
+                if let Ok(file) = std::fs::OpenOptions::new().write(true).open(&image) {
+                    let now = std::time::SystemTime::now();
+                    let times = std::fs::FileTimes::new()
+                        .set_accessed(now)
+                        .set_modified(now);
+                    let _ = file.set_times(times);
+                }
+                Ok(Some(image))
+            } else {
+                Ok(None)
+            }
+        }
 
-        cache.get(cache_key)
+        #[cfg(not(target_os = "macos"))]
+        {
+            if !self.config.cache.enabled {
+                return Ok(None);
+            }
+
+            let cache_dir = self.resolve_cache_dir().join("rootfs");
+            let cache = match RootfsCache::new(&cache_dir) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to open rootfs cache, skipping");
+                    return Ok(None);
+                }
+            };
+
+            cache.get(cache_key)
+        }
     }
 
     /// Store a built rootfs in the cache for future reuse.
@@ -363,40 +413,95 @@ impl VmManager {
         rootfs_path: &Path,
         description: &str,
     ) {
-        if !self.config.cache.enabled {
-            return;
-        }
+        #[cfg(target_os = "macos")]
+        {
+            use std::process::Command;
 
-        let cache_dir = self.resolve_cache_dir().join("rootfs");
-        let cache = match RootfsCache::new(&cache_dir) {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to open rootfs cache for storing");
+            if !self.config.cache.enabled {
                 return;
             }
-        };
-
-        match cache.put(cache_key, rootfs_path, description) {
-            Ok(_) => {
-                tracing::debug!(
-                    cache_key = %&cache_key[..cache_key.len().min(12)],
-                    description = %description,
-                    "Stored rootfs in cache"
-                );
-                // Prune if needed — but never evict a cache entry that is in use as
-                // a live overlay lower for a concurrent box (deleting the lowerdir
-                // under its mount(2) is the same-image concurrency bug this guards).
-                let protected = self.referenced_rootfs_cache_keys();
-                if let Err(e) = cache.prune_protecting(
-                    self.config.cache.max_rootfs_entries,
-                    self.config.cache.max_cache_bytes,
-                    &protected,
-                ) {
-                    tracing::warn!(error = %e, "Failed to prune rootfs cache");
-                }
+            let cache_dir = self.resolve_cache_dir().join("rootfs-apfs-v2");
+            if let Err(error) = std::fs::create_dir_all(&cache_dir) {
+                tracing::warn!(%error, "Failed to create APFS rootfs cache");
+                return;
             }
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to store rootfs in cache");
+            let mountpoint = rootfs_path.parent().unwrap_or(rootfs_path);
+            let box_dir = mountpoint.parent().unwrap_or(mountpoint);
+            let source = box_dir.join("rootfs-apfs-v2.sparseimage");
+            let destination = cache_dir.join(format!("{cache_key}.sparseimage"));
+            let temporary = cache_dir.join(format!(".{cache_key}.tmp-{}", std::process::id()));
+
+            crate::rootfs::unmount_box_rootfs(rootfs_path);
+            let cloned = Command::new("cp")
+                .arg("-c")
+                .arg(&source)
+                .arg(&temporary)
+                .status()
+                .is_ok_and(|status| status.success());
+            if cloned {
+                if let Err(error) = std::fs::rename(&temporary, &destination) {
+                    tracing::warn!(%error, "Failed to publish APFS rootfs cache image");
+                } else {
+                    tracing::debug!(
+                        cache_key = %&cache_key[..cache_key.len().min(12)],
+                        %description,
+                        "Stored case-sensitive APFS rootfs cache"
+                    );
+                    if let Err(error) = prune_apfs_rootfs_cache(
+                        &cache_dir,
+                        self.config.cache.max_rootfs_entries,
+                        self.config.cache.max_cache_bytes,
+                        cache_key,
+                    ) {
+                        tracing::warn!(%error, "Failed to prune APFS rootfs cache");
+                    }
+                }
+            } else {
+                tracing::warn!(source = %source.display(), "Failed to clone APFS rootfs cache image");
+                let _ = std::fs::remove_file(&temporary);
+            }
+            if let Err(error) = self.rootfs_provider.prepare_empty(box_dir) {
+                tracing::warn!(%error, "Failed to remount rootfs after caching");
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            if !self.config.cache.enabled {
+                return;
+            }
+
+            let cache_dir = self.resolve_cache_dir().join("rootfs");
+            let cache = match RootfsCache::new(&cache_dir) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to open rootfs cache for storing");
+                    return;
+                }
+            };
+
+            match cache.put(cache_key, rootfs_path, description) {
+                Ok(_) => {
+                    tracing::debug!(
+                        cache_key = %&cache_key[..cache_key.len().min(12)],
+                        description = %description,
+                        "Stored rootfs in cache"
+                    );
+                    // Prune if needed — but never evict a cache entry that is in use as
+                    // a live overlay lower for a concurrent box (deleting the lowerdir
+                    // under its mount(2) is the same-image concurrency bug this guards).
+                    let protected = self.referenced_rootfs_cache_keys();
+                    if let Err(e) = cache.prune_protecting(
+                        self.config.cache.max_rootfs_entries,
+                        self.config.cache.max_cache_bytes,
+                        &protected,
+                    ) {
+                        tracing::warn!(error = %e, "Failed to prune rootfs cache");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to store rootfs in cache");
+                }
             }
         }
     }
@@ -412,6 +517,7 @@ impl VmManager {
     /// Rootfs-cache keys currently in use as an overlay lower by some live box.
     /// Boxes live under `<home>/boxes/<id>/`; a removed box's marker is gone with
     /// its dir, so an evictable key is simply one no live box references.
+    #[cfg(not(target_os = "macos"))]
     fn referenced_rootfs_cache_keys(&self) -> std::collections::HashSet<String> {
         let mut set = std::collections::HashSet::new();
         if let Ok(entries) = std::fs::read_dir(self.home_dir.join("boxes")) {
@@ -688,6 +794,72 @@ impl VmManager {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn prune_apfs_rootfs_cache(
+    cache_dir: &Path,
+    max_entries: usize,
+    max_allocated_bytes: u64,
+    protected_key: &str,
+) -> std::io::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    struct Entry {
+        path: PathBuf,
+        key: String,
+        modified: std::time::SystemTime,
+        allocated_bytes: u64,
+    }
+
+    let mut entries = Vec::new();
+    for item in std::fs::read_dir(cache_dir)? {
+        let item = item?;
+        let path = item.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let Some(key) = name.strip_suffix(".sparseimage") else {
+            continue;
+        };
+        if key.starts_with('.') || !item.file_type()?.is_file() {
+            continue;
+        }
+        let key = key.to_string();
+        let metadata = item.metadata()?;
+        entries.push(Entry {
+            path,
+            key,
+            modified: metadata.modified().unwrap_or(std::time::UNIX_EPOCH),
+            // `len()` is the sparse image's 64 GiB virtual capacity. `blocks()`
+            // reflects physical 512-byte blocks and is the bounded resource.
+            allocated_bytes: metadata.blocks().saturating_mul(512),
+        });
+    }
+
+    entries.sort_by_key(|entry| entry.modified);
+    let mut count = entries.len();
+    let mut allocated: u64 = entries.iter().map(|entry| entry.allocated_bytes).sum();
+    for entry in entries {
+        if count <= max_entries && allocated <= max_allocated_bytes {
+            break;
+        }
+        if entry.key == protected_key {
+            continue;
+        }
+        match std::fs::remove_file(&entry.path) {
+            Ok(()) => {
+                count = count.saturating_sub(1);
+                allocated = allocated.saturating_sub(entry.allocated_bytes);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                count = count.saturating_sub(1);
+                allocated = allocated.saturating_sub(entry.allocated_bytes);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
 /// Read the snapshot-restore copy-on-write overlay lower marker, if present and
 /// non-empty. `snapshot restore` writes the snapshot's stored rootfs path here;
 /// the runtime mounts it as a read-only overlay lower instead of copying the
@@ -847,6 +1019,7 @@ mod tests {
         assert!(!cache_dir.exists());
     }
 
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn test_store_rootfs_cache_success() {
         let tmp = TempDir::new().unwrap();
@@ -865,6 +1038,7 @@ mod tests {
         assert!(result.is_some());
     }
 
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn test_store_rootfs_cache_prunes_on_store() {
         let tmp = TempDir::new().unwrap();
@@ -885,6 +1059,58 @@ mod tests {
         let cache_dir = tmp.path().join("cache").join("rootfs");
         let cache = RootfsCache::new(&cache_dir).unwrap();
         assert!(cache.entry_count().unwrap() <= 2);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_prune_apfs_rootfs_cache_bounds_entries_and_protects_new_entry() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().join("rootfs-apfs");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        for key in ["oldest", "middle", "new"] {
+            std::fs::write(
+                cache_dir.join(format!("{key}.sparseimage")),
+                vec![b'x'; 4096],
+            )
+            .unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        std::fs::write(cache_dir.join(".partial.tmp-1"), b"temporary").unwrap();
+
+        prune_apfs_rootfs_cache(&cache_dir, 1, u64::MAX, "new").unwrap();
+
+        assert!(!cache_dir.join("oldest.sparseimage").exists());
+        assert!(!cache_dir.join("middle.sparseimage").exists());
+        assert!(cache_dir.join("new.sparseimage").exists());
+        assert!(cache_dir.join(".partial.tmp-1").exists());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_prune_apfs_rootfs_cache_uses_allocated_bytes_not_virtual_length() {
+        use std::os::unix::fs::MetadataExt;
+
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().join("rootfs-apfs");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let old = cache_dir.join("old.sparseimage");
+        let protected = cache_dir.join("protected.sparseimage");
+        std::fs::write(&old, vec![b'x'; 8192]).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::fs::write(&protected, vec![b'y'; 4096]).unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&protected)
+            .unwrap()
+            .set_len(64 * 1024 * 1024 * 1024)
+            .unwrap();
+        let protected_allocated = protected.metadata().unwrap().blocks() * 512;
+
+        prune_apfs_rootfs_cache(&cache_dir, usize::MAX, protected_allocated, "protected").unwrap();
+
+        assert!(!old.exists());
+        assert!(protected.exists());
     }
 
     #[cfg(unix)]
@@ -977,6 +1203,7 @@ mod tests {
         assert_eq!(request.user, Some("1000:1000".to_string()));
     }
 
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn test_try_and_store_roundtrip() {
         let tmp = TempDir::new().unwrap();

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -360,6 +360,57 @@ impl VmManager {
         self.exec_client.as_ref()
     }
 
+    #[cfg(unix)]
+    async fn connect_exec_client_for_request(socket_path: &Path) -> Result<ExecClient> {
+        const ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
+        let client = ExecClient::connect(socket_path).await?;
+        match tokio::time::timeout(ATTEMPT_TIMEOUT, client.heartbeat()).await {
+            Ok(Ok(true)) => Ok(client),
+            Ok(Ok(false)) => Err(BoxError::ExecError(format!(
+                "Exec client not connected: heartbeat failed at {}",
+                socket_path.display()
+            ))),
+            Ok(Err(error)) => Err(error),
+            Err(_) => Err(BoxError::ExecError(format!(
+                "Exec client not connected: heartbeat timed out at {}",
+                socket_path.display()
+            ))),
+        }
+    }
+
+    /// Wait until the guest exec server can complete a heartbeat.
+    ///
+    /// Cold foreground boots may proceed after the short diagnostic readiness
+    /// cap so logs remain visible. A warm pool has a stronger contract: an idle
+    /// VM must actually be executable before it is published to callers.
+    #[cfg(unix)]
+    pub async fn wait_for_exec_available(&mut self, timeout: std::time::Duration) -> Result<()> {
+        let socket_path = self
+            .exec_socket_path
+            .clone()
+            .ok_or_else(|| BoxError::ExecError("Exec socket path is unavailable".to_string()))?;
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            match Self::connect_exec_client_for_request(&socket_path).await {
+                Ok(client) => {
+                    self.exec_client = Some(client);
+                    return Ok(());
+                }
+                Err(error) if tokio::time::Instant::now() < deadline => {
+                    tracing::debug!(%error, "Waiting for pooled VM exec readiness");
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    pub async fn wait_for_exec_available(&mut self, _timeout: std::time::Duration) -> Result<()> {
+        Ok(())
+    }
+
     /// Attach this manager to an already-running shim process.
     ///
     /// This is useful for crash recovery or control-plane restart flows where
@@ -544,18 +595,44 @@ impl VmManager {
         spec_json: &[u8],
         timeout: std::time::Duration,
     ) -> Result<a3s_box_core::exec::ExecOutput> {
+        let log_dir = self.home_dir.join("boxes").join(&self.box_id).join("logs");
+        let console_out_path = log_dir.join("console.log");
+        let console_err_path = a3s_box_core::log::stderr_console_path(&console_out_path);
+        let console_out_start = std::fs::metadata(&console_out_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        let console_err_start = std::fs::metadata(&console_err_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+
         let acked = {
-            let client = self
-                .exec_client
-                .as_ref()
-                .ok_or_else(|| BoxError::ExecError("Exec client not connected".to_string()))?;
+            let owned_client;
+            let client = if let Some(client) = self.exec_client.as_ref() {
+                client
+            } else {
+                let socket_path = self
+                    .exec_socket_path
+                    .as_deref()
+                    .ok_or_else(|| BoxError::ExecError("Exec client not connected".to_string()))?;
+                owned_client = Self::connect_exec_client_for_request(socket_path).await?;
+                &owned_client
+            };
             client.spawn_main(Some(spec_json)).await?
         };
-        if !acked {
-            return Err(BoxError::ExecError(
-                "spawn-main was not acknowledged by the guest".to_string(),
-            ));
-        }
+        let exit_wait_timeout = if acked {
+            timeout
+        } else {
+            // Very short deferred mains can exit and halt the VM before the
+            // guest's ACK frame makes it back to the host. Treat a missing ACK as
+            // provisional: if the VM exits promptly, the spawn succeeded and the
+            // real exit code/logs are authoritative; otherwise fail quickly
+            // instead of waiting the full command timeout for an IDLE VM.
+            tracing::debug!(
+                box_id = %self.box_id,
+                "spawn-main was not acknowledged; waiting briefly for main exit"
+            );
+            timeout.min(std::time::Duration::from_secs(2))
+        };
 
         // Wait for the main to exit — guest-init persists the code and halts the VM.
         let start = std::time::Instant::now();
@@ -563,40 +640,73 @@ impl VmManager {
             if let Some(code) = self.try_wait_exit().await? {
                 break code;
             }
-            if start.elapsed() >= timeout {
-                return Err(BoxError::ExecError(
-                    "deferred main did not exit within the timeout".to_string(),
-                ));
+            if start.elapsed() >= exit_wait_timeout {
+                let message = if acked {
+                    "deferred main did not exit within the timeout"
+                } else {
+                    "spawn-main was not acknowledged by the guest"
+                };
+                return Err(BoxError::ExecError(message.to_string()));
             }
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         };
 
         // Let the shim's log processor finish draining console.log into the json
-        // file (it flushes as the VM halts): poll until container.json stops
-        // growing for one interval (bounded at 1s) instead of a fixed sleep —
-        // fast when the drain is already done, safe when it lags.
-        let json_path = self
-            .home_dir
-            .join("boxes")
-            .join(&self.box_id)
-            .join("logs")
-            .join("container.json");
+        // file (it flushes as the VM halts). A single short "stable length"
+        // sample is not enough here: deferred-main can persist its exit code
+        // before the final stdout/stderr bytes have reached the host tailer,
+        // especially with pre-warmed pools. Require a small quiet window before
+        // reading logs, bounded so no-output commands still return promptly.
+        let json_path = log_dir.join("container.json");
         let drain_start = std::time::Instant::now();
-        let mut last_len = u64::MAX;
+        let max_wait = std::time::Duration::from_secs(2);
+        let min_wait = std::time::Duration::from_millis(500);
+        let quiet_window = std::time::Duration::from_millis(200);
+        let mut last_len: Option<u64> = None;
+        let mut last_change = drain_start;
         loop {
             let len = std::fs::metadata(&json_path).map(|m| m.len()).unwrap_or(0);
-            if len == last_len || drain_start.elapsed() >= std::time::Duration::from_secs(1) {
+            if last_len != Some(len) {
+                last_len = Some(len);
+                last_change = std::time::Instant::now();
+            }
+            let elapsed = drain_start.elapsed();
+            if elapsed >= max_wait || (elapsed >= min_wait && last_change.elapsed() >= quiet_window)
+            {
                 break;
             }
-            last_len = len;
-            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
-        let (stdout, stderr) = self.read_container_logs();
+        let (mut stdout, mut stderr) = self.read_container_logs();
+        if stdout.is_empty() {
+            stdout = Self::read_file_from_offset(&console_out_path, console_out_start);
+        }
+        if stderr.is_empty() {
+            stderr = Self::read_file_from_offset(&console_err_path, console_err_start);
+        }
         Ok(a3s_box_core::exec::ExecOutput {
             stdout,
             stderr,
             exit_code,
         })
+    }
+
+    fn read_file_from_offset(path: &Path, offset: u64) -> Vec<u8> {
+        use std::io::{Read, Seek, SeekFrom};
+
+        let mut file = match std::fs::File::open(path) {
+            Ok(file) => file,
+            Err(_) => return vec![],
+        };
+        if file.seek(SeekFrom::Start(offset)).is_err() {
+            return vec![];
+        }
+
+        let mut bytes = Vec::new();
+        if file.read_to_end(&mut bytes).is_err() {
+            return vec![];
+        }
+        bytes
     }
 
     /// Read the box's json-file console logs, split into stdout/stderr by stream.
@@ -649,10 +759,17 @@ impl VmManager {
         }
         drop(state);
 
-        let client = self
-            .exec_client
-            .as_ref()
-            .ok_or_else(|| BoxError::ExecError("Exec client not connected".to_string()))?;
+        let owned_client;
+        let client = if let Some(client) = self.exec_client.as_ref() {
+            client
+        } else {
+            let socket_path = self
+                .exec_socket_path
+                .as_deref()
+                .ok_or_else(|| BoxError::ExecError("Exec client not connected".to_string()))?;
+            owned_client = Self::connect_exec_client_for_request(socket_path).await?;
+            &owned_client
+        };
 
         let exec_start = std::time::Instant::now();
         let result = client.exec_command(request).await;
@@ -795,6 +912,38 @@ impl VmManager {
                     .join(","),
             ));
 
+            spec.network = Some(net_config);
+        }
+
+        #[cfg(target_os = "macos")]
+        if spec.network.is_none()
+            && matches!(self.config.network, a3s_box_core::NetworkMode::Tsi)
+            && !self.config.port_map.is_empty()
+        {
+            let net_config = match self.setup_published_default_network() {
+                Ok(network) => network,
+                Err(error) => {
+                    self.cleanup_boot_failure().await;
+                    return Err(error);
+                }
+            };
+            let ip_cidr = format!("{}/{}", net_config.ip_address, net_config.prefix_len);
+            spec.entrypoint
+                .env
+                .push(("A3S_NET_IP".to_string(), ip_cidr));
+            spec.entrypoint.env.push((
+                "A3S_NET_GATEWAY".to_string(),
+                net_config.gateway.to_string(),
+            ));
+            spec.entrypoint.env.push((
+                "A3S_NET_DNS".to_string(),
+                net_config
+                    .dns_servers
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(","),
+            ));
             spec.network = Some(net_config);
         }
 

--- a/src/runtime/src/vm/network.rs
+++ b/src/runtime/src/vm/network.rs
@@ -8,6 +8,46 @@ use crate::vmm::NetworkInstanceConfig;
 use super::VmManager;
 
 impl VmManager {
+    /// Configure an isolated virtio-net backend for a default-network box that
+    /// publishes host ports on macOS.
+    ///
+    /// libkrun's reverse TSI listener can accept TCP while stalling payloads,
+    /// especially when the client is another TSI guest. A private netproxy
+    /// instance provides the same outbound connectivity and published-port CLI
+    /// contract without joining a user-visible bridge network.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn setup_published_default_network(&mut self) -> Result<NetworkInstanceConfig> {
+        let ip = std::net::Ipv4Addr::new(10, 89, 0, 2);
+        let gateway = std::net::Ipv4Addr::new(10, 89, 0, 1);
+        let prefix_len = 24;
+        let dns_servers: Vec<std::net::Ipv4Addr> = if self.config.dns.is_empty() {
+            vec![std::net::Ipv4Addr::new(8, 8, 8, 8)]
+        } else {
+            self.config
+                .dns
+                .iter()
+                .filter_map(|value| value.parse().ok())
+                .collect()
+        };
+        let box_dir = self.home_dir.join("boxes").join(&self.box_id);
+        let mut netproxy = crate::network::NetProxyManager::new(&box_dir);
+        netproxy.spawn(ip, gateway, prefix_len, &dns_servers, &self.config.port_map)?;
+        let config = NetworkInstanceConfig {
+            net_socket_path: netproxy.socket_path().to_path_buf(),
+            net_stats_path: Some(netproxy.stats_path().to_path_buf()),
+            net_socket_fd: netproxy.net_socket_fd(),
+            net_proxy_fd: netproxy.net_proxy_fd(),
+            bridge_socket_dir: None,
+            ip_address: ip,
+            gateway,
+            prefix_len,
+            mac_address: [0x02, 0x42, 0x0a, 0x59, 0x00, 0x02],
+            dns_servers,
+        };
+        self.net_manager = Some(Box::new(netproxy));
+        Ok(config)
+    }
+
     /// Write `/etc/hostname` when a hostname override is configured.
     pub(crate) fn write_hostname_file(&self, layout: &super::BoxLayout) -> Result<()> {
         let Some(hostname) = self.config.hostname.as_deref() else {
@@ -131,6 +171,8 @@ impl VmManager {
             net_socket_fd,
             #[cfg(target_os = "macos")]
             net_proxy_fd,
+            #[cfg(target_os = "macos")]
+            bridge_socket_dir: Some(macos_bridge_socket_dir(&self.home_dir, network_name)),
             ip_address: ip,
             gateway,
             prefix_len,
@@ -228,6 +270,21 @@ impl VmManager {
         tracing::debug!(hosts = %hosts_content.trim(), "Configured guest /etc/hosts for DNS discovery");
         Ok(())
     }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_bridge_socket_dir(home: &std::path::Path, network_name: &str) -> std::path::PathBuf {
+    use sha2::{Digest, Sha256};
+
+    let mut digest = Sha256::new();
+    digest.update(home.as_os_str().as_encoded_bytes());
+    digest.update([0]);
+    digest.update(network_name.as_bytes());
+    let key = hex::encode(digest.finalize());
+    let uid = unsafe { libc::getuid() };
+    std::path::PathBuf::from("/private/tmp/a3s-box-switches")
+        .join(uid.to_string())
+        .join(&key[..24])
 }
 
 /// Parse a MAC address string "02:42:0a:58:00:02" into [u8; 6].

--- a/src/runtime/src/vm/spec.rs
+++ b/src/runtime/src/vm/spec.rs
@@ -123,14 +123,13 @@ impl VmManager {
                     );
                     (exec, args, oci_config.env.clone())
                 }
-                None => (
-                    "/bin/sh".to_string(),
-                    vec![
-                        "-c".to_string(),
-                        "echo No command specified; exec /bin/sh".to_string(),
-                    ],
-                    vec![],
-                ),
+                None => {
+                    let (exec, args) = Self::resolve_config_entrypoint(
+                        &self.config.cmd,
+                        self.config.entrypoint_override.as_deref(),
+                    );
+                    (exec, args, vec![])
+                }
             };
             a3s_box_core::env::merge_env_pairs(&mut container_env, &self.config.extra_env);
 
@@ -371,14 +370,18 @@ impl VmManager {
                         env,
                     }
                 }
-                None => Entrypoint {
-                    executable: "/bin/sh".to_string(),
-                    args: vec![
-                        "-c".to_string(),
-                        "echo No command specified; exec /bin/sh".to_string(),
-                    ],
-                    env: self.config.extra_env.clone(),
-                },
+                None => {
+                    let (executable, args) = Self::resolve_config_entrypoint(
+                        &self.config.cmd,
+                        self.config.entrypoint_override.as_deref(),
+                    );
+
+                    Entrypoint {
+                        executable,
+                        args,
+                        env: self.config.extra_env.clone(),
+                    }
+                }
             }
         };
 
@@ -402,6 +405,12 @@ impl VmManager {
         entrypoint
             .env
             .push(("BOX_CRI_PORT_FWD".to_string(), "1".to_string()));
+
+        if self.config.persistent {
+            entrypoint
+                .env
+                .push(("BOX_PERSIST_ROOTFS_METADATA".to_string(), "1".to_string()));
+        }
 
         // Inject sidecar configuration so guest-init can launch the sidecar process
         if let Some(ref sidecar) = self.config.sidecar {
@@ -520,14 +529,41 @@ impl VmManager {
             (exec, args)
         } else {
             // Neither set: fall back to /bin/sh (universal across all Linux distros)
-            (
-                "/bin/sh".to_string(),
-                vec![
-                    "-c".to_string(),
-                    "echo No command specified; exec /bin/sh".to_string(),
-                ],
-            )
+            Self::default_entrypoint()
         }
+    }
+
+    /// Resolve an entrypoint from the box config alone.
+    ///
+    /// Snapshot restores can mount a prepared rootfs without an OCI config file,
+    /// but the CLI record still preserves the original ENTRYPOINT/CMD. Keep the
+    /// same Docker ordering here: entrypoint args first, then CMD.
+    fn resolve_config_entrypoint(
+        cmd: &[String],
+        entrypoint_override: Option<&[String]>,
+    ) -> (String, Vec<String>) {
+        if let Some(entrypoint) = entrypoint_override.filter(|entrypoint| !entrypoint.is_empty()) {
+            let exec = entrypoint[0].clone();
+            let mut args: Vec<String> = entrypoint.iter().skip(1).cloned().collect();
+            args.extend(cmd.iter().cloned());
+            (exec, args)
+        } else if !cmd.is_empty() {
+            let exec = cmd[0].clone();
+            let args: Vec<String> = cmd.iter().skip(1).cloned().collect();
+            (exec, args)
+        } else {
+            Self::default_entrypoint()
+        }
+    }
+
+    fn default_entrypoint() -> (String, Vec<String>) {
+        (
+            "/bin/sh".to_string(),
+            vec![
+                "-c".to_string(),
+                "echo No command specified; exec /bin/sh".to_string(),
+            ],
+        )
     }
 
     fn guest_init_exec_path(rootfs_path: &Path) -> Option<&'static str> {
@@ -916,6 +952,20 @@ mod tests {
     }
 
     #[test]
+    fn test_persistent_box_requests_terminal_rootfs_metadata() {
+        let dir = tempdir().unwrap();
+        let layout = test_layout(dir.path(), Some(test_oci_config(None, None)), true);
+        let mut vm = test_vm_manager(BoxConfig {
+            persistent: true,
+            ..Default::default()
+        });
+
+        let spec = vm.build_instance_spec(&layout).unwrap();
+
+        assert_eq!(env_value(&spec, "BOX_PERSIST_ROOTFS_METADATA"), Some("1"));
+    }
+
+    #[test]
     fn test_run_path_plumbs_cpu_cgroup_limits_to_guest() {
         // The `run` boot path must hand the CPU cgroup limits to guest-init as
         // A3S_SEC_CPU_* (the same vars the CRI path emits and the guest consumes),
@@ -1228,6 +1278,60 @@ mod tests {
         fs::write(rootfs.join("sbin").join("init"), b"guest-init").unwrap();
 
         assert_eq!(VmManager::guest_init_exec_path(rootfs), Some("/sbin/init"));
+    }
+
+    #[test]
+    fn test_build_instance_spec_restored_rootfs_uses_saved_cmd_with_guest_init() {
+        let dir = tempdir().unwrap();
+        let layout = test_layout(dir.path(), None, true);
+        let mut vm = test_vm_manager(BoxConfig {
+            cmd: vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "sleep 3600".to_string(),
+            ],
+            ..Default::default()
+        });
+
+        let spec = vm.build_instance_spec(&layout).unwrap();
+
+        assert_eq!(spec.entrypoint.executable, "/sbin/init");
+        assert_eq!(
+            env_value(&spec, "BOX_EXEC_EXEC").map(b64d).as_deref(),
+            Some("/bin/sh")
+        );
+        assert_eq!(env_value(&spec, "BOX_EXEC_ARGC"), Some("2"));
+        assert_eq!(
+            env_value(&spec, "BOX_EXEC_ARG_0").map(b64d).as_deref(),
+            Some("-c")
+        );
+        assert_eq!(
+            env_value(&spec, "BOX_EXEC_ARG_1").map(b64d).as_deref(),
+            Some("sleep 3600")
+        );
+        assert!(!spec
+            .entrypoint
+            .env
+            .iter()
+            .any(|(_, value)| value.contains("No command specified")));
+    }
+
+    #[test]
+    fn test_build_instance_spec_restored_rootfs_uses_saved_entrypoint_without_guest_init() {
+        let dir = tempdir().unwrap();
+        let layout = test_layout(dir.path(), None, false);
+        let mut vm = test_vm_manager(BoxConfig {
+            cmd: vec!["hello".to_string()],
+            entrypoint_override: Some(vec!["/bin/echo".to_string(), "prefix".to_string()]),
+            extra_env: vec![("FOO".to_string(), "bar".to_string())],
+            ..Default::default()
+        });
+
+        let spec = vm.build_instance_spec(&layout).unwrap();
+
+        assert_eq!(spec.entrypoint.executable, "/bin/echo");
+        assert_eq!(spec.entrypoint.args, vec!["prefix", "hello"]);
+        assert_eq!(env_value(&spec, "FOO"), Some("bar"));
     }
 
     #[test]

--- a/src/sdk/src/client/core.rs
+++ b/src/sdk/src/client/core.rs
@@ -377,6 +377,7 @@ impl A3sBoxClient {
                 target: request.target,
                 no_cache: request.no_cache,
                 metrics: None,
+                run_pool: None,
             },
             store,
         )

--- a/src/shim/src/krun/context.rs
+++ b/src/shim/src/krun/context.rs
@@ -288,6 +288,7 @@ impl KrunContext {
     /// # Arguments
     /// * `port_map` - Slice of "host_port:guest_port" strings (e.g., ["8080:80", "3000:3000"])
     #[cfg(not(target_os = "windows"))]
+    #[allow(dead_code)]
     pub unsafe fn set_port_map(&self, port_map: &[String]) -> Result<()> {
         tracing::debug!(port_map = ?port_map, "Setting TSI port mappings");
         let entries: Vec<CString> = port_map

--- a/src/shim/src/main.rs
+++ b/src/shim/src/main.rs
@@ -22,7 +22,7 @@ use a3s_box_core::PORT_FWD_VSOCK_PORT;
 #[cfg(not(target_os = "windows"))]
 use a3s_box_core::{ATTEST_VSOCK_PORT, PORT_FWD_VSOCK_PORT, PTY_VSOCK_PORT};
 #[cfg(target_os = "macos")]
-use a3s_box_netproxy::spawn_inherited_netproxy;
+use a3s_box_netproxy::{spawn_inherited_netproxy, InheritedNetProxyConfig};
 use clap::Parser;
 use krun::KrunContext;
 #[cfg(target_os = "windows")]
@@ -298,6 +298,7 @@ fn parse_cpuset_spec(spec: &str) -> std::result::Result<Vec<usize>, String> {
 }
 
 #[cfg(not(target_os = "windows"))]
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 fn tsi_port_map_for_spec(spec: &InstanceSpec) -> Vec<String> {
     if native_bridge_port_forwarding_handles_spec(spec) {
         return Vec::new();
@@ -315,11 +316,13 @@ fn tsi_port_map_for_spec(spec: &InstanceSpec) -> Vec<String> {
 // host_port_map once a virtio-net device is attached anyway, so feeding it the
 // port map is dead work; let the backend own forwarding instead.
 #[cfg(not(target_os = "windows"))]
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 fn native_bridge_port_forwarding_handles_spec(spec: &InstanceSpec) -> bool {
     spec.network.is_some()
 }
 
 #[cfg(not(target_os = "windows"))]
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 fn is_auto_assigned_host_port(mapping: &str) -> bool {
     mapping
         .split_once(':')
@@ -477,7 +480,7 @@ unsafe fn configure_and_start_vm(spec: &InstanceSpec) -> Result<()> {
     // Must be called before add_vsock_port to avoid EINVAL from libkrun.
     // Skip entries handled by bridge-native forwarding or host_port=0
     // auto-assignment, which would fail with EINVAL in libkrun's TSI.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
     {
         let valid_port_map = tsi_port_map_for_spec(spec);
 
@@ -661,12 +664,16 @@ unsafe fn configure_and_start_vm(spec: &InstanceSpec) -> Result<()> {
             if let Some(proxy_fd) = net_config.net_proxy_fd {
                 spawn_inherited_netproxy(
                     proxy_fd,
-                    net_config.ip_address,
-                    net_config.gateway,
-                    net_config.prefix_len,
-                    &net_config.dns_servers,
-                    &spec.port_map,
-                    net_config.net_stats_path.clone(),
+                    InheritedNetProxyConfig {
+                        guest_ip: net_config.ip_address,
+                        gateway: net_config.gateway,
+                        prefix_len: net_config.prefix_len,
+                        dns_servers: &net_config.dns_servers,
+                        port_map: &spec.port_map,
+                        stats_path: net_config.net_stats_path.clone(),
+                        bridge_socket_dir: net_config.bridge_socket_dir.clone(),
+                        own_mac: net_config.mac_address,
+                    },
                 )?;
             }
             log_inherited_net_fd(fd);
@@ -698,6 +705,13 @@ unsafe fn configure_and_start_vm(spec: &InstanceSpec) -> Result<()> {
         apply_user_config(&ctx, user)?;
     }
 
+    // Keep split-console descriptors owned by the shim until start_enter
+    // returns. Closing them before the final log drain establishes a real EOF
+    // boundary; leaking them with mem::forget made short detached output race
+    // the processor indefinitely.
+    #[cfg(unix)]
+    let mut split_console_files: Option<(std::fs::File, std::fs::File)> = None;
+
     // Configure console output if specified
     if let Some(console_path) = &spec.console_output {
         let console_str = console_path
@@ -726,9 +740,7 @@ unsafe fn configure_and_start_vm(spec: &InstanceSpec) -> Result<()> {
             };
             if let (Ok(out_f), Ok(err_f)) = (open(console_path), open(&err_path)) {
                 ctx.add_split_console(-1, out_f.as_raw_fd(), err_f.as_raw_fd())?;
-                // Keep the fds open for the VM's lifetime.
-                std::mem::forget(out_f);
-                std::mem::forget(err_f);
+                split_console_files = Some((out_f, err_f));
                 tracing::debug!("split console enabled (stdout/stderr separated)");
                 split_done = true;
             }
@@ -795,6 +807,7 @@ unsafe fn configure_and_start_vm(spec: &InstanceSpec) -> Result<()> {
     // daemonless home for log processing — a detached `run -d` box keeps logging
     // after the launching CLI exits (the processor used to die with that CLI).
     let log_stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let log_ready = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let log_thread = spec.console_output.as_ref().map(|console| {
         let console = console.clone();
         let log_dir = console
@@ -803,15 +816,45 @@ unsafe fn configure_and_start_vm(spec: &InstanceSpec) -> Result<()> {
             .unwrap_or_else(|| std::path::PathBuf::from("."));
         let config = spec.log_config.clone();
         let stop = log_stop.clone();
+        let ready = log_ready.clone();
         std::thread::spawn(move || {
-            a3s_box_core::log::run_log_processor(&console, &log_dir, &config, &stop);
+            a3s_box_core::log::run_log_processor_with_ready(
+                &console,
+                &log_dir,
+                &config,
+                &stop,
+                Some(&ready),
+            );
         })
     });
+
+    if log_thread.is_some() {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while log_ready.load(std::sync::atomic::Ordering::Acquire) < 2 {
+            if std::time::Instant::now() >= deadline {
+                log_stop.store(true, std::sync::atomic::Ordering::SeqCst);
+                if let Some(handle) = log_thread {
+                    let _ = handle.join();
+                }
+                return Err(BoxError::BoxBootError {
+                    message: "log processor did not become ready before VM start".to_string(),
+                    hint: None,
+                });
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+    }
 
     // Start VM. start_enter RETURNS with the guest exit status once the guest
     // exits (status >= 0) or on a start failure (status < 0).
     tracing::info!(box_id = %spec.box_id, "Starting VM (process takeover)");
     let status = ctx.start_enter();
+
+    // No guest writes are valid after start_enter returns. Close the shim's
+    // console descriptors before signaling the readers so their final EOF is
+    // authoritative and all kernel-buffered output is visible.
+    #[cfg(unix)]
+    drop(split_console_files);
 
     // Guest has exited and console.log is fully flushed: signal the processor to
     // drain the remainder and stop, then join so the final lines reach
@@ -819,6 +862,38 @@ unsafe fn configure_and_start_vm(spec: &InstanceSpec) -> Result<()> {
     log_stop.store(true, std::sync::atomic::Ordering::SeqCst);
     if let Some(handle) = log_thread {
         let _ = handle.join();
+    }
+    if let Some(console) = spec.console_output.as_ref() {
+        let structured = a3s_box_core::log::json_log_path(
+            console
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(".")),
+        );
+        let stderr_console = a3s_box_core::log::stderr_console_path(console);
+        let structured_empty = structured.metadata().map(|m| m.len() == 0).unwrap_or(true);
+        let raw_has_output = console.metadata().map(|m| m.len() > 0).unwrap_or(false)
+            || stderr_console
+                .metadata()
+                .map(|m| m.len() > 0)
+                .unwrap_or(false);
+        if structured_empty
+            && raw_has_output
+            && spec.log_config.driver == a3s_box_core::log::LogDriver::JsonFile
+        {
+            // A very short VM can finish while the first processor is sitting
+            // on a provisional console EOF. Its raw files are authoritative at
+            // this point (start_enter returned and the write fds are closed), so
+            // repair the empty projection synchronously. The empty guard makes
+            // this idempotent and prevents duplicate records.
+            a3s_box_core::log::run_log_processor(
+                console,
+                console
+                    .parent()
+                    .unwrap_or_else(|| std::path::Path::new(".")),
+                &spec.log_config,
+                &log_stop,
+            );
+        }
     }
 
     // If we reach here, either:
@@ -984,7 +1059,7 @@ mod tests {
         assert!(parse_ulimit("sigpending=100:200").is_some());
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
     #[test]
     fn test_tsi_port_map_for_spec_filters_auto_assigned_host_ports() {
         let spec = InstanceSpec {
@@ -1036,6 +1111,8 @@ mod tests {
             net_socket_fd: Some(42),
             #[cfg(target_os = "macos")]
             net_proxy_fd: Some(43),
+            #[cfg(target_os = "macos")]
+            bridge_socket_dir: Some(std::path::PathBuf::from("/tmp/a3s-switch")),
             ip_address: "10.89.0.2".parse().unwrap(),
             gateway: "10.89.0.1".parse().unwrap(),
             prefix_len: 24,


### PR DESCRIPTION
## Summary

This change resolves the complete current open-issue backlog (#16–#26):

- route macOS Dockerfile `RUN` builds through the safe BuildKit VM backend and preserve repeated/quoted build args
- add full Compose parameter expansion before validation
- make detached health checks process-owned and generation-fenced
- preserve guest uid/gid/mode/symlink/hardlink metadata across `commit`
- repair macOS bridge peer switching and default-mode published-port application data
- eliminate macOS virtio-fs descriptor double-close failures (depends on A3S-Lab/libkrun#2)
- add case-sensitive APFS rootfs images without exposing APFS volume metadata
- bound `info` probes and add production-ready warm-pool/client paths, package caches, and startup diagnostics
- harden OCI build/layer behavior and add regression coverage

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p a3s-box-core -p a3s-box-runtime -p a3s-box-cli -p a3s-box-shim -p a3s-box-netproxy --all-targets -- -D warnings`
- all selected targets: 1,167 runtime tests + CLI/core/netproxy/shim targets, 0 failures
- release build on macOS arm64
- real guest regressions:
  - safe automatic BuildKit `RUN` and BuildKit VM build args containing spaces
  - Compose `${VAR:-default}` unset/set cases
  - detached health state reaches `healthy` with non-null last check
  - commit round-trip preserves root `0:0`, mode `0755`, and execution
  - bridge peer DNS + HTTP payload
  - default-mode client receives Redis `PONG` through host LAN published port
  - 2,000-file virtio-fs tar traversal
  - distinct `/bin/sh` vs `/BIN/SH` and `/tmp/Foo` vs `/tmp/foo` identities
  - release Node workspace/package-cache probe and bounded `info` (~0.02s)

Closes #16
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21
Closes #22
Closes #23
Closes #24
Closes #25
Closes #26