### PR TITLE
feat(compat): serve E2B lifecycle routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,13 @@ jobs:
         with:
           version: '0.11.8'
           enable-cache: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build Rust lifecycle fixture server
+        run: cd src && cargo build -p a3s-box-compat --bin a3s-box-e2b-fixture-server
       - name: Verify official client lifecycle requests
-        run: python3 compat/e2b/fixtures/official-clients/run_fixtures.py verify
+        run: >-
+          python3 compat/e2b/fixtures/official-clients/run_fixtures.py verify
+          --rust-server-bin src/target/debug/a3s-box-e2b-fixture-server
 
   # ── Build check (compile only, no artifacts) ────────────────────
   build-check:

--- a/README.md
+++ b/README.md
@@ -309,6 +309,13 @@ Interpreter contracts under [`compat/e2b/`](compat/e2b/README.md). CI regenerate
 their endpoint, field, error, descriptor, and public-export inventories and
 rejects unreviewed protocol drift.
 
+The Phase 2 preview now includes an owner-scoped Rust lifecycle router for
+create, connect, get, list, timeout, and kill. CI runs the pinned official
+Python sync/async, TypeScript, and Code Interpreter clients against that router
+through an in-memory repository and fake execution manager. This is protocol
+evidence only; durable persistence and real `--isolation sandbox` execution
+remain later Phase 2 gates.
+
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in
 [`docs/e2b-compatible-sdk-design.md`](docs/e2b-compatible-sdk-design.md). Until

--- a/compat/e2b/fixtures/official-clients/README.md
+++ b/compat/e2b/fixtures/official-clients/README.md
@@ -3,7 +3,7 @@
 These fixtures execute the published, unmodified Python sync, Python async,
 TypeScript, and Code Interpreter packages pinned by `upstream.lock.json`.
 Their create, connect, list, timeout, kill, and not-found flows run against a
-deterministic recording server.
+deterministic recording server and the Rust lifecycle router.
 
 The runner downloads the exact wheel and npm tarball URLs from the source lock,
 verifies SHA-256 and npm integrity before installation, and records only stable
@@ -17,6 +17,17 @@ Run with Python 3.10 or newer, Node.js 20 or newer, npm, and internet access:
 ```bash
 python3 compat/e2b/fixtures/official-clients/run_fixtures.py generate
 python3 compat/e2b/fixtures/official-clients/run_fixtures.py verify
+```
+
+The repository CI builds the Rust fixture server and makes the live router run
+mandatory:
+
+```bash
+cd src
+cargo build -p a3s-box-compat --bin a3s-box-e2b-fixture-server
+cd ..
+python3 compat/e2b/fixtures/official-clients/run_fixtures.py verify \
+  --rust-server-bin src/target/debug/a3s-box-e2b-fixture-server
 ```
 
 The runner uses `uv` when it is available on `PATH`, then falls back to the

