### PR TITLE
fix(sandbox): annotate cgroup controller collection

### DIFF
--- a/src/runtime/src/sandbox/capability.rs
+++ b/src/runtime/src/sandbox/capability.rs
@@ -559,7 +559,7 @@ fn probe_cgroup_v2() -> CgroupV2Evidence {
         (Some(mountpoint), Some(relative)) => safe_join_cgroup(mountpoint, relative),
         _ => None,
     };
-    let controllers = current_path
+    let controllers: Vec<String> = current_path
         .as_ref()
         .and_then(|path| read_trimmed(path.join("cgroup.controllers")))
         .map(|line| line.split_whitespace().map(ToString::to_string).collect())


### PR DESCRIPTION
## Summary

- add the concrete `Vec<String>` type required by the Linux-only cgroup v2 capability probe
- restore Linux Clippy and test compilation after #36

## Validation

- `cargo fmt --all`
- `cargo check -p a3s-box-runtime --lib`
- `cargo test -p a3s-box-runtime sandbox:: --lib` (15 passed)