### PR TITLE
feat(runtime): orchestrate local managed executions

### DIFF
--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -760,6 +760,14 @@ creation intent matches, persists transitional lifecycle claims, rejects stale
 state or generation comparisons, and advances the generation exactly once when
 pause or resume completes. These file transactions are the local lifecycle
 source of truth; backend calls remain outside the state lock.
+`LocalExecutionManager` now implements the backend-neutral lifecycle contract
+over that store and an injectable runtime backend. It persists a `starting`
+claim before launch, keeps pause policy with the corresponding transitional
+record, performs state-file work on Tokio blocking workers, and resolves
+ambiguous backend errors from runtime observations before publishing a result.
+Startup reconciliation can therefore distinguish an unstarted claim from a
+runtime that became ready before its durable `running` publication. The
+production `VmManager` backend is still a separate remaining gate.
 Slice 4 remains incomplete until the real `ExecutionManager` owns
 create/start/run for both callers.
 

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -208,10 +208,12 @@ impl BoxRecord {
     /// runtime service cannot operate on a record written by incompatible
     /// code.
     pub fn managed_state(&self) -> a3s_box_core::Result<Option<ManagedExecutionState>> {
-        if self.managed_execution.is_none() {
+        let Some(metadata) = self.managed_execution.as_ref() else {
             return Ok(None);
-        }
-        ManagedExecutionState::from_status(&self.status).map(Some)
+        };
+        let state = ManagedExecutionState::from_status(&self.status)?;
+        validate_pending_operation(state, metadata.pending_operation.as_ref())?;
+        Ok(Some(state))
     }
 
     /// Render a concise lifecycle status with health, exit, and restart annotations.
@@ -244,6 +246,7 @@ impl BoxRecord {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManagedExecutionState {
     Creating,
+    Starting,
     Running,
     Pausing,
     Paused,
@@ -258,6 +261,7 @@ impl ManagedExecutionState {
     pub const fn as_status(self) -> &'static str {
         match self {
             Self::Creating => "creating",
+            Self::Starting => "starting",
             Self::Running => "running",
             Self::Pausing => "pausing",
             Self::Paused => "paused",
@@ -274,6 +278,7 @@ impl ManagedExecutionState {
             // Accept the legacy pre-start and terminal spellings so records
             // created during the state-schema migration remain recoverable.
             "created" | "creating" => Ok(Self::Creating),
+            "starting" => Ok(Self::Starting),
             "running" => Ok(Self::Running),
             "pausing" => Ok(Self::Pausing),
             "paused" => Ok(Self::Paused),
@@ -336,6 +341,19 @@ pub struct ManagedExecutionMetadata {
     pub request: CreateExecutionRequest,
     /// Backend resolution validated before any launch side effects.
     pub plan: ResolvedExecutionPlan,
+    /// Lifecycle side effect claimed before calling the backend.
+    #[serde(default)]
+    pub pending_operation: Option<ManagedExecutionOperation>,
+}
+
+/// Recoverable backend operation associated with a transitional state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ManagedExecutionOperation {
+    Start,
+    Pause { keep_memory: bool },
+    Resume,
+    Kill,
 }
 
 impl ManagedExecutionMetadata {
@@ -356,6 +374,7 @@ impl ManagedExecutionMetadata {
             generation,
             request,
             plan,
+            pending_operation: None,
         })
     }
 
@@ -373,6 +392,42 @@ impl ManagedExecutionMetadata {
             ));
         }
         Ok(())
+    }
+}
+
+fn validate_pending_operation(
+    state: ManagedExecutionState,
+    operation: Option<&ManagedExecutionOperation>,
+) -> a3s_box_core::Result<()> {
+    let consistent = matches!(
+        (state, operation),
+        (
+            ManagedExecutionState::Starting,
+            Some(ManagedExecutionOperation::Start)
+        ) | (
+            ManagedExecutionState::Pausing,
+            Some(ManagedExecutionOperation::Pause { .. })
+        ) | (
+            ManagedExecutionState::Resuming,
+            Some(ManagedExecutionOperation::Resume)
+        ) | (
+            ManagedExecutionState::Killing,
+            Some(ManagedExecutionOperation::Kill)
+        ) | (
+            ManagedExecutionState::Creating
+                | ManagedExecutionState::Running
+                | ManagedExecutionState::Paused
+                | ManagedExecutionState::Stopped
+                | ManagedExecutionState::Failed,
+            None
+        )
+    );
+    if consistent {
+        Ok(())
+    } else {
+        Err(a3s_box_core::BoxError::StateError(format!(
+            "managed execution state {state} has inconsistent pending operation"
+        )))
     }
 }
 

--- a/src/runtime/src/box_state.rs
+++ b/src/runtime/src/box_state.rs
@@ -494,6 +494,20 @@ mod tests {
             .contains("unknown managed execution state"));
     }
 