--- a/compat/e2b/fixtures/official-clients/expected/python-async.jsonl
+++ b/compat/e2b/fixtures/official-clients/expected/python-async.jsonl
@@ -6,4 +6,4 @@
 {"body":null,"client":"python-async","headers":{"user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"DELETE","path":"/sandboxes/missing-sandbox","query":[]}
 {"body":{"timeout":300},"client":"python-async","headers":{"content-type":"application/json","user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"POST","path":"/sandboxes/missing-sandbox/connect","query":[]}
 {"body":{"allow_internet_access":true,"autoPause":false,"autoResume":{"enabled":false},"envVars":{},"metadata":{},"secure":true,"templateID":"code-interpreter-v1","timeout":300},"client":"python-async","headers":{"content-type":"application/json","user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"POST","path":"/sandboxes","query":[]}
-{"body":null,"client":"python-async","headers":{"user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"DELETE","path":"/sandboxes/fixture-sandbox","query":[]}
+{"body":null,"client":"python-async","headers":{"user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"DELETE","path":"/sandboxes/fixture-interpreter","query":[]}

--- a/compat/e2b/fixtures/official-clients/expected/python-sync.jsonl
+++ b/compat/e2b/fixtures/official-clients/expected/python-sync.jsonl
@@ -6,4 +6,4 @@
 {"body":null,"client":"python-sync","headers":{"user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"DELETE","path":"/sandboxes/missing-sandbox","query":[]}
 {"body":{"timeout":300},"client":"python-sync","headers":{"content-type":"application/json","user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"POST","path":"/sandboxes/missing-sandbox/connect","query":[]}
 {"body":{"allow_internet_access":true,"autoPause":false,"autoResume":{"enabled":false},"envVars":{},"metadata":{},"secure":true,"templateID":"code-interpreter-v1","timeout":300},"client":"python-sync","headers":{"content-type":"application/json","user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"POST","path":"/sandboxes","query":[]}
-{"body":null,"client":"python-sync","headers":{"user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"DELETE","path":"/sandboxes/fixture-sandbox","query":[]}
+{"body":null,"client":"python-sync","headers":{"user-agent":"e2b-python-sdk/2.32.0","x-api-key":"e2b_a1b2c3"},"method":"DELETE","path":"/sandboxes/fixture-interpreter","query":[]}

--- a/compat/e2b/fixtures/official-clients/expected/typescript.jsonl
+++ b/compat/e2b/fixtures/official-clients/expected/typescript.jsonl
@@ -6,4 +6,4 @@
 {"body":null,"client":"typescript","headers":{"user-agent":"e2b-js-sdk/2.33.0","x-api-key":"e2b_a1b2c3"},"method":"DELETE","path":"/sandboxes/missing-sandbox","query":[]}
 {"body":{"timeout":300},"client":"typescript","headers":{"content-type":"application/json","user-agent":"e2b-js-sdk/2.33.0","x-api-key":"e2b_a1b2c3"},"method":"POST","path":"/sandboxes/missing-sandbox/connect","query":[]}
 {"body":{"allow_internet_access":true,"autoPause":false,"autoResume":{"enabled":false},"secure":true,"templateID":"code-interpreter-v1","timeout":300},"client":"typescript","headers":{"content-type":"application/json","user-agent":"e2b-js-sdk/2.33.0","x-api-key":"e2b_a1b2c3"},"method":"POST","path":"/sandboxes","query":[]}
-{"body":null,"client":"typescript","headers":{"user-agent":"e2b-js-sdk/2.33.0","x-api-key":"e2b_a1b2c3"},"method":"DELETE","path":"/sandboxes/fixture-sandbox","query":[]}
+{"body":null,"client":"typescript","headers":{"user-agent":"e2b-js-sdk/2.33.0","x-api-key":"e2b_a1b2c3"},"method":"DELETE","path":"/sandboxes/fixture-interpreter","query":[]}

--- a/compat/e2b/fixtures/official-clients/mock_server.py
+++ b/compat/e2b/fixtures/official-clients/mock_server.py
@@ -15,16 +15,17 @@ from typing import Any, ClassVar
 
 
 SANDBOX_ID = "fixture-sandbox"
+INTERPRETER_SANDBOX_ID = "fixture-interpreter"
 MISSING_SANDBOX_ID = "missing-sandbox"
 
 
-def sandbox_response() -> dict[str, Any]:
+def sandbox_response(sandbox_id: str) -> dict[str, Any]:
     return {
         "clientID": "fixture-client",
         "domain": "fixture.invalid",
         "envdAccessToken": "fixture-envd-token",
         "envdVersion": "0.1.3",
-        "sandboxID": SANDBOX_ID,
+        "sandboxID": sandbox_id,
         "templateID": "fixture-template",
         "trafficAccessToken": "fixture-traffic-token",
     }
@@ -53,6 +54,7 @@ class FixtureHandler(BaseHTTPRequestHandler):
     capture_path: ClassVar[Path]
     client_name: ClassVar[str]
     capture_lock: ClassVar[threading.Lock] = threading.Lock()
+    create_count: ClassVar[int] = 0
 
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         self._handle()
@@ -73,14 +75,24 @@ class FixtureHandler(BaseHTTPRequestHandler):
 
         path = parsed.path
         if self.command == "POST" and path == "/sandboxes":
-            self._json(HTTPStatus.CREATED, sandbox_response())
+            with self.capture_lock:
+                self.__class__.create_count += 1
+                sandbox_id = (
+                    SANDBOX_ID
+                    if self.create_count == 1
+                    else INTERPRETER_SANDBOX_ID
+                )
+            self._json(HTTPStatus.CREATED, sandbox_response(sandbox_id))
         elif self.command == "POST" and path == f"/sandboxes/{SANDBOX_ID}/connect":
-            self._json(HTTPStatus.OK, sandbox_response())
+            self._json(HTTPStatus.OK, sandbox_response(SANDBOX_ID))
         elif self.command == "GET" and path == "/v2/sandboxes":
             self._json(HTTPStatus.OK, [listed_sandbox()])
         elif self.command == "POST" and path == f"/sandboxes/{SANDBOX_ID}/timeout":
             self._empty(HTTPStatus.NO_CONTENT)
-        elif self.command == "DELETE" and path == f"/sandboxes/{SANDBOX_ID}":
+        elif self.command == "DELETE" and path in {
+            f"/sandboxes/{SANDBOX_ID}",
+            f"/sandboxes/{INTERPRETER_SANDBOX_ID}",
+        }:
             self._empty(HTTPStatus.NO_CONTENT)
         elif MISSING_SANDBOX_ID in path:
             self._json(

--- a/compat/e2b/fixtures/official-clients/python_client.py
+++ b/compat/e2b/fixtures/official-clients/python_client.py
@@ -20,6 +20,7 @@ from e2b_code_interpreter import Sandbox as CodeInterpreter
 
 API_KEY = "e2b_a1b2c3"
 SANDBOX_ID = "fixture-sandbox"
+INTERPRETER_SANDBOX_ID = "fixture-interpreter"
 MISSING_SANDBOX_ID = "missing-sandbox"
 
 
@@ -71,6 +72,7 @@ def run_sync(api_url: str) -> None:
         raise AssertionError("missing sandbox connect must raise SandboxNotFoundException")
 
     interpreter = CodeInterpreter.create(**connection(api_url))
+    assert interpreter.sandbox_id == INTERPRETER_SANDBOX_ID
     assert interpreter.kill()
 
 
@@ -105,6 +107,7 @@ async def run_async(api_url: str) -> None:
         raise AssertionError("missing sandbox connect must raise SandboxNotFoundException")
 
     interpreter = await AsyncCodeInterpreter.create(**connection(api_url))
+    assert interpreter.sandbox_id == INTERPRETER_SANDBOX_ID
     assert await interpreter.kill()
 
 

--- a/compat/e2b/fixtures/official-clients/run_fixtures.py
+++ b/compat/e2b/fixtures/official-clients/run_fixtures.py
@@ -235,6 +235,31 @@ def run_client(
         )
 
 
+def run_rust_client(
+    label: str,
+    command: list[str],
+    temp: Path,
+    server_bin: Path,
+) -> None:
+    port_file = temp / f"{label}-rust.port"
+    server = subprocess.Popen(
+        [str(server_bin), "--port-file", str(port_file)],
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while not port_file.exists():
+            if server.poll() is not None:
+                raise RuntimeError(f"Rust fixture server exited before {label} started")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Rust fixture server did not start for {label}")
+            time.sleep(0.02)
+        api_url = f"http://127.0.0.1:{port_file.read_text(encoding='utf-8')}"
+        subprocess.run([*command, api_url], check=True)
+    finally:
+        server.terminate()
+        server.wait(timeout=10)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("mode", choices=["generate", "verify"], nargs="?", default="verify")
@@ -247,6 +272,11 @@ def main() -> None:
         "--artifact-cache",
         type=Path,
         help="reuse verified SDK artifacts from this directory",
+    )
+    parser.add_argument(
+        "--rust-server-bin",
+        type=Path,
+        help="also run every official client against this Rust fixture server",
     )
     args = parser.parse_args()
     artifacts = load_artifacts()
@@ -281,6 +311,28 @@ def main() -> None:
             temp,
             update,
         )
+        if args.rust_server_bin:
+            server_bin = args.rust_server_bin.resolve()
+            if not server_bin.is_file():
+                raise FileNotFoundError(f"Rust fixture server not found: {server_bin}")
+            run_rust_client(
+                "python-sync",
+                [str(python), str(FIXTURE_DIR / "python_client.py"), "sync"],
+                temp,
+                server_bin,
+            )
+            run_rust_client(
+                "python-async",
+                [str(python), str(FIXTURE_DIR / "python_client.py"), "async"],
+                temp,
+                server_bin,
+            )
+            run_rust_client(
+                "typescript",
+                ["node", str(typescript_client)],
+                temp,
+                server_bin,
+            )
 
 
 if __name__ == "__main__":

--- a/compat/e2b/fixtures/official-clients/typescript_client.mjs
+++ b/compat/e2b/fixtures/official-clients/typescript_client.mjs
@@ -54,4 +54,5 @@ await assert.rejects(
 )
 
 const interpreter = await CodeInterpreter.create(connection)
+assert.equal(interpreter.sandboxId, 'fixture-interpreter')
 assert.equal(await interpreter.kill(), true)

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,6 +1,6 @@
 # E2B Protocol Compatibility and SDK Design
 
-Status: **Phase 1 complete; Phase 2 architecture selected**
+Status: **Phase 1 complete; Phase 2 in progress (slices 1 and 2 complete)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -726,9 +726,10 @@ Phase 2 is delivered as small, immediately merged changes:
 1. **Complete:** add lifecycle domain types, transition tests, repository and
    execution interfaces, and deterministic clock/token fakes. No network
    listener.
-2. Add the HTTP lifecycle router and run the checked-in official Python sync,
-   Python async, and TypeScript fixtures against the Rust service with a fake
-   execution manager.
+2. **Complete:** add the owner-scoped HTTP lifecycle router and run the
+   checked-in official Python sync, Python async, TypeScript, and Code
+   Interpreter fixtures against the Rust service with a fake execution
+   manager.
 3. Add SQLite migrations, compare-and-swap repository operations, expiry
    reaping, restart reconciliation, and corruption/restart tests.
 4. Extract canonical A3S state and the runtime `ExecutionManager`; switch CLI
@@ -743,6 +744,13 @@ Each slice must pass its focused tests and repository CI before merge. The
 Phase 2 gate remains closed until slice 5 proves real create/connect/list/
 timeout/kill behavior; passing the fake adapter in slice 2 is protocol evidence
 only.
+
+Slice 2 evidence includes exact recorder drift checks plus live requests from
+the pinned, unmodified clients to the Rust router. The live gate was also run
+on an A3S OS host before merge. It covers authentication, owner isolation,
+create, connect, get, list filtering, timeout replacement, kill, not-found
+mapping, and Code Interpreter creation. It does not change the manifest's
+`full_compatibility=false` value.
 
 ## Delivery phases and gates
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -41,8 +41,10 @@ dependencies = [
  "a3s-box-core",
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "hex",
+ "hyper 0.14.32",
  "prost",
  "prost-types",
  "serde",
@@ -52,6 +54,8 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tower 0.4.13",
+ "url",
 ]
 
 [[package]]
@@ -476,7 +480,11 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper 0.1.2",
+ "tokio",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
@@ -3156,6 +3164,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1.35", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 
 # gRPC
+axum = { version = "0.6", features = ["json"] }
 tonic = "0.11"
 tonic-build = "0.11"
 prost = "0.12"
@@ -87,6 +88,7 @@ rustls-pki-types = "1"
 
 # HTTP client (for skill downloads)
 reqwest = { version = "0.11", features = ["json", "stream"] }
+url = "2.5"
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/compat/Cargo.toml
+++ b/src/compat/Cargo.toml
@@ -11,6 +11,7 @@ description = "Protocol compatibility service and contract fixtures for A3S Box"
 a3s-box-core = { version = "3.0", path = "../core" }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+axum = { workspace = true }
 chrono = { workspace = true }
 hex = { workspace = true }
 prost = { workspace = true }
@@ -21,10 +22,17 @@ serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+hyper = { workspace = true }
+tower = { workspace = true, features = ["util"] }
 
 [[bin]]
 name = "a3s-box-e2b-contract"
 path = "src/main.rs"
+
+[[bin]]
+name = "a3s-box-e2b-fixture-server"
+path = "src/bin/a3s-box-e2b-fixture-server.rs"

--- a/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
+++ b/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
@@ -1,0 +1,380 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use a3s_box_compat::control::{
+    Clock, ControlService, ControlServiceDependencies, IdentityProviderResult, IssuedToken,
+    MemorySandboxRepository, ResolvedTemplate, SandboxIdentity, SandboxIdentityProvider,
+    SecretToken, StoredToken, TemplateProvider, TemplateProviderError, TemplateProviderResult,
+    TokenIssuer, TokenIssuerError, TokenIssuerResult, TokenResolver, TokenScope,
+};
+use a3s_box_compat::http::{
+    lifecycle_router, AuthenticatedAccount, AuthenticationError, AuthenticationResult,
+    CredentialScheme, CredentialVerifier, CursorDecoder, CursorError, CursorResult,
+    LifecycleHttpConfig, LifecycleHttpState, PresentedCredential,
+};
+use a3s_box_core::{
+    resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionId,
+    ExecutionIsolation, ExecutionLease, ExecutionManager, ExecutionManagerError,
+    ExecutionManagerResult, ExecutionState, ExecutionStatus, KillOutcome, OperationId,
+    ReconcileOutcome, ResourceConfig,
+};
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+use chrono::{DateTime, TimeZone, Utc};
+use sha2::{Digest, Sha256};
+
+const API_KEY: &str = "e2b_a1b2c3";
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("Error: {error:#}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<()> {
+    let port_file = parse_port_file()?;
+    let clock = Arc::new(FixedClock(fixture_time()?));
+    let tokens = Arc::new(FixtureTokens);
+    let service = Arc::new(ControlService::new(ControlServiceDependencies {
+        repository: Arc::new(MemorySandboxRepository::default()),
+        executions: Arc::new(FixtureExecutionManager::new(clock.clone())),
+        clock,
+        identities: Arc::new(FixtureIdentities::default()),
+        templates: Arc::new(FixtureTemplates),
+        token_issuer: tokens.clone(),
+        token_resolver: tokens,
+    }));
+    let state = LifecycleHttpState::new(
+        service,
+        Arc::new(FixtureCredentialVerifier),
+        Arc::new(FixtureCursorDecoder),
+        LifecycleHttpConfig {
+            domain: Some("fixture.invalid".to_string()),
+            ..LifecycleHttpConfig::default()
+        },
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("bind fixture listener")?;
+    let address = listener.local_addr().context("read fixture address")?;
+    tokio::fs::write(&port_file, address.port().to_string())
+        .await
+        .with_context(|| format!("write fixture port file {}", port_file.display()))?;
+    let listener = listener
+        .into_std()
+        .context("convert fixture listener to std")?;
+    axum::Server::from_tcp(listener)
+        .context("create fixture HTTP server")?
+        .serve(lifecycle_router(state).into_make_service())
+        .await
+        .context("serve fixture HTTP requests")
+}
+
+fn parse_port_file() -> Result<PathBuf> {
+    let mut arguments = std::env::args().skip(1);
+    let mut port_file = None;
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--port-file" => {
+                port_file = Some(PathBuf::from(
+                    arguments.next().context("--port-file requires a path")?,
+                ));
+            }
+            _ => bail!("unknown argument {argument}"),
+        }
+    }
+    port_file.context("--port-file is required")
+}
+
+fn fixture_time() -> Result<DateTime<Utc>> {
+    Utc.with_ymd_and_hms(2026, 7, 14, 12, 0, 0)
+        .single()
+        .context("fixture timestamp is invalid")
+}
+
+struct FixedClock(DateTime<Utc>);
+
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+#[derive(Default)]
+struct FixtureIdentities {
+    next: AtomicU64,
+}
+
+impl SandboxIdentityProvider for FixtureIdentities {
+    fn next_identity(&self) -> IdentityProviderResult<SandboxIdentity> {
+        let sequence = self.next.fetch_add(1, Ordering::Relaxed) + 1;
+        let sandbox_id = match sequence {
+            1 => "fixture-sandbox".to_string(),
+            2 => "fixture-interpreter".to_string(),
+            value => format!("fixture-sandbox-{value}"),
+        };
+        Ok(SandboxIdentity {
+            sandbox_id: a3s_box_compat::control::SandboxId::new(sandbox_id)
+                .map_err(|error| fixture_identity_error(error.to_string()))?,
+            operation_id: OperationId::new(format!("fixture-operation-{sequence}"))
+                .map_err(|error| fixture_identity_error(error.to_string()))?,
+        })
+    }
+}
+
+fn fixture_identity_error(message: String) -> a3s_box_compat::control::IdentityProviderError {
+    a3s_box_compat::control::IdentityProviderError::Unavailable(message)
+}
+
+struct FixtureTemplates;
+
+#[async_trait]
+impl TemplateProvider for FixtureTemplates {
+    async fn resolve(&self, template_id: &str) -> TemplateProviderResult<ResolvedTemplate> {
+        if !matches!(template_id, "fixture-template" | "code-interpreter-v1") {
+            return Err(TemplateProviderError::NotFound(template_id.to_string()));
+        }
+        Ok(ResolvedTemplate {
+            config: BoxConfig {
+                isolation: ExecutionIsolation::Sandbox,
+                image: format!("fixture.invalid/{template_id}:latest"),
+                resources: ResourceConfig {
+                    vcpus: 2,
+                    memory_mb: 512,
+                    disk_mb: 1024,
+                    timeout: 300,
+                },
+                ..BoxConfig::default()
+            },
+            envd_version: "0.1.3".to_string(),
+        })
+    }
+}
+
+struct FixtureTokens;
+
+#[async_trait]
+impl TokenIssuer for FixtureTokens {
+    async fn issue(&self, scope: TokenScope) -> TokenIssuerResult<IssuedToken> {
+        let secret = match scope {
+            TokenScope::Envd => "fixture-envd-token",
+            TokenScope::Traffic => "fixture-traffic-token",
+        };
+        Ok(IssuedToken {
+            secret: SecretToken::new(secret)?,
+            stored: store_fixture_token(secret)?,
+        })
+    }
+}
+
+#[async_trait]
+impl TokenResolver for FixtureTokens {
+    async fn resolve(&self, stored: &StoredToken) -> TokenIssuerResult<SecretToken> {
+        let digest = Sha256::digest(stored.ciphertext());
+        if &digest[..] != stored.digest() {
+            return Err(TokenIssuerError::InvalidMaterial);
+        }
+        let value = std::str::from_utf8(stored.ciphertext())
+            .map_err(|_| TokenIssuerError::InvalidMaterial)?;
+        SecretToken::new(value)
+    }
+}
+
+fn store_fixture_token(secret: &str) -> TokenIssuerResult<StoredToken> {
+    let ciphertext = secret.as_bytes().to_vec();
+    let digest = Sha256::digest(&ciphertext).to_vec();
+    StoredToken::new(1, ciphertext, digest).map_err(|_| TokenIssuerError::InvalidMaterial)
+}
+
+struct FixtureCredentialVerifier;
+
+#[async_trait]
+impl CredentialVerifier for FixtureCredentialVerifier {
+    async fn verify(
+        &self,
+        credential: &PresentedCredential,
+    ) -> AuthenticationResult<AuthenticatedAccount> {
+        if credential.scheme() != CredentialScheme::ApiKey || credential.expose_secret() != API_KEY
+        {
+            return Err(AuthenticationError::Invalid);
+        }
+        Ok(AuthenticatedAccount {
+            owner_id: "fixture-owner".to_string(),
+            client_id: "fixture-client".to_string(),
+        })
+    }
+}
+
+struct FixtureCursorDecoder;
+
+impl CursorDecoder for FixtureCursorDecoder {
+    fn decode(&self, value: &str) -> CursorResult<Option<a3s_box_compat::control::SandboxCursor>> {
+        if value == "cursor-0" {
+            Ok(None)
+        } else {
+            Err(CursorError::Invalid)
+        }
+    }
+}
+
+#[derive(Clone)]
+struct FixtureExecution {
+    lease: ExecutionLease,
+    state: ExecutionState,
+}
+
+struct FixtureExecutionManager {
+    clock: Arc<dyn Clock>,
+    operations: Mutex<BTreeMap<String, String>>,
+    executions: Mutex<BTreeMap<String, FixtureExecution>>,
+}
+
+impl FixtureExecutionManager {
+    fn new(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            clock,
+            operations: Mutex::new(BTreeMap::new()),
+            executions: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    fn operations(&self) -> ExecutionManagerResult<MutexGuard<'_, BTreeMap<String, String>>> {
+        self.operations.lock().map_err(|_| {
+            ExecutionManagerError::Unavailable("fixture operation lock poisoned".into())
+        })
+    }
+
+    fn executions(
+        &self,
+    ) -> ExecutionManagerResult<MutexGuard<'_, BTreeMap<String, FixtureExecution>>> {
+        self.executions.lock().map_err(|_| {
+            ExecutionManagerError::Unavailable("fixture execution lock poisoned".into())
+        })
+    }
+}
+
+#[async_trait]
+impl ExecutionManager for FixtureExecutionManager {
+    async fn create_and_start(
+        &self,
+        request: CreateExecutionRequest,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        if let Some(execution_id) = self.operations()?.get(operation_id.as_str()).cloned() {
+            return self
+                .executions()?
+                .get(&execution_id)
+                .map(|execution| execution.lease.clone())
+                .ok_or_else(|| {
+                    ExecutionManagerError::Internal(
+                        "fixture operation references a missing execution".into(),
+                    )
+                });
+        }
+
+        let plan = resolve_execution(&request.config)
+            .map_err(|error| ExecutionManagerError::InvalidRequest(error.to_string()))?;
+        let execution_id = ExecutionId::new(format!("execution-{}", operation_id.as_str()))?;
+        let lease = ExecutionLease {
+            execution_id: execution_id.clone(),
+            generation: ExecutionGeneration::INITIAL,
+            plan,
+            resources: request.config.resources,
+            started_at: self.clock.now(),
+        };
+        self.executions()?.insert(
+            execution_id.to_string(),
+            FixtureExecution {
+                lease: lease.clone(),
+                state: ExecutionState::Running,
+            },
+        );
+        self.operations()?
+            .insert(operation_id.as_str().to_string(), execution_id.to_string());
+        Ok(lease)
+    }
+
+    async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
+        let executions = self.executions()?;
+        let execution = executions
+            .get(execution_id.as_str())
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        Ok(ExecutionStatus {
+            execution_id: execution_id.clone(),
+            generation: execution.lease.generation,
+            state: execution.state,
+            plan: execution.lease.plan.clone(),
+        })
+    }
+
+    async fn resume(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let mut executions = self.executions()?;
+        let execution = executions
+            .get_mut(execution_id.as_str())
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        if execution.lease.generation != generation || execution.state != ExecutionState::Paused {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id.clone(),
+                message: "stale fixture resume".to_string(),
+            });
+        }
+        let next_generation = generation.get().checked_add(1).ok_or_else(|| {
+            ExecutionManagerError::Internal("fixture execution generation is exhausted".into())
+        })?;
+        execution.lease.generation = ExecutionGeneration::new(next_generation)?;
+        execution.state = ExecutionState::Running;
+        Ok(execution.lease.clone())
+    }
+
+    async fn kill(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        let mut executions = self.executions()?;
+        let execution = executions
+            .get_mut(execution_id.as_str())
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        if execution.lease.generation != generation {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id.clone(),
+                message: "stale fixture kill".to_string(),
+            });
+        }
+        if execution.state == ExecutionState::Stopped {
+            return Ok(KillOutcome::AlreadyStopped);
+        }
+        execution.state = ExecutionState::Stopped;
+        Ok(KillOutcome::Killed)
+    }
+
+    async fn reconcile(
+        &self,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ReconcileOutcome> {
+        let Some(execution_id) = self.operations()?.get(operation_id.as_str()).cloned() else {
+            return Ok(ReconcileOutcome::Absent);
+        };
+        let executions = self.executions()?;
+        let execution = executions.get(&execution_id).ok_or_else(|| {
+            ExecutionManagerError::Internal(
+                "fixture operation references a missing execution".into(),
+            )
+        })?;
+        Ok(match execution.state {
+            ExecutionState::Creating => ReconcileOutcome::Creating,
+            ExecutionState::Running | ExecutionState::Paused => {
+                ReconcileOutcome::Ready(execution.lease.clone())
+            }
+            ExecutionState::Stopped | ExecutionState::Failed => ReconcileOutcome::Failed,
+        })
+    }
+}

--- a/src/compat/src/control/credential.rs
+++ b/src/compat/src/control/credential.rs
@@ -143,3 +143,8 @@ pub type TokenIssuerResult<T> = std::result::Result<T, TokenIssuerError>;
 pub trait TokenIssuer: Send + Sync {
     async fn issue(&self, scope: TokenScope) -> TokenIssuerResult<IssuedToken>;
 }
+
+#[async_trait]
+pub trait TokenResolver: Send + Sync {
+    async fn resolve(&self, stored: &StoredToken) -> TokenIssuerResult<SecretToken>;
+}

--- a/src/compat/src/control/memory.rs
+++ b/src/compat/src/control/memory.rs
@@ -1,0 +1,118 @@
+use std::collections::BTreeMap;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use async_trait::async_trait;
+
+use super::{
+    CompareAndSwapResult, RepositoryError, RepositoryResult, SandboxGeneration, SandboxId,
+    SandboxListFilter, SandboxPage, SandboxRecord, SandboxRepository,
+};
+
+/// Process-local repository used by protocol fixtures and focused tests.
+///
+/// It deliberately has no durability guarantees. The production compatibility
+/// service uses the transactional repository introduced by the persistence
+/// slice.
+#[derive(Debug, Default)]
+pub struct MemorySandboxRepository {
+    records: RwLock<BTreeMap<SandboxId, SandboxRecord>>,
+}
+
+impl MemorySandboxRepository {
+    fn read(&self) -> RepositoryResult<RwLockReadGuard<'_, BTreeMap<SandboxId, SandboxRecord>>> {
+        self.records
+            .read()
+            .map_err(|_| RepositoryError::Unavailable("memory repository lock poisoned".into()))
+    }
+
+    fn write(&self) -> RepositoryResult<RwLockWriteGuard<'_, BTreeMap<SandboxId, SandboxRecord>>> {
+        self.records
+            .write()
+            .map_err(|_| RepositoryError::Unavailable("memory repository lock poisoned".into()))
+    }
+}
+
+#[async_trait]
+impl SandboxRepository for MemorySandboxRepository {
+    async fn insert(&self, record: SandboxRecord) -> RepositoryResult<()> {
+        let mut records = self.write()?;
+        if records.contains_key(record.sandbox_id()) {
+            return Err(RepositoryError::Duplicate(record.sandbox_id().clone()));
+        }
+        records.insert(record.sandbox_id().clone(), record);
+        Ok(())
+    }
+
+    async fn get(&self, sandbox_id: &SandboxId) -> RepositoryResult<Option<SandboxRecord>> {
+        Ok(self.read()?.get(sandbox_id).cloned())
+    }
+
+    async fn list(&self, filter: &SandboxListFilter) -> RepositoryResult<SandboxPage> {
+        let records = self.read()?;
+        let mut matching = records
+            .values()
+            .filter(|record| record.owner_id() == filter.owner_id)
+            .filter(|record| {
+                record
+                    .public_state()
+                    .is_some_and(|state| filter.states.is_empty() || filter.states.contains(&state))
+            })
+            .filter(|record| {
+                filter
+                    .metadata
+                    .iter()
+                    .all(|(key, value)| record.metadata().get(key) == Some(value))
+            })
+            .filter(|record| {
+                filter.after.as_ref().is_none_or(|cursor| {
+                    (record.created_at(), record.sandbox_id())
+                        > (cursor.created_at, &cursor.sandbox_id)
+                })
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        matching.sort_by(|left, right| {
+            (left.created_at(), left.sandbox_id()).cmp(&(right.created_at(), right.sandbox_id()))
+        });
+
+        let limit = filter.limit.get() as usize;
+        let has_more = matching.len() > limit;
+        matching.truncate(limit);
+        let next = has_more
+            .then(|| matching.last())
+            .flatten()
+            .map(|last| super::SandboxCursor {
+                created_at: last.created_at(),
+                sandbox_id: last.sandbox_id().clone(),
+            });
+        Ok(SandboxPage {
+            records: matching,
+            next,
+        })
+    }
+
+    async fn compare_and_swap(
+        &self,
+        sandbox_id: &SandboxId,
+        expected: SandboxGeneration,
+        replacement: SandboxRecord,
+    ) -> RepositoryResult<CompareAndSwapResult> {
+        if replacement.sandbox_id() != sandbox_id || replacement.generation() <= expected {
+            return Err(RepositoryError::Corrupt(
+                "invalid compare-and-swap replacement".to_string(),
+            ));
+        }
+
+        let mut records = self.write()?;
+        let Some(current) = records.get(sandbox_id) else {
+            return Ok(CompareAndSwapResult::NotFound);
+        };
+        if current.generation() != expected {
+            return Ok(CompareAndSwapResult::Conflict {
+                actual_generation: current.generation(),
+            });
+        }
+        records.insert(sandbox_id.clone(), replacement);
+        Ok(CompareAndSwapResult::Updated)
+    }
+}

--- a/src/compat/src/control/mod.rs
+++ b/src/compat/src/control/mod.rs
@@ -1,21 +1,38 @@
 mod credential;
+mod memory;
 mod model;
 mod ports;
 mod repository;
+mod service;
 
 pub use credential::{
     IssuedToken, SandboxCredentials, SecretToken, StoredToken, TokenIssuer, TokenIssuerError,
-    TokenIssuerResult, TokenScope,
+    TokenIssuerResult, TokenResolver, TokenScope,
 };
+pub use memory::MemorySandboxRepository;
 pub use model::{
     LifecycleError, LifecycleFailure, LifecyclePolicy, LifecycleState, NewSandboxRecord,
     OnTimeoutAction, PublicSandboxState, SandboxGeneration, SandboxId, SandboxRecord,
 };
-pub use ports::{Clock, SystemClock};
+pub use ports::{
+    Clock, IdentityProviderError, IdentityProviderResult, ResolvedTemplate, SandboxIdentity,
+    SandboxIdentityProvider, SystemClock, TemplateProvider, TemplateProviderError,
+    TemplateProviderResult,
+};
 pub use repository::{
     CompareAndSwapResult, RepositoryError, RepositoryResult, SandboxCursor, SandboxListFilter,
     SandboxPage, SandboxRepository,
 };
+pub use service::{
+    ConnectionDisposition, ControlService, ControlServiceDependencies, ControlServiceError,
+    ControlServiceResult, CreateSandboxRequest, SandboxConnection,
+};
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod service_tests;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/src/compat/src/control/model.rs
+++ b/src/compat/src/control/model.rs
@@ -139,6 +139,7 @@ pub enum LifecycleFailure {
 pub struct NewSandboxRecord {
     pub sandbox_id: SandboxId,
     pub operation_id: OperationId,
+    pub owner_id: String,
     pub template_id: String,
     pub plan: ResolvedExecutionPlan,
     pub resources: ResourceConfig,
@@ -147,6 +148,8 @@ pub struct NewSandboxRecord {
     pub expires_at: DateTime<Utc>,
     pub metadata: BTreeMap<String, String>,
     pub envd_version: String,
+    pub secure: bool,
+    pub allow_internet_access: Option<bool>,
     pub credentials: SandboxCredentials,
 }
 
@@ -154,6 +157,7 @@ pub struct NewSandboxRecord {
 pub struct SandboxRecord {
     sandbox_id: SandboxId,
     operation_id: OperationId,
+    owner_id: String,
     execution_id: Option<ExecutionId>,
     execution_generation: Option<ExecutionGeneration>,
     generation: SandboxGeneration,
@@ -167,15 +171,20 @@ pub struct SandboxRecord {
     expires_at: DateTime<Utc>,
     metadata: BTreeMap<String, String>,
     envd_version: String,
+    secure: bool,
+    allow_internet_access: Option<bool>,
     credentials: SandboxCredentials,
     failure: Option<LifecycleFailure>,
 }
 
 impl SandboxRecord {
     pub fn creating(new: NewSandboxRecord) -> Result<Self, LifecycleError> {
-        if new.template_id.trim().is_empty() || new.envd_version.trim().is_empty() {
+        if new.owner_id.trim().is_empty()
+            || new.template_id.trim().is_empty()
+            || new.envd_version.trim().is_empty()
+        {
             return Err(LifecycleError::InvalidIdentity(
-                "template ID and envd version cannot be empty".to_string(),
+                "owner ID, template ID, and envd version cannot be empty".to_string(),
             ));
         }
         if new.expires_at < new.created_at {
@@ -184,6 +193,7 @@ impl SandboxRecord {
         Ok(Self {
             sandbox_id: new.sandbox_id,
             operation_id: new.operation_id,
+            owner_id: new.owner_id,
             execution_id: None,
             execution_generation: None,
             generation: SandboxGeneration::INITIAL,
@@ -197,6 +207,8 @@ impl SandboxRecord {
             expires_at: new.expires_at,
             metadata: new.metadata,
             envd_version: new.envd_version,
+            secure: new.secure,
+            allow_internet_access: new.allow_internet_access,
             credentials: new.credentials,
             failure: None,
         })
@@ -208,6 +220,10 @@ impl SandboxRecord {
 
     pub fn operation_id(&self) -> &OperationId {
         &self.operation_id
+    }
+
+    pub fn owner_id(&self) -> &str {
+        &self.owner_id
     }
 
     pub fn execution_id(&self) -> Option<&ExecutionId> {
@@ -260,6 +276,14 @@ impl SandboxRecord {
 
     pub fn envd_version(&self) -> &str {
         &self.envd_version
+    }
+
+    pub const fn secure(&self) -> bool {
+        self.secure
+    }
+
+    pub const fn allow_internet_access(&self) -> Option<bool> {
+        self.allow_internet_access
     }
 
     pub fn credentials(&self) -> &SandboxCredentials {

--- a/src/compat/src/control/ports.rs
+++ b/src/compat/src/control/ports.rs
@@ -1,4 +1,9 @@
+use a3s_box_core::{BoxConfig, OperationId};
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use thiserror::Error;
+
+use super::SandboxId;
 
 pub trait Clock: Send + Sync {
     fn now(&self) -> DateTime<Utc>;
@@ -11,4 +16,45 @@ impl Clock for SystemClock {
     fn now(&self) -> DateTime<Utc> {
         Utc::now()
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct SandboxIdentity {
+    pub sandbox_id: SandboxId,
+    pub operation_id: OperationId,
+}
+
+#[derive(Debug, Error)]
+pub enum IdentityProviderError {
+    #[error("sandbox identity provider is unavailable: {0}")]
+    Unavailable(String),
+}
+
+pub type IdentityProviderResult<T> = std::result::Result<T, IdentityProviderError>;
+
+pub trait SandboxIdentityProvider: Send + Sync {
+    fn next_identity(&self) -> IdentityProviderResult<SandboxIdentity>;
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedTemplate {
+    pub config: BoxConfig,
+    pub envd_version: String,
+}
+
+#[derive(Debug, Error)]
+pub enum TemplateProviderError {
+    #[error("sandbox template not found: {0}")]
+    NotFound(String),
+    #[error("sandbox template is invalid: {0}")]
+    Invalid(String),
+    #[error("sandbox template provider is unavailable: {0}")]
+    Unavailable(String),
+}
+
+pub type TemplateProviderResult<T> = std::result::Result<T, TemplateProviderError>;
+
+#[async_trait]
+pub trait TemplateProvider: Send + Sync {
+    async fn resolve(&self, template_id: &str) -> TemplateProviderResult<ResolvedTemplate>;
 }

--- a/src/compat/src/control/repository.rs
+++ b/src/compat/src/control/repository.rs
@@ -15,6 +15,7 @@ pub struct SandboxCursor {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SandboxListFilter {
+    pub owner_id: String,
     pub metadata: BTreeMap<String, String>,
     pub states: BTreeSet<PublicSandboxState>,
     pub limit: NonZeroU32,

--- a/src/compat/src/control/service.rs
+++ b/src/compat/src/control/service.rs
@@ -1,0 +1,357 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use a3s_box_core::{resolve_execution, CreateExecutionRequest, ExecutionManager, NetworkMode};
+use chrono::{DateTime, Duration, Utc};
+use thiserror::Error;
+
+use super::{
+    Clock, CompareAndSwapResult, IdentityProviderError, LifecycleError, LifecycleFailure,
+    LifecyclePolicy, LifecycleState, NewSandboxRecord, RepositoryError, SandboxCredentials,
+    SandboxIdentityProvider, SandboxListFilter, SandboxPage, SandboxRecord, SandboxRepository,
+    SecretToken, TemplateProvider, TemplateProviderError, TokenIssuer, TokenIssuerError,
+    TokenResolver, TokenScope,
+};
+
+#[derive(Debug, Clone)]
+pub struct CreateSandboxRequest {
+    pub owner_id: String,
+    pub template_id: String,
+    pub timeout_seconds: u32,
+    pub lifecycle: LifecyclePolicy,
+    pub metadata: BTreeMap<String, String>,
+    pub env_vars: BTreeMap<String, String>,
+    pub secure: bool,
+    pub allow_internet_access: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionDisposition {
+    Created,
+    AlreadyRunning,
+    Resumed,
+}
+
+pub struct SandboxConnection {
+    pub record: SandboxRecord,
+    pub envd_access_token: SecretToken,
+    pub traffic_access_token: SecretToken,
+    pub disposition: ConnectionDisposition,
+}
+
+impl std::fmt::Debug for SandboxConnection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SandboxConnection")
+            .field("record", &self.record)
+            .field("envd_access_token", &self.envd_access_token)
+            .field("traffic_access_token", &self.traffic_access_token)
+            .field("disposition", &self.disposition)
+            .finish()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ControlServiceError {
+    #[error("invalid sandbox request: {0}")]
+    InvalidRequest(String),
+    #[error("sandbox not found: {0}")]
+    NotFound(super::SandboxId),
+    #[error("sandbox lifecycle conflict: {0}")]
+    Conflict(super::SandboxId),
+    #[error(transparent)]
+    Repository(#[from] RepositoryError),
+    #[error(transparent)]
+    Execution(#[from] a3s_box_core::ExecutionManagerError),
+    #[error(transparent)]
+    Identity(#[from] IdentityProviderError),
+    #[error(transparent)]
+    Template(#[from] TemplateProviderError),
+    #[error(transparent)]
+    Credential(#[from] TokenIssuerError),
+    #[error("sandbox lifecycle failed: {0}")]
+    Lifecycle(#[from] LifecycleError),
+}
+
+pub type ControlServiceResult<T> = std::result::Result<T, ControlServiceError>;
+
+#[derive(Clone)]
+pub struct ControlService {
+    repository: Arc<dyn SandboxRepository>,
+    executions: Arc<dyn ExecutionManager>,
+    clock: Arc<dyn Clock>,
+    identities: Arc<dyn SandboxIdentityProvider>,
+    templates: Arc<dyn TemplateProvider>,
+    token_issuer: Arc<dyn TokenIssuer>,
+    token_resolver: Arc<dyn TokenResolver>,
+}
+
+pub struct ControlServiceDependencies {
+    pub repository: Arc<dyn SandboxRepository>,
+    pub executions: Arc<dyn ExecutionManager>,
+    pub clock: Arc<dyn Clock>,
+    pub identities: Arc<dyn SandboxIdentityProvider>,
+    pub templates: Arc<dyn TemplateProvider>,
+    pub token_issuer: Arc<dyn TokenIssuer>,
+    pub token_resolver: Arc<dyn TokenResolver>,
+}
+
+impl ControlService {
+    pub fn new(dependencies: ControlServiceDependencies) -> Self {
+        Self {
+            repository: dependencies.repository,
+            executions: dependencies.executions,
+            clock: dependencies.clock,
+            identities: dependencies.identities,
+            templates: dependencies.templates,
+            token_issuer: dependencies.token_issuer,
+            token_resolver: dependencies.token_resolver,
+        }
+    }
+
+    pub async fn create(
+        &self,
+        request: CreateSandboxRequest,
+    ) -> ControlServiceResult<SandboxConnection> {
+        if request.template_id.trim().is_empty() {
+            return Err(ControlServiceError::InvalidRequest(
+                "template ID cannot be empty".to_string(),
+            ));
+        }
+
+        let identity = self.identities.next_identity()?;
+        let template = self.templates.resolve(&request.template_id).await?;
+        let mut config = template.config;
+        config.resources.timeout = u64::from(request.timeout_seconds);
+        config.extra_env.extend(request.env_vars);
+        match request.allow_internet_access {
+            Some(false) => config.network = NetworkMode::None,
+            Some(true) if matches!(config.network, NetworkMode::None) => {
+                config.network = NetworkMode::Tsi;
+            }
+            _ => {}
+        }
+        let plan = resolve_execution(&config)
+            .map_err(|error| ControlServiceError::InvalidRequest(error.to_string()))?;
+        let now = self.clock.now();
+        let expires_at = expiry_from(now, request.timeout_seconds)?;
+        let envd = self.token_issuer.issue(TokenScope::Envd).await?;
+        let traffic = self.token_issuer.issue(TokenScope::Traffic).await?;
+
+        let mut record = SandboxRecord::creating(NewSandboxRecord {
+            sandbox_id: identity.sandbox_id,
+            operation_id: identity.operation_id,
+            owner_id: request.owner_id,
+            template_id: request.template_id,
+            plan,
+            resources: config.resources.clone(),
+            lifecycle: request.lifecycle,
+            created_at: now,
+            expires_at,
+            metadata: request.metadata.clone(),
+            envd_version: template.envd_version,
+            secure: request.secure,
+            allow_internet_access: request.allow_internet_access,
+            credentials: SandboxCredentials {
+                envd: envd.stored,
+                traffic: traffic.stored,
+            },
+        })?;
+        self.repository.insert(record.clone()).await?;
+
+        let execution_request = CreateExecutionRequest {
+            external_sandbox_id: record.sandbox_id().to_string(),
+            config,
+            labels: request.metadata,
+        };
+        let lease = match self
+            .executions
+            .create_and_start(execution_request, record.operation_id())
+            .await
+        {
+            Ok(lease) => lease,
+            Err(error) => {
+                let expected = record.generation();
+                record.mark_failed(LifecycleFailure::RuntimeFailed)?;
+                self.replace(expected, record).await?;
+                return Err(error.into());
+            }
+        };
+
+        let expected = record.generation();
+        if let Err(error) = record.mark_running(lease) {
+            record.mark_failed(LifecycleFailure::RuntimeFailed)?;
+            self.replace(expected, record).await?;
+            return Err(error.into());
+        }
+        self.replace(expected, record.clone()).await?;
+
+        Ok(SandboxConnection {
+            record,
+            envd_access_token: envd.secret,
+            traffic_access_token: traffic.secret,
+            disposition: ConnectionDisposition::Created,
+        })
+    }
+
+    pub async fn connect(
+        &self,
+        owner_id: &str,
+        sandbox_id: &super::SandboxId,
+        timeout_seconds: u32,
+    ) -> ControlServiceResult<SandboxConnection> {
+        let mut record = self.require_visible(owner_id, sandbox_id).await?;
+        let disposition = match record.state() {
+            LifecycleState::Running => ConnectionDisposition::AlreadyRunning,
+            LifecycleState::Paused => {
+                let execution_id = record
+                    .execution_id()
+                    .cloned()
+                    .ok_or_else(|| ControlServiceError::Conflict(sandbox_id.clone()))?;
+                let execution_generation = record
+                    .execution_generation()
+                    .ok_or_else(|| ControlServiceError::Conflict(sandbox_id.clone()))?;
+                let expected = record.generation();
+                record.begin_resume()?;
+                self.replace(expected, record.clone()).await?;
+
+                let lease = match self
+                    .executions
+                    .resume(&execution_id, execution_generation)
+                    .await
+                {
+                    Ok(lease) => lease,
+                    Err(error) => {
+                        let expected = record.generation();
+                        record.mark_failed(LifecycleFailure::RuntimeFailed)?;
+                        self.replace(expected, record).await?;
+                        return Err(error.into());
+                    }
+                };
+                let expected = record.generation();
+                record.mark_running(lease)?;
+                self.replace(expected, record.clone()).await?;
+                ConnectionDisposition::Resumed
+            }
+            _ => return Err(ControlServiceError::Conflict(sandbox_id.clone())),
+        };
+
+        let expected = record.generation();
+        record.replace_expiry(expiry_from(self.clock.now(), timeout_seconds)?)?;
+        self.replace(expected, record.clone()).await?;
+        self.connection(record, disposition).await
+    }
+
+    pub async fn get(
+        &self,
+        owner_id: &str,
+        sandbox_id: &super::SandboxId,
+    ) -> ControlServiceResult<SandboxRecord> {
+        self.require_visible(owner_id, sandbox_id).await
+    }
+
+    pub async fn list(&self, filter: &SandboxListFilter) -> ControlServiceResult<SandboxPage> {
+        Ok(self.repository.list(filter).await?)
+    }
+
+    pub async fn set_timeout(
+        &self,
+        owner_id: &str,
+        sandbox_id: &super::SandboxId,
+        timeout_seconds: u32,
+    ) -> ControlServiceResult<()> {
+        let mut record = self.require_visible(owner_id, sandbox_id).await?;
+        let expected = record.generation();
+        record.replace_expiry(expiry_from(self.clock.now(), timeout_seconds)?)?;
+        self.replace(expected, record).await
+    }
+
+    pub async fn kill(
+        &self,
+        owner_id: &str,
+        sandbox_id: &super::SandboxId,
+    ) -> ControlServiceResult<bool> {
+        let Some(mut record) = self.repository.get(sandbox_id).await? else {
+            return Ok(false);
+        };
+        if record.owner_id() != owner_id || record.is_terminal() {
+            return Ok(false);
+        }
+
+        let execution = record
+            .execution_id()
+            .cloned()
+            .zip(record.execution_generation());
+        let expected = record.generation();
+        record.begin_kill()?;
+        self.replace(expected, record.clone()).await?;
+
+        if let Some((execution_id, generation)) = execution {
+            self.executions.kill(&execution_id, generation).await?;
+        }
+
+        let expected = record.generation();
+        record.mark_killed()?;
+        self.replace(expected, record).await?;
+        Ok(true)
+    }
+
+    async fn require_visible(
+        &self,
+        owner_id: &str,
+        sandbox_id: &super::SandboxId,
+    ) -> ControlServiceResult<SandboxRecord> {
+        let record = self
+            .repository
+            .get(sandbox_id)
+            .await?
+            .ok_or_else(|| ControlServiceError::NotFound(sandbox_id.clone()))?;
+        if record.owner_id() != owner_id || record.public_state().is_none() {
+            return Err(ControlServiceError::NotFound(sandbox_id.clone()));
+        }
+        Ok(record)
+    }
+
+    async fn connection(
+        &self,
+        record: SandboxRecord,
+        disposition: ConnectionDisposition,
+    ) -> ControlServiceResult<SandboxConnection> {
+        let envd_access_token = self
+            .token_resolver
+            .resolve(&record.credentials().envd)
+            .await?;
+        let traffic_access_token = self
+            .token_resolver
+            .resolve(&record.credentials().traffic)
+            .await?;
+        Ok(SandboxConnection {
+            record,
+            envd_access_token,
+            traffic_access_token,
+            disposition,
+        })
+    }
+
+    async fn replace(
+        &self,
+        expected: super::SandboxGeneration,
+        replacement: SandboxRecord,
+    ) -> ControlServiceResult<()> {
+        let sandbox_id = replacement.sandbox_id().clone();
+        match self
+            .repository
+            .compare_and_swap(&sandbox_id, expected, replacement)
+            .await?
+        {
+            CompareAndSwapResult::Updated => Ok(()),
+            CompareAndSwapResult::NotFound => Err(ControlServiceError::NotFound(sandbox_id)),
+            CompareAndSwapResult::Conflict { .. } => Err(ControlServiceError::Conflict(sandbox_id)),
+        }
+    }
+}
+
+fn expiry_from(now: DateTime<Utc>, timeout_seconds: u32) -> ControlServiceResult<DateTime<Utc>> {
+    now.checked_add_signed(Duration::seconds(i64::from(timeout_seconds)))
+        .ok_or_else(|| ControlServiceError::InvalidRequest("sandbox timeout is too large".into()))
+}

--- a/src/compat/src/control/service_tests.rs
+++ b/src/compat/src/control/service_tests.rs
@@ -1,0 +1,128 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU32;
+
+use chrono::Duration;
+
+use super::test_support::{assert_sandbox_request, create_request, test_time, TestHarness};
+use super::*;
+
+#[tokio::test]
+async fn lifecycle_service_runs_the_official_control_flow() {
+    let harness = TestHarness::new();
+    let created = harness
+        .service
+        .create(create_request("owner-1"))
+        .await
+        .unwrap();
+    assert_eq!(created.disposition, ConnectionDisposition::Created);
+    assert_eq!(created.record.sandbox_id().as_str(), "sandbox-1");
+    assert_eq!(created.record.owner_id(), "owner-1");
+    assert_eq!(
+        created.record.public_state(),
+        Some(PublicSandboxState::Running)
+    );
+    assert_eq!(
+        created.record.expires_at(),
+        test_time() + Duration::seconds(321)
+    );
+    assert_eq!(
+        created.envd_access_token.expose_secret(),
+        "fixture-envd-token"
+    );
+    assert_eq!(
+        created.traffic_access_token.expose_secret(),
+        "fixture-traffic-token"
+    );
+    assert_sandbox_request(&harness.executions.requests()[0]);
+
+    let sandbox_id = created.record.sandbox_id().clone();
+    let connected = harness
+        .service
+        .connect("owner-1", &sandbox_id, 222)
+        .await
+        .unwrap();
+    assert_eq!(connected.disposition, ConnectionDisposition::AlreadyRunning);
+    assert_eq!(
+        connected.record.expires_at(),
+        test_time() + Duration::seconds(222)
+    );
+
+    let page = harness
+        .service
+        .list(&SandboxListFilter {
+            owner_id: "owner-1".to_string(),
+            metadata: BTreeMap::from([("team".to_string(), "alpha beta".to_string())]),
+            states: BTreeSet::from([PublicSandboxState::Running, PublicSandboxState::Paused]),
+            limit: NonZeroU32::new(2).unwrap(),
+            after: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+
+    harness
+        .service
+        .set_timeout("owner-1", &sandbox_id, 123)
+        .await
+        .unwrap();
+    assert_eq!(
+        harness
+            .service
+            .get("owner-1", &sandbox_id)
+            .await
+            .unwrap()
+            .expires_at(),
+        test_time() + Duration::seconds(123)
+    );
+    assert!(harness.service.kill("owner-1", &sandbox_id).await.unwrap());
+    assert!(!harness.service.kill("owner-1", &sandbox_id).await.unwrap());
+    assert!(matches!(
+        harness.service.connect("owner-1", &sandbox_id, 300).await,
+        Err(ControlServiceError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn lifecycle_service_hides_sandboxes_from_other_owners() {
+    let harness = TestHarness::new();
+    let created = harness
+        .service
+        .create(create_request("owner-1"))
+        .await
+        .unwrap();
+    let sandbox_id = created.record.sandbox_id().clone();
+
+    assert!(matches!(
+        harness.service.get("owner-2", &sandbox_id).await,
+        Err(ControlServiceError::NotFound(_))
+    ));
+    assert!(!harness.service.kill("owner-2", &sandbox_id).await.unwrap());
+    let page = harness
+        .service
+        .list(&SandboxListFilter {
+            owner_id: "owner-2".to_string(),
+            metadata: BTreeMap::new(),
+            states: BTreeSet::new(),
+            limit: NonZeroU32::new(100).unwrap(),
+            after: None,
+        })
+        .await
+        .unwrap();
+    assert!(page.records.is_empty());
+}
+
+#[tokio::test]
+async fn failed_runtime_create_is_not_published() {
+    let harness = TestHarness::new();
+    harness.executions.fail_create();
+
+    assert!(matches!(
+        harness.service.create(create_request("owner-1")).await,
+        Err(ControlServiceError::Execution(_))
+    ));
+    let sandbox_id = SandboxId::new("sandbox-1").unwrap();
+    assert!(matches!(
+        harness.service.get("owner-1", &sandbox_id).await,
+        Err(ControlServiceError::NotFound(_))
+    ));
+}

--- a/src/compat/src/control/test_support.rs
+++ b/src/compat/src/control/test_support.rs
@@ -1,0 +1,314 @@
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use a3s_box_core::{
+    resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionId,
+    ExecutionIsolation, ExecutionLease, ExecutionManager, ExecutionManagerError,
+    ExecutionManagerResult, ExecutionState, ExecutionStatus, KillOutcome, NetworkMode, OperationId,
+    ReconcileOutcome, ResourceConfig,
+};
+use async_trait::async_trait;
+use chrono::{DateTime, TimeZone, Utc};
+use sha2::{Digest, Sha256};
+
+use super::*;
+
+pub(crate) struct TestHarness {
+    pub service: Arc<ControlService>,
+    pub executions: Arc<RecordingExecutionManager>,
+}
+
+impl TestHarness {
+    pub fn new() -> Self {
+        let clock = Arc::new(FixedClock(test_time()));
+        let executions = Arc::new(RecordingExecutionManager::new(clock.clone()));
+        let tokens = Arc::new(TestTokens);
+        let service = Arc::new(ControlService::new(ControlServiceDependencies {
+            repository: Arc::new(MemorySandboxRepository::default()),
+            executions: executions.clone(),
+            clock,
+            identities: Arc::new(TestIdentities::default()),
+            templates: Arc::new(TestTemplates),
+            token_issuer: tokens.clone(),
+            token_resolver: tokens,
+        }));
+        Self {
+            service,
+            executions,
+        }
+    }
+}
+
+pub(crate) fn create_request(owner_id: &str) -> CreateSandboxRequest {
+    CreateSandboxRequest {
+        owner_id: owner_id.to_string(),
+        template_id: "fixture-template".to_string(),
+        timeout_seconds: 321,
+        lifecycle: LifecyclePolicy {
+            on_timeout: OnTimeoutAction::Pause,
+            auto_resume: false,
+            keep_memory_on_pause: false,
+        },
+        metadata: BTreeMap::from([
+            ("purpose".to_string(), "fixture".to_string()),
+            ("team".to_string(), "alpha beta".to_string()),
+        ]),
+        env_vars: BTreeMap::from([
+            ("ALPHA".to_string(), "one".to_string()),
+            ("BETA".to_string(), "two".to_string()),
+        ]),
+        secure: true,
+        allow_internet_access: Some(false),
+    }
+}
+
+pub(crate) fn test_time() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 14, 12, 0, 0)
+        .single()
+        .unwrap()
+}
+
+struct FixedClock(DateTime<Utc>);
+
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+#[derive(Default)]
+struct TestIdentities {
+    sequence: AtomicU64,
+}
+
+impl SandboxIdentityProvider for TestIdentities {
+    fn next_identity(&self) -> IdentityProviderResult<SandboxIdentity> {
+        let sequence = self.sequence.fetch_add(1, Ordering::Relaxed) + 1;
+        Ok(SandboxIdentity {
+            sandbox_id: SandboxId::new(format!("sandbox-{sequence}")).unwrap(),
+            operation_id: OperationId::new(format!("operation-{sequence}")).unwrap(),
+        })
+    }
+}
+
+struct TestTemplates;
+
+#[async_trait]
+impl TemplateProvider for TestTemplates {
+    async fn resolve(&self, template_id: &str) -> TemplateProviderResult<ResolvedTemplate> {
+        if template_id != "fixture-template" && template_id != "code-interpreter-v1" {
+            return Err(TemplateProviderError::NotFound(template_id.to_string()));
+        }
+        Ok(ResolvedTemplate {
+            config: BoxConfig {
+                isolation: ExecutionIsolation::Sandbox,
+                resources: ResourceConfig {
+                    vcpus: 2,
+                    memory_mb: 512,
+                    disk_mb: 1024,
+                    timeout: 300,
+                },
+                ..BoxConfig::default()
+            },
+            envd_version: "0.1.3".to_string(),
+        })
+    }
+}
+
+struct TestTokens;
+
+#[async_trait]
+impl TokenIssuer for TestTokens {
+    async fn issue(&self, scope: TokenScope) -> TokenIssuerResult<IssuedToken> {
+        let secret = match scope {
+            TokenScope::Envd => "fixture-envd-token",
+            TokenScope::Traffic => "fixture-traffic-token",
+        };
+        Ok(IssuedToken {
+            secret: SecretToken::new(secret)?,
+            stored: stored_token(secret),
+        })
+    }
+}
+
+#[async_trait]
+impl TokenResolver for TestTokens {
+    async fn resolve(&self, stored: &StoredToken) -> TokenIssuerResult<SecretToken> {
+        SecretToken::new(
+            std::str::from_utf8(stored.ciphertext())
+                .map_err(|_| TokenIssuerError::InvalidMaterial)?,
+        )
+    }
+}
+
+fn stored_token(secret: &str) -> StoredToken {
+    let ciphertext = secret.as_bytes().to_vec();
+    let digest = Sha256::digest(&ciphertext).to_vec();
+    StoredToken::new(1, ciphertext, digest).unwrap()
+}
+
+#[derive(Clone)]
+struct TestExecution {
+    lease: ExecutionLease,
+    state: ExecutionState,
+}
+
+pub(crate) struct RecordingExecutionManager {
+    clock: Arc<dyn Clock>,
+    fail_create: AtomicBool,
+    requests: Mutex<Vec<CreateExecutionRequest>>,
+    operations: Mutex<BTreeMap<String, String>>,
+    executions: Mutex<BTreeMap<String, TestExecution>>,
+}
+
+impl RecordingExecutionManager {
+    fn new(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            clock,
+            fail_create: AtomicBool::new(false),
+            requests: Mutex::new(Vec::new()),
+            operations: Mutex::new(BTreeMap::new()),
+            executions: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    pub fn requests(&self) -> Vec<CreateExecutionRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    pub fn fail_create(&self) {
+        self.fail_create.store(true, Ordering::Relaxed);
+    }
+}
+
+#[async_trait]
+impl ExecutionManager for RecordingExecutionManager {
+    async fn create_and_start(
+        &self,
+        request: CreateExecutionRequest,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        if self.fail_create.load(Ordering::Relaxed) {
+            return Err(ExecutionManagerError::Unavailable("test failure".into()));
+        }
+        self.requests.lock().unwrap().push(request.clone());
+        let plan = resolve_execution(&request.config)
+            .map_err(|error| ExecutionManagerError::InvalidRequest(error.to_string()))?;
+        let execution_id = ExecutionId::new(format!("execution-{}", operation_id.as_str()))?;
+        let lease = ExecutionLease {
+            execution_id: execution_id.clone(),
+            generation: ExecutionGeneration::INITIAL,
+            plan,
+            resources: request.config.resources,
+            started_at: self.clock.now(),
+        };
+        self.operations
+            .lock()
+            .unwrap()
+            .insert(operation_id.as_str().to_string(), execution_id.to_string());
+        self.executions.lock().unwrap().insert(
+            execution_id.to_string(),
+            TestExecution {
+                lease: lease.clone(),
+                state: ExecutionState::Running,
+            },
+        );
+        Ok(lease)
+    }
+
+    async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
+        let executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get(execution_id.as_str())
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        Ok(ExecutionStatus {
+            execution_id: execution_id.clone(),
+            generation: execution.lease.generation,
+            state: execution.state,
+            plan: execution.lease.plan.clone(),
+        })
+    }
+
+    async fn resume(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let mut executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get_mut(execution_id.as_str())
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        if execution.lease.generation != generation || execution.state != ExecutionState::Paused {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id.clone(),
+                message: "stale test resume".to_string(),
+            });
+        }
+        execution.state = ExecutionState::Running;
+        execution.lease.generation = ExecutionGeneration::new(generation.get() + 1)?;
+        Ok(execution.lease.clone())
+    }
+
+    async fn kill(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        let mut executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get_mut(execution_id.as_str())
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        if execution.lease.generation != generation {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id.clone(),
+                message: "stale test kill".to_string(),
+            });
+        }
+        if execution.state == ExecutionState::Stopped {
+            Ok(KillOutcome::AlreadyStopped)
+        } else {
+            execution.state = ExecutionState::Stopped;
+            Ok(KillOutcome::Killed)
+        }
+    }
+
+    async fn reconcile(
+        &self,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ReconcileOutcome> {
+        let Some(execution_id) = self
+            .operations
+            .lock()
+            .unwrap()
+            .get(operation_id.as_str())
+            .cloned()
+        else {
+            return Ok(ReconcileOutcome::Absent);
+        };
+        let executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get(&execution_id)
+            .ok_or_else(|| ExecutionManagerError::Internal("missing test execution".to_string()))?;
+        Ok(match execution.state {
+            ExecutionState::Creating => ReconcileOutcome::Creating,
+            ExecutionState::Running | ExecutionState::Paused => {
+                ReconcileOutcome::Ready(execution.lease.clone())
+            }
+            ExecutionState::Stopped | ExecutionState::Failed => ReconcileOutcome::Failed,
+        })
+    }
+}
+
+pub(crate) fn assert_sandbox_request(request: &CreateExecutionRequest) {
+    assert_eq!(request.config.isolation, ExecutionIsolation::Sandbox);
+    assert_eq!(request.config.network, NetworkMode::None);
+    assert_eq!(request.config.resources.timeout, 321);
+    assert_eq!(
+        request.config.extra_env,
+        vec![
+            ("ALPHA".to_string(), "one".to_string()),
+            ("BETA".to_string(), "two".to_string()),
+        ]
+    );
+}

--- a/src/compat/src/control/tests.rs
+++ b/src/compat/src/control/tests.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroU32;
-use std::sync::Mutex;
 
 use a3s_box_core::{
     resolve_execution, BoxConfig, ExecutionGeneration, ExecutionId, ExecutionLease,
@@ -31,6 +30,7 @@ fn creating_record(id: &str) -> SandboxRecord {
     SandboxRecord::creating(NewSandboxRecord {
         sandbox_id: SandboxId::new(id).unwrap(),
         operation_id: OperationId::new(format!("operation-{id}")).unwrap(),
+        owner_id: "fixture-client".to_string(),
         template_id: "code-interpreter-v1".to_string(),
         plan,
         resources: config.resources,
@@ -43,6 +43,8 @@ fn creating_record(id: &str) -> SandboxRecord {
         expires_at: instant(0) + Duration::seconds(300),
         metadata: BTreeMap::from([("team".to_string(), "fixture".to_string())]),
         envd_version: "0.1.3".to_string(),
+        secure: true,
+        allow_internet_access: Some(false),
         credentials: SandboxCredentials {
             envd: stored_token(10),
             traffic: stored_token(20),
@@ -140,97 +142,9 @@ fn killed_record_is_terminal() {
     ));
 }
 
-#[derive(Default)]
-struct MemoryRepository {
-    records: Mutex<BTreeMap<SandboxId, SandboxRecord>>,
-}
-
-#[async_trait]
-impl SandboxRepository for MemoryRepository {
-    async fn insert(&self, record: SandboxRecord) -> RepositoryResult<()> {
-        let mut records = self.records.lock().unwrap();
-        if records.contains_key(record.sandbox_id()) {
-            return Err(RepositoryError::Duplicate(record.sandbox_id().clone()));
-        }
-        records.insert(record.sandbox_id().clone(), record);
-        Ok(())
-    }
-
-    async fn get(&self, sandbox_id: &SandboxId) -> RepositoryResult<Option<SandboxRecord>> {
-        Ok(self.records.lock().unwrap().get(sandbox_id).cloned())
-    }
-
-    async fn list(&self, filter: &SandboxListFilter) -> RepositoryResult<SandboxPage> {
-        let records = self.records.lock().unwrap();
-        let mut matching = records
-            .values()
-            .filter(|record| {
-                filter.states.is_empty()
-                    || record
-                        .public_state()
-                        .is_some_and(|state| filter.states.contains(&state))
-            })
-            .filter(|record| {
-                filter
-                    .metadata
-                    .iter()
-                    .all(|(key, value)| record.metadata().get(key) == Some(value))
-            })
-            .filter(|record| {
-                filter.after.as_ref().is_none_or(|cursor| {
-                    (record.created_at(), record.sandbox_id())
-                        > (cursor.created_at, &cursor.sandbox_id)
-                })
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        matching.sort_by(|left, right| {
-            (left.created_at(), left.sandbox_id()).cmp(&(right.created_at(), right.sandbox_id()))
-        });
-        let limit = filter.limit.get() as usize;
-        let has_more = matching.len() > limit;
-        matching.truncate(limit);
-        let next = has_more.then(|| {
-            let last = matching.last().unwrap();
-            SandboxCursor {
-                created_at: last.created_at(),
-                sandbox_id: last.sandbox_id().clone(),
-            }
-        });
-        Ok(SandboxPage {
-            records: matching,
-            next,
-        })
-    }
-
-    async fn compare_and_swap(
-        &self,
-        sandbox_id: &SandboxId,
-        expected: SandboxGeneration,
-        replacement: SandboxRecord,
-    ) -> RepositoryResult<CompareAndSwapResult> {
-        if replacement.sandbox_id() != sandbox_id || replacement.generation() <= expected {
-            return Err(RepositoryError::Corrupt(
-                "invalid compare-and-swap replacement".to_string(),
-            ));
-        }
-        let mut records = self.records.lock().unwrap();
-        let Some(current) = records.get(sandbox_id) else {
-            return Ok(CompareAndSwapResult::NotFound);
-        };
-        if current.generation() != expected {
-            return Ok(CompareAndSwapResult::Conflict {
-                actual_generation: current.generation(),
-            });
-        }
-        records.insert(sandbox_id.clone(), replacement);
-        Ok(CompareAndSwapResult::Updated)
-    }
-}
-
 #[tokio::test]
 async fn repository_compare_and_swap_rejects_stale_generation() {
-    let repository = MemoryRepository::default();
+    let repository = MemorySandboxRepository::default();
     let mut original = creating_record("sandbox-1");
     repository.insert(original.clone()).await.unwrap();
     let stale_generation = original.generation();
@@ -262,7 +176,7 @@ async fn repository_compare_and_swap_rejects_stale_generation() {
 
 #[tokio::test]
 async fn repository_list_port_preserves_cursor_and_filters() {
-    let repository = MemoryRepository::default();
+    let repository = MemorySandboxRepository::default();
     for id in ["sandbox-1", "sandbox-2"] {
         let mut record = creating_record(id);
         record.mark_running(execution_lease(&record, 1)).unwrap();
@@ -270,6 +184,7 @@ async fn repository_list_port_preserves_cursor_and_filters() {
     }
     let first = repository
         .list(&SandboxListFilter {
+            owner_id: "fixture-client".to_string(),
             metadata: BTreeMap::from([("team".to_string(), "fixture".to_string())]),
             states: BTreeSet::from([PublicSandboxState::Running]),
             limit: NonZeroU32::new(1).unwrap(),
@@ -282,6 +197,7 @@ async fn repository_list_port_preserves_cursor_and_filters() {
 
     let second = repository
         .list(&SandboxListFilter {
+            owner_id: "fixture-client".to_string(),
             metadata: BTreeMap::new(),
             states: BTreeSet::new(),
             limit: NonZeroU32::new(1).unwrap(),

--- a/src/compat/src/http/auth.rs
+++ b/src/compat/src/http/auth.rs
@@ -1,0 +1,115 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use axum::http::{header, HeaderMap};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialScheme {
+    ApiKey,
+    Bearer,
+    Supabase,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct PresentedCredential {
+    scheme: CredentialScheme,
+    secret: String,
+    owner_hint: Option<String>,
+}
+
+impl PresentedCredential {
+    pub fn from_headers(headers: &HeaderMap) -> AuthenticationResult<Self> {
+        if let Some(value) = headers.get("x-api-key") {
+            return Ok(Self {
+                scheme: CredentialScheme::ApiKey,
+                secret: header_value(value)?,
+                owner_hint: None,
+            });
+        }
+
+        if let Some(value) = headers.get("x-supabase-token") {
+            let owner_hint = headers
+                .get("x-supabase-team")
+                .map(header_value)
+                .transpose()?;
+            return Ok(Self {
+                scheme: CredentialScheme::Supabase,
+                secret: header_value(value)?,
+                owner_hint,
+            });
+        }
+
+        if let Some(value) = headers.get(header::AUTHORIZATION) {
+            let authorization = header_value(value)?;
+            let secret = authorization
+                .strip_prefix("Bearer ")
+                .filter(|secret| !secret.is_empty())
+                .ok_or(AuthenticationError::Invalid)?;
+            let owner_hint = headers.get("x-team-id").map(header_value).transpose()?;
+            return Ok(Self {
+                scheme: CredentialScheme::Bearer,
+                secret: secret.to_string(),
+                owner_hint,
+            });
+        }
+
+        Err(AuthenticationError::Missing)
+    }
+
+    pub const fn scheme(&self) -> CredentialScheme {
+        self.scheme
+    }
+
+    pub fn expose_secret(&self) -> &str {
+        &self.secret
+    }
+
+    pub fn owner_hint(&self) -> Option<&str> {
+        self.owner_hint.as_deref()
+    }
+}
+
+impl fmt::Debug for PresentedCredential {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PresentedCredential")
+            .field("scheme", &self.scheme)
+            .field("secret", &"[REDACTED]")
+            .field("owner_hint", &self.owner_hint)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedAccount {
+    pub owner_id: String,
+    pub client_id: String,
+}
+
+#[derive(Debug, Error)]
+pub enum AuthenticationError {
+    #[error("authentication credential is missing")]
+    Missing,
+    #[error("authentication credential is invalid")]
+    Invalid,
+    #[error("authentication provider is unavailable: {0}")]
+    Unavailable(String),
+}
+
+pub type AuthenticationResult<T> = std::result::Result<T, AuthenticationError>;
+
+#[async_trait]
+pub trait CredentialVerifier: Send + Sync {
+    async fn verify(
+        &self,
+        credential: &PresentedCredential,
+    ) -> AuthenticationResult<AuthenticatedAccount>;
+}
+
+fn header_value(value: &axum::http::HeaderValue) -> AuthenticationResult<String> {
+    value
+        .to_str()
+        .map(str::to_string)
+        .map_err(|_| AuthenticationError::Invalid)
+}

--- a/src/compat/src/http/cursor.rs
+++ b/src/compat/src/http/cursor.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+
+use crate::control::SandboxCursor;
+
+#[derive(Debug, Error)]
+pub enum CursorError {
+    #[error("sandbox cursor is invalid")]
+    Invalid,
+    #[error("sandbox cursor provider is unavailable: {0}")]
+    Unavailable(String),
+}
+
+pub type CursorResult<T> = std::result::Result<T, CursorError>;
+
+pub trait CursorDecoder: Send + Sync {
+    fn decode(&self, value: &str) -> CursorResult<Option<SandboxCursor>>;
+}
+
+#[derive(Debug, Default)]
+pub struct RejectingCursorDecoder;
+
+impl CursorDecoder for RejectingCursorDecoder {
+    fn decode(&self, _value: &str) -> CursorResult<Option<SandboxCursor>> {
+        Err(CursorError::Invalid)
+    }
+}

--- a/src/compat/src/http/dto.rs
+++ b/src/compat/src/http/dto.rs
@@ -1,0 +1,319 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU32;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::control::{
+    ConnectionDisposition, CreateSandboxRequest, LifecyclePolicy, OnTimeoutAction,
+    PublicSandboxState, SandboxConnection, SandboxListFilter, SandboxRecord,
+};
+
+use super::cursor::CursorDecoder;
+use super::error::ApiError;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NewSandboxBody {
+    #[serde(rename = "templateID")]
+    template_id: String,
+    #[serde(default = "default_timeout")]
+    timeout: u32,
+    #[serde(rename = "autoPause", default)]
+    auto_pause: bool,
+    #[serde(rename = "autoPauseMemory", default = "default_true")]
+    auto_pause_memory: bool,
+    #[serde(rename = "autoResume", default)]
+    auto_resume: AutoResumeBody,
+    #[serde(default)]
+    secure: bool,
+    #[serde(default)]
+    allow_internet_access: Option<bool>,
+    #[serde(default)]
+    metadata: BTreeMap<String, String>,
+    #[serde(rename = "envVars", default)]
+    env_vars: BTreeMap<String, String>,
+    #[serde(default)]
+    network: Option<serde_json::Value>,
+    #[serde(default)]
+    mcp: Option<serde_json::Value>,
+    #[serde(rename = "volumeMounts", default)]
+    volume_mounts: Vec<serde_json::Value>,
+}
+
+impl NewSandboxBody {
+    pub fn into_control(self, owner_id: String) -> Result<CreateSandboxRequest, ApiError> {
+        if self.network.is_some() || self.mcp.is_some() || !self.volume_mounts.is_empty() {
+            return Err(ApiError::bad_request(
+                "network, MCP, and volume mount overrides are not available in this preview",
+            ));
+        }
+        if self.auto_resume.enabled && self.auto_pause && !self.auto_pause_memory {
+            return Err(ApiError::bad_request(
+                "auto-resume requires memory-preserving auto-pause",
+            ));
+        }
+        Ok(CreateSandboxRequest {
+            owner_id,
+            template_id: self.template_id,
+            timeout_seconds: self.timeout,
+            lifecycle: LifecyclePolicy {
+                on_timeout: if self.auto_pause {
+                    OnTimeoutAction::Pause
+                } else {
+                    OnTimeoutAction::Kill
+                },
+                auto_resume: self.auto_resume.enabled,
+                keep_memory_on_pause: self.auto_pause_memory,
+            },
+            metadata: self.metadata,
+            env_vars: self.env_vars,
+            secure: self.secure,
+            allow_internet_access: self.allow_internet_access,
+        })
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AutoResumeBody {
+    #[serde(default)]
+    enabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimeoutBody {
+    pub timeout: u32,
+}
+
+pub fn parse_list_filter(
+    owner_id: String,
+    raw_query: Option<&str>,
+    cursors: &dyn CursorDecoder,
+) -> Result<SandboxListFilter, ApiError> {
+    let mut metadata = BTreeMap::new();
+    let mut states = BTreeSet::new();
+    let mut limit = NonZeroU32::new(100).unwrap_or(NonZeroU32::MIN);
+    let mut after = None;
+
+    for (name, value) in url::form_urlencoded::parse(raw_query.unwrap_or_default().as_bytes()) {
+        match name.as_ref() {
+            "metadata" => metadata.extend(parse_metadata(&value)?),
+            "state" => {
+                for state in value.split(',') {
+                    states.insert(match state {
+                        "running" => PublicSandboxState::Running,
+                        "paused" => PublicSandboxState::Paused,
+                        _ => return Err(ApiError::bad_request("invalid sandbox state filter")),
+                    });
+                }
+            }
+            "limit" => {
+                let parsed = value
+                    .parse::<u32>()
+                    .ok()
+                    .filter(|value| (1..=100).contains(value))
+                    .and_then(NonZeroU32::new)
+                    .ok_or_else(|| ApiError::bad_request("limit must be between 1 and 100"))?;
+                limit = parsed;
+            }
+            "nextToken" => after = cursors.decode(&value)?.or(after),
+            _ => {
+                return Err(ApiError::bad_request(
+                    "unknown sandbox list query parameter",
+                ))
+            }
+        }
+    }
+
+    Ok(SandboxListFilter {
+        owner_id,
+        metadata,
+        states,
+        limit,
+        after,
+    })
+}
+
+fn parse_metadata(value: &str) -> Result<BTreeMap<String, String>, ApiError> {
+    let mut metadata = BTreeMap::new();
+    for (key, value) in url::form_urlencoded::parse(value.as_bytes()) {
+        let decoded = url::form_urlencoded::parse(format!("value={value}").as_bytes())
+            .next()
+            .map(|(_, value)| value.into_owned())
+            .unwrap_or_default();
+        if key.is_empty() {
+            return Err(ApiError::bad_request("metadata keys cannot be empty"));
+        }
+        metadata.insert(key.into_owned(), decoded);
+    }
+    Ok(metadata)
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxResponse {
+    #[serde(rename = "templateID")]
+    template_id: String,
+    #[serde(rename = "sandboxID")]
+    sandbox_id: String,
+    #[serde(rename = "clientID")]
+    client_id: String,
+    #[serde(rename = "envdVersion")]
+    envd_version: String,
+    envd_access_token: String,
+    traffic_access_token: Option<String>,
+    domain: Option<String>,
+}
+
+impl SandboxResponse {
+    pub fn from_connection(
+        connection: SandboxConnection,
+        client_id: String,
+        domain: Option<String>,
+    ) -> (Self, ConnectionDisposition) {
+        let disposition = connection.disposition;
+        let response = Self {
+            template_id: connection.record.template_id().to_string(),
+            sandbox_id: connection.record.sandbox_id().to_string(),
+            client_id,
+            envd_version: connection.record.envd_version().to_string(),
+            envd_access_token: connection.envd_access_token.expose_secret().to_string(),
+            traffic_access_token: Some(connection.traffic_access_token.expose_secret().to_string()),
+            domain,
+        };
+        (response, disposition)
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListedSandboxResponse {
+    #[serde(rename = "templateID")]
+    template_id: String,
+    #[serde(rename = "sandboxID")]
+    sandbox_id: String,
+    #[serde(rename = "clientID")]
+    client_id: String,
+    started_at: String,
+    end_at: String,
+    cpu_count: u32,
+    #[serde(rename = "memoryMB")]
+    memory_mb: u32,
+    #[serde(rename = "diskSizeMB")]
+    disk_size_mb: u32,
+    metadata: BTreeMap<String, String>,
+    state: PublicSandboxState,
+    envd_version: String,
+    volume_mounts: Vec<VolumeMountResponse>,
+}
+
+impl ListedSandboxResponse {
+    pub fn from_record(record: &SandboxRecord, client_id: String) -> Option<Self> {
+        Some(Self {
+            template_id: record.template_id().to_string(),
+            sandbox_id: record.sandbox_id().to_string(),
+            client_id,
+            started_at: format_time(record.started_at()?),
+            end_at: format_time(record.expires_at()),
+            cpu_count: record.resources().vcpus,
+            memory_mb: record.resources().memory_mb,
+            disk_size_mb: record.resources().disk_mb,
+            metadata: record.metadata().clone(),
+            state: record.public_state()?,
+            envd_version: record.envd_version().to_string(),
+            volume_mounts: Vec::new(),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxDetailResponse {
+    #[serde(flatten)]
+    listed: ListedSandboxResponse,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    envd_access_token: Option<String>,
+    allow_internet_access: Option<bool>,
+    domain: Option<String>,
+    lifecycle: LifecycleResponse,
+}
+
+impl SandboxDetailResponse {
+    pub fn from_record(
+        record: &SandboxRecord,
+        client_id: String,
+        domain: Option<String>,
+    ) -> Option<Self> {
+        Some(Self {
+            listed: ListedSandboxResponse::from_record(record, client_id)?,
+            envd_access_token: None,
+            allow_internet_access: record.allow_internet_access(),
+            domain,
+            lifecycle: LifecycleResponse {
+                auto_resume: record.lifecycle().auto_resume,
+                on_timeout: record.lifecycle().on_timeout,
+            },
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LifecycleResponse {
+    auto_resume: bool,
+    on_timeout: OnTimeoutAction,
+}
+
+#[derive(Debug, Serialize)]
+struct VolumeMountResponse {
+    name: String,
+    path: String,
+}
+
+fn default_timeout() -> u32 {
+    15
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn format_time(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::{CursorError, CursorResult};
+
+    struct FixtureCursor;
+
+    impl CursorDecoder for FixtureCursor {
+        fn decode(&self, value: &str) -> CursorResult<Option<crate::control::SandboxCursor>> {
+            if value == "cursor-0" {
+                Ok(None)
+            } else {
+                Err(CursorError::Invalid)
+            }
+        }
+    }
+
+    #[test]
+    fn parses_the_official_clients_nested_metadata_query() {
+        let filter = parse_list_filter(
+            "fixture-client".to_string(),
+            Some(
+                "limit=2&metadata=team%3Dalpha%252520beta&nextToken=cursor-0&state=running%2Cpaused",
+            ),
+            &FixtureCursor,
+        )
+        .unwrap();
+
+        assert_eq!(filter.metadata.get("team").unwrap(), "alpha beta");
+        assert_eq!(filter.limit.get(), 2);
+        assert_eq!(filter.states.len(), 2);
+    }
+}

--- a/src/compat/src/http/error.rs
+++ b/src/compat/src/http/error.rs
@@ -1,0 +1,123 @@
+use axum::extract::rejection::JsonRejection;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+
+use crate::control::{ControlServiceError, RepositoryError, TemplateProviderError};
+
+use super::{AuthenticationError, CursorError};
+
+#[derive(Debug)]
+pub struct ApiError {
+    status: StatusCode,
+    message: String,
+}
+
+impl ApiError {
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
+    }
+
+    pub fn not_found() -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            message: "Sandbox not found".to_string(),
+        }
+    }
+
+    pub fn unauthorized(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::UNAUTHORIZED,
+            message: message.into(),
+        }
+    }
+
+    pub fn internal() -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: "Internal server error".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    code: u16,
+    message: String,
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = ErrorResponse {
+            code: self.status.as_u16(),
+            message: self.message,
+        };
+        (self.status, Json(body)).into_response()
+    }
+}
+
+impl From<JsonRejection> for ApiError {
+    fn from(error: JsonRejection) -> Self {
+        Self::bad_request(format!("Invalid JSON request: {}", error.body_text()))
+    }
+}
+
+impl From<AuthenticationError> for ApiError {
+    fn from(error: AuthenticationError) -> Self {
+        match error {
+            AuthenticationError::Missing | AuthenticationError::Invalid => {
+                Self::unauthorized("Invalid authentication credentials")
+            }
+            AuthenticationError::Unavailable(_) => Self::internal(),
+        }
+    }
+}
+
+impl From<CursorError> for ApiError {
+    fn from(error: CursorError) -> Self {
+        match error {
+            CursorError::Invalid => Self::bad_request("Invalid pagination cursor"),
+            CursorError::Unavailable(_) => Self::internal(),
+        }
+    }
+}
+
+impl From<ControlServiceError> for ApiError {
+    fn from(error: ControlServiceError) -> Self {
+        match error {
+            ControlServiceError::InvalidRequest(message) => Self::bad_request(message),
+            ControlServiceError::NotFound(_) => Self::not_found(),
+            ControlServiceError::Conflict(_) => Self {
+                status: StatusCode::CONFLICT,
+                message: "Sandbox lifecycle conflict".to_string(),
+            },
+            ControlServiceError::Template(TemplateProviderError::NotFound(_)) => Self::not_found(),
+            ControlServiceError::Template(TemplateProviderError::Invalid(message)) => {
+                Self::bad_request(message)
+            }
+            ControlServiceError::Repository(RepositoryError::Duplicate(_)) => Self {
+                status: StatusCode::CONFLICT,
+                message: "Sandbox already exists".to_string(),
+            },
+            ControlServiceError::Execution(a3s_box_core::ExecutionManagerError::NotFound(_)) => {
+                Self::not_found()
+            }
+            ControlServiceError::Execution(a3s_box_core::ExecutionManagerError::Conflict {
+                ..
+            })
+            | ControlServiceError::Lifecycle(_) => Self {
+                status: StatusCode::CONFLICT,
+                message: "Sandbox lifecycle conflict".to_string(),
+            },
+            ControlServiceError::Repository(_)
+            | ControlServiceError::Execution(_)
+            | ControlServiceError::Identity(_)
+            | ControlServiceError::Template(_)
+            | ControlServiceError::Credential(_) => Self::internal(),
+        }
+    }
+}

--- a/src/compat/src/http/lifecycle.rs
+++ b/src/compat/src/http/lifecycle.rs
@@ -1,0 +1,118 @@
+use axum::extract::{rejection::JsonRejection, Extension, Path, RawQuery, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+
+use crate::control::{ConnectionDisposition, SandboxId};
+
+use super::dto::{
+    parse_list_filter, ListedSandboxResponse, NewSandboxBody, SandboxDetailResponse,
+    SandboxResponse, TimeoutBody,
+};
+use super::error::ApiError;
+use super::router::LifecycleHttpState;
+use super::AuthenticatedAccount;
+
+pub async fn create(
+    State(state): State<LifecycleHttpState>,
+    Extension(account): Extension<AuthenticatedAccount>,
+    body: Result<Json<NewSandboxBody>, JsonRejection>,
+) -> Result<impl IntoResponse, ApiError> {
+    let request = body?.0.into_control(account.owner_id)?;
+    let connection = state.service().create(request).await?;
+    let (response, _) = SandboxResponse::from_connection(
+        connection,
+        account.client_id,
+        state.domain().map(str::to_string),
+    );
+    Ok((StatusCode::CREATED, Json(response)))
+}
+
+pub async fn connect(
+    State(state): State<LifecycleHttpState>,
+    Extension(account): Extension<AuthenticatedAccount>,
+    Path(sandbox_id): Path<String>,
+    body: Result<Json<TimeoutBody>, JsonRejection>,
+) -> Result<impl IntoResponse, ApiError> {
+    let sandbox_id = parse_sandbox_id(sandbox_id)?;
+    let connection = state
+        .service()
+        .connect(&account.owner_id, &sandbox_id, body?.0.timeout)
+        .await?;
+    let (response, disposition) = SandboxResponse::from_connection(
+        connection,
+        account.client_id,
+        state.domain().map(str::to_string),
+    );
+    let status = match disposition {
+        ConnectionDisposition::Resumed => StatusCode::CREATED,
+        ConnectionDisposition::AlreadyRunning | ConnectionDisposition::Created => StatusCode::OK,
+    };
+    Ok((status, Json(response)))
+}
+
+pub async fn list(
+    State(state): State<LifecycleHttpState>,
+    Extension(account): Extension<AuthenticatedAccount>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<Json<Vec<ListedSandboxResponse>>, ApiError> {
+    let filter = parse_list_filter(
+        account.owner_id,
+        raw_query.as_deref(),
+        state.cursors().as_ref(),
+    )?;
+    let page = state.service().list(&filter).await?;
+    let records = page
+        .records
+        .iter()
+        .filter_map(|record| ListedSandboxResponse::from_record(record, account.client_id.clone()))
+        .collect();
+    Ok(Json(records))
+}
+
+pub async fn get(
+    State(state): State<LifecycleHttpState>,
+    Extension(account): Extension<AuthenticatedAccount>,
+    Path(sandbox_id): Path<String>,
+) -> Result<Json<SandboxDetailResponse>, ApiError> {
+    let sandbox_id = parse_sandbox_id(sandbox_id)?;
+    let record = state.service().get(&account.owner_id, &sandbox_id).await?;
+    let response = SandboxDetailResponse::from_record(
+        &record,
+        account.client_id,
+        state.domain().map(str::to_string),
+    )
+    .ok_or_else(ApiError::not_found)?;
+    Ok(Json(response))
+}
+
+pub async fn set_timeout(
+    State(state): State<LifecycleHttpState>,
+    Extension(account): Extension<AuthenticatedAccount>,
+    Path(sandbox_id): Path<String>,
+    body: Result<Json<TimeoutBody>, JsonRejection>,
+) -> Result<StatusCode, ApiError> {
+    let sandbox_id = parse_sandbox_id(sandbox_id)?;
+    state
+        .service()
+        .set_timeout(&account.owner_id, &sandbox_id, body?.0.timeout)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn kill(
+    State(state): State<LifecycleHttpState>,
+    Extension(account): Extension<AuthenticatedAccount>,
+    Path(sandbox_id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let sandbox_id = parse_sandbox_id(sandbox_id)?;
+    if state.service().kill(&account.owner_id, &sandbox_id).await? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ApiError::not_found())
+    }
+}
+
+fn parse_sandbox_id(value: String) -> Result<SandboxId, ApiError> {
+    SandboxId::new(value).map_err(|_| ApiError::bad_request("Invalid sandbox ID"))
+}

--- a/src/compat/src/http/mod.rs
+++ b/src/compat/src/http/mod.rs
@@ -1,0 +1,16 @@
+mod auth;
+mod cursor;
+mod dto;
+mod error;
+mod lifecycle;
+mod router;
+
+pub use auth::{
+    AuthenticatedAccount, AuthenticationError, AuthenticationResult, CredentialScheme,
+    CredentialVerifier, PresentedCredential,
+};
+pub use cursor::{CursorDecoder, CursorError, CursorResult, RejectingCursorDecoder};
+pub use router::{lifecycle_router, LifecycleHttpConfig, LifecycleHttpState};
+
+#[cfg(test)]
+mod tests;

--- a/src/compat/src/http/router.rs
+++ b/src/compat/src/http/router.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use axum::extract::{DefaultBodyLimit, State};
+use axum::http::Request;
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::Router;
+
+use crate::control::ControlService;
+
+use super::auth::{CredentialVerifier, PresentedCredential};
+use super::cursor::CursorDecoder;
+use super::error::ApiError;
+use super::lifecycle;
+
+#[derive(Debug, Clone)]
+pub struct LifecycleHttpConfig {
+    pub domain: Option<String>,
+    pub max_json_bytes: usize,
+}
+
+impl Default for LifecycleHttpConfig {
+    fn default() -> Self {
+        Self {
+            domain: None,
+            max_json_bytes: 1024 * 1024,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct LifecycleHttpState {
+    service: Arc<ControlService>,
+    verifier: Arc<dyn CredentialVerifier>,
+    cursors: Arc<dyn CursorDecoder>,
+    config: LifecycleHttpConfig,
+}
+
+impl LifecycleHttpState {
+    pub fn new(
+        service: Arc<ControlService>,
+        verifier: Arc<dyn CredentialVerifier>,
+        cursors: Arc<dyn CursorDecoder>,
+        config: LifecycleHttpConfig,
+    ) -> Self {
+        Self {
+            service,
+            verifier,
+            cursors,
+            config,
+        }
+    }
+
+    pub(crate) fn service(&self) -> &ControlService {
+        &self.service
+    }
+
+    pub(crate) fn cursors(&self) -> &Arc<dyn CursorDecoder> {
+        &self.cursors
+    }
+
+    pub(crate) fn domain(&self) -> Option<&str> {
+        self.config.domain.as_deref()
+    }
+}
+
+pub fn lifecycle_router(state: LifecycleHttpState) -> Router {
+    let max_json_bytes = state.config.max_json_bytes;
+    Router::new()
+        .route("/sandboxes", post(lifecycle::create))
+        .route("/v2/sandboxes", get(lifecycle::list))
+        .route(
+            "/sandboxes/:sandbox_id",
+            get(lifecycle::get).delete(lifecycle::kill),
+        )
+        .route("/sandboxes/:sandbox_id/connect", post(lifecycle::connect))
+        .route(
+            "/sandboxes/:sandbox_id/timeout",
+            post(lifecycle::set_timeout),
+        )
+        .fallback(fallback)
+        .route_layer(middleware::from_fn_with_state(state.clone(), authenticate))
+        .layer(DefaultBodyLimit::max(max_json_bytes))
+        .with_state(state)
+}
+
+async fn authenticate<B>(
+    State(state): State<LifecycleHttpState>,
+    mut request: Request<B>,
+    next: Next<B>,
+) -> Response {
+    let result = async {
+        let credential = PresentedCredential::from_headers(request.headers())?;
+        let account = state.verifier.verify(&credential).await?;
+        request.extensions_mut().insert(account);
+        Ok::<_, ApiError>(next.run(request).await)
+    }
+    .await;
+    result.unwrap_or_else(IntoResponse::into_response)
+}
+
+async fn fallback() -> ApiError {
+    ApiError::not_found()
+}

--- a/src/compat/src/http/tests.rs
+++ b/src/compat/src/http/tests.rs
@@ -1,0 +1,192 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use axum::Router;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+use crate::control::test_support::TestHarness;
+
+use super::*;
+
+struct TestCredentialVerifier;
+
+#[async_trait]
+impl CredentialVerifier for TestCredentialVerifier {
+    async fn verify(
+        &self,
+        credential: &PresentedCredential,
+    ) -> AuthenticationResult<AuthenticatedAccount> {
+        if credential.scheme() != CredentialScheme::ApiKey
+            || credential.expose_secret() != "e2b_a1b2c3"
+        {
+            return Err(AuthenticationError::Invalid);
+        }
+        Ok(AuthenticatedAccount {
+            owner_id: "owner-1".to_string(),
+            client_id: "fixture-client".to_string(),
+        })
+    }
+}
+
+struct TestCursorDecoder;
+
+impl CursorDecoder for TestCursorDecoder {
+    fn decode(&self, value: &str) -> CursorResult<Option<crate::control::SandboxCursor>> {
+        if value == "cursor-0" {
+            Ok(None)
+        } else {
+            Err(CursorError::Invalid)
+        }
+    }
+}
+
+fn app() -> Router {
+    let harness = TestHarness::new();
+    lifecycle_router(LifecycleHttpState::new(
+        harness.service,
+        Arc::new(TestCredentialVerifier),
+        Arc::new(TestCursorDecoder),
+        LifecycleHttpConfig {
+            domain: Some("fixture.invalid".to_string()),
+            ..LifecycleHttpConfig::default()
+        },
+    ))
+}
+
+#[tokio::test]
+async fn router_serves_the_pinned_official_lifecycle_shape() {
+    let app = app();
+    let create_body = json!({
+        "allow_internet_access": false,
+        "autoPause": true,
+        "autoPauseMemory": false,
+        "autoResume": {"enabled": false},
+        "envVars": {"ALPHA": "one", "BETA": "two"},
+        "metadata": {"purpose": "fixture", "team": "alpha beta"},
+        "secure": true,
+        "templateID": "fixture-template",
+        "timeout": 321
+    });
+    let response = send(&app, Method::POST, "/sandboxes", Some(create_body), true).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = body_json(response).await;
+    assert_eq!(created["sandboxID"], "sandbox-1");
+    assert_eq!(created["clientID"], "fixture-client");
+    assert_eq!(created["envdAccessToken"], "fixture-envd-token");
+    assert_eq!(created["trafficAccessToken"], "fixture-traffic-token");
+    assert_eq!(created["domain"], "fixture.invalid");
+
+    let response = send(
+        &app,
+        Method::POST,
+        "/sandboxes/sandbox-1/connect",
+        Some(json!({"timeout": 222})),
+        true,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = send(
+        &app,
+        Method::GET,
+        "/v2/sandboxes?limit=2&metadata=team%3Dalpha%252520beta&nextToken=cursor-0&state=running%2Cpaused",
+        None,
+        true,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let listed = body_json(response).await;
+    assert_eq!(listed.as_array().unwrap().len(), 1);
+    assert_eq!(listed[0]["sandboxID"], "sandbox-1");
+    assert_eq!(listed[0]["state"], "running");
+
+    let response = send(&app, Method::GET, "/sandboxes/sandbox-1", None, true).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let detail = body_json(response).await;
+    assert_eq!(detail["allowInternetAccess"], false);
+    assert_eq!(detail["lifecycle"]["onTimeout"], "pause");
+
+    let response = send(
+        &app,
+        Method::POST,
+        "/sandboxes/sandbox-1/timeout",
+        Some(json!({"timeout": 123})),
+        true,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let response = send(&app, Method::DELETE, "/sandboxes/sandbox-1", None, true).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let response = send(
+        &app,
+        Method::DELETE,
+        "/sandboxes/missing-sandbox",
+        None,
+        true,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(body_json(response).await["code"], 404);
+}
+
+#[tokio::test]
+async fn router_requires_authentication_and_maps_invalid_json() {
+    let app = app();
+    let response = send(&app, Method::GET, "/v2/sandboxes", None, false).await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/sandboxes")
+        .header("x-api-key", "e2b_a1b2c3")
+        .header("content-type", "application/json")
+        .body(Body::from("{"))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn presented_credentials_redact_secret_debug_material() {
+    let headers = axum::http::HeaderMap::from_iter([(
+        axum::http::HeaderName::from_static("x-api-key"),
+        axum::http::HeaderValue::from_static("e2b_a1b2c3"),
+    )]);
+    let credential = PresentedCredential::from_headers(&headers).unwrap();
+    let debug = format!("{credential:?}");
+    assert!(!debug.contains("e2b_a1b2c3"));
+    assert!(debug.contains("REDACTED"));
+}
+
+async fn send(
+    app: &Router,
+    method: Method,
+    uri: &str,
+    body: Option<Value>,
+    authenticated: bool,
+) -> axum::response::Response {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if authenticated {
+        builder = builder.header("x-api-key", "e2b_a1b2c3");
+    }
+    let body = if let Some(body) = body {
+        builder = builder.header("content-type", "application/json");
+        Body::from(serde_json::to_vec(&body).unwrap())
+    } else {
+        Body::empty()
+    };
+    app.clone()
+        .oneshot(builder.body(body).unwrap())
+        .await
+        .unwrap()
+}
+
+async fn body_json(response: axum::response::Response) -> Value {
+    let bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}

--- a/src/compat/src/lib.rs
+++ b/src/compat/src/lib.rs
@@ -8,5 +8,6 @@ mod openapi;
 mod proto;
 
 pub mod control;
+pub mod http;
 
 pub use fixture::{generate_fixture, verify_fixture, FixturePaths};


### PR DESCRIPTION
## Summary

- add an owner-scoped lifecycle service with generation-fenced repository and execution ports
- implement authenticated create, connect, get, list, timeout, and kill HTTP routes
- add a deterministic Rust fixture server backed by an in-memory repository and fake execution manager
- require pinned official Python sync/async, TypeScript, and Code Interpreter clients to run against the Rust router in CI
- preserve full_compatibility=false until real sandbox execution and the remaining protocol phases pass

## Validation

- cargo fmt --all -- --check
- cargo test -p a3s-box-core -p a3s-box-compat
- cargo clippy -p a3s-box-core -p a3s-box-compat --all-targets -- -D warnings
- cargo run -p a3s-box-compat --bin a3s-box-e2b-contract -- verify
- pinned official clients against recorder and live Rust fixture server on A3S OS