### PR TITLE
fix(sandbox): own current cgroup path

### DIFF
--- a/src/runtime/src/sandbox/capability.rs
+++ b/src/runtime/src/sandbox/capability.rs
@@ -553,8 +553,8 @@ fn probe_seccomp_and_privileges(snapshot: &mut SandboxCapabilitySnapshot) {
 fn probe_cgroup_v2() -> CgroupV2Evidence {
     let mountpoint = read_trimmed("/proc/self/mountinfo")
         .and_then(|contents| parse_cgroup2_mountpoint(&contents));
-    let relative =
-        read_trimmed("/proc/self/cgroup").and_then(|contents| parse_current_cgroup_path(&contents));
+    let relative = read_trimmed("/proc/self/cgroup")
+        .and_then(|contents| parse_current_cgroup_path(&contents).map(ToString::to_string));
     let current_path = match (&mountpoint, &relative) {
         (Some(mountpoint), Some(relative)) => safe_join_cgroup(mountpoint, relative),
         _ => None,


### PR DESCRIPTION
## Summary

- retain the parsed cgroup v2 path after `/proc/self/cgroup` contents are released
- fix Linux-only E0515 compilation in Clippy and tests

## Validation

- `cargo fmt --all`
- `cargo check -p a3s-box-runtime --lib`
- `cargo test -p a3s-box-runtime sandbox:: --lib` (15 passed)