### PR TITLE
feat(runtime): fence managed lifecycle transitions

### DIFF
--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -754,6 +754,12 @@ Managed records also have an optional typed recovery envelope containing the
 operation ID, runtime generation, full creation request, and resolved execution
 plan. Legacy CLI records omit it, while the runtime manager will persist it
 before launch to make create retries and restart reconciliation deterministic.
+The runtime now also owns a strict managed-execution store. It atomically
+reserves creation operations, returns an existing record only when the full
+creation intent matches, persists transitional lifecycle claims, rejects stale
+state or generation comparisons, and advances the generation exactly once when
+pause or resume completes. These file transactions are the local lifecycle
+source of truth; backend calls remain outside the state lock.
 Slice 4 remains incomplete until the real `ExecutionManager` owns
 create/start/run for both callers.
 

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -34,6 +34,10 @@ pub struct BoxRecord {
     #[serde(default)]
     pub managed_execution: Option<ManagedExecutionMetadata>,
     /// Persisted lifecycle state.
+    ///
+    /// Legacy records use `created`, `running`, `paused`, `stopped`, and
+    /// `dead`. Managed executions additionally use the durable transition
+    /// states defined by [`ManagedExecutionState`].
     pub status: String,
     /// Shim process PID while the execution is active.
     pub pid: Option<u32>,
@@ -190,7 +194,24 @@ impl BoxRecord {
 
     /// Whether the persisted lifecycle state represents an active execution.
     pub fn is_active(&self) -> bool {
+        if self.managed_execution.is_some() {
+            return self
+                .managed_state()
+                .is_ok_and(|state| state.is_some_and(ManagedExecutionState::keeps_resources));
+        }
         matches!(self.status.as_str(), "running" | "paused")
+    }
+
+    /// Parse the lifecycle state of a managed execution.
+    ///
+    /// Legacy records return `None`. Unknown managed states fail closed so a
+    /// runtime service cannot operate on a record written by incompatible
+    /// code.
+    pub fn managed_state(&self) -> a3s_box_core::Result<Option<ManagedExecutionState>> {
+        if self.managed_execution.is_none() {
+            return Ok(None);
+        }
+        ManagedExecutionState::from_status(&self.status).map(Some)
     }
 
     /// Render a concise lifecycle status with health, exit, and restart annotations.
@@ -212,6 +233,74 @@ impl BoxRecord {
         } else {
             format!("{} ({})", self.status, annotations.join(", "))
         }
+    }
+}
+
+/// Durable lifecycle state for an execution owned by `ExecutionManager`.
+///
+/// Transitional states are persisted before backend side effects. This lets
+/// a restarted manager distinguish work that was never claimed from work that
+/// may already have reached the runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManagedExecutionState {
+    Creating,
+    Running,
+    Pausing,
+    Paused,
+    Resuming,
+    Killing,
+    Stopped,
+    Failed,
+}
+
+impl ManagedExecutionState {
+    /// Canonical value written to [`BoxRecord::status`].
+    pub const fn as_status(self) -> &'static str {
+        match self {
+            Self::Creating => "creating",
+            Self::Running => "running",
+            Self::Pausing => "pausing",
+            Self::Paused => "paused",
+            Self::Resuming => "resuming",
+            Self::Killing => "killing",
+            Self::Stopped => "stopped",
+            Self::Failed => "failed",
+        }
+    }
+
+    /// Parse a persisted managed lifecycle state.
+    pub fn from_status(status: &str) -> a3s_box_core::Result<Self> {
+        match status {
+            // Accept the legacy pre-start and terminal spellings so records
+            // created during the state-schema migration remain recoverable.
+            "created" | "creating" => Ok(Self::Creating),
+            "running" => Ok(Self::Running),
+            "pausing" => Ok(Self::Pausing),
+            "paused" => Ok(Self::Paused),
+            "resuming" => Ok(Self::Resuming),
+            "killing" => Ok(Self::Killing),
+            "stopped" => Ok(Self::Stopped),
+            "dead" | "failed" => Ok(Self::Failed),
+            other => Err(a3s_box_core::BoxError::StateError(format!(
+                "unknown managed execution state: {other}"
+            ))),
+        }
+    }
+
+    /// Whether host resources may still belong to this execution.
+    pub const fn keeps_resources(self) -> bool {
+        !matches!(self, Self::Stopped | Self::Failed)
+    }
+
+    /// Whether no further lifecycle operation can revive this execution.
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Stopped | Self::Failed)
+    }
+}
+
+impl std::fmt::Display for ManagedExecutionState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_status())
     }
 }
 
