### PR TITLE
feat(compat): add lifecycle domain ports

### DIFF
--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -723,8 +723,9 @@ begun.
 
 Phase 2 is delivered as small, immediately merged changes:
 
-1. Add lifecycle domain types, transition tests, repository and execution
-   interfaces, and deterministic clock/token fakes. No network listener.
+1. **Complete:** add lifecycle domain types, transition tests, repository and
+   execution interfaces, and deterministic clock/token fakes. No network
+   listener.
 2. Add the HTTP lifecycle router and run the checked-in official Python sync,
    Python async, and TypeScript fixtures against the Rust service with a fake
    execution manager.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -38,7 +38,10 @@ dependencies = [
 name = "a3s-box-compat"
 version = "3.0.9"
 dependencies = [
+ "a3s-box-core",
  "anyhow",
+ "async-trait",
+ "chrono",
  "hex",
  "prost",
  "prost-types",
@@ -47,6 +50,8 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/src/compat/Cargo.toml
+++ b/src/compat/Cargo.toml
@@ -8,7 +8,10 @@ repository.workspace = true
 description = "Protocol compatibility service and contract fixtures for A3S Box"
 
 [dependencies]
+a3s-box-core = { version = "3.0", path = "../core" }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
+chrono = { workspace = true }
 hex = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
@@ -17,6 +20,10 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
 
 [[bin]]
 name = "a3s-box-e2b-contract"

--- a/src/compat/src/control/credential.rs
+++ b/src/compat/src/control/credential.rs
@@ -1,0 +1,145 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::model::LifecycleError;
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "StoredTokenRepr", into = "StoredTokenRepr")]
+pub struct StoredToken {
+    key_version: u32,
+    ciphertext: Vec<u8>,
+    digest: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredTokenRepr {
+    key_version: u32,
+    ciphertext: Vec<u8>,
+    digest: Vec<u8>,
+}
+
+impl TryFrom<StoredTokenRepr> for StoredToken {
+    type Error = LifecycleError;
+
+    fn try_from(value: StoredTokenRepr) -> Result<Self, Self::Error> {
+        Self::new(value.key_version, value.ciphertext, value.digest)
+    }
+}
+
+impl From<StoredToken> for StoredTokenRepr {
+    fn from(value: StoredToken) -> Self {
+        Self {
+            key_version: value.key_version,
+            ciphertext: value.ciphertext,
+            digest: value.digest,
+        }
+    }
+}
+
+impl StoredToken {
+    pub fn new(
+        key_version: u32,
+        ciphertext: Vec<u8>,
+        digest: Vec<u8>,
+    ) -> Result<Self, LifecycleError> {
+        if key_version == 0 || ciphertext.is_empty() || digest.is_empty() {
+            return Err(LifecycleError::InvalidCredentialMaterial);
+        }
+        Ok(Self {
+            key_version,
+            ciphertext,
+            digest,
+        })
+    }
+
+    pub const fn key_version(&self) -> u32 {
+        self.key_version
+    }
+
+    pub fn ciphertext(&self) -> &[u8] {
+        &self.ciphertext
+    }
+
+    pub fn digest(&self) -> &[u8] {
+        &self.digest
+    }
+}
+
+impl fmt::Debug for StoredToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StoredToken")
+            .field("key_version", &self.key_version)
+            .field("ciphertext", &"[REDACTED]")
+            .field("digest", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxCredentials {
+    pub envd: StoredToken,
+    pub traffic: StoredToken,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SecretToken(String);
+
+impl SecretToken {
+    pub fn new(value: impl Into<String>) -> TokenIssuerResult<Self> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(TokenIssuerError::InvalidMaterial);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn expose_secret(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SecretToken([REDACTED])")
+    }
+}
+
+pub struct IssuedToken {
+    pub secret: SecretToken,
+    pub stored: StoredToken,
+}
+
+impl fmt::Debug for IssuedToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IssuedToken")
+            .field("secret", &self.secret)
+            .field("stored", &self.stored)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenScope {
+    Envd,
+    Traffic,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TokenIssuerError {
+    #[error("token material is invalid")]
+    InvalidMaterial,
+    #[error("token provider is unavailable: {0}")]
+    Unavailable(String),
+}
+
+pub type TokenIssuerResult<T> = std::result::Result<T, TokenIssuerError>;
+
+#[async_trait]
+pub trait TokenIssuer: Send + Sync {
+    async fn issue(&self, scope: TokenScope) -> TokenIssuerResult<IssuedToken>;
+}

--- a/src/compat/src/control/mod.rs
+++ b/src/compat/src/control/mod.rs
@@ -1,0 +1,21 @@
+mod credential;
+mod model;
+mod ports;
+mod repository;
+
+pub use credential::{
+    IssuedToken, SandboxCredentials, SecretToken, StoredToken, TokenIssuer, TokenIssuerError,
+    TokenIssuerResult, TokenScope,
+};
+pub use model::{
+    LifecycleError, LifecycleFailure, LifecyclePolicy, LifecycleState, NewSandboxRecord,
+    OnTimeoutAction, PublicSandboxState, SandboxGeneration, SandboxId, SandboxRecord,
+};
+pub use ports::{Clock, SystemClock};
+pub use repository::{
+    CompareAndSwapResult, RepositoryError, RepositoryResult, SandboxCursor, SandboxListFilter,
+    SandboxPage, SandboxRepository,
+};
+
+#[cfg(test)]
+mod tests;

--- a/src/compat/src/control/model.rs
+++ b/src/compat/src/control/model.rs
@@ -1,0 +1,413 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use a3s_box_core::{
+    ExecutionGeneration, ExecutionId, ExecutionLease, OperationId, ResolvedExecutionPlan,
+    ResourceConfig,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::credential::SandboxCredentials;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct SandboxId(String);
+
+impl SandboxId {
+    pub fn new(value: impl Into<String>) -> Result<Self, LifecycleError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(LifecycleError::InvalidIdentity(
+                "sandbox ID cannot be empty".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SandboxId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for SandboxId {
+    type Error = LifecycleError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<SandboxId> for String {
+    fn from(value: SandboxId) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(try_from = "u64", into = "u64")]
+pub struct SandboxGeneration(u64);
+
+impl SandboxGeneration {
+    pub const INITIAL: Self = Self(1);
+
+    pub fn new(value: u64) -> Result<Self, LifecycleError> {
+        if value == 0 {
+            return Err(LifecycleError::InvalidIdentity(
+                "sandbox generation must be greater than zero".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    fn next(self) -> Result<Self, LifecycleError> {
+        self.0
+            .checked_add(1)
+            .map(Self)
+            .ok_or(LifecycleError::GenerationExhausted)
+    }
+}
+
+impl TryFrom<u64> for SandboxGeneration {
+    type Error = LifecycleError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<SandboxGeneration> for u64 {
+    fn from(value: SandboxGeneration) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleState {
+    Creating,
+    Running,
+    Pausing,
+    Paused,
+    Resuming,
+    Killing,
+    Killed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PublicSandboxState {
+    Running,
+    Paused,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OnTimeoutAction {
+    Kill,
+    Pause,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecyclePolicy {
+    pub on_timeout: OnTimeoutAction,
+    pub auto_resume: bool,
+    pub keep_memory_on_pause: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleFailure {
+    PolicyRejected,
+    RuntimeFailed,
+    ReconciliationFailed,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewSandboxRecord {
+    pub sandbox_id: SandboxId,
+    pub operation_id: OperationId,
+    pub template_id: String,
+    pub plan: ResolvedExecutionPlan,
+    pub resources: ResourceConfig,
+    pub lifecycle: LifecyclePolicy,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub metadata: BTreeMap<String, String>,
+    pub envd_version: String,
+    pub credentials: SandboxCredentials,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxRecord {
+    sandbox_id: SandboxId,
+    operation_id: OperationId,
+    execution_id: Option<ExecutionId>,
+    execution_generation: Option<ExecutionGeneration>,
+    generation: SandboxGeneration,
+    template_id: String,
+    plan: ResolvedExecutionPlan,
+    resources: ResourceConfig,
+    lifecycle: LifecyclePolicy,
+    state: LifecycleState,
+    created_at: DateTime<Utc>,
+    started_at: Option<DateTime<Utc>>,
+    expires_at: DateTime<Utc>,
+    metadata: BTreeMap<String, String>,
+    envd_version: String,
+    credentials: SandboxCredentials,
+    failure: Option<LifecycleFailure>,
+}
+
+impl SandboxRecord {
+    pub fn creating(new: NewSandboxRecord) -> Result<Self, LifecycleError> {
+        if new.template_id.trim().is_empty() || new.envd_version.trim().is_empty() {
+            return Err(LifecycleError::InvalidIdentity(
+                "template ID and envd version cannot be empty".to_string(),
+            ));
+        }
+        if new.expires_at < new.created_at {
+            return Err(LifecycleError::InvalidExpiry);
+        }
+        Ok(Self {
+            sandbox_id: new.sandbox_id,
+            operation_id: new.operation_id,
+            execution_id: None,
+            execution_generation: None,
+            generation: SandboxGeneration::INITIAL,
+            template_id: new.template_id,
+            plan: new.plan,
+            resources: new.resources,
+            lifecycle: new.lifecycle,
+            state: LifecycleState::Creating,
+            created_at: new.created_at,
+            started_at: None,
+            expires_at: new.expires_at,
+            metadata: new.metadata,
+            envd_version: new.envd_version,
+            credentials: new.credentials,
+            failure: None,
+        })
+    }
+
+    pub fn sandbox_id(&self) -> &SandboxId {
+        &self.sandbox_id
+    }
+
+    pub fn operation_id(&self) -> &OperationId {
+        &self.operation_id
+    }
+
+    pub fn execution_id(&self) -> Option<&ExecutionId> {
+        self.execution_id.as_ref()
+    }
+
+    pub const fn execution_generation(&self) -> Option<ExecutionGeneration> {
+        self.execution_generation
+    }
+
+    pub const fn generation(&self) -> SandboxGeneration {
+        self.generation
+    }
+
+    pub fn template_id(&self) -> &str {
+        &self.template_id
+    }
+
+    pub fn plan(&self) -> &ResolvedExecutionPlan {
+        &self.plan
+    }
+
+    pub fn resources(&self) -> &ResourceConfig {
+        &self.resources
+    }
+
+    pub fn lifecycle(&self) -> &LifecyclePolicy {
+        &self.lifecycle
+    }
+
+    pub const fn state(&self) -> LifecycleState {
+        self.state
+    }
+
+    pub const fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
+    }
+
+    pub const fn started_at(&self) -> Option<DateTime<Utc>> {
+        self.started_at
+    }
+
+    pub const fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+
+    pub fn metadata(&self) -> &BTreeMap<String, String> {
+        &self.metadata
+    }
+
+    pub fn envd_version(&self) -> &str {
+        &self.envd_version
+    }
+
+    pub fn credentials(&self) -> &SandboxCredentials {
+        &self.credentials
+    }
+
+    pub const fn failure(&self) -> Option<LifecycleFailure> {
+        self.failure
+    }
+
+    pub const fn public_state(&self) -> Option<PublicSandboxState> {
+        match self.state {
+            LifecycleState::Running => Some(PublicSandboxState::Running),
+            LifecycleState::Paused => Some(PublicSandboxState::Paused),
+            _ => None,
+        }
+    }
+
+    pub const fn is_terminal(&self) -> bool {
+        matches!(self.state, LifecycleState::Killed | LifecycleState::Failed)
+    }
+
+    pub fn mark_running(
+        &mut self,
+        lease: ExecutionLease,
+    ) -> Result<SandboxGeneration, LifecycleError> {
+        self.require_state(&[LifecycleState::Creating, LifecycleState::Resuming])?;
+        if lease.plan != self.plan {
+            return Err(LifecycleError::ExecutionPlanMismatch);
+        }
+        if let Some(execution_id) = &self.execution_id {
+            if execution_id != &lease.execution_id {
+                return Err(LifecycleError::ExecutionIdentityMismatch);
+            }
+        }
+        let next = self.generation.next()?;
+        self.execution_id = Some(lease.execution_id);
+        self.execution_generation = Some(lease.generation);
+        self.resources = lease.resources;
+        self.started_at.get_or_insert(lease.started_at);
+        self.state = LifecycleState::Running;
+        self.failure = None;
+        self.generation = next;
+        Ok(next)
+    }
+
+    pub fn begin_pause(&mut self) -> Result<SandboxGeneration, LifecycleError> {
+        self.transition(&[LifecycleState::Running], LifecycleState::Pausing)
+    }
+
+    pub fn mark_paused(&mut self) -> Result<SandboxGeneration, LifecycleError> {
+        self.transition(&[LifecycleState::Pausing], LifecycleState::Paused)
+    }
+
+    pub fn begin_resume(&mut self) -> Result<SandboxGeneration, LifecycleError> {
+        if self.execution_id.is_none() || self.execution_generation.is_none() {
+            return Err(LifecycleError::MissingExecution);
+        }
+        self.transition(&[LifecycleState::Paused], LifecycleState::Resuming)
+    }
+
+    pub fn begin_kill(&mut self) -> Result<SandboxGeneration, LifecycleError> {
+        self.transition(
+            &[
+                LifecycleState::Creating,
+                LifecycleState::Running,
+                LifecycleState::Pausing,
+                LifecycleState::Paused,
+                LifecycleState::Resuming,
+                LifecycleState::Failed,
+            ],
+            LifecycleState::Killing,
+        )
+    }
+
+    pub fn mark_killed(&mut self) -> Result<SandboxGeneration, LifecycleError> {
+        self.transition(&[LifecycleState::Killing], LifecycleState::Killed)
+    }
+
+    pub fn mark_failed(
+        &mut self,
+        failure: LifecycleFailure,
+    ) -> Result<SandboxGeneration, LifecycleError> {
+        self.require_state(&[
+            LifecycleState::Creating,
+            LifecycleState::Pausing,
+            LifecycleState::Resuming,
+        ])?;
+        let next = self.generation.next()?;
+        self.state = LifecycleState::Failed;
+        self.failure = Some(failure);
+        self.generation = next;
+        Ok(next)
+    }
+
+    pub fn replace_expiry(
+        &mut self,
+        expires_at: DateTime<Utc>,
+    ) -> Result<SandboxGeneration, LifecycleError> {
+        self.require_state(&[LifecycleState::Running, LifecycleState::Paused])?;
+        let next = self.generation.next()?;
+        self.expires_at = expires_at;
+        self.generation = next;
+        Ok(next)
+    }
+
+    fn transition(
+        &mut self,
+        allowed: &[LifecycleState],
+        target: LifecycleState,
+    ) -> Result<SandboxGeneration, LifecycleError> {
+        self.require_state(allowed)?;
+        let next = self.generation.next()?;
+        self.state = target;
+        self.generation = next;
+        Ok(next)
+    }
+
+    fn require_state(&self, allowed: &[LifecycleState]) -> Result<(), LifecycleError> {
+        if allowed.contains(&self.state) {
+            return Ok(());
+        }
+        Err(LifecycleError::InvalidTransition {
+            from: self.state,
+            allowed: allowed.to_vec(),
+        })
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum LifecycleError {
+    #[error("invalid lifecycle identity: {0}")]
+    InvalidIdentity(String),
+    #[error("sandbox expiry cannot precede creation")]
+    InvalidExpiry,
+    #[error("invalid credential material")]
+    InvalidCredentialMaterial,
+    #[error("invalid lifecycle transition from {from:?}; expected one of {allowed:?}")]
+    InvalidTransition {
+        from: LifecycleState,
+        allowed: Vec<LifecycleState>,
+    },
+    #[error("sandbox generation is exhausted")]
+    GenerationExhausted,
+    #[error("runtime returned a different resolved execution plan")]
+    ExecutionPlanMismatch,
+    #[error("runtime returned a different execution identity")]
+    ExecutionIdentityMismatch,
+    #[error("sandbox has no runtime execution to resume")]
+    MissingExecution,
+}

--- a/src/compat/src/control/ports.rs
+++ b/src/compat/src/control/ports.rs
@@ -1,0 +1,14 @@
+use chrono::{DateTime, Utc};
+
+pub trait Clock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+#[derive(Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}

--- a/src/compat/src/control/repository.rs
+++ b/src/compat/src/control/repository.rs
@@ -1,0 +1,70 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU32;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+
+use super::{PublicSandboxState, SandboxGeneration, SandboxId, SandboxRecord};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxCursor {
+    pub created_at: DateTime<Utc>,
+    pub sandbox_id: SandboxId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxListFilter {
+    pub metadata: BTreeMap<String, String>,
+    pub states: BTreeSet<PublicSandboxState>,
+    pub limit: NonZeroU32,
+    pub after: Option<SandboxCursor>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SandboxPage {
+    pub records: Vec<SandboxRecord>,
+    pub next: Option<SandboxCursor>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompareAndSwapResult {
+    Updated,
+    NotFound,
+    Conflict {
+        actual_generation: SandboxGeneration,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum RepositoryError {
+    #[error("sandbox already exists: {0}")]
+    Duplicate(SandboxId),
+    #[error("sandbox repository unavailable: {0}")]
+    Unavailable(String),
+    #[error("sandbox repository contains invalid data: {0}")]
+    Corrupt(String),
+}
+
+pub type RepositoryResult<T> = std::result::Result<T, RepositoryError>;
+
+/// Transactional persistence boundary for compatibility lifecycle records.
+#[async_trait]
+pub trait SandboxRepository: Send + Sync {
+    async fn insert(&self, record: SandboxRecord) -> RepositoryResult<()>;
+
+    async fn get(&self, sandbox_id: &SandboxId) -> RepositoryResult<Option<SandboxRecord>>;
+
+    async fn list(&self, filter: &SandboxListFilter) -> RepositoryResult<SandboxPage>;
+
+    /// Replace one record only when its persisted generation equals `expected`.
+    ///
+    /// Implementations must reject a replacement with a different sandbox ID
+    /// or a generation that does not advance `expected`.
+    async fn compare_and_swap(
+        &self,
+        sandbox_id: &SandboxId,
+        expected: SandboxGeneration,
+        replacement: SandboxRecord,
+    ) -> RepositoryResult<CompareAndSwapResult>;
+}

--- a/src/compat/src/control/tests.rs
+++ b/src/compat/src/control/tests.rs
@@ -1,0 +1,387 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU32;
+use std::sync::Mutex;
+
+use a3s_box_core::{
+    resolve_execution, BoxConfig, ExecutionGeneration, ExecutionId, ExecutionLease,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ExecutionStatus, KillOutcome,
+    OperationId, ReconcileOutcome,
+};
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, TimeZone, Utc};
+
+use super::*;
+
+fn instant(second: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 14, 12, 0, second)
+        .single()
+        .unwrap()
+}
+
+fn stored_token(marker: u8) -> StoredToken {
+    StoredToken::new(1, vec![marker, 1], vec![marker, 2]).unwrap()
+}
+
+fn creating_record(id: &str) -> SandboxRecord {
+    let config = BoxConfig {
+        isolation: a3s_box_core::ExecutionIsolation::Sandbox,
+        ..BoxConfig::default()
+    };
+    let plan = resolve_execution(&config).unwrap();
+    SandboxRecord::creating(NewSandboxRecord {
+        sandbox_id: SandboxId::new(id).unwrap(),
+        operation_id: OperationId::new(format!("operation-{id}")).unwrap(),
+        template_id: "code-interpreter-v1".to_string(),
+        plan,
+        resources: config.resources,
+        lifecycle: LifecyclePolicy {
+            on_timeout: OnTimeoutAction::Kill,
+            auto_resume: false,
+            keep_memory_on_pause: false,
+        },
+        created_at: instant(0),
+        expires_at: instant(0) + Duration::seconds(300),
+        metadata: BTreeMap::from([("team".to_string(), "fixture".to_string())]),
+        envd_version: "0.1.3".to_string(),
+        credentials: SandboxCredentials {
+            envd: stored_token(10),
+            traffic: stored_token(20),
+        },
+    })
+    .unwrap()
+}
+
+fn execution_lease(record: &SandboxRecord, generation: u64) -> ExecutionLease {
+    ExecutionLease {
+        execution_id: ExecutionId::new("execution-1").unwrap(),
+        generation: ExecutionGeneration::new(generation).unwrap(),
+        plan: record.plan().clone(),
+        resources: record.resources().clone(),
+        started_at: instant(1),
+    }
+}
+
+#[test]
+fn lifecycle_transitions_are_generation_fenced() {
+    let mut record = creating_record("sandbox-1");
+    assert_eq!(record.generation(), SandboxGeneration::INITIAL);
+    assert_eq!(record.public_state(), None);
+
+    assert_eq!(
+        record.mark_running(execution_lease(&record, 1)).unwrap(),
+        SandboxGeneration::new(2).unwrap()
+    );
+    assert_eq!(record.public_state(), Some(PublicSandboxState::Running));
+    let started_at = record.started_at();
+
+    record
+        .replace_expiry(instant(0) + Duration::seconds(600))
+        .unwrap();
+    record.begin_pause().unwrap();
+    record.mark_paused().unwrap();
+    assert_eq!(record.public_state(), Some(PublicSandboxState::Paused));
+    record.begin_resume().unwrap();
+    record.mark_running(execution_lease(&record, 2)).unwrap();
+
+    assert_eq!(record.generation(), SandboxGeneration::new(7).unwrap());
+    assert_eq!(record.started_at(), started_at);
+    assert_eq!(record.execution_generation().unwrap().get(), 2);
+}
+
+#[test]
+fn invalid_transition_does_not_mutate_record() {
+    let mut record = creating_record("sandbox-1");
+    let generation = record.generation();
+
+    let error = record.begin_resume().unwrap_err();
+
+    assert_eq!(error, LifecycleError::MissingExecution);
+    assert_eq!(record.state(), LifecycleState::Creating);
+    assert_eq!(record.generation(), generation);
+}
+
+#[test]
+fn persisted_control_identifiers_preserve_invariants() {
+    assert!(serde_json::from_str::<SandboxId>("\"\"").is_err());
+    assert!(serde_json::from_str::<SandboxGeneration>("0").is_err());
+    assert!(serde_json::from_str::<StoredToken>(
+        r#"{"key_version":0,"ciphertext":[],"digest":[]}"#
+    )
+    .is_err());
+}
+
+#[test]
+fn runtime_plan_mismatch_does_not_publish_execution() {
+    let mut record = creating_record("sandbox-1");
+    let config = BoxConfig::default();
+    let mut lease = execution_lease(&record, 1);
+    lease.plan = resolve_execution(&config).unwrap();
+
+    assert_eq!(
+        record.mark_running(lease).unwrap_err(),
+        LifecycleError::ExecutionPlanMismatch
+    );
+    assert_eq!(record.state(), LifecycleState::Creating);
+    assert_eq!(record.execution_id(), None);
+    assert_eq!(record.generation(), SandboxGeneration::INITIAL);
+}
+
+#[test]
+fn killed_record_is_terminal() {
+    let mut record = creating_record("sandbox-1");
+    record.mark_running(execution_lease(&record, 1)).unwrap();
+    record.begin_kill().unwrap();
+    record.mark_killed().unwrap();
+
+    assert!(record.is_terminal());
+    assert!(matches!(
+        record.begin_kill(),
+        Err(LifecycleError::InvalidTransition { .. })
+    ));
+}
+
+#[derive(Default)]
+struct MemoryRepository {
+    records: Mutex<BTreeMap<SandboxId, SandboxRecord>>,
+}
+
+#[async_trait]
+impl SandboxRepository for MemoryRepository {
+    async fn insert(&self, record: SandboxRecord) -> RepositoryResult<()> {
+        let mut records = self.records.lock().unwrap();
+        if records.contains_key(record.sandbox_id()) {
+            return Err(RepositoryError::Duplicate(record.sandbox_id().clone()));
+        }
+        records.insert(record.sandbox_id().clone(), record);
+        Ok(())
+    }
+
+    async fn get(&self, sandbox_id: &SandboxId) -> RepositoryResult<Option<SandboxRecord>> {
+        Ok(self.records.lock().unwrap().get(sandbox_id).cloned())
+    }
+
+    async fn list(&self, filter: &SandboxListFilter) -> RepositoryResult<SandboxPage> {
+        let records = self.records.lock().unwrap();
+        let mut matching = records
+            .values()
+            .filter(|record| {
+                filter.states.is_empty()
+                    || record
+                        .public_state()
+                        .is_some_and(|state| filter.states.contains(&state))
+            })
+            .filter(|record| {
+                filter
+                    .metadata
+                    .iter()
+                    .all(|(key, value)| record.metadata().get(key) == Some(value))
+            })
+            .filter(|record| {
+                filter.after.as_ref().is_none_or(|cursor| {
+                    (record.created_at(), record.sandbox_id())
+                        > (cursor.created_at, &cursor.sandbox_id)
+                })
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        matching.sort_by(|left, right| {
+            (left.created_at(), left.sandbox_id()).cmp(&(right.created_at(), right.sandbox_id()))
+        });
+        let limit = filter.limit.get() as usize;
+        let has_more = matching.len() > limit;
+        matching.truncate(limit);
+        let next = has_more.then(|| {
+            let last = matching.last().unwrap();
+            SandboxCursor {
+                created_at: last.created_at(),
+                sandbox_id: last.sandbox_id().clone(),
+            }
+        });
+        Ok(SandboxPage {
+            records: matching,
+            next,
+        })
+    }
+
+    async fn compare_and_swap(
+        &self,
+        sandbox_id: &SandboxId,
+        expected: SandboxGeneration,
+        replacement: SandboxRecord,
+    ) -> RepositoryResult<CompareAndSwapResult> {
+        if replacement.sandbox_id() != sandbox_id || replacement.generation() <= expected {
+            return Err(RepositoryError::Corrupt(
+                "invalid compare-and-swap replacement".to_string(),
+            ));
+        }
+        let mut records = self.records.lock().unwrap();
+        let Some(current) = records.get(sandbox_id) else {
+            return Ok(CompareAndSwapResult::NotFound);
+        };
+        if current.generation() != expected {
+            return Ok(CompareAndSwapResult::Conflict {
+                actual_generation: current.generation(),
+            });
+        }
+        records.insert(sandbox_id.clone(), replacement);
+        Ok(CompareAndSwapResult::Updated)
+    }
+}
+
+#[tokio::test]
+async fn repository_compare_and_swap_rejects_stale_generation() {
+    let repository = MemoryRepository::default();
+    let mut original = creating_record("sandbox-1");
+    repository.insert(original.clone()).await.unwrap();
+    let stale_generation = original.generation();
+
+    original
+        .mark_running(execution_lease(&original, 1))
+        .unwrap();
+    assert_eq!(
+        repository
+            .compare_and_swap(original.sandbox_id(), stale_generation, original.clone())
+            .await
+            .unwrap(),
+        CompareAndSwapResult::Updated
+    );
+
+    let mut stale = original.clone();
+    stale.replace_expiry(instant(30)).unwrap();
+    let stale_id = stale.sandbox_id().clone();
+    assert_eq!(
+        repository
+            .compare_and_swap(&stale_id, stale_generation, stale)
+            .await
+            .unwrap(),
+        CompareAndSwapResult::Conflict {
+            actual_generation: original.generation(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn repository_list_port_preserves_cursor_and_filters() {
+    let repository = MemoryRepository::default();
+    for id in ["sandbox-1", "sandbox-2"] {
+        let mut record = creating_record(id);
+        record.mark_running(execution_lease(&record, 1)).unwrap();
+        repository.insert(record).await.unwrap();
+    }
+    let first = repository
+        .list(&SandboxListFilter {
+            metadata: BTreeMap::from([("team".to_string(), "fixture".to_string())]),
+            states: BTreeSet::from([PublicSandboxState::Running]),
+            limit: NonZeroU32::new(1).unwrap(),
+            after: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(first.records.len(), 1);
+    assert_eq!(first.records[0].sandbox_id().as_str(), "sandbox-1");
+
+    let second = repository
+        .list(&SandboxListFilter {
+            metadata: BTreeMap::new(),
+            states: BTreeSet::new(),
+            limit: NonZeroU32::new(1).unwrap(),
+            after: first.next,
+        })
+        .await
+        .unwrap();
+    assert_eq!(second.records.len(), 1);
+    assert_eq!(second.records[0].sandbox_id().as_str(), "sandbox-2");
+    assert!(second.next.is_none());
+}
+
+struct FixedClock(DateTime<Utc>);
+
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+struct FixedTokenIssuer;
+
+#[async_trait]
+impl TokenIssuer for FixedTokenIssuer {
+    async fn issue(&self, scope: TokenScope) -> TokenIssuerResult<IssuedToken> {
+        let marker = match scope {
+            TokenScope::Envd => 1,
+            TokenScope::Traffic => 2,
+        };
+        Ok(IssuedToken {
+            secret: SecretToken::new(format!("secret-{marker}")).unwrap(),
+            stored: stored_token(marker),
+        })
+    }
+}
+
+#[tokio::test]
+async fn deterministic_ports_do_not_expose_token_material_in_debug() {
+    let clock = FixedClock(instant(9));
+    let issued = FixedTokenIssuer.issue(TokenScope::Envd).await.unwrap();
+
+    assert_eq!(clock.now(), instant(9));
+    assert_eq!(issued.secret.expose_secret(), "secret-1");
+    let debug = format!("{issued:?}");
+    assert!(!debug.contains("secret-1"));
+    assert!(debug.contains("REDACTED"));
+}
+
+struct ObjectSafeExecutionManager;
+
+#[async_trait]
+impl a3s_box_core::ExecutionManager for ObjectSafeExecutionManager {
+    async fn create_and_start(
+        &self,
+        _request: a3s_box_core::CreateExecutionRequest,
+        _operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        Err(ExecutionManagerError::Unavailable("fixture".to_string()))
+    }
+
+    async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
+        Ok(ExecutionStatus {
+            execution_id: execution_id.clone(),
+            generation: ExecutionGeneration::INITIAL,
+            state: ExecutionState::Running,
+            plan: creating_record("manager-check").plan().clone(),
+        })
+    }
+
+    async fn resume(
+        &self,
+        execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        Err(ExecutionManagerError::NotFound(execution_id.clone()))
+    }
+
+    async fn kill(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        Ok(KillOutcome::AlreadyStopped)
+    }
+
+    async fn reconcile(
+        &self,
+        _operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ReconcileOutcome> {
+        Ok(ReconcileOutcome::Absent)
+    }
+}
+
+#[tokio::test]
+async fn execution_manager_port_is_object_safe() {
+    let manager: &dyn a3s_box_core::ExecutionManager = &ObjectSafeExecutionManager;
+    let execution_id = ExecutionId::new("execution-1").unwrap();
+
+    assert_eq!(
+        manager.inspect(&execution_id).await.unwrap().state,
+        ExecutionState::Running
+    );
+}

--- a/src/compat/src/lib.rs
+++ b/src/compat/src/lib.rs
@@ -7,4 +7,6 @@ mod model;
 mod openapi;
 mod proto;
 
+pub mod control;
+
 pub use fixture::{generate_fixture, verify_fixture, FixturePaths};

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -59,9 +59,12 @@ pub use snapshot::{SnapshotConfig, SnapshotMetadata};
 pub use tee::ATTEST_VSOCK_PORT;
 pub use tee::{detect_tee, is_tee_available, TeeCapability, TeeType};
 pub use traits::{
-    AuditSink, CacheBackend, CacheEntry, CacheStats, CredentialProvider, EventBus, ImageRegistry,
-    ImageStoreBackend, MetricsCollector, NetworkStoreBackend, NoopMetrics, PulledImage,
-    SnapshotStoreBackend, StoredImage, VolumeStoreBackend,
+    AuditSink, CacheBackend, CacheEntry, CacheStats, CreateExecutionRequest, CredentialProvider,
+    EventBus, ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManager,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ExecutionStatus, ImageRegistry,
+    ImageStoreBackend, KillOutcome, MetricsCollector, NetworkStoreBackend, NoopMetrics,
+    OperationId, PulledImage, ReconcileOutcome, SnapshotStoreBackend, StoredImage,
+    VolumeStoreBackend,
 };
 pub use vmm::{
     Entrypoint, FsMount, InstanceSpec, NetworkInstanceConfig, TeeInstanceConfig, VmHandler,

--- a/src/core/src/traits/execution.rs
+++ b/src/core/src/traits/execution.rs
@@ -1,0 +1,269 @@
+//! Backend-neutral lifecycle interface for managed A3S executions.
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::config::{BoxConfig, ResourceConfig};
+use crate::execution::ResolvedExecutionPlan;
+
+/// Stable identifier assigned to one runtime execution.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct ExecutionId(String);
+
+impl ExecutionId {
+    pub fn new(value: impl Into<String>) -> ExecutionManagerResult<Self> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(ExecutionManagerError::InvalidRequest(
+                "execution ID cannot be empty".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ExecutionId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for ExecutionId {
+    type Error = ExecutionManagerError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ExecutionId> for String {
+    fn from(value: ExecutionId) -> Self {
+        value.0
+    }
+}
+
+/// Idempotency identity for a lifecycle operation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct OperationId(String);
+
+impl OperationId {
+    pub fn new(value: impl Into<String>) -> ExecutionManagerResult<Self> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(ExecutionManagerError::InvalidRequest(
+                "operation ID cannot be empty".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for OperationId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for OperationId {
+    type Error = ExecutionManagerError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<OperationId> for String {
+    fn from(value: OperationId) -> Self {
+        value.0
+    }
+}
+
+/// Runtime generation used to reject stale lifecycle operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(try_from = "u64", into = "u64")]
+pub struct ExecutionGeneration(u64);
+
+impl ExecutionGeneration {
+    pub const INITIAL: Self = Self(1);
+
+    pub fn new(value: u64) -> ExecutionManagerResult<Self> {
+        if value == 0 {
+            return Err(ExecutionManagerError::InvalidRequest(
+                "execution generation must be greater than zero".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl TryFrom<u64> for ExecutionGeneration {
+    type Error = ExecutionManagerError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ExecutionGeneration> for u64 {
+    fn from(value: ExecutionGeneration) -> Self {
+        value.0
+    }
+}
+
+/// A fully resolved request submitted to the runtime lifecycle facade.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateExecutionRequest {
+    /// Public identity used only as an untrusted diagnostic label.
+    pub external_sandbox_id: String,
+    /// Backend-neutral runtime configuration resolved from template policy.
+    pub config: BoxConfig,
+    /// Labels persisted with the internal execution.
+    pub labels: BTreeMap<String, String>,
+}
+
+/// Evidence returned when a runtime execution is ready.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionLease {
+    pub execution_id: ExecutionId,
+    pub generation: ExecutionGeneration,
+    pub plan: ResolvedExecutionPlan,
+    pub resources: ResourceConfig,
+    pub started_at: DateTime<Utc>,
+}
+
+/// Runtime state visible through the backend-neutral lifecycle facade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionState {
+    Creating,
+    Running,
+    Paused,
+    Stopped,
+    Failed,
+}
+
+/// Current state and generation of one execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionStatus {
+    pub execution_id: ExecutionId,
+    pub generation: ExecutionGeneration,
+    pub state: ExecutionState,
+    pub plan: ResolvedExecutionPlan,
+}
+
+/// Result of an idempotent runtime kill request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KillOutcome {
+    Killed,
+    AlreadyStopped,
+}
+
+/// Runtime evidence recovered after a service restart.
+#[derive(Debug, Clone)]
+pub enum ReconcileOutcome {
+    Absent,
+    Creating,
+    Ready(ExecutionLease),
+    Failed,
+}
+
+/// Errors returned by the lifecycle facade without exposing backend internals.
+#[derive(Debug, Error)]
+pub enum ExecutionManagerError {
+    #[error("invalid execution request: {0}")]
+    InvalidRequest(String),
+    #[error("execution not found: {0}")]
+    NotFound(ExecutionId),
+    #[error("execution conflict for {execution_id}: {message}")]
+    Conflict {
+        execution_id: ExecutionId,
+        message: String,
+    },
+    #[error("execution backend unavailable: {0}")]
+    Unavailable(String),
+    #[error("execution lifecycle failed: {0}")]
+    Internal(String),
+}
+
+pub type ExecutionManagerResult<T> = std::result::Result<T, ExecutionManagerError>;
+
+/// Backend-neutral lifecycle facade shared by the CLI, SDK, and remote service.
+#[async_trait]
+pub trait ExecutionManager: Send + Sync {
+    /// Create and start exactly one execution for `operation_id`.
+    async fn create_and_start(
+        &self,
+        request: CreateExecutionRequest,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ExecutionLease>;
+
+    async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus>;
+
+    async fn resume(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease>;
+
+    async fn kill(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<KillOutcome>;
+
+    async fn reconcile(
+        &self,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ReconcileOutcome>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifiers_reject_empty_values() {
+        assert!(matches!(
+            ExecutionId::new("  "),
+            Err(ExecutionManagerError::InvalidRequest(_))
+        ));
+        assert!(matches!(
+            OperationId::new(""),
+            Err(ExecutionManagerError::InvalidRequest(_))
+        ));
+    }
+
+    #[test]
+    fn generation_rejects_zero() {
+        assert!(matches!(
+            ExecutionGeneration::new(0),
+            Err(ExecutionManagerError::InvalidRequest(_))
+        ));
+        assert_eq!(ExecutionGeneration::INITIAL.get(), 1);
+        assert!(serde_json::from_str::<ExecutionGeneration>("0").is_err());
+    }
+
+    #[test]
+    fn identifier_deserialization_preserves_invariants() {
+        assert!(serde_json::from_str::<ExecutionId>("\"\"").is_err());
+        assert!(serde_json::from_str::<OperationId>("\" \"").is_err());
+    }
+}

--- a/src/core/src/traits/mod.rs
+++ b/src/core/src/traits/mod.rs
@@ -8,6 +8,7 @@ pub mod audit;
 pub mod cache;
 pub mod credential;
 pub mod event;
+pub mod execution;
 pub mod metrics;
 pub mod registry;
 pub mod store;
@@ -16,6 +17,11 @@ pub use audit::AuditSink;
 pub use cache::{CacheBackend, CacheEntry, CacheStats};
 pub use credential::CredentialProvider;
 pub use event::EventBus;
+pub use execution::{
+    CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManager,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ExecutionStatus, KillOutcome,
+    OperationId, ReconcileOutcome,
+};
 pub use metrics::{MetricsCollector, NoopMetrics};
 pub use registry::{ImageRegistry, PulledImage};
 pub use store::{


### PR DESCRIPTION
## Summary

- add a backend-neutral execution lifecycle facade to a3s-box-core
- add generation-fenced compatibility lifecycle records and CAS repository ports
- add credential, clock, and token issuer ports with deterministic tests
- mark Phase 2 Slice 1 complete in the SDK design

## Validation

- cargo fmt --all -- --check
- cargo test -p a3s-box-core -p a3s-box-compat
- cargo clippy -p a3s-box-core -p a3s-box-compat --all-targets -- -D warnings
- cargo run -p a3s-box-compat --bin a3s-box-e2b-contract -- verify