### PR TITLE
ci: upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           cd src
           cargo build --release -p a3s-box-cli -p a3s-box-shim --target x86_64-pc-windows-msvc
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: windows-whpx
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Init submodules
         run: git -c http.extraheader= submodule update --init --recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -30,7 +30,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Init submodules
         run: git -c http.extraheader= submodule update --init --recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -54,7 +54,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Init submodules
         run: git -c http.extraheader= submodule update --init --recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -86,7 +86,7 @@ jobs:
             os: macos-14
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Init submodules
         run: git -c http.extraheader= submodule update --init --recursive
 
@@ -123,7 +123,7 @@ jobs:
     needs: [fmt, clippy, test]
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Init submodules
         run: git -c http.extraheader= submodule update --init --recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -173,7 +173,7 @@ jobs:
     env:
       A3S_REGISTRY_MIRRORS: ${{ vars.KVM_CI_REGISTRY_MIRRORS || 'docker.io=docker.m.daocloud.io' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Init submodules
         run: git -c http.extraheader= submodule update --init --recursive
       # The self-hosted runner already has a working rustup/cargo. Using

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           cd src
           cargo build --release -p a3s-box-cli -p a3s-box-shim --target x86_64-pc-windows-msvc
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: windows-whpx
           path: |

--- a/.github/workflows/publish-libkrun-sys.yml
+++ b/.github/workflows/publish-libkrun-sys.yml
@@ -101,7 +101,7 @@ jobs:
           Compress-Archive -Path $DIR -DestinationPath "$DIR.zip"
           echo "ASSET=$DIR.zip" >> $env:GITHUB_ENV
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: windows-dll
           path: ${{ env.ASSET }}
@@ -140,7 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: windows-dll
           path: artifacts

--- a/.github/workflows/publish-libkrun-sys.yml
+++ b/.github/workflows/publish-libkrun-sys.yml
@@ -101,7 +101,7 @@ jobs:
           Compress-Archive -Path $DIR -DestinationPath "$DIR.zip"
           echo "ASSET=$DIR.zip" >> $env:GITHUB_ENV
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: windows-dll
           path: ${{ env.ASSET }}
@@ -140,7 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v7
         with:
           name: windows-dll
           path: artifacts

--- a/.github/workflows/publish-libkrun-sys.yml
+++ b/.github/workflows/publish-libkrun-sys.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build Windows krun.dll
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -112,7 +112,7 @@ jobs:
     needs: build-windows-dll
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -138,7 +138,7 @@ jobs:
     needs: [build-windows-dll, publish-crate]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -16,7 +16,7 @@ jobs:
     name: Publish to winget
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
           tar czf "${DIR}.tar.gz" "$DIR"
           echo "ASSET=${DIR}.tar.gz" >> "$GITHUB_ENV"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -174,7 +174,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       A3S_DEPS_STUB: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Init submodules
         run: git -c http.extraheader= submodule update --init --recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -62,7 +62,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Init submodules
         run: |
@@ -197,7 +197,7 @@ jobs:
     env:
       A3S_DEPS_STUB: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Init submodules
         run: git -c http.extraheader= submodule update --init --recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -279,7 +279,7 @@ jobs:
           done
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: A3S-Lab/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
           tar czf "${DIR}.tar.gz" "$DIR"
           echo "ASSET=${DIR}.tar.gz" >> "$GITHUB_ENV"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -174,7 +174,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v7
         with:
           path: artifacts
 


### PR DESCRIPTION
Upgrade workflow actions that still target deprecated Node.js 20 runtimes:

- `actions/checkout`: v4 → v5
- `actions/upload-artifact`: v4 → v5
- `actions/download-artifact`: v4 → v5

GitHub currently forces these older actions onto Node.js 24 and emits deprecation annotations.

Validation:
- all workflow YAML files parse successfully
- no v4 references for these actions remain
- `git diff --check` passes