### PR TITLE
feat(runtime): persist managed execution recovery metadata

### DIFF
--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -750,6 +750,10 @@ facade. The runtime now also owns strict and recovery-compatible reads, the
 cross-process advisory lock, durable atomic writes, and synchronous
 read-modify-write transactions. The Rust SDK uses that store directly; the CLI
 keeps only its process reconciliation and resource-cleanup policy wrapper.
+Managed records also have an optional typed recovery envelope containing the
+operation ID, runtime generation, full creation request, and resolved execution
+plan. Legacy CLI records omit it, while the runtime manager will persist it
+before launch to make create retries and restart reconciliation deterministic.
 Slice 4 remains incomplete until the real `ExecutionManager` owns
 create/start/run for both callers.
 

--- a/src/cli/src/boot.rs
+++ b/src/cli/src/boot.rs
@@ -440,6 +440,7 @@ mod tests {
             name: "test_box".to_string(),
             image: "alpine:latest".to_string(),
             isolation: Default::default(),
+            managed_execution: None,
             status: "stopped".to_string(),
             pid: None,
             pid_start_time: None,

--- a/src/cli/src/commands/compose.rs
+++ b/src/cli/src/commands/compose.rs
@@ -551,6 +551,7 @@ async fn execute_up(
             name: box_name,
             image,
             isolation: record_isolation,
+            managed_execution: None,
             status: "running".to_string(),
             pid,
             pid_start_time: pid.and_then(crate::process::pid_start_time),

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -112,6 +112,7 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         name: name.clone(),
         image: args.common.image.clone(),
         isolation,
+        managed_execution: None,
         status: "created".to_string(),
         pid: None,
         pid_start_time: None,

--- a/src/cli/src/commands/ps.rs
+++ b/src/cli/src/commands/ps.rs
@@ -200,6 +200,7 @@ mod tests {
             name: name.to_string(),
             image: "alpine:latest".to_string(),
             isolation: Default::default(),
+            managed_execution: None,
             status: status.to_string(),
             pid: None,
             pid_start_time: None,

--- a/src/cli/src/commands/rename.rs
+++ b/src/cli/src/commands/rename.rs
@@ -47,6 +47,7 @@ mod tests {
             name: name.to_string(),
             image: "alpine:latest".to_string(),
             isolation: Default::default(),
+            managed_execution: None,
             status: "created".to_string(),
             pid: None,
             pid_start_time: None,

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -569,6 +569,7 @@ async fn setup_and_boot(args: &RunArgs) -> Result<RunContext, Box<dyn std::error
         name: name.clone(),
         image: args.common.image.clone(),
         isolation: common::execution_isolation(&args.common),
+        managed_execution: None,
         status: "running".to_string(),
         pid,
         pid_start_time: pid.and_then(crate::process::pid_start_time),

--- a/src/cli/src/commands/snapshot.rs
+++ b/src/cli/src/commands/snapshot.rs
@@ -248,6 +248,7 @@ async fn execute_restore(args: SnapshotRestoreArgs) -> Result<(), Box<dyn std::e
         name: box_name,
         image: meta.image.clone(),
         isolation: Default::default(),
+        managed_execution: None,
         status: "created".to_string(),
         pid: None,
         pid_start_time: None,

--- a/src/cli/src/resolve.rs
+++ b/src/cli/src/resolve.rs
@@ -84,6 +84,7 @@ mod tests {
             name: name.to_string(),
             image: "test:latest".to_string(),
             isolation: Default::default(),
+            managed_execution: None,
             status: "created".to_string(),
             pid: None,
             pid_start_time: None,

--- a/src/cli/src/state/tests.rs
+++ b/src/cli/src/state/tests.rs
@@ -19,6 +19,7 @@ fn sample_record(id: &str, name: &str, status: &str) -> BoxRecord {
         name: name.to_string(),
         image: "alpine:latest".to_string(),
         isolation: Default::default(),
+        managed_execution: None,
         status: status.to_string(),
         pid: if status == "running" {
             Some(99999)

--- a/src/cli/src/test_helpers.rs
+++ b/src/cli/src/test_helpers.rs
@@ -16,6 +16,7 @@ pub mod fixtures {
             name: name.to_string(),
             image: "alpine:latest".to_string(),
             isolation: Default::default(),
+            managed_execution: None,
             status: status.to_string(),
             pid,
             pid_start_time: None,

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -5,7 +5,10 @@ use std::path::PathBuf;
 
 use a3s_box_core::config::ResourceLimits;
 use a3s_box_core::log::LogConfig;
-use a3s_box_core::{ExecutionIsolation, NetworkMode};
+use a3s_box_core::{
+    CreateExecutionRequest, ExecutionGeneration, ExecutionIsolation, NetworkMode, OperationId,
+    ResolvedExecutionPlan,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -23,6 +26,13 @@ pub struct BoxRecord {
     /// Requested execution isolation. Records written before this field default to MicroVM.
     #[serde(default)]
     pub isolation: ExecutionIsolation,
+    /// Runtime lifecycle identity and recoverable creation intent.
+    ///
+    /// Legacy CLI-created records omit this field. Managed executions persist
+    /// it before launch so an operation can be reconciled after a service
+    /// restart without creating a second execution.
+    #[serde(default)]
+    pub managed_execution: Option<ManagedExecutionMetadata>,
     /// Persisted lifecycle state.
     pub status: String,
     /// Shim process PID while the execution is active.
@@ -224,6 +234,59 @@ pub struct HealthCheck {
     pub start_period_secs: u64,
 }
 
+/// Durable lifecycle metadata for an execution owned by [`ExecutionManager`].
+///
+/// [`ExecutionManager`]: a3s_box_core::ExecutionManager
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedExecutionMetadata {
+    /// Idempotency key of the create operation.
+    pub operation_id: OperationId,
+    /// Runtime generation used to reject stale lifecycle requests.
+    pub generation: ExecutionGeneration,
+    /// Full creation intent required to recover an interrupted launch.
+    pub request: CreateExecutionRequest,
+    /// Backend resolution validated before any launch side effects.
+    pub plan: ResolvedExecutionPlan,
+}
+
+impl ManagedExecutionMetadata {
+    /// Build validated recovery metadata from one creation request.
+    pub fn new(
+        operation_id: OperationId,
+        generation: ExecutionGeneration,
+        request: CreateExecutionRequest,
+    ) -> a3s_box_core::Result<Self> {
+        if request.external_sandbox_id.trim().is_empty() {
+            return Err(a3s_box_core::BoxError::ConfigError(
+                "external sandbox ID cannot be empty".to_string(),
+            ));
+        }
+        let plan = a3s_box_core::resolve_execution(&request.config)?;
+        Ok(Self {
+            operation_id,
+            generation,
+            request,
+            plan,
+        })
+    }
+
+    /// Validate deserialized metadata before it participates in reconciliation.
+    pub fn validate(&self) -> a3s_box_core::Result<()> {
+        if self.request.external_sandbox_id.trim().is_empty() {
+            return Err(a3s_box_core::BoxError::StateError(
+                "managed execution has an empty external sandbox ID".to_string(),
+            ));
+        }
+        let resolved = a3s_box_core::resolve_execution(&self.request.config)?;
+        if resolved != self.plan {
+            return Err(a3s_box_core::BoxError::StateError(
+                "managed execution plan does not match its persisted creation request".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 fn default_restart_policy() -> String {
     "no".to_string()
 }
@@ -276,6 +339,7 @@ mod tests {
         let record: BoxRecord = serde_json::from_value(value).unwrap();
 
         assert_eq!(record.isolation, ExecutionIsolation::Microvm);
+        assert!(record.managed_execution.is_none());
         assert_eq!(record.virtiofs_cache.as_deref(), Some("always"));
         assert_eq!(record.restart_policy, "no");
         assert_eq!(record.health_status, "none");
@@ -283,5 +347,64 @@ mod tests {
             serde_json::to_value(record).unwrap()["virtiofs_cache"],
             "always"
         );
+    }
+
+    #[test]
+    fn managed_execution_metadata_round_trips_recovery_intent() {
+        let mut config = a3s_box_core::BoxConfig {
+            image: "alpine:latest".to_string(),
+            isolation: ExecutionIsolation::Sandbox,
+            ..Default::default()
+        };
+        config.resources.vcpus = 1;
+        config.resources.memory_mb = 128;
+        let metadata = ManagedExecutionMetadata::new(
+            OperationId::new("create-op-1").unwrap(),
+            ExecutionGeneration::INITIAL,
+            CreateExecutionRequest {
+                external_sandbox_id: "sandbox-1".to_string(),
+                config,
+                labels: Default::default(),
+            },
+        )
+        .unwrap();
+        let mut value = minimal_record();
+        value["managed_execution"] = serde_json::to_value(metadata).unwrap();
+
+        let record: BoxRecord = serde_json::from_value(value).unwrap();
+        let encoded = serde_json::to_value(&record).unwrap();
+        let managed = record.managed_execution.unwrap();
+
+        assert_eq!(managed.operation_id.as_str(), "create-op-1");
+        assert_eq!(managed.generation, ExecutionGeneration::INITIAL);
+        assert_eq!(managed.request.external_sandbox_id, "sandbox-1");
+        assert_eq!(
+            managed.request.config.isolation,
+            ExecutionIsolation::Sandbox
+        );
+        assert_eq!(encoded["managed_execution"]["generation"], 1);
+    }
+
+    #[test]
+    fn managed_execution_validation_rejects_plan_drift() {
+        let config = a3s_box_core::BoxConfig {
+            image: "alpine:latest".to_string(),
+            isolation: ExecutionIsolation::Sandbox,
+            ..Default::default()
+        };
+        let mut metadata = ManagedExecutionMetadata::new(
+            OperationId::new("create-op-1").unwrap(),
+            ExecutionGeneration::INITIAL,
+            CreateExecutionRequest {
+                external_sandbox_id: "sandbox-1".to_string(),
+                config,
+                labels: Default::default(),
+            },
+        )
+        .unwrap();
+        metadata.plan =
+            a3s_box_core::resolve_execution(&a3s_box_core::BoxConfig::default()).unwrap();
+
+        assert!(metadata.validate().is_err());
     }
 }

--- a/src/runtime/src/box_state.rs
+++ b/src/runtime/src/box_state.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::file_lock::FileLock;
 use crate::store_io::quarantine_label;
 use crate::BoxRecord;
+use a3s_box_core::OperationId;
 
 /// Durable collection of local box execution records.
 ///
@@ -113,7 +114,13 @@ impl BoxStateStore {
         }
 
         let data = std::fs::read_to_string(path)?;
-        match serde_json::from_str::<Vec<BoxRecord>>(&data) {
+        let parsed = serde_json::from_str::<Vec<BoxRecord>>(&data)
+            .map_err(|error| error.to_string())
+            .and_then(|records| {
+                validate_managed_records(&records)?;
+                Ok(records)
+            });
+        match parsed {
             Ok(records) => Ok(Self::from_records(path.to_path_buf(), records)),
             Err(error) if corruption_policy == CorruptionPolicy::ReturnError => {
                 Err(std::io::Error::new(std::io::ErrorKind::InvalidData, error))
@@ -133,6 +140,8 @@ impl BoxStateStore {
     }
 
     fn write_unlocked(&self) -> std::io::Result<()> {
+        validate_managed_records(&self.records)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -178,6 +187,29 @@ impl BoxStateStore {
         self.records.iter().find(|record| record.name == name)
     }
 
+    /// Find a managed execution by its idempotent creation operation.
+    pub fn find_by_operation_id(&self, operation_id: &OperationId) -> Option<&BoxRecord> {
+        self.records.iter().find(|record| {
+            record
+                .managed_execution
+                .as_ref()
+                .is_some_and(|metadata| &metadata.operation_id == operation_id)
+        })
+    }
+
+    /// Find a mutable managed execution by its idempotent creation operation.
+    pub fn find_by_operation_id_mut(
+        &mut self,
+        operation_id: &OperationId,
+    ) -> Option<&mut BoxRecord> {
+        self.records.iter_mut().find(|record| {
+            record
+                .managed_execution
+                .as_ref()
+                .is_some_and(|metadata| &metadata.operation_id == operation_id)
+        })
+    }
+
     /// Find records matching a full-ID or short-ID prefix.
     pub fn find_by_id_prefix(&self, prefix: &str) -> Vec<&BoxRecord> {
         self.records
@@ -193,6 +225,25 @@ impl BoxStateStore {
             .filter(|record| all || record.status == "running")
             .collect()
     }
+}
+
+fn validate_managed_records(records: &[BoxRecord]) -> Result<(), String> {
+    let mut operation_ids = std::collections::HashSet::new();
+    for record in records {
+        let Some(metadata) = &record.managed_execution else {
+            continue;
+        };
+        metadata
+            .validate()
+            .map_err(|error| format!("invalid managed execution {}: {error}", record.id))?;
+        if !operation_ids.insert(metadata.operation_id.clone()) {
+            return Err(format!(
+                "duplicate managed operation ID: {}",
+                metadata.operation_id
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -225,6 +276,28 @@ mod tests {
             "auto_remove": false
         }))
         .unwrap()
+    }
+
+    fn managed_record(id: &str, operation_id: OperationId) -> BoxRecord {
+        let mut record = record(id);
+        let config = a3s_box_core::BoxConfig {
+            image: "alpine:latest".to_string(),
+            isolation: a3s_box_core::ExecutionIsolation::Sandbox,
+            ..Default::default()
+        };
+        record.managed_execution = Some(
+            crate::ManagedExecutionMetadata::new(
+                operation_id,
+                a3s_box_core::ExecutionGeneration::INITIAL,
+                a3s_box_core::CreateExecutionRequest {
+                    external_sandbox_id: format!("sandbox-{id}"),
+                    config,
+                    labels: Default::default(),
+                },
+            )
+            .unwrap(),
+        );
+        record
     }
 
     #[test]
@@ -308,6 +381,85 @@ mod tests {
             persisted.records()[0].virtiofs_cache.as_deref(),
             Some("always")
         );
+    }
+
+    #[test]
+    fn operation_lookup_ignores_legacy_records_and_finds_managed_intent() {
+        let operation_id = OperationId::new("operation-1").unwrap();
+        let managed = managed_record("managed", operation_id.clone());
+        let mut store =
+            BoxStateStore::from_records("/tmp/boxes.json", vec![record("legacy"), managed]);
+
+        assert_eq!(
+            store.find_by_operation_id(&operation_id).unwrap().id,
+            "managed"
+        );
+        store
+            .find_by_operation_id_mut(&operation_id)
+            .unwrap()
+            .status = "running".to_string();
+        assert_eq!(store.find_by_id("managed").unwrap().status, "running");
+        assert!(store
+            .find_by_operation_id(&OperationId::new("missing").unwrap())
+            .is_none());
+    }
+
+    #[test]
+    fn strict_load_rejects_duplicate_managed_operation_ids() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("boxes.json");
+        let operation_id = OperationId::new("operation-1").unwrap();
+        let records = vec![
+            managed_record("first", operation_id.clone()),
+            managed_record("second", operation_id),
+        ];
+        std::fs::write(&path, serde_json::to_vec(&records).unwrap()).unwrap();
+
+        let error = BoxStateStore::load(&path).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("duplicate managed operation ID"));
+    }
+
+    #[test]
+    fn transaction_rejects_duplicate_operation_without_changing_disk() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("boxes.json");
+        let operation_id = OperationId::new("operation-1").unwrap();
+        BoxStateStore::from_records(
+            path.clone(),
+            vec![managed_record("first", operation_id.clone())],
+        )
+        .save()
+        .unwrap();
+
+        let error = BoxStateStore::modify(&path, |store| {
+            store
+                .records_mut()
+                .push(managed_record("second", operation_id));
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        let persisted = BoxStateStore::load(&path).unwrap();
+        assert_eq!(persisted.records().len(), 1);
+        assert_eq!(persisted.records()[0].id, "first");
+    }
+
+    #[test]
+    fn strict_load_rejects_managed_plan_drift() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("boxes.json");
+        let mut record = managed_record("managed", OperationId::new("operation-1").unwrap());
+        record.managed_execution.as_mut().unwrap().plan =
+            a3s_box_core::resolve_execution(&a3s_box_core::BoxConfig::default()).unwrap();
+        std::fs::write(&path, serde_json::to_vec(&vec![record]).unwrap()).unwrap();
+
+        let error = BoxStateStore::load(&path).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("does not match"));
     }
 
     #[cfg(unix)]

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -55,7 +55,7 @@ pub mod scale;
 pub use audit::{read_audit_log, AuditLog, AuditQuery};
 
 // Canonical local execution metadata
-pub use box_record::{BoxRecord, HealthCheck};
+pub use box_record::{BoxRecord, HealthCheck, ManagedExecutionMetadata};
 pub use box_state::BoxStateStore;
 
 // gRPC clients

--- a/src/sdk/src/client/core.rs
+++ b/src/sdk/src/client/core.rs
@@ -706,6 +706,7 @@ impl A3sBoxClient {
             name: box_name,
             image: metadata.image.clone(),
             isolation: Default::default(),
+            managed_execution: None,
             status: "created".to_string(),
             pid: None,
             pid_start_time: None,

--- a/src/sdk/src/client/tests/common.rs
+++ b/src/sdk/src/client/tests/common.rs
@@ -106,6 +106,7 @@
             name: name.to_string(),
             image: "alpine:latest".to_string(),
             isolation: Default::default(),
+            managed_execution: None,
             status: status.to_string(),
             pid: if matches!(status, "running" | "paused") {
                 Some(std::process::id())


### PR DESCRIPTION
## Summary

- add optional typed managed-execution recovery metadata to canonical box records
- persist operation identity, runtime generation, full create intent, and resolved backend plan
- validate request/plan consistency and reject duplicate operation IDs on load and before writes
- add operation lookup APIs for the runtime manager while preserving legacy CLI records
- document the next Slice 4 recovery foundation without marking the slice complete

## Validation

- `cargo test -p a3s-box-runtime -p a3s-box-cli -p a3s-box-sdk`
- `cargo clippy -p a3s-box-runtime -p a3s-box-cli -p a3s-box-sdk --all-targets -- -D warnings -A clippy::needless_return` (allows one pre-existing macOS-only cfg lint in `runtime/src/sandbox/capability.rs`)
- `cargo fmt --all -- --check`
- `git diff --check`

Tests cover legacy deserialization, recovery-intent round trips, plan drift, duplicate operations, and transaction rollback. No Docker, OrbStack, or local sandbox runtime was started.