### PR TITLE
chore(release): v3.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to A3S Box will be documented in this file.
 
+## [3.0.9] — 2026-07-11
+
+### Added
+
+- **macOS fault-injection endurance runner.** A new isolated Apple Silicon/HVF
+  harness supports staged 2-hour, 24-hour, and 72-hour soak validation with
+  shim/CLI termination, recovery assertions, resource sampling, admission
+  gates, and machine-readable evidence.
+
+### Changed
+
+- **Native Node.js 24 GitHub Actions.** Checkout and artifact actions now use
+  their native Node.js 24 releases, removing deprecation warnings from CI and
+  release workflows.
+- **Faster and more predictable runtime paths.** Package-cache preparation,
+  warm-pool routing, bounded `info`, and macOS BuildKit VM execution have been
+  tightened for repeated development and CI workloads.
+
+### Fixed
+
+- **Runtime correctness across lifecycle, networking, and storage.** Fixes
+  include detached health scheduling, Compose variable defaults, quoted build
+  arguments, commit metadata preservation, bridge peer and published Redis data
+  paths, case-sensitive APFS rootfs handling, and virtiofs descriptor lifetime.
+- **Cross-platform builds.** OCI metadata and warm-pool clients now compile on
+  Windows, with Unix-only commit and health paths correctly gated.
+- **Release automation.** The libkrun publish workflow is valid YAML again and
+  no longer creates failed zero-job runs on every push.
+
 ## [3.0.8] — 2026-07-09
 
 ### Changed

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "a3s-box-cli"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-core"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "a3s-common",
  "async-trait",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cri"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-guest-init"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "a3s-box-core",
  "a3s-common",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-lambda"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-netproxy"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "a3s-box-core",
  "libc",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-runtime"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-sdk"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-shim"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-libkrun-sys"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "libc",
  "num_cpus",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 h2 = { path = "third_party/h2" }
 
 [workspace.package]
-version = "3.0.8"
+version = "3.0.9"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/src/runtime/src/vmm/controller.rs
+++ b/src/runtime/src/vmm/controller.rs
@@ -541,7 +541,10 @@ exec /bin/sleep 30
     #[cfg(unix)]
     fn wait_for_file(path: &std::path::Path) {
         for _ in 0..250 {
-            if path.exists() {
+            // Shell redirection creates the file before `printf` writes its
+            // contents. Waiting for existence alone makes the test race with
+            // the fake shim and intermittently observe an empty value in CI.
+            if path.metadata().is_ok_and(|metadata| metadata.len() > 0) {
                 return;
             }
             std::thread::sleep(std::time::Duration::from_millis(20));
@@ -602,6 +605,8 @@ exec /bin/sleep 30
 
         let mut handler = controller.start(&spec).await.unwrap();
         wait_for_file(&args_file);
+        wait_for_file(&restore_file);
+        wait_for_file(&temp.path().join("logs").join("shim.stderr.log"));
 
         assert!(socket_dir.exists());
         let args = std::fs::read_to_string(&args_file).unwrap();


### PR DESCRIPTION
Prepare the v3.0.9 patch release.

- bump the workspace and lockfile package versions to 3.0.9
- document runtime correctness, cross-platform, CI, and macOS fault-soak improvements

Validation:
- `A3S_DEPS_STUB=1 cargo check -p a3s-box-cli -p a3s-box-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`