### PR TITLE
fix(sandbox): clean detached runtime state

### DIFF
--- a/src/cli/src/boot.rs
+++ b/src/cli/src/boot.rs
@@ -233,7 +233,7 @@ pub async fn boot_and_record(
             if let Some(pid) = booted_pid {
                 crate::process::graceful_stop(pid, libc::SIGTERM, 5).await;
             }
-            crate::cleanup::cleanup_removed_box(record);
+            crate::cleanup::cleanup_removed_box(record)?;
             Ok(BootOutcome::RemovedDuringBoot)
         }
     }

--- a/src/cli/src/cleanup.rs
+++ b/src/cli/src/cleanup.rs
@@ -75,7 +75,8 @@ pub(crate) fn remove_host_cgroup(box_id: &str) {
 }
 
 /// Remove transient host resources for a stopped box while keeping its state.
-pub fn cleanup_stopped_box(record: &BoxRecord) {
+pub fn cleanup_stopped_box(record: &BoxRecord) -> a3s_box_core::error::Result<()> {
+    cleanup_sandbox_runtime(record)?;
     // Detach volumes but KEEP the network endpoint (network_name = None): a
     // persistent (non---rm) box must retain its IP/MAC across stop/start, the
     // same way `restart.rs` does (it skips this cleanup). Releasing it on stop
@@ -89,6 +90,7 @@ pub fn cleanup_stopped_box(record: &BoxRecord) {
     a3s_box_runtime::rootfs::unmount_box_rootfs(&record.box_dir.join("rootfs"));
     cleanup_external_socket_dir(&record.box_dir, &record.exec_socket_path);
     remove_host_cgroup(&record.id);
+    Ok(())
 }
 
 /// Remove anonymous volumes created from OCI `VOLUME` declarations.
@@ -132,7 +134,7 @@ pub fn cleanup_external_socket_dir(box_dir: &Path, exec_socket_path: &Path) {
 }
 
 /// Remove all host-side resources owned by a box record.
-pub fn cleanup_removed_box(record: &BoxRecord) {
+pub fn cleanup_removed_box(record: &BoxRecord) -> a3s_box_core::error::Result<()> {
     if record.auto_remove {
         if let Err(err) = crate::log_archive::archive_removed_logs(record) {
             tracing::debug!(
@@ -142,6 +144,8 @@ pub fn cleanup_removed_box(record: &BoxRecord) {
             );
         }
     }
+
+    cleanup_sandbox_runtime(record)?;
 
     cleanup_record_resources(record);
     cleanup_anonymous_volumes(&record.anonymous_volumes);
@@ -169,11 +173,27 @@ pub fn cleanup_removed_box(record: &BoxRecord) {
     if fs_mount_dir.exists() {
         let _ = std::fs::remove_dir_all(&fs_mount_dir);
     }
+    Ok(())
+}
+
+fn cleanup_sandbox_runtime(record: &BoxRecord) -> a3s_box_core::error::Result<()> {
+    if !record.isolation.is_sandbox() {
+        return Ok(());
+    }
+
+    a3s_box_runtime::vm::reap::cleanup_recorded_sandbox_runtime(&record.box_dir, &record.id)
 }
 
 /// Roll back a box record that was partially created.
 pub fn cleanup_partial_box_record(record: &BoxRecord, state: Option<&mut StateFile>) {
-    cleanup_removed_box(record);
+    if let Err(err) = cleanup_removed_box(record) {
+        tracing::warn!(
+            box_id = %record.id,
+            error = %err,
+            "Failed to clean partial Box resources; preserving state for recovery"
+        );
+        return;
+    }
 
     if let Some(state) = state {
         if let Err(err) = state.remove(&record.id) {

--- a/src/cli/src/commands/kill.rs
+++ b/src/cli/src/commands/kill.rs
@@ -169,13 +169,13 @@ async fn kill_one(
     // clobber a concurrent run/monitor/compose write with our pre-await snapshot.
     if is_stopping_signal(signal) {
         if record.auto_remove {
-            cleanup::cleanup_removed_box(&record);
+            cleanup::cleanup_removed_box(&record)?;
             StateFile::remove_record(&box_id)?;
             println!("{name} (auto-removed)");
             return Ok(());
         }
 
-        cleanup::cleanup_stopped_box(&record);
+        cleanup::cleanup_stopped_box(&record)?;
 
         let exit_code = signaled_exit_code(signal);
         StateFile::modify(|s| {

--- a/src/cli/src/commands/rm.rs
+++ b/src/cli/src/commands/rm.rs
@@ -64,7 +64,7 @@ fn rm_one(
 
     let box_id = record.id.clone();
     let name = record.name.clone();
-    cleanup::cleanup_removed_box(&record);
+    cleanup::cleanup_removed_box(&record)?;
 
     // Remove from state atomically under the lock (avoids clobbering concurrent
     // monitor/CLI writers that rewrite the whole record vector), then keep this

--- a/src/cli/src/commands/stop.rs
+++ b/src/cli/src/commands/stop.rs
@@ -79,13 +79,13 @@ async fn stop_one(
     );
 
     if auto_remove {
-        cleanup::cleanup_removed_box(&record_snapshot);
+        cleanup::cleanup_removed_box(&record_snapshot)?;
         StateFile::remove_record(&box_id)?;
         println!("{name} (auto-removed)");
         return Ok(());
     }
 
-    cleanup::cleanup_stopped_box(&record_snapshot);
+    cleanup::cleanup_stopped_box(&record_snapshot)?;
 
     // Apply the status change atomically (load-fresh + mutate + save under the
     // state lock) so it cannot clobber a concurrent run/monitor/compose write

--- a/src/cli/src/state/file.rs
+++ b/src/cli/src/state/file.rs
@@ -385,10 +385,12 @@ impl StateFile {
         let outcome = sf.reconcile();
         if outcome.changed {
             for record in &outcome.stopped {
-                crate::cleanup::cleanup_stopped_box(record);
+                crate::cleanup::cleanup_stopped_box(record)
+                    .map_err(|error| std::io::Error::other(error.to_string()))?;
             }
             for record in &outcome.removed {
-                crate::cleanup::cleanup_removed_box(record);
+                crate::cleanup::cleanup_removed_box(record)
+                    .map_err(|error| std::io::Error::other(error.to_string()))?;
             }
             sf.write_to_disk()?;
         }

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -20,6 +20,30 @@ pub fn reap_orphaned_box(box_id: &str) {
     reap_orphaned_box_in(&a3s_box_core::dirs_home(), box_id);
 }
 
+/// Delete a durable Sandbox OCI runtime generation without removing its Box
+/// rootfs or persisted CLI state.
+///
+/// Callers must run this before unmounting or deleting Box paths: a failed
+/// runtime cleanup may mean a shared-kernel process still uses the rootfs.
+#[cfg(target_os = "linux")]
+pub fn cleanup_recorded_sandbox_runtime(box_dir: &Path, box_id: &str) -> a3s_box_core::Result<()> {
+    cleanup_recorded_sandbox_runtime_in(&a3s_box_core::dirs_home(), box_dir, box_id)
+}
+
+#[cfg(target_os = "linux")]
+fn cleanup_recorded_sandbox_runtime_in(
+    home_dir: &Path,
+    box_dir: &Path,
+    box_id: &str,
+) -> a3s_box_core::Result<()> {
+    match reap_orphaned_crun(home_dir, box_dir, box_id) {
+        SandboxReap::NotPresent | SandboxReap::Cleaned => Ok(()),
+        SandboxReap::Failed => Err(a3s_box_core::BoxError::StateError(format!(
+            "Failed to clean recorded Sandbox runtime for {box_id}; refusing to touch its rootfs"
+        ))),
+    }
+}
+
 /// [`reap_orphaned_box`] against an explicit home directory (for testing).
 #[cfg(target_os = "linux")]
 fn reap_orphaned_box_in(home_dir: &Path, box_id: &str) {
@@ -214,8 +238,9 @@ fn reap_orphaned_crun(home_dir: &Path, box_dir: &Path, box_id: &str) -> SandboxR
         }
     }
 
-    let _ = std::fs::remove_file(&record_path);
+    let _ = std::fs::remove_dir_all(&record.bundle_dir);
     let _ = std::fs::remove_dir_all(&record.runtime_root);
+    let _ = std::fs::remove_file(&record_path);
     tracing::info!(box_id, "Reaped orphaned crun Sandbox after runtime restart");
     SandboxReap::Cleaned
 }
@@ -243,6 +268,14 @@ fn wait_for_exit(pids: &[i32], timeout: std::time::Duration) {
 /// Non-Linux builds are development stubs (no microVMs to reap).
 #[cfg(not(target_os = "linux"))]
 pub fn reap_orphaned_box(_box_id: &str) {}
+
+#[cfg(not(target_os = "linux"))]
+pub fn cleanup_recorded_sandbox_runtime(
+    _box_dir: &std::path::Path,
+    _box_id: &str,
+) -> a3s_box_core::Result<()> {
+    Ok(())
+}
 
 #[cfg(all(test, not(target_os = "linux")))]
 mod tests {
@@ -312,5 +345,17 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         // No boxes/<id> dir at all — must not panic or error.
         reap_orphaned_box_in(home.path(), "absent-box-uuid");
+    }
+
+    #[test]
+    fn cleanup_absent_sandbox_runtime_preserves_box_directory() {
+        let home = tempfile::tempdir().unwrap();
+        let box_id = "cleanup-test-no-runtime-record";
+        let box_dir = home.path().join("boxes").join(box_id);
+        std::fs::create_dir_all(&box_dir).unwrap();
+
+        cleanup_recorded_sandbox_runtime_in(home.path(), &box_dir, box_id).unwrap();
+
+        assert!(box_dir.exists());
     }
 }


### PR DESCRIPTION
## Summary

- expose validated cleanup for durable Sandbox runtime records before callers touch a shared rootfs
- invoke certified crun kill/delete cleanup from stopped and removed CLI lifecycle paths
- remove the runtime root, seccomp cache, runtime record, and generated bundle while preserving a stopped Box rootfs/state
- propagate cleanup failure so state is retained for recovery instead of silently deleting ownership metadata
- add Linux regression coverage proving absent runtime cleanup preserves the Box directory

## Validation

- `cargo fmt --all`
- `cargo check -p a3s-box-runtime -p a3s-box-cli`
- `cargo test -p a3s-box-runtime sandbox:: --lib`
- `cargo test -p a3s-box-cli cleanup --lib`
- real A3S OS reproduction on `dd62a47` confirmed the stale runtime root/cache/record/bundle before this fix

Closes #45