@@ -373,6 +462,11 @@ mod tests {
 
         let record: BoxRecord = serde_json::from_value(value).unwrap();
         let encoded = serde_json::to_value(&record).unwrap();
+        assert_eq!(
+            record.managed_state().unwrap(),
+            Some(ManagedExecutionState::Creating)
+        );
+        assert!(record.is_active());
         let managed = record.managed_execution.unwrap();
 
         assert_eq!(managed.operation_id.as_str(), "create-op-1");

--- a/src/runtime/src/box_state.rs
+++ b/src/runtime/src/box_state.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::file_lock::FileLock;
 use crate::store_io::quarantine_label;
 use crate::BoxRecord;
-use a3s_box_core::OperationId;
+use a3s_box_core::{ExecutionId, OperationId};
 
 /// Durable collection of local box execution records.
 ///
@@ -66,6 +66,17 @@ impl BoxStateStore {
         path: &Path,
         f: impl FnOnce(&mut Self) -> std::io::Result<R>,
     ) -> std::io::Result<R> {
+        Self::modify_with_policy(path, CorruptionPolicy::ReturnError, f)
+    }
+
+    /// Apply a strict atomic transaction with a caller-defined error type.
+    ///
+    /// This is equivalent to [`Self::modify`] but lets a domain repository
+    /// return typed conflicts while still converting state I/O errors.
+    pub fn transact<R, E>(path: &Path, f: impl FnOnce(&mut Self) -> Result<R, E>) -> Result<R, E>
+    where
+        E: From<std::io::Error>,
+    {
         Self::modify_with_policy(path, CorruptionPolicy::ReturnError, f)
     }
 
@@ -235,6 +246,11 @@ fn validate_managed_records(records: &[BoxRecord]) -> Result<(), String> {
         };
         metadata
             .validate()
+            .map_err(|error| format!("invalid managed execution {}: {error}", record.id))?;
+        ExecutionId::new(record.id.clone())
+            .map_err(|error| format!("invalid managed execution {}: {error}", record.id))?;
+        record
+            .managed_state()
             .map_err(|error| format!("invalid managed execution {}: {error}", record.id))?;
         if !operation_ids.insert(metadata.operation_id.clone()) {
             return Err(format!(
@@ -460,6 +476,22 @@ mod tests {
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
         assert!(error.to_string().contains("does not match"));
+    }
+
+    #[test]
+    fn strict_load_rejects_unknown_managed_lifecycle_state() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("boxes.json");
+        let mut record = managed_record("managed", OperationId::new("operation-1").unwrap());
+        record.status = "future-state".to_string();
+        std::fs::write(&path, serde_json::to_vec(&vec![record]).unwrap()).unwrap();
+
+        let error = BoxStateStore::load(&path).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error
+            .to_string()
+            .contains("unknown managed execution state"));
     }
 
     #[cfg(unix)]

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -23,6 +23,7 @@ pub mod fs;
 pub mod grpc;
 pub mod host_check;
 pub mod log;
+pub mod managed_execution_store;
 pub mod network;
 pub mod oci;
 pub mod prom;
@@ -55,8 +56,12 @@ pub mod scale;
 pub use audit::{read_audit_log, AuditLog, AuditQuery};
 
 // Canonical local execution metadata
-pub use box_record::{BoxRecord, HealthCheck, ManagedExecutionMetadata};
+pub use box_record::{BoxRecord, HealthCheck, ManagedExecutionMetadata, ManagedExecutionState};
 pub use box_state::BoxStateStore;
+pub use managed_execution_store::{
+    ManagedExecutionReservation, ManagedExecutionStore, ManagedExecutionStoreError,
+    ManagedExecutionStoreResult,
+};
 
 // gRPC clients
 #[cfg(unix)]

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -1,0 +1,544 @@
+//! Durable generation-fenced transitions for managed local executions.
+
+use std::path::{Path, PathBuf};
+
+use a3s_box_core::{ExecutionGeneration, ExecutionId, OperationId};
+use thiserror::Error;
+
+use crate::{BoxRecord, BoxStateStore, ManagedExecutionState};
+
+/// Strict durable repository used by the local `ExecutionManager`.
+#[derive(Debug, Clone)]
+pub struct ManagedExecutionStore {
+    path: PathBuf,
+}
+
+/// Result of reserving an idempotent create operation.
+#[derive(Debug, Clone)]
+pub enum ManagedExecutionReservation {
+    /// The creation intent was inserted by this call.
+    Reserved(BoxRecord),
+    /// The operation already existed with the same creation intent.
+    Existing(BoxRecord),
+}
+
+impl ManagedExecutionReservation {
+    pub const fn is_new(&self) -> bool {
+        matches!(self, Self::Reserved(_))
+    }
+
+    pub fn record(&self) -> &BoxRecord {
+        match self {
+            Self::Reserved(record) | Self::Existing(record) => record,
+        }
+    }
+
+    pub fn into_record(self) -> BoxRecord {
+        match self {
+            Self::Reserved(record) | Self::Existing(record) => record,
+        }
+    }
+}
+
+/// Fail-closed errors from managed lifecycle persistence.
+#[derive(Debug, Error)]
+pub enum ManagedExecutionStoreError {
+    #[error("managed execution state I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("managed execution not found: {0}")]
+    NotFound(ExecutionId),
+    #[error("execution record is not managed: {0}")]
+    Unmanaged(ExecutionId),
+    #[error("managed execution conflict for {execution_id}: {message}")]
+    Conflict {
+        execution_id: ExecutionId,
+        message: String,
+    },
+    #[error("invalid managed execution record: {0}")]
+    InvalidRecord(String),
+    #[error("invalid managed execution transition for {execution_id}: {from} -> {to}")]
+    InvalidTransition {
+        execution_id: ExecutionId,
+        from: ManagedExecutionState,
+        to: ManagedExecutionState,
+    },
+}
+
+pub type ManagedExecutionStoreResult<T> = std::result::Result<T, ManagedExecutionStoreError>;
+
+impl ManagedExecutionStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Return one managed record without mutating or reconciling state.
+    pub fn get(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> ManagedExecutionStoreResult<Option<BoxRecord>> {
+        let store = BoxStateStore::load_readonly(&self.path)?;
+        let Some(record) = store.find_by_id(execution_id.as_str()).cloned() else {
+            return Ok(None);
+        };
+        if record.managed_execution.is_none() {
+            return Err(ManagedExecutionStoreError::Unmanaged(execution_id.clone()));
+        }
+        Ok(Some(record))
+    }
+
+    /// Return the record reserved by an idempotent creation operation.
+    pub fn get_by_operation_id(
+        &self,
+        operation_id: &OperationId,
+    ) -> ManagedExecutionStoreResult<Option<BoxRecord>> {
+        let store = BoxStateStore::load_readonly(&self.path)?;
+        Ok(store.find_by_operation_id(operation_id).cloned())
+    }
+
+    /// Atomically reserve one creation operation before backend side effects.
+    ///
+    /// Retrying the same operation with the same full request returns the
+    /// existing record. Reusing an operation ID for different creation intent
+    /// fails without changing durable state.
+    pub fn reserve(
+        &self,
+        mut record: BoxRecord,
+    ) -> ManagedExecutionStoreResult<ManagedExecutionReservation> {
+        let execution_id = validate_new_record(&record)?;
+        record.status = ManagedExecutionState::Creating.as_status().to_string();
+        let incoming_metadata = record
+            .managed_execution
+            .as_ref()
+            .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?
+            .clone();
+
+        BoxStateStore::transact(&self.path, move |store| {
+            if let Some(existing) = store
+                .find_by_operation_id(&incoming_metadata.operation_id)
+                .cloned()
+            {
+                let existing_id = ExecutionId::new(existing.id.clone()).map_err(|error| {
+                    ManagedExecutionStoreError::InvalidRecord(error.to_string())
+                })?;
+                let existing_metadata = existing
+                    .managed_execution
+                    .as_ref()
+                    .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(existing_id.clone()))?;
+                if !same_creation_intent(existing_metadata, &incoming_metadata)? {
+                    return Err(ManagedExecutionStoreError::Conflict {
+                        execution_id: existing_id,
+                        message: format!(
+                            "operation {} was already reserved with different creation intent",
+                            incoming_metadata.operation_id
+                        ),
+                    });
+                }
+                return Ok(ManagedExecutionReservation::Existing(existing));
+            }
+
+            if store.find_by_id(execution_id.as_str()).is_some() {
+                return Err(ManagedExecutionStoreError::Conflict {
+                    execution_id,
+                    message: "execution ID is already present".to_string(),
+                });
+            }
+
+            store.records_mut().push(record.clone());
+            Ok(ManagedExecutionReservation::Reserved(record))
+        })
+    }
+
+    /// Atomically compare generation and state, then persist one legal edge.
+    ///
+    /// Completing pause and resume advances the runtime generation exactly
+    /// once. Claim, rollback, terminal, and kill transitions retain the current
+    /// generation.
+    pub fn transition(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+        expected_state: ManagedExecutionState,
+        next_state: ManagedExecutionState,
+    ) -> ManagedExecutionStoreResult<BoxRecord> {
+        let execution_id = execution_id.clone();
+        BoxStateStore::transact(&self.path, move |store| {
+            let record = store
+                .find_by_id_mut(execution_id.as_str())
+                .ok_or_else(|| ManagedExecutionStoreError::NotFound(execution_id.clone()))?;
+            let actual_state = record
+                .managed_state()
+                .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+            let metadata = record
+                .managed_execution
+                .as_ref()
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+
+            if metadata.generation != expected_generation || actual_state != expected_state {
+                return Err(ManagedExecutionStoreError::Conflict {
+                    execution_id: execution_id.clone(),
+                    message: format!(
+                        "expected {expected_state} generation {}, found {actual_state} generation {}",
+                        expected_generation.get(),
+                        metadata.generation.get()
+                    ),
+                });
+            }
+
+            let next_generation = transition_generation(
+                &execution_id,
+                expected_state,
+                next_state,
+                expected_generation,
+            )?;
+            record.status = next_state.as_status().to_string();
+            record
+                .managed_execution
+                .as_mut()
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?
+                .generation = next_generation;
+            Ok(record.clone())
+        })
+    }
+}
+
+fn validate_new_record(record: &BoxRecord) -> ManagedExecutionStoreResult<ExecutionId> {
+    let execution_id = ExecutionId::new(record.id.clone())
+        .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?;
+    let metadata = record
+        .managed_execution
+        .as_ref()
+        .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+    metadata
+        .validate()
+        .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?;
+    let state = record
+        .managed_state()
+        .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?
+        .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+    if state != ManagedExecutionState::Creating {
+        return Err(ManagedExecutionStoreError::InvalidRecord(format!(
+            "new execution {execution_id} must be creating, found {state}"
+        )));
+    }
+    if metadata.generation != ExecutionGeneration::INITIAL {
+        return Err(ManagedExecutionStoreError::InvalidRecord(format!(
+            "new execution {execution_id} must start at generation {}",
+            ExecutionGeneration::INITIAL.get()
+        )));
+    }
+    Ok(execution_id)
+}
+
+fn same_creation_intent(
+    left: &crate::ManagedExecutionMetadata,
+    right: &crate::ManagedExecutionMetadata,
+) -> ManagedExecutionStoreResult<bool> {
+    let left_request = serde_json::to_value(&left.request)
+        .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?;
+    let right_request = serde_json::to_value(&right.request)
+        .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?;
+    Ok(left_request == right_request && left.plan == right.plan)
+}
+
+fn transition_generation(
+    execution_id: &ExecutionId,
+    from: ManagedExecutionState,
+    to: ManagedExecutionState,
+    current: ExecutionGeneration,
+) -> ManagedExecutionStoreResult<ExecutionGeneration> {
+    use ManagedExecutionState::{
+        Creating, Failed, Killing, Paused, Pausing, Resuming, Running, Stopped,
+    };
+
+    let legal = matches!(
+        (from, to),
+        (Creating, Running | Killing | Stopped | Failed)
+            | (Running, Pausing | Killing | Stopped | Failed)
+            | (Pausing, Paused | Running | Killing | Stopped | Failed)
+            | (Paused, Resuming | Killing | Stopped | Failed)
+            | (Resuming, Running | Paused | Killing | Stopped | Failed)
+            | (Killing, Stopped | Failed)
+    );
+    if !legal {
+        return Err(ManagedExecutionStoreError::InvalidTransition {
+            execution_id: execution_id.clone(),
+            from,
+            to,
+        });
+    }
+
+    if matches!((from, to), (Pausing, Paused) | (Resuming, Running)) {
+        let value = current.get().checked_add(1).ok_or_else(|| {
+            ManagedExecutionStoreError::InvalidRecord(format!(
+                "execution {execution_id} generation is exhausted"
+            ))
+        })?;
+        return ExecutionGeneration::new(value)
+            .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()));
+    }
+    Ok(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use a3s_box_core::{CreateExecutionRequest, ExecutionIsolation};
+
+    use super::*;
+    use crate::ManagedExecutionMetadata;
+
+    fn managed_record(id: &str, operation: &str) -> BoxRecord {
+        let mut record: BoxRecord = serde_json::from_value(serde_json::json!({
+            "id": id,
+            "short_id": BoxRecord::make_short_id(id),
+            "name": format!("box-{id}"),
+            "image": "alpine:latest",
+            "isolation": "sandbox",
+            "status": "creating",
+            "pid": null,
+            "cpus": 1,
+            "memory_mb": 128,
+            "volumes": [],
+            "env": {},
+            "cmd": ["sh"],
+            "box_dir": format!("/tmp/{id}"),
+            "console_log": format!("/tmp/{id}/console.log"),
+            "created_at": "2026-07-14T12:00:00Z",
+            "started_at": null,
+            "auto_remove": false
+        }))
+        .unwrap();
+        let config = a3s_box_core::BoxConfig {
+            image: "alpine:latest".to_string(),
+            isolation: ExecutionIsolation::Sandbox,
+            ..Default::default()
+        };
+        record.managed_execution = Some(
+            ManagedExecutionMetadata::new(
+                OperationId::new(operation).unwrap(),
+                ExecutionGeneration::INITIAL,
+                CreateExecutionRequest {
+                    external_sandbox_id: "sandbox-1".to_string(),
+                    config,
+                    labels: Default::default(),
+                },
+            )
+            .unwrap(),
+        );
+        record
+    }
+
+    #[test]
+    fn reservation_is_idempotent_for_the_same_full_request() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = ManagedExecutionStore::new(directory.path().join("boxes.json"));
+
+        let first = store.reserve(managed_record("execution-1", "operation-1"));
+        let retry = store.reserve(managed_record("execution-2", "operation-1"));
+
+        assert!(first.unwrap().is_new());
+        let retry = retry.unwrap();
+        assert!(!retry.is_new());
+        assert_eq!(retry.record().id, "execution-1");
+        assert_eq!(
+            BoxStateStore::load(store.path()).unwrap().records().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn reservation_rejects_operation_reuse_with_different_intent() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = ManagedExecutionStore::new(directory.path().join("boxes.json"));
+        store
+            .reserve(managed_record("execution-1", "operation-1"))
+            .unwrap();
+        let mut conflicting = managed_record("execution-2", "operation-1");
+        conflicting
+            .managed_execution
+            .as_mut()
+            .unwrap()
+            .request
+            .external_sandbox_id = "sandbox-2".to_string();
+
+        let error = store.reserve(conflicting).unwrap_err();
+
+        assert!(matches!(error, ManagedExecutionStoreError::Conflict { .. }));
+        assert_eq!(
+            BoxStateStore::load(store.path()).unwrap().records().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn pause_and_resume_completion_advance_generation_once() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = ManagedExecutionStore::new(directory.path().join("boxes.json"));
+        let id = ExecutionId::new("execution-1").unwrap();
+        store
+            .reserve(managed_record(id.as_str(), "operation-1"))
+            .unwrap();
+
+        let running = store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Creating,
+                ManagedExecutionState::Running,
+            )
+            .unwrap();
+        assert_eq!(
+            running.managed_execution.unwrap().generation,
+            ExecutionGeneration::INITIAL
+        );
+        store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Running,
+                ManagedExecutionState::Pausing,
+            )
+            .unwrap();
+        let paused = store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Pausing,
+                ManagedExecutionState::Paused,
+            )
+            .unwrap();
+        let generation_two = ExecutionGeneration::new(2).unwrap();
+        assert_eq!(paused.managed_execution.unwrap().generation, generation_two);
+        store
+            .transition(
+                &id,
+                generation_two,
+                ManagedExecutionState::Paused,
+                ManagedExecutionState::Resuming,
+            )
+            .unwrap();
+        let resumed = store
+            .transition(
+                &id,
+                generation_two,
+                ManagedExecutionState::Resuming,
+                ManagedExecutionState::Running,
+            )
+            .unwrap();
+        assert_eq!(
+            resumed.managed_execution.unwrap().generation,
+            ExecutionGeneration::new(3).unwrap()
+        );
+    }
+
+    #[test]
+    fn stale_generation_and_invalid_edges_do_not_change_disk() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = ManagedExecutionStore::new(directory.path().join("boxes.json"));
+        let id = ExecutionId::new("execution-1").unwrap();
+        store
+            .reserve(managed_record(id.as_str(), "operation-1"))
+            .unwrap();
+        store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Creating,
+                ManagedExecutionState::Running,
+            )
+            .unwrap();
+
+        let stale = store.transition(
+            &id,
+            ExecutionGeneration::new(2).unwrap(),
+            ManagedExecutionState::Running,
+            ManagedExecutionState::Pausing,
+        );
+        let invalid = store.transition(
+            &id,
+            ExecutionGeneration::INITIAL,
+            ManagedExecutionState::Running,
+            ManagedExecutionState::Paused,
+        );
+
+        assert!(matches!(
+            stale,
+            Err(ManagedExecutionStoreError::Conflict { .. })
+        ));
+        assert!(matches!(
+            invalid,
+            Err(ManagedExecutionStoreError::InvalidTransition { .. })
+        ));
+        let persisted = store.get(&id).unwrap().unwrap();
+        assert_eq!(
+            persisted.managed_state().unwrap(),
+            Some(ManagedExecutionState::Running)
+        );
+        assert_eq!(
+            persisted.managed_execution.unwrap().generation,
+            ExecutionGeneration::INITIAL
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn concurrent_claims_have_one_winner() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = Arc::new(ManagedExecutionStore::new(
+            directory.path().join("boxes.json"),
+        ));
+        let id = ExecutionId::new("execution-1").unwrap();
+        store
+            .reserve(managed_record(id.as_str(), "operation-1"))
+            .unwrap();
+        store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Creating,
+                ManagedExecutionState::Running,
+            )
+            .unwrap();
+        let barrier = Arc::new(Barrier::new(3));
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let id = id.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store.transition(
+                        &id,
+                        ExecutionGeneration::INITIAL,
+                        ManagedExecutionState::Running,
+                        ManagedExecutionState::Pausing,
+                    )
+                })
+            })
+            .collect();
+        barrier.wait();
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(ManagedExecutionStoreError::Conflict { .. })))
+                .count(),
+            1
+        );
+        assert_eq!(
+            store.get(&id).unwrap().unwrap().managed_state().unwrap(),
+            Some(ManagedExecutionState::Pausing)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a strict runtime-owned managed execution state machine with durable transitional states
- atomically reserve idempotent create operations and reject request drift
- enforce generation- and state-fenced lifecycle transitions under the shared state lock
- advance generations exactly once after pause and resume completion
- fail closed on unknown managed states and document the Slice 4 foundation

## Validation

- cargo test -p a3s-box-runtime (1203 passed, 1 ignored)
- cargo test -p a3s-box-cli -p a3s-box-sdk (CLI 730 passed; SDK 30 passed)
- cargo clippy -p a3s-box-runtime -p a3s-box-cli -p a3s-box-sdk --all-targets -- -D warnings -A clippy::needless_return
- cargo fmt --all -- --check
- git diff --check

No Docker, OrbStack, or local sandbox runtime was started.