+    #[test]
+    fn strict_load_rejects_transition_without_matching_pending_operation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("boxes.json");
+        let mut record = managed_record("managed", OperationId::new("operation-1").unwrap());
+        record.status = "pausing".to_string();
+        std::fs::write(&path, serde_json::to_vec(&vec![record]).unwrap()).unwrap();
+
+        let error = BoxStateStore::load(&path).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("inconsistent pending operation"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn concurrent_transactions_do_not_lose_records() {

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod file_lock;
 pub mod fs;
 pub mod grpc;
 pub mod host_check;
+pub mod local_execution;
 pub mod log;
 pub mod managed_execution_store;
 pub mod network;
@@ -56,8 +57,14 @@ pub mod scale;
 pub use audit::{read_audit_log, AuditLog, AuditQuery};
 
 // Canonical local execution metadata
-pub use box_record::{BoxRecord, HealthCheck, ManagedExecutionMetadata, ManagedExecutionState};
+pub use box_record::{
+    BoxRecord, HealthCheck, ManagedExecutionMetadata, ManagedExecutionOperation,
+    ManagedExecutionState,
+};
 pub use box_state::BoxStateStore;
+pub use local_execution::{
+    LocalExecutionBackend, LocalExecutionHandle, LocalExecutionManager, LocalExecutionObservation,
+};
 pub use managed_execution_store::{
     ManagedExecutionReservation, ManagedExecutionStore, ManagedExecutionStoreError,
     ManagedExecutionStoreResult,

--- a/src/runtime/src/local_execution/api.rs
+++ b/src/runtime/src/local_execution/api.rs
@@ -1,0 +1,161 @@
+use a3s_box_core::{
+    CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManager,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ExecutionStatus, KillOutcome,
+    OperationId, ReconcileOutcome,
+};
+use async_trait::async_trait;
+
+use super::support::{managed_state, outcome_from_record, require_generation, state_conflict};
+use super::{
+    build_managed_record, status_from_record, LocalExecutionManager, ManagedExecutionState,
+    RuntimeUpdate,
+};
+
+#[async_trait]
+impl ExecutionManager for LocalExecutionManager {
+    async fn create_and_start(
+        &self,
+        request: CreateExecutionRequest,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let execution_id = ExecutionId::new(uuid::Uuid::new_v4().to_string())?;
+        let record = build_managed_record(
+            &self.home_dir,
+            &execution_id,
+            operation_id.clone(),
+            request,
+            chrono::Utc::now(),
+        )?;
+        let reservation = self.reserve(record).await?;
+        self.ensure_started(reservation.into_record()).await
+    }
+
+    async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
+        let record = self
+            .get(execution_id)
+            .await?
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        let (record, state) = self.observe_record(record).await?;
+        status_from_record(&record, state)
+    }
+
+    async fn pause(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+        keep_memory: bool,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let record = self
+            .get(execution_id)
+            .await?
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        require_generation(&record, execution_id, expected_generation)?;
+        if managed_state(&record)? != ManagedExecutionState::Running {
+            return Err(state_conflict(&record, execution_id, "pause"));
+        }
+        let claimed = self
+            .transition(
+                &record,
+                ManagedExecutionState::Running,
+                ManagedExecutionState::Pausing,
+                RuntimeUpdate::PauseClaim(keep_memory),
+            )
+            .await?;
+        self.finish_pause(claimed).await
+    }
+
+    async fn resume(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let record = self
+            .get(execution_id)
+            .await?
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        require_generation(&record, execution_id, expected_generation)?;
+        if managed_state(&record)? != ManagedExecutionState::Paused {
+            return Err(state_conflict(&record, execution_id, "resume"));
+        }
+        let claimed = self
+            .transition(
+                &record,
+                ManagedExecutionState::Paused,
+                ManagedExecutionState::Resuming,
+                RuntimeUpdate::None,
+            )
+            .await?;
+        self.finish_resume(claimed).await
+    }
+
+    async fn kill(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        let record = self
+            .get(execution_id)
+            .await?
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        require_generation(&record, execution_id, expected_generation)?;
+        let state = managed_state(&record)?;
+        if state.is_terminal() {
+            return Ok(KillOutcome::AlreadyStopped);
+        }
+        let claimed = if state == ManagedExecutionState::Killing {
+            record
+        } else {
+            self.transition(
+                &record,
+                state,
+                ManagedExecutionState::Killing,
+                RuntimeUpdate::None,
+            )
+            .await?
+        };
+        self.finish_kill(claimed).await
+    }
+
+    async fn reconcile(
+        &self,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ReconcileOutcome> {
+        let Some(record) = self.get_by_operation(operation_id).await? else {
+            return Ok(ReconcileOutcome::Absent);
+        };
+        match managed_state(&record)? {
+            ManagedExecutionState::Creating | ManagedExecutionState::Starting => {
+                self.recover_start(record).await
+            }
+            ManagedExecutionState::Pausing => {
+                let (record, state) = self.observe_record(record).await?;
+                if managed_state(&record)? == ManagedExecutionState::Pausing
+                    && state == ExecutionState::Running
+                {
+                    return self.finish_pause(record).await.map(ReconcileOutcome::Ready);
+                }
+                outcome_from_record(record, state)
+            }
+            ManagedExecutionState::Resuming => {
+                let (record, state) = self.observe_record(record).await?;
+                if managed_state(&record)? == ManagedExecutionState::Resuming
+                    && state == ExecutionState::Paused
+                {
+                    return self
+                        .finish_resume(record)
+                        .await
+                        .map(ReconcileOutcome::Ready);
+                }
+                outcome_from_record(record, state)
+            }
+            ManagedExecutionState::Killing => {
+                self.finish_kill(record).await?;
+                Ok(ReconcileOutcome::Failed)
+            }
+            _ => {
+                let (record, state) = self.observe_record(record).await?;
+                outcome_from_record(record, state)
+            }
+        }
+    }
+}

--- a/src/runtime/src/local_execution/backend.rs
+++ b/src/runtime/src/local_execution/backend.rs
@@ -1,0 +1,95 @@
+//! Injectable process/runtime boundary for local execution orchestration.
+
+use std::path::PathBuf;
+
+use a3s_box_core::{
+    ExecutionId, ExecutionManagerError, ExecutionManagerResult, ExecutionState, KillOutcome,
+};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::BoxRecord;
+
+/// Runtime evidence persisted after an execution becomes ready.
+#[derive(Debug, Clone)]
+pub struct LocalExecutionHandle {
+    pub started_at: DateTime<Utc>,
+    pub pid: Option<u32>,
+    pub pid_start_time: Option<u64>,
+    pub exec_socket_path: PathBuf,
+    pub console_log: PathBuf,
+    pub anonymous_volumes: Vec<String>,
+}
+
+impl LocalExecutionHandle {
+    pub(crate) fn validate(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<()> {
+        if self.pid.is_none() && self.pid_start_time.is_some() {
+            return Err(ExecutionManagerError::Internal(format!(
+                "backend returned a PID start time without a PID for {execution_id}"
+            )));
+        }
+        if self.exec_socket_path.as_os_str().is_empty() {
+            return Err(ExecutionManagerError::Internal(format!(
+                "backend returned an empty exec socket path for {execution_id}"
+            )));
+        }
+        if self.console_log.as_os_str().is_empty() {
+            return Err(ExecutionManagerError::Internal(format!(
+                "backend returned an empty console log path for {execution_id}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// One backend observation used during inspection and restart recovery.
+#[derive(Debug, Clone)]
+pub struct LocalExecutionObservation {
+    pub state: ExecutionState,
+    pub handle: Option<LocalExecutionHandle>,
+    pub exit_code: Option<i32>,
+}
+
+impl LocalExecutionObservation {
+    pub(crate) fn validate(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<()> {
+        match self.state {
+            ExecutionState::Running | ExecutionState::Paused => {
+                self.handle.as_ref().ok_or_else(|| {
+                    ExecutionManagerError::Internal(format!(
+                        "backend returned {:?} without runtime evidence for {execution_id}",
+                        self.state
+                    ))
+                })?;
+            }
+            ExecutionState::Creating | ExecutionState::Stopped | ExecutionState::Failed => {}
+        }
+        if let Some(handle) = &self.handle {
+            handle.validate(execution_id)?;
+        }
+        Ok(())
+    }
+}
+
+/// Backend operations invoked outside the durable state lock.
+///
+/// Implementations must key all host/runtime paths by [`BoxRecord::id`]. The
+/// external sandbox ID in managed metadata is an untrusted diagnostic label.
+#[async_trait]
+pub trait LocalExecutionBackend: Send + Sync {
+    async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle>;
+
+    async fn inspect(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionObservation>;
+
+    async fn pause(
+        &self,
+        record: &BoxRecord,
+        keep_memory: bool,
+    ) -> ExecutionManagerResult<LocalExecutionHandle>;
+
+    async fn resume(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle>;
+
+    async fn kill(&self, record: &BoxRecord) -> ExecutionManagerResult<KillOutcome>;
+}

--- a/src/runtime/src/local_execution/create.rs
+++ b/src/runtime/src/local_execution/create.rs
@@ -1,0 +1,203 @@
+use a3s_box_core::{ExecutionLease, ExecutionManagerError, ExecutionManagerResult, ExecutionState};
+
+use super::record::{execution_id, lease_from_record};
+use super::store::RuntimeUpdate;
+use super::support::{managed_state, required_handle};
+use super::{BoxRecord, LocalExecutionManager, ManagedExecutionState};
+
+impl LocalExecutionManager {
+    pub(super) async fn ensure_started(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        match managed_state(&record)? {
+            ManagedExecutionState::Creating => self.claim_and_start(record).await,
+            ManagedExecutionState::Starting => {
+                let execution_id = execution_id(&record)?;
+                match self.backend.inspect(&record).await {
+                    Ok(observation) => {
+                        observation.validate(&execution_id)?;
+                        match observation.state {
+                            ExecutionState::Running => {
+                                let handle = required_handle(&observation, &execution_id)?;
+                                let running = self
+                                    .complete_with_handle(
+                                        &record,
+                                        ManagedExecutionState::Starting,
+                                        ManagedExecutionState::Running,
+                                        handle,
+                                    )
+                                    .await?;
+                                lease_from_record(&running)
+                            }
+                            ExecutionState::Creating => Err(ExecutionManagerError::Unavailable(
+                                format!("execution {execution_id} is still starting"),
+                            )),
+                            ExecutionState::Stopped | ExecutionState::Failed => {
+                                self.transition(
+                                    &record,
+                                    ManagedExecutionState::Starting,
+                                    ManagedExecutionState::Failed,
+                                    RuntimeUpdate::Terminal(observation.exit_code),
+                                )
+                                .await?;
+                                Err(ExecutionManagerError::Conflict {
+                                    execution_id: execution_id.clone(),
+                                    message: "the reserved creation operation is terminal"
+                                        .to_string(),
+                                })
+                            }
+                            ExecutionState::Paused => Err(ExecutionManagerError::Internal(
+                                format!("execution {execution_id} became paused while starting"),
+                            )),
+                        }
+                    }
+                    Err(ExecutionManagerError::NotFound(_)) => {
+                        Err(ExecutionManagerError::Unavailable(format!(
+                            "execution {execution_id} has been claimed for startup"
+                        )))
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+            ManagedExecutionState::Running | ManagedExecutionState::Paused => {
+                lease_from_record(&record)
+            }
+            state => Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id(&record)?,
+                message: format!("creation operation is {state}"),
+            }),
+        }
+    }
+
+    pub(super) async fn claim_and_start(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let claimed = match self
+            .transition(
+                &record,
+                ManagedExecutionState::Creating,
+                ManagedExecutionState::Starting,
+                RuntimeUpdate::None,
+            )
+            .await
+        {
+            Ok(claimed) => claimed,
+            Err(ExecutionManagerError::Conflict { .. }) => {
+                let id = execution_id(&record)?;
+                let current = self
+                    .get(&id)
+                    .await?
+                    .ok_or_else(|| ExecutionManagerError::NotFound(id.clone()))?;
+                return self.ensure_started_after_lost_claim(current).await;
+            }
+            Err(error) => return Err(error),
+        };
+
+        let execution_id = execution_id(&claimed)?;
+        match self.backend.start(&claimed).await {
+            Ok(handle) => {
+                handle.validate(&execution_id)?;
+                let running = self
+                    .complete_with_handle(
+                        &claimed,
+                        ManagedExecutionState::Starting,
+                        ManagedExecutionState::Running,
+                        handle,
+                    )
+                    .await?;
+                lease_from_record(&running)
+            }
+            Err(error) => self.resolve_start_error(claimed, error).await,
+        }
+    }
+
+    async fn ensure_started_after_lost_claim(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        match managed_state(&record)? {
+            ManagedExecutionState::Running | ManagedExecutionState::Paused => {
+                lease_from_record(&record)
+            }
+            ManagedExecutionState::Starting => {
+                let id = execution_id(&record)?;
+                match self.backend.inspect(&record).await {
+                    Ok(observation) if observation.state == ExecutionState::Running => {
+                        observation.validate(&id)?;
+                        let running = self
+                            .complete_with_handle(
+                                &record,
+                                ManagedExecutionState::Starting,
+                                ManagedExecutionState::Running,
+                                required_handle(&observation, &id)?,
+                            )
+                            .await?;
+                        lease_from_record(&running)
+                    }
+                    Ok(_) | Err(ExecutionManagerError::NotFound(_)) => {
+                        Err(ExecutionManagerError::Unavailable(format!(
+                            "execution {id} startup is owned by another caller"
+                        )))
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+            state => Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id(&record)?,
+                message: format!("creation claim moved to {state}"),
+            }),
+        }
+    }
+
+    async fn resolve_start_error(
+        &self,
+        claimed: BoxRecord,
+        start_error: ExecutionManagerError,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let id = execution_id(&claimed)?;
+        match self.backend.inspect(&claimed).await {
+            Ok(observation) => {
+                observation.validate(&id)?;
+                match observation.state {
+                    ExecutionState::Running => {
+                        let running = self
+                            .complete_with_handle(
+                                &claimed,
+                                ManagedExecutionState::Starting,
+                                ManagedExecutionState::Running,
+                                required_handle(&observation, &id)?,
+                            )
+                            .await?;
+                        lease_from_record(&running)
+                    }
+                    ExecutionState::Stopped | ExecutionState::Failed => {
+                        let _ = self
+                            .transition(
+                                &claimed,
+                                ManagedExecutionState::Starting,
+                                ManagedExecutionState::Failed,
+                                RuntimeUpdate::Terminal(observation.exit_code),
+                            )
+                            .await;
+                        Err(start_error)
+                    }
+                    ExecutionState::Creating | ExecutionState::Paused => Err(start_error),
+                }
+            }
+            Err(ExecutionManagerError::NotFound(_)) => {
+                let _ = self
+                    .transition(
+                        &claimed,
+                        ManagedExecutionState::Starting,
+                        ManagedExecutionState::Failed,
+                        RuntimeUpdate::Terminal(None),
+                    )
+                    .await;
+                Err(start_error)
+            }
+            Err(_) => Err(start_error),
+        }
+    }
+}

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -1,0 +1,48 @@
+//! Durable implementation of the backend-neutral local execution lifecycle.
+
+mod api;
+mod backend;
+mod create;
+mod operations;
+mod record;
+mod recovery;
+mod store;
+mod support;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+pub use backend::{LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation};
+use record::{build_managed_record, status_from_record};
+use store::RuntimeUpdate;
+
+use crate::{BoxRecord, ManagedExecutionOperation, ManagedExecutionState, ManagedExecutionStore};
+
+/// Local lifecycle facade shared by service, CLI, and SDK adapters.
+#[derive(Clone)]
+pub struct LocalExecutionManager {
+    store: ManagedExecutionStore,
+    home_dir: PathBuf,
+    backend: Arc<dyn LocalExecutionBackend>,
+}
+
+impl LocalExecutionManager {
+    pub fn new(
+        state_path: impl Into<PathBuf>,
+        home_dir: impl Into<PathBuf>,
+        backend: Arc<dyn LocalExecutionBackend>,
+    ) -> Self {
+        Self {
+            store: ManagedExecutionStore::new(state_path),
+            home_dir: home_dir.into(),
+            backend,
+        }
+    }
+
+    pub fn state_path(&self) -> &std::path::Path {
+        self.store.path()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/runtime/src/local_execution/operations.rs
+++ b/src/runtime/src/local_execution/operations.rs
@@ -1,0 +1,192 @@
+use a3s_box_core::{
+    ExecutionLease, ExecutionManagerError, ExecutionManagerResult, ExecutionState, KillOutcome,
+};
+
+use super::record::{execution_id, lease_from_record};
+use super::store::RuntimeUpdate;
+use super::support::{pending_pause_policy, required_handle};
+use super::{BoxRecord, LocalExecutionManager, ManagedExecutionState};
+
+impl LocalExecutionManager {
+    pub(super) async fn finish_pause(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let id = execution_id(&record)?;
+        let keep_memory = pending_pause_policy(&record, &id)?;
+        match self.backend.pause(&record, keep_memory).await {
+            Ok(handle) => {
+                handle.validate(&id)?;
+                let paused = self
+                    .complete_with_handle(
+                        &record,
+                        ManagedExecutionState::Pausing,
+                        ManagedExecutionState::Paused,
+                        handle,
+                    )
+                    .await?;
+                lease_from_record(&paused)
+            }
+            Err(error) => match self.resolve_pause_error(record).await {
+                Some(lease) => Ok(lease),
+                None => Err(error),
+            },
+        }
+    }
+
+    async fn resolve_pause_error(&self, record: BoxRecord) -> Option<ExecutionLease> {
+        let Ok(id) = execution_id(&record) else {
+            return None;
+        };
+        match self.backend.inspect(&record).await {
+            Ok(observation) if observation.state == ExecutionState::Paused => {
+                if observation.validate(&id).is_ok() {
+                    if let Ok(handle) = required_handle(&observation, &id) {
+                        let paused = self
+                            .complete_with_handle(
+                                &record,
+                                ManagedExecutionState::Pausing,
+                                ManagedExecutionState::Paused,
+                                handle,
+                            )
+                            .await
+                            .ok()?;
+                        return lease_from_record(&paused).ok();
+                    }
+                }
+            }
+            Ok(observation) if observation.state == ExecutionState::Running => {
+                let _ = self
+                    .transition(
+                        &record,
+                        ManagedExecutionState::Pausing,
+                        ManagedExecutionState::Running,
+                        RuntimeUpdate::None,
+                    )
+                    .await;
+            }
+            _ => {}
+        }
+        None
+    }
+
+    pub(super) async fn finish_resume(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let id = execution_id(&record)?;
+        match self.backend.resume(&record).await {
+            Ok(handle) => {
+                handle.validate(&id)?;
+                let running = self
+                    .complete_with_handle(
+                        &record,
+                        ManagedExecutionState::Resuming,
+                        ManagedExecutionState::Running,
+                        handle,
+                    )
+                    .await?;
+                lease_from_record(&running)
+            }
+            Err(error) => match self.resolve_resume_error(record).await {
+                Some(lease) => Ok(lease),
+                None => Err(error),
+            },
+        }
+    }
+
+    async fn resolve_resume_error(&self, record: BoxRecord) -> Option<ExecutionLease> {
+        let Ok(id) = execution_id(&record) else {
+            return None;
+        };
+        match self.backend.inspect(&record).await {
+            Ok(observation) if observation.state == ExecutionState::Running => {
+                if observation.validate(&id).is_ok() {
+                    if let Ok(handle) = required_handle(&observation, &id) {
+                        let running = self
+                            .complete_with_handle(
+                                &record,
+                                ManagedExecutionState::Resuming,
+                                ManagedExecutionState::Running,
+                                handle,
+                            )
+                            .await
+                            .ok()?;
+                        return lease_from_record(&running).ok();
+                    }
+                }
+            }
+            Ok(observation) if observation.state == ExecutionState::Paused => {
+                let _ = self
+                    .transition(
+                        &record,
+                        ManagedExecutionState::Resuming,
+                        ManagedExecutionState::Paused,
+                        RuntimeUpdate::None,
+                    )
+                    .await;
+            }
+            _ => {}
+        }
+        None
+    }
+
+    pub(super) async fn finish_kill(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        match self.backend.kill(&record).await {
+            Ok(outcome) => {
+                self.transition(
+                    &record,
+                    ManagedExecutionState::Killing,
+                    ManagedExecutionState::Stopped,
+                    RuntimeUpdate::Terminal(None),
+                )
+                .await?;
+                Ok(outcome)
+            }
+            Err(ExecutionManagerError::NotFound(_)) => {
+                self.transition(
+                    &record,
+                    ManagedExecutionState::Killing,
+                    ManagedExecutionState::Stopped,
+                    RuntimeUpdate::Terminal(None),
+                )
+                .await?;
+                Ok(KillOutcome::AlreadyStopped)
+            }
+            Err(error) => match self.resolve_kill_error(record).await {
+                Some(outcome) => Ok(outcome),
+                None => Err(error),
+            },
+        }
+    }
+
+    async fn resolve_kill_error(&self, record: BoxRecord) -> Option<KillOutcome> {
+        let terminal = match self.backend.inspect(&record).await {
+            Err(ExecutionManagerError::NotFound(_)) => true,
+            Ok(observation)
+                if matches!(
+                    observation.state,
+                    ExecutionState::Stopped | ExecutionState::Failed
+                ) =>
+            {
+                true
+            }
+            _ => false,
+        };
+        if !terminal {
+            return None;
+        }
+        self.transition(
+            &record,
+            ManagedExecutionState::Killing,
+            ManagedExecutionState::Stopped,
+            RuntimeUpdate::Terminal(None),
+        )
+        .await
+        .ok()?;
+        Some(KillOutcome::Killed)
+    }
+}

--- a/src/runtime/src/local_execution/record.rs
+++ b/src/runtime/src/local_execution/record.rs
@@ -1,0 +1,167 @@
+//! Canonical record mapping for managed local executions.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use a3s_box_core::log::LogConfig;
+use a3s_box_core::{
+    CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionLease,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ExecutionStatus, NetworkMode,
+    OperationId,
+};
+use chrono::{DateTime, Utc};
+
+use super::LocalExecutionHandle;
+use crate::{BoxRecord, ManagedExecutionMetadata, ManagedExecutionState};
+
+pub(crate) fn build_managed_record(
+    home_dir: &Path,
+    execution_id: &ExecutionId,
+    operation_id: OperationId,
+    request: CreateExecutionRequest,
+    now: DateTime<Utc>,
+) -> ExecutionManagerResult<BoxRecord> {
+    let metadata =
+        ManagedExecutionMetadata::new(operation_id, ExecutionGeneration::INITIAL, request.clone())
+            .map_err(|error| ExecutionManagerError::InvalidRequest(error.to_string()))?;
+    let config = &request.config;
+    let short_id = BoxRecord::make_short_id(execution_id.as_str());
+    let box_dir = home_dir.join("boxes").join(execution_id.as_str());
+    let network_name = match &config.network {
+        NetworkMode::Bridge { network } => Some(network.clone()),
+        NetworkMode::Tsi | NetworkMode::None => None,
+    };
+    let env = config.extra_env.iter().cloned().collect::<HashMap<_, _>>();
+    let labels = request
+        .labels
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+
+    Ok(BoxRecord {
+        id: execution_id.to_string(),
+        short_id: short_id.clone(),
+        name: format!("managed-{short_id}"),
+        image: config.image.clone(),
+        isolation: config.isolation,
+        managed_execution: Some(metadata),
+        status: ManagedExecutionState::Creating.as_status().to_string(),
+        pid: None,
+        pid_start_time: None,
+        cpus: config.resources.vcpus,
+        memory_mb: config.resources.memory_mb,
+        volumes: config.volumes.clone(),
+        virtiofs_cache: config.virtiofs_cache.clone(),
+        env,
+        cmd: config.cmd.clone(),
+        entrypoint: config.entrypoint_override.clone(),
+        box_dir: box_dir.clone(),
+        exec_socket_path: box_dir.join("sockets/exec.sock"),
+        console_log: box_dir.join("logs/console.log"),
+        created_at: now,
+        started_at: None,
+        auto_remove: false,
+        hostname: config.hostname.clone(),
+        user: config.user.clone(),
+        workdir: config.workdir.clone(),
+        restart_policy: "no".to_string(),
+        port_map: config.port_map.clone(),
+        labels,
+        stopped_by_user: false,
+        restart_count: 0,
+        max_restart_count: 0,
+        exit_code: None,
+        health_check: None,
+        healthcheck_disabled: false,
+        health_status: "none".to_string(),
+        health_retries: 0,
+        health_last_check: None,
+        network_mode: config.network.clone(),
+        network_name,
+        volume_names: Vec::new(),
+        tmpfs: config.tmpfs.clone(),
+        anonymous_volumes: Vec::new(),
+        resource_limits: config.resource_limits.clone(),
+        log_config: LogConfig::default(),
+        add_host: config.add_hosts.clone(),
+        platform: None,
+        init: false,
+        read_only: config.read_only,
+        cap_add: config.cap_add.clone(),
+        cap_drop: config.cap_drop.clone(),
+        security_opt: config.security_opt.clone(),
+        privileged: config.privileged,
+        devices: Vec::new(),
+        gpus: None,
+        shm_size: None,
+        stop_signal: None,
+        stop_timeout: None,
+        oom_kill_disable: false,
+        oom_score_adj: None,
+    })
+}
+
+pub(crate) fn apply_handle(record: &mut BoxRecord, handle: &LocalExecutionHandle) {
+    record.pid = handle.pid;
+    record.pid_start_time = handle.pid_start_time;
+    record.exec_socket_path = handle.exec_socket_path.clone();
+    record.console_log = handle.console_log.clone();
+    record.started_at = Some(handle.started_at);
+    record.anonymous_volumes = handle.anonymous_volumes.clone();
+    record.exit_code = None;
+}
+
+pub(crate) fn clear_live_runtime(record: &mut BoxRecord, exit_code: Option<i32>) {
+    record.pid = None;
+    record.pid_start_time = None;
+    record.exit_code = exit_code;
+    record.health_status = "none".to_string();
+    record.health_retries = 0;
+}
+
+pub(crate) fn lease_from_record(record: &BoxRecord) -> ExecutionManagerResult<ExecutionLease> {
+    let execution_id = execution_id(record)?;
+    let metadata = metadata(record, &execution_id)?;
+    let started_at = record.started_at.ok_or_else(|| {
+        ExecutionManagerError::Internal(format!(
+            "managed execution {execution_id} is ready without a start timestamp"
+        ))
+    })?;
+    Ok(ExecutionLease {
+        execution_id,
+        generation: metadata.generation,
+        plan: metadata.plan.clone(),
+        resources: metadata.request.config.resources.clone(),
+        started_at,
+    })
+}
+
+pub(crate) fn status_from_record(
+    record: &BoxRecord,
+    state: ExecutionState,
+) -> ExecutionManagerResult<ExecutionStatus> {
+    let execution_id = execution_id(record)?;
+    let metadata = metadata(record, &execution_id)?;
+    Ok(ExecutionStatus {
+        execution_id,
+        generation: metadata.generation,
+        state,
+        plan: metadata.plan.clone(),
+    })
+}
+
+pub(crate) fn execution_id(record: &BoxRecord) -> ExecutionManagerResult<ExecutionId> {
+    ExecutionId::new(record.id.clone())
+        .map_err(|error| ExecutionManagerError::Internal(error.to_string()))
+}
+
+fn metadata<'a>(
+    record: &'a BoxRecord,
+    execution_id: &ExecutionId,
+) -> ExecutionManagerResult<&'a ManagedExecutionMetadata> {
+    record.managed_execution.as_ref().ok_or_else(|| {
+        ExecutionManagerError::Internal(format!(
+            "execution {execution_id} lost managed lifecycle metadata"
+        ))
+    })
+}

--- a/src/runtime/src/local_execution/recovery.rs
+++ b/src/runtime/src/local_execution/recovery.rs
@@ -1,0 +1,182 @@
+use a3s_box_core::{
+    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ReconcileOutcome,
+};
+
+use super::record::{execution_id, lease_from_record};
+use super::support::{managed_state, outcome_from_record, required_handle};
+use super::{BoxRecord, LocalExecutionManager, ManagedExecutionState, RuntimeUpdate};
+
+impl LocalExecutionManager {
+    pub(super) async fn observe_record(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<(BoxRecord, ExecutionState)> {
+        let internal = managed_state(&record)?;
+        match internal {
+            ManagedExecutionState::Creating => return Ok((record, ExecutionState::Creating)),
+            ManagedExecutionState::Stopped => return Ok((record, ExecutionState::Stopped)),
+            ManagedExecutionState::Failed => return Ok((record, ExecutionState::Failed)),
+            _ => {}
+        }
+        let id = execution_id(&record)?;
+        let observation = match self.backend.inspect(&record).await {
+            Ok(observation) => observation,
+            Err(ExecutionManagerError::NotFound(_)) => {
+                if internal == ManagedExecutionState::Starting {
+                    return Ok((record, ExecutionState::Creating));
+                }
+                let terminal = if internal == ManagedExecutionState::Killing {
+                    ManagedExecutionState::Stopped
+                } else {
+                    ManagedExecutionState::Failed
+                };
+                let record = self
+                    .transition(&record, internal, terminal, RuntimeUpdate::Terminal(None))
+                    .await?;
+                let state = if terminal == ManagedExecutionState::Stopped {
+                    ExecutionState::Stopped
+                } else {
+                    ExecutionState::Failed
+                };
+                return Ok((record, state));
+            }
+            Err(error) => return Err(error),
+        };
+        observation.validate(&id)?;
+
+        match (internal, observation.state) {
+            (ManagedExecutionState::Starting, ExecutionState::Running) => {
+                let record = self
+                    .complete_with_handle(
+                        &record,
+                        internal,
+                        ManagedExecutionState::Running,
+                        required_handle(&observation, &id)?,
+                    )
+                    .await?;
+                Ok((record, ExecutionState::Running))
+            }
+            (ManagedExecutionState::Starting, ExecutionState::Creating) => {
+                Ok((record, ExecutionState::Creating))
+            }
+            (ManagedExecutionState::Pausing, ExecutionState::Paused) => {
+                let record = self
+                    .complete_with_handle(
+                        &record,
+                        internal,
+                        ManagedExecutionState::Paused,
+                        required_handle(&observation, &id)?,
+                    )
+                    .await?;
+                Ok((record, ExecutionState::Paused))
+            }
+            (ManagedExecutionState::Pausing, ExecutionState::Running)
+            | (ManagedExecutionState::Pausing, ExecutionState::Creating) => {
+                Ok((record, ExecutionState::Running))
+            }
+            (ManagedExecutionState::Resuming, ExecutionState::Running) => {
+                let record = self
+                    .complete_with_handle(
+                        &record,
+                        internal,
+                        ManagedExecutionState::Running,
+                        required_handle(&observation, &id)?,
+                    )
+                    .await?;
+                Ok((record, ExecutionState::Running))
+            }
+            (ManagedExecutionState::Resuming, ExecutionState::Paused)
+            | (ManagedExecutionState::Resuming, ExecutionState::Creating) => {
+                Ok((record, ExecutionState::Paused))
+            }
+            (ManagedExecutionState::Killing, ExecutionState::Running) => {
+                Ok((record, ExecutionState::Running))
+            }
+            (ManagedExecutionState::Killing, ExecutionState::Paused) => {
+                Ok((record, ExecutionState::Paused))
+            }
+            (ManagedExecutionState::Killing, ExecutionState::Creating) => {
+                Ok((record, ExecutionState::Creating))
+            }
+            (ManagedExecutionState::Running, ExecutionState::Running) => {
+                Ok((record, ExecutionState::Running))
+            }
+            (ManagedExecutionState::Paused, ExecutionState::Paused) => {
+                Ok((record, ExecutionState::Paused))
+            }
+            (_, ExecutionState::Stopped) | (_, ExecutionState::Failed) => {
+                let target = if observation.state == ExecutionState::Stopped {
+                    ManagedExecutionState::Stopped
+                } else {
+                    ManagedExecutionState::Failed
+                };
+                let record = self
+                    .transition(
+                        &record,
+                        internal,
+                        target,
+                        RuntimeUpdate::Terminal(observation.exit_code),
+                    )
+                    .await?;
+                Ok((record, observation.state))
+            }
+            _ => Err(ExecutionManagerError::Internal(format!(
+                "persisted state {internal} disagrees with backend state {:?} for {id}",
+                observation.state
+            ))),
+        }
+    }
+
+    pub(super) async fn recover_start(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ReconcileOutcome> {
+        let state = managed_state(&record)?;
+        let record = if state == ManagedExecutionState::Starting {
+            match self.backend.inspect(&record).await {
+                Err(ExecutionManagerError::NotFound(_)) => {
+                    self.transition(
+                        &record,
+                        ManagedExecutionState::Starting,
+                        ManagedExecutionState::Creating,
+                        RuntimeUpdate::None,
+                    )
+                    .await?
+                }
+                Ok(observation) => {
+                    let id = execution_id(&record)?;
+                    observation.validate(&id)?;
+                    if observation.state == ExecutionState::Running {
+                        let running = self
+                            .complete_with_handle(
+                                &record,
+                                ManagedExecutionState::Starting,
+                                ManagedExecutionState::Running,
+                                required_handle(&observation, &id)?,
+                            )
+                            .await?;
+                        return Ok(ReconcileOutcome::Ready(lease_from_record(&running)?));
+                    }
+                    if observation.state == ExecutionState::Creating {
+                        return Ok(ReconcileOutcome::Creating);
+                    }
+                    let failed = self
+                        .transition(
+                            &record,
+                            ManagedExecutionState::Starting,
+                            ManagedExecutionState::Failed,
+                            RuntimeUpdate::Terminal(observation.exit_code),
+                        )
+                        .await?;
+                    return outcome_from_record(failed, ExecutionState::Failed);
+                }
+                Err(error) => return Err(error),
+            }
+        } else {
+            record
+        };
+        self.claim_and_start(record)
+            .await
+            .map(ReconcileOutcome::Ready)
+    }
+}

--- a/src/runtime/src/local_execution/store.rs
+++ b/src/runtime/src/local_execution/store.rs
@@ -1,0 +1,165 @@
+use a3s_box_core::{
+    ExecutionGeneration, ExecutionId, ExecutionManagerError, ExecutionManagerResult, OperationId,
+};
+
+use super::record::{apply_handle, clear_live_runtime, execution_id};
+use super::support::{generation, managed_state};
+use super::{LocalExecutionHandle, LocalExecutionManager};
+use crate::{
+    BoxRecord, ManagedExecutionOperation, ManagedExecutionReservation, ManagedExecutionState,
+    ManagedExecutionStoreError,
+};
+
+impl LocalExecutionManager {
+    pub(super) async fn reserve(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ManagedExecutionReservation> {
+        let store = self.store.clone();
+        run_store(move || store.reserve(record)).await
+    }
+
+    pub(super) async fn get(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> ExecutionManagerResult<Option<BoxRecord>> {
+        let store = self.store.clone();
+        let execution_id = execution_id.clone();
+        run_store(move || store.get(&execution_id)).await
+    }
+
+    pub(super) async fn get_by_operation(
+        &self,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<Option<BoxRecord>> {
+        let store = self.store.clone();
+        let operation_id = operation_id.clone();
+        run_store(move || store.get_by_operation_id(&operation_id)).await
+    }
+
+    pub(super) async fn transition(
+        &self,
+        record: &BoxRecord,
+        from: ManagedExecutionState,
+        to: ManagedExecutionState,
+        update: RuntimeUpdate,
+    ) -> ExecutionManagerResult<BoxRecord> {
+        let store = self.store.clone();
+        let execution_id = execution_id(record)?;
+        let generation = generation(record, &execution_id)?;
+        run_store(move || {
+            store.transition_with(&execution_id, generation, from, to, |record| match update {
+                RuntimeUpdate::None => {}
+                RuntimeUpdate::Handle(handle) => apply_handle(record, &handle),
+                RuntimeUpdate::Terminal(exit_code) => clear_live_runtime(record, exit_code),
+                RuntimeUpdate::PauseClaim(keep_memory) => {
+                    if let Some(metadata) = record.managed_execution.as_mut() {
+                        metadata.pending_operation =
+                            Some(ManagedExecutionOperation::Pause { keep_memory });
+                    }
+                }
+            })
+        })
+        .await
+    }
+
+    pub(super) async fn complete_with_handle(
+        &self,
+        record: &BoxRecord,
+        from: ManagedExecutionState,
+        to: ManagedExecutionState,
+        handle: LocalExecutionHandle,
+    ) -> ExecutionManagerResult<BoxRecord> {
+        let execution_id = execution_id(record)?;
+        let current_generation = generation(record, &execution_id)?;
+        let expected_generation = if matches!(
+            (from, to),
+            (
+                ManagedExecutionState::Pausing,
+                ManagedExecutionState::Paused
+            ) | (
+                ManagedExecutionState::Resuming,
+                ManagedExecutionState::Running
+            )
+        ) {
+            ExecutionGeneration::new(current_generation.get().checked_add(1).ok_or_else(|| {
+                ExecutionManagerError::Internal(format!(
+                    "execution {execution_id} generation is exhausted"
+                ))
+            })?)?
+        } else {
+            current_generation
+        };
+        match self
+            .transition(record, from, to, RuntimeUpdate::Handle(handle))
+            .await
+        {
+            Ok(record) => Ok(record),
+            Err(error @ ExecutionManagerError::Conflict { .. }) => {
+                let Some(current) = self.get(&execution_id).await? else {
+                    return Err(ExecutionManagerError::NotFound(execution_id));
+                };
+                if managed_state(&current)? == to
+                    && generation(&current, &execution_id)? == expected_generation
+                {
+                    Ok(current)
+                } else {
+                    Err(error)
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+pub(super) enum RuntimeUpdate {
+    None,
+    Handle(LocalExecutionHandle),
+    Terminal(Option<i32>),
+    PauseClaim(bool),
+}
+
+async fn run_store<T>(
+    operation: impl FnOnce() -> Result<T, ManagedExecutionStoreError> + Send + 'static,
+) -> ExecutionManagerResult<T>
+where
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|error| {
+            ExecutionManagerError::Internal(format!("managed state task failed: {error}"))
+        })?
+        .map_err(map_store_error)
+}
+
+fn map_store_error(error: ManagedExecutionStoreError) -> ExecutionManagerError {
+    match error {
+        ManagedExecutionStoreError::Io(error) => {
+            ExecutionManagerError::Unavailable(error.to_string())
+        }
+        ManagedExecutionStoreError::NotFound(execution_id) => {
+            ExecutionManagerError::NotFound(execution_id)
+        }
+        ManagedExecutionStoreError::Conflict {
+            execution_id,
+            message,
+        } => ExecutionManagerError::Conflict {
+            execution_id,
+            message,
+        },
+        ManagedExecutionStoreError::Unmanaged(execution_id) => ExecutionManagerError::Internal(
+            format!("execution record is not managed: {execution_id}"),
+        ),
+        ManagedExecutionStoreError::InvalidRecord(message) => {
+            ExecutionManagerError::Internal(message)
+        }
+        ManagedExecutionStoreError::InvalidTransition {
+            execution_id,
+            from,
+            to,
+        } => ExecutionManagerError::Internal(format!(
+            "invalid managed transition for {execution_id}: {from} -> {to}"
+        )),
+    }
+}

--- a/src/runtime/src/local_execution/support.rs
+++ b/src/runtime/src/local_execution/support.rs
@@ -1,0 +1,108 @@
+use a3s_box_core::{
+    ExecutionGeneration, ExecutionId, ExecutionManagerError, ExecutionManagerResult,
+    ExecutionState, ReconcileOutcome,
+};
+
+use super::record::lease_from_record;
+use super::{
+    BoxRecord, LocalExecutionHandle, LocalExecutionObservation, ManagedExecutionOperation,
+    ManagedExecutionState,
+};
+
+pub(super) fn managed_state(record: &BoxRecord) -> ExecutionManagerResult<ManagedExecutionState> {
+    record
+        .managed_state()
+        .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?
+        .ok_or_else(|| {
+            ExecutionManagerError::Internal(format!("execution {} is not managed", record.id))
+        })
+}
+
+pub(super) fn generation(
+    record: &BoxRecord,
+    execution_id: &ExecutionId,
+) -> ExecutionManagerResult<ExecutionGeneration> {
+    record
+        .managed_execution
+        .as_ref()
+        .map(|metadata| metadata.generation)
+        .ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "execution {execution_id} has no managed generation"
+            ))
+        })
+}
+
+pub(super) fn require_generation(
+    record: &BoxRecord,
+    execution_id: &ExecutionId,
+    expected: ExecutionGeneration,
+) -> ExecutionManagerResult<()> {
+    let actual = generation(record, execution_id)?;
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(ExecutionManagerError::Conflict {
+            execution_id: execution_id.clone(),
+            message: format!(
+                "expected generation {}, found {}",
+                expected.get(),
+                actual.get()
+            ),
+        })
+    }
+}
+
+pub(super) fn state_conflict(
+    record: &BoxRecord,
+    execution_id: &ExecutionId,
+    operation: &str,
+) -> ExecutionManagerError {
+    let state = managed_state(record)
+        .map(|state| state.to_string())
+        .unwrap_or_else(|error| error.to_string());
+    ExecutionManagerError::Conflict {
+        execution_id: execution_id.clone(),
+        message: format!("cannot {operation} execution in state {state}"),
+    }
+}
+
+pub(super) fn required_handle(
+    observation: &LocalExecutionObservation,
+    execution_id: &ExecutionId,
+) -> ExecutionManagerResult<LocalExecutionHandle> {
+    observation.handle.clone().ok_or_else(|| {
+        ExecutionManagerError::Internal(format!(
+            "backend returned no runtime evidence for {execution_id}"
+        ))
+    })
+}
+
+pub(super) fn pending_pause_policy(
+    record: &BoxRecord,
+    execution_id: &ExecutionId,
+) -> ExecutionManagerResult<bool> {
+    match record
+        .managed_execution
+        .as_ref()
+        .and_then(|metadata| metadata.pending_operation.as_ref())
+    {
+        Some(ManagedExecutionOperation::Pause { keep_memory }) => Ok(*keep_memory),
+        _ => Err(ExecutionManagerError::Internal(format!(
+            "pausing execution {execution_id} has no persisted pause policy"
+        ))),
+    }
+}
+
+pub(super) fn outcome_from_record(
+    record: BoxRecord,
+    state: ExecutionState,
+) -> ExecutionManagerResult<ReconcileOutcome> {
+    match state {
+        ExecutionState::Creating => Ok(ReconcileOutcome::Creating),
+        ExecutionState::Running | ExecutionState::Paused => {
+            Ok(ReconcileOutcome::Ready(lease_from_record(&record)?))
+        }
+        ExecutionState::Stopped | ExecutionState::Failed => Ok(ReconcileOutcome::Failed),
+    }
+}

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -1,0 +1,513 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use a3s_box_core::{
+    BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionIsolation,
+    ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionState, KillOutcome,
+    NetworkMode, OperationId, ReconcileOutcome,
+};
+use async_trait::async_trait;
+use chrono::{TimeZone, Utc};
+
+use super::*;
+use crate::{ManagedExecutionState, ManagedExecutionStore};
+
+#[derive(Clone)]
+struct FakeExecution {
+    state: ExecutionState,
+    handle: LocalExecutionHandle,
+    exit_code: Option<i32>,
+}
+
+#[derive(Default)]
+struct FakeBackend {
+    executions: Mutex<HashMap<String, FakeExecution>>,
+    starts: AtomicUsize,
+    pauses: AtomicUsize,
+    resumes: AtomicUsize,
+    kills: AtomicUsize,
+    fail_pause: AtomicBool,
+    fail_pause_after_effect: AtomicBool,
+    last_keep_memory: Mutex<Option<bool>>,
+}
+
+impl FakeBackend {
+    fn handle(record: &BoxRecord) -> LocalExecutionHandle {
+        LocalExecutionHandle {
+            started_at: Utc.with_ymd_and_hms(2026, 7, 14, 12, 30, 0).unwrap(),
+            pid: Some(4242),
+            pid_start_time: Some(777),
+            exec_socket_path: record.box_dir.join("sockets/exec.sock"),
+            console_log: record.box_dir.join("logs/console.log"),
+            anonymous_volumes: vec!["anonymous-1".to_string()],
+        }
+    }
+
+    fn execution_id(record: &BoxRecord) -> ExecutionId {
+        ExecutionId::new(record.id.clone()).unwrap()
+    }
+
+    fn stop_externally(&self, execution_id: &ExecutionId, exit_code: i32) {
+        let mut executions = self.executions.lock().unwrap();
+        let execution = executions.get_mut(execution_id.as_str()).unwrap();
+        execution.state = ExecutionState::Stopped;
+        execution.exit_code = Some(exit_code);
+    }
+}
+
+#[async_trait]
+impl LocalExecutionBackend for FakeBackend {
+    async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
+        let mut executions = self.executions.lock().unwrap();
+        if let Some(execution) = executions.get(&record.id) {
+            return match execution.state {
+                ExecutionState::Running | ExecutionState::Paused => Ok(execution.handle.clone()),
+                state => Err(ExecutionManagerError::Conflict {
+                    execution_id: Self::execution_id(record),
+                    message: format!("fake execution is {state:?}"),
+                }),
+            };
+        }
+        self.starts.fetch_add(1, Ordering::Relaxed);
+        let handle = Self::handle(record);
+        executions.insert(
+            record.id.clone(),
+            FakeExecution {
+                state: ExecutionState::Running,
+                handle: handle.clone(),
+                exit_code: None,
+            },
+        );
+        Ok(handle)
+    }
+
+    async fn inspect(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionObservation> {
+        let executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get(&record.id)
+            .ok_or_else(|| ExecutionManagerError::NotFound(Self::execution_id(record)))?;
+        Ok(LocalExecutionObservation {
+            state: execution.state,
+            handle: matches!(
+                execution.state,
+                ExecutionState::Running | ExecutionState::Paused
+            )
+            .then(|| execution.handle.clone()),
+            exit_code: execution.exit_code,
+        })
+    }
+
+    async fn pause(
+        &self,
+        record: &BoxRecord,
+        keep_memory: bool,
+    ) -> ExecutionManagerResult<LocalExecutionHandle> {
+        self.pauses.fetch_add(1, Ordering::Relaxed);
+        *self.last_keep_memory.lock().unwrap() = Some(keep_memory);
+        if self.fail_pause.load(Ordering::Relaxed) {
+            return Err(ExecutionManagerError::Unavailable(
+                "fake pause is unavailable".to_string(),
+            ));
+        }
+        let mut executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get_mut(&record.id)
+            .ok_or_else(|| ExecutionManagerError::NotFound(Self::execution_id(record)))?;
+        if execution.state != ExecutionState::Running {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: Self::execution_id(record),
+                message: "fake execution is not running".to_string(),
+            });
+        }
+        execution.state = ExecutionState::Paused;
+        if self.fail_pause_after_effect.load(Ordering::Relaxed) {
+            return Err(ExecutionManagerError::Unavailable(
+                "fake pause response was lost".to_string(),
+            ));
+        }
+        Ok(execution.handle.clone())
+    }
+
+    async fn resume(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
+        self.resumes.fetch_add(1, Ordering::Relaxed);
+        let mut executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get_mut(&record.id)
+            .ok_or_else(|| ExecutionManagerError::NotFound(Self::execution_id(record)))?;
+        if execution.state != ExecutionState::Paused {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: Self::execution_id(record),
+                message: "fake execution is not paused".to_string(),
+            });
+        }
+        execution.state = ExecutionState::Running;
+        Ok(execution.handle.clone())
+    }
+
+    async fn kill(&self, record: &BoxRecord) -> ExecutionManagerResult<KillOutcome> {
+        self.kills.fetch_add(1, Ordering::Relaxed);
+        let mut executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get_mut(&record.id)
+            .ok_or_else(|| ExecutionManagerError::NotFound(Self::execution_id(record)))?;
+        if execution.state == ExecutionState::Stopped {
+            return Ok(KillOutcome::AlreadyStopped);
+        }
+        execution.state = ExecutionState::Stopped;
+        Ok(KillOutcome::Killed)
+    }
+}
+
+fn harness() -> (tempfile::TempDir, LocalExecutionManager, Arc<FakeBackend>) {
+    let directory = tempfile::tempdir().unwrap();
+    let backend = Arc::new(FakeBackend::default());
+    let manager = LocalExecutionManager::new(
+        directory.path().join("boxes.json"),
+        directory.path().join("home"),
+        backend.clone(),
+    );
+    (directory, manager, backend)
+}
+
+fn request(external_id: &str) -> CreateExecutionRequest {
+    let mut labels = BTreeMap::new();
+    labels.insert("purpose".to_string(), "test".to_string());
+    CreateExecutionRequest {
+        external_sandbox_id: external_id.to_string(),
+        config: BoxConfig {
+            image: "alpine:3.20".to_string(),
+            isolation: ExecutionIsolation::Sandbox,
+            network: NetworkMode::None,
+            resources: a3s_box_core::ResourceConfig {
+                vcpus: 1,
+                memory_mb: 128,
+                disk_mb: 512,
+                timeout: 300,
+            },
+            ..Default::default()
+        },
+        labels,
+    }
+}
+
+fn operation(value: &str) -> OperationId {
+    OperationId::new(value).unwrap()
+}
+
+fn persisted(manager: &LocalExecutionManager, execution_id: &ExecutionId) -> BoxRecord {
+    ManagedExecutionStore::new(manager.state_path().to_path_buf())
+        .get(execution_id)
+        .unwrap()
+        .unwrap()
+}
+
+async fn reserve_starting(
+    manager: &LocalExecutionManager,
+    execution_id: &ExecutionId,
+    operation_id: &OperationId,
+) -> BoxRecord {
+    let record = build_managed_record(
+        &manager.home_dir,
+        execution_id,
+        operation_id.clone(),
+        request("external-recovery-id"),
+        Utc::now(),
+    )
+    .unwrap();
+    let record = manager.reserve(record).await.unwrap().into_record();
+    manager
+        .transition(
+            &record,
+            ManagedExecutionState::Creating,
+            ManagedExecutionState::Starting,
+            RuntimeUpdate::None,
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn create_persists_trusted_identity_and_returns_running_lease() {
+    let (directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+
+    let lease = manager
+        .create_and_start(request("external/../../sandbox"), &operation_id)
+        .await
+        .unwrap();
+    let status = manager.inspect(&lease.execution_id).await.unwrap();
+    let record = persisted(&manager, &lease.execution_id);
+
+    assert_eq!(status.state, ExecutionState::Running);
+    assert_eq!(status.generation, ExecutionGeneration::INITIAL);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        record
+            .managed_execution
+            .as_ref()
+            .unwrap()
+            .request
+            .external_sandbox_id,
+        "external/../../sandbox"
+    );
+    assert!(!record.name.contains("external"));
+    assert!(record
+        .box_dir
+        .starts_with(directory.path().join("home/boxes")));
+    assert_eq!(record.pid, Some(4242));
+    assert_eq!(record.anonymous_volumes, vec!["anonymous-1"]);
+}
+
+#[tokio::test]
+async fn repeated_create_is_idempotent_and_request_drift_conflicts() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+    let create_request = request("sandbox-1");
+
+    let first = manager
+        .create_and_start(create_request.clone(), &operation_id)
+        .await
+        .unwrap();
+    let retry = manager
+        .create_and_start(create_request, &operation_id)
+        .await
+        .unwrap();
+    let drift = manager
+        .create_and_start(request("sandbox-2"), &operation_id)
+        .await;
+
+    assert_eq!(retry.execution_id, first.execution_id);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+    assert!(matches!(drift, Err(ExecutionManagerError::Conflict { .. })));
+}
+
+#[tokio::test]
+async fn concurrent_create_calls_start_one_internal_execution() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+    let create_request = request("sandbox-1");
+
+    let (left, right) = tokio::join!(
+        manager.create_and_start(create_request.clone(), &operation_id),
+        manager.create_and_start(create_request.clone(), &operation_id),
+    );
+    let retry = manager
+        .create_and_start(create_request, &operation_id)
+        .await
+        .unwrap();
+
+    let successes: Vec<_> = [left, right].into_iter().filter_map(Result::ok).collect();
+    assert!(!successes.is_empty());
+    assert!(successes
+        .iter()
+        .all(|lease| lease.execution_id == retry.execution_id));
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn pause_and_resume_are_generation_fenced_and_persist_policy() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation_id)
+        .await
+        .unwrap();
+
+    let paused = manager
+        .pause(&running.execution_id, running.generation, true)
+        .await
+        .unwrap();
+    let stale = manager
+        .resume(&running.execution_id, running.generation)
+        .await;
+    let resumed = manager
+        .resume(&paused.execution_id, paused.generation)
+        .await
+        .unwrap();
+
+    assert_eq!(paused.generation, ExecutionGeneration::new(2).unwrap());
+    assert_eq!(resumed.generation, ExecutionGeneration::new(3).unwrap());
+    assert!(matches!(stale, Err(ExecutionManagerError::Conflict { .. })));
+    assert_eq!(*backend.last_keep_memory.lock().unwrap(), Some(true));
+    assert_eq!(backend.pauses.load(Ordering::Relaxed), 1);
+    assert_eq!(backend.resumes.load(Ordering::Relaxed), 1);
+    let record = persisted(&manager, &running.execution_id);
+    assert_eq!(
+        record.managed_state().unwrap(),
+        Some(ManagedExecutionState::Running)
+    );
+    assert!(record
+        .managed_execution
+        .unwrap()
+        .pending_operation
+        .is_none());
+}
+
+#[tokio::test]
+async fn failed_pause_rolls_back_without_changing_backend_or_generation() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-1"))
+        .await
+        .unwrap();
+    backend.fail_pause.store(true, Ordering::Relaxed);
+
+    let error = manager
+        .pause(&running.execution_id, running.generation, false)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ExecutionManagerError::Unavailable(_)));
+    let record = persisted(&manager, &running.execution_id);
+    assert_eq!(
+        record.managed_state().unwrap(),
+        Some(ManagedExecutionState::Running)
+    );
+    assert_eq!(
+        record.managed_execution.unwrap().generation,
+        ExecutionGeneration::INITIAL
+    );
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn ambiguous_pause_error_uses_backend_evidence_and_publishes_success() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-1"))
+        .await
+        .unwrap();
+    backend
+        .fail_pause_after_effect
+        .store(true, Ordering::Relaxed);
+
+    let paused = manager
+        .pause(&running.execution_id, running.generation, true)
+        .await
+        .unwrap();
+
+    assert_eq!(paused.generation, ExecutionGeneration::new(2).unwrap());
+    assert_eq!(
+        persisted(&manager, &running.execution_id)
+            .managed_state()
+            .unwrap(),
+        Some(ManagedExecutionState::Paused)
+    );
+}
+
+#[tokio::test]
+async fn kill_is_generation_fenced_and_idempotent() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-1"))
+        .await
+        .unwrap();
+
+    let killed = manager
+        .kill(&running.execution_id, running.generation)
+        .await
+        .unwrap();
+    let repeated = manager
+        .kill(&running.execution_id, running.generation)
+        .await
+        .unwrap();
+
+    assert_eq!(killed, KillOutcome::Killed);
+    assert_eq!(repeated, KillOutcome::AlreadyStopped);
+    assert_eq!(backend.kills.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        manager.inspect(&running.execution_id).await.unwrap().state,
+        ExecutionState::Stopped
+    );
+}
+
+#[tokio::test]
+async fn startup_reconciliation_restarts_a_claim_without_backend_evidence() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+    let execution_id = ExecutionId::new("execution-recovery-1").unwrap();
+    reserve_starting(&manager, &execution_id, &operation_id).await;
+
+    let outcome = manager.reconcile(&operation_id).await.unwrap();
+
+    let ReconcileOutcome::Ready(lease) = outcome else {
+        panic!("expected ready reconciliation");
+    };
+    assert_eq!(lease.execution_id, execution_id);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn startup_reconciliation_publishes_an_already_started_backend_once() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+    let execution_id = ExecutionId::new("execution-recovery-1").unwrap();
+    let starting = reserve_starting(&manager, &execution_id, &operation_id).await;
+    backend.start(&starting).await.unwrap();
+
+    let outcome = manager.reconcile(&operation_id).await.unwrap();
+
+    let ReconcileOutcome::Ready(lease) = outcome else {
+        panic!("expected ready reconciliation");
+    };
+    assert_eq!(lease.execution_id, execution_id);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn reconciliation_completes_pause_after_backend_side_effect() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation_id)
+        .await
+        .unwrap();
+    let record = persisted(&manager, &running.execution_id);
+    let pausing = manager
+        .transition(
+            &record,
+            ManagedExecutionState::Running,
+            ManagedExecutionState::Pausing,
+            RuntimeUpdate::PauseClaim(true),
+        )
+        .await
+        .unwrap();
+    backend.pause(&pausing, true).await.unwrap();
+
+    let outcome = manager.reconcile(&operation_id).await.unwrap();
+
+    let ReconcileOutcome::Ready(lease) = outcome else {
+        panic!("expected ready reconciliation");
+    };
+    assert_eq!(lease.generation, ExecutionGeneration::new(2).unwrap());
+    assert_eq!(backend.pauses.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        manager.inspect(&running.execution_id).await.unwrap().state,
+        ExecutionState::Paused
+    );
+}
+
+#[tokio::test]
+async fn inspection_persists_an_external_terminal_observation() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-1"))
+        .await
+        .unwrap();
+    backend.stop_externally(&running.execution_id, 7);
+
+    let status = manager.inspect(&running.execution_id).await.unwrap();
+    let record = persisted(&manager, &running.execution_id);
+
+    assert_eq!(status.state, ExecutionState::Stopped);
+    assert_eq!(record.exit_code, Some(7));
+    assert_eq!(record.pid, None);
+    assert_eq!(
+        record.managed_state().unwrap(),
+        Some(ManagedExecutionState::Stopped)
+    );
+}

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use a3s_box_core::{ExecutionGeneration, ExecutionId, OperationId};
 use thiserror::Error;
 
-use crate::{BoxRecord, BoxStateStore, ManagedExecutionState};
+use crate::{BoxRecord, BoxStateStore, ManagedExecutionOperation, ManagedExecutionState};
 
 /// Strict durable repository used by the local `ExecutionManager`.
 #[derive(Debug, Clone)]
@@ -164,6 +164,25 @@ impl ManagedExecutionStore {
         expected_state: ManagedExecutionState,
         next_state: ManagedExecutionState,
     ) -> ManagedExecutionStoreResult<BoxRecord> {
+        self.transition_with(
+            execution_id,
+            expected_generation,
+            expected_state,
+            next_state,
+            |_| {},
+        )
+    }
+
+    /// Persist one legal transition and update runtime evidence in the same
+    /// transaction.
+    pub fn transition_with(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+        expected_state: ManagedExecutionState,
+        next_state: ManagedExecutionState,
+        update: impl FnOnce(&mut BoxRecord),
+    ) -> ManagedExecutionStoreResult<BoxRecord> {
         let execution_id = execution_id.clone();
         BoxStateStore::transact(&self.path, move |store| {
             let record = store
@@ -195,12 +214,48 @@ impl ManagedExecutionStore {
                 next_state,
                 expected_generation,
             )?;
+            let original_metadata = record
+                .managed_execution
+                .as_ref()
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?
+                .clone();
+            update(record);
+            if record.id != execution_id.as_str() {
+                return Err(ManagedExecutionStoreError::InvalidRecord(format!(
+                    "transition changed execution ID {execution_id}"
+                )));
+            }
+            let updated_metadata = record
+                .managed_execution
+                .as_ref()
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+            if updated_metadata.operation_id != original_metadata.operation_id
+                || !same_creation_intent(updated_metadata, &original_metadata)?
+            {
+                return Err(ManagedExecutionStoreError::InvalidRecord(format!(
+                    "transition changed creation identity for {execution_id}"
+                )));
+            }
             record.status = next_state.as_status().to_string();
-            record
+            let metadata = record
                 .managed_execution
                 .as_mut()
-                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?
-                .generation = next_generation;
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+            metadata.generation = next_generation;
+            metadata.pending_operation = match next_state {
+                ManagedExecutionState::Starting => Some(ManagedExecutionOperation::Start),
+                ManagedExecutionState::Pausing => match metadata.pending_operation.take() {
+                    Some(operation @ ManagedExecutionOperation::Pause { .. }) => Some(operation),
+                    _ => Some(ManagedExecutionOperation::Pause { keep_memory: false }),
+                },
+                ManagedExecutionState::Resuming => Some(ManagedExecutionOperation::Resume),
+                ManagedExecutionState::Killing => Some(ManagedExecutionOperation::Kill),
+                ManagedExecutionState::Creating
+                | ManagedExecutionState::Running
+                | ManagedExecutionState::Paused
+                | ManagedExecutionState::Stopped
+                | ManagedExecutionState::Failed => None,
+            };
             Ok(record.clone())
         })
     }
@@ -252,12 +307,13 @@ fn transition_generation(
     current: ExecutionGeneration,
 ) -> ManagedExecutionStoreResult<ExecutionGeneration> {
     use ManagedExecutionState::{
-        Creating, Failed, Killing, Paused, Pausing, Resuming, Running, Stopped,
+        Creating, Failed, Killing, Paused, Pausing, Resuming, Running, Starting, Stopped,
     };
 
     let legal = matches!(
         (from, to),
-        (Creating, Running | Killing | Stopped | Failed)
+        (Creating, Starting | Killing | Stopped | Failed)
+            | (Starting, Creating | Running | Killing | Stopped | Failed)
             | (Running, Pausing | Killing | Stopped | Failed)
             | (Pausing, Paused | Running | Killing | Stopped | Failed)
             | (Paused, Resuming | Killing | Stopped | Failed)
@@ -385,11 +441,19 @@ mod tests {
             .reserve(managed_record(id.as_str(), "operation-1"))
             .unwrap();
 
-        let running = store
+        store
             .transition(
                 &id,
                 ExecutionGeneration::INITIAL,
                 ManagedExecutionState::Creating,
+                ManagedExecutionState::Starting,
+            )
+            .unwrap();
+        let running = store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Starting,
                 ManagedExecutionState::Running,
             )
             .unwrap();
@@ -450,6 +514,14 @@ mod tests {
                 &id,
                 ExecutionGeneration::INITIAL,
                 ManagedExecutionState::Creating,
+                ManagedExecutionState::Starting,
+            )
+            .unwrap();
+        store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Starting,
                 ManagedExecutionState::Running,
             )
             .unwrap();
@@ -502,6 +574,14 @@ mod tests {
                 &id,
                 ExecutionGeneration::INITIAL,
                 ManagedExecutionState::Creating,
+                ManagedExecutionState::Starting,
+            )
+            .unwrap();
+        store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Starting,
                 ManagedExecutionState::Running,
             )
             .unwrap();


### PR DESCRIPTION
## Summary

- implement the backend-neutral ExecutionManager over the durable local state store
- add an injectable runtime backend boundary for the next VmManager adapter batch
- persist starting claims and pending pause policy before backend side effects
- keep state I/O off async workers and never hold the state lock across backend calls
- reconcile pre-launch, post-launch/pre-publication, pause, resume, kill, and external-stop crash windows
- keep external sandbox IDs out of runtime IDs, names, and host paths
- split lifecycle code by create, recovery, operations, persistence, record mapping, and backend concerns

## Validation

- cargo test -p a3s-box-runtime -p a3s-box-cli -p a3s-box-sdk (runtime 1214 passed, 1 ignored; CLI 730 passed; SDK 30 passed)
- 11 focused LocalExecutionManager tests, including concurrent create and ambiguous pause completion
- cargo clippy -p a3s-box-runtime -p a3s-box-cli -p a3s-box-sdk --all-targets -- -D warnings -A clippy::needless_return
- cargo fmt --all -- --check
- git diff --check

No Docker, OrbStack, local VM, or local sandbox runtime was started. The real VmManager backend remains a separate gate.