### PR TITLE
refactor(runtime): centralize process identity checks

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "uuid",
+ "windows-sys 0.48.0",
  "x509-cert",
  "xz2",
  "zstd",

--- a/src/cli/src/process.rs
+++ b/src/cli/src/process.rs
@@ -1,5 +1,7 @@
 //! Shared process management utilities for CLI commands.
 
+pub use a3s_box_runtime::{is_process_alive, is_process_alive_with_identity, pid_start_time};
+
 /// Result of asking a VM/shim process to stop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StopOutcome {
@@ -20,12 +22,6 @@ impl StopOutcome {
             Self::ForceKilled => Some(137),
         }
     }
-}
-
-/// Check if a process is alive.
-#[cfg(unix)]
-pub fn is_process_alive(pid: u32) -> bool {
-    unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 
 /// Whether `pid` has exited, treating a zombie (an exited-but-unreaped child)
@@ -58,64 +54,6 @@ pub fn is_process_exited(pid: u32) -> bool {
 #[cfg(not(unix))]
 pub fn is_process_exited(pid: u32) -> bool {
     !is_process_alive(pid)
-}
-
-/// Read a process's start time (field 22 of `/proc/<pid>/stat`, in clock ticks
-/// since boot) as a stable identity token. After a crash or reboot the kernel
-/// can reassign the old shim PID to an unrelated process; the start time lets us
-/// tell the original process apart from a reused PID. `None` when it cannot be
-/// determined (non-Linux, or the process is already gone).
-#[cfg(target_os = "linux")]
-pub fn pid_start_time(pid: u32) -> Option<u64> {
-    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-    // Format: "<pid> (<comm>) <state> ...". comm may contain spaces/parens, so
-    // scan past the final ')': the tokens after it begin at field 3 (state), so
-    // field 22 (starttime) is the 20th of those (index 19).
-    let after = &stat[stat.rfind(')')? + 1..];
-    after
-        .split_whitespace()
-        .nth(19)
-        .and_then(|s| s.parse::<u64>().ok())
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn pid_start_time(_pid: u32) -> Option<u64> {
-    None
-}
-
-/// Liveness with PID-identity verification: the process is alive only if it
-/// exists AND — when an identity token was recorded — its current start time
-/// still matches. After a reboot or PID reuse the start time differs, so a stale
-/// record is treated as dead and no signal is ever delivered to an unrelated
-/// process. A `None` expected token (records persisted before this field
-/// existed) falls back to the bare liveness check, so an in-place upgrade never
-/// mis-marks a still-running box.
-pub fn is_process_alive_with_identity(pid: u32, expected_start: Option<u64>) -> bool {
-    if !is_process_alive(pid) {
-        return false;
-    }
-    match expected_start {
-        Some(expected) => pid_start_time(pid) == Some(expected),
-        None => true,
-    }
-}
-
-#[cfg(windows)]
-pub fn is_process_alive(pid: u32) -> bool {
-    use windows_sys::Win32::Foundation::STILL_ACTIVE;
-    use windows_sys::Win32::System::Threading::{
-        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_INFORMATION,
-    };
-    unsafe {
-        let handle = OpenProcess(PROCESS_QUERY_INFORMATION, 0, pid);
-        if handle == 0 {
-            return false;
-        }
-        let mut exit_code = 0u32;
-        let ok = GetExitCodeProcess(handle, &mut exit_code);
-        windows_sys::Win32::Foundation::CloseHandle(handle);
-        ok != 0 && exit_code == STILL_ACTIVE as u32
-    }
 }
 
 /// Terminate a process immediately.

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -85,6 +85,12 @@ prometheus = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 a3s-box-netproxy = { version = "3.0", path = "../netproxy" }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.48", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }
+
 [target.'cfg(unix)'.dependencies]
 # TEE attestation verification
 p384 = { workspace = true }

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -27,6 +27,7 @@ pub mod log;
 pub mod managed_execution_store;
 pub mod network;
 pub mod oci;
+pub mod process;
 pub mod prom;
 pub mod resize;
 pub mod rootfs;
@@ -69,6 +70,7 @@ pub use managed_execution_store::{
     ManagedExecutionReservation, ManagedExecutionStore, ManagedExecutionStoreError,
     ManagedExecutionStoreResult,
 };
+pub use process::{is_process_alive, is_process_alive_with_identity, pid_start_time};
 
 // gRPC clients
 #[cfg(unix)]

--- a/src/runtime/src/process.rs
+++ b/src/runtime/src/process.rs
@@ -1,0 +1,115 @@
+//! Host process identity helpers shared by runtime consumers.
+
+/// Check whether a host process exists.
+///
+/// On Unix, `EPERM` still means the process exists even though the caller is
+/// not allowed to signal it.
+#[cfg(unix)]
+pub fn is_process_alive(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    let result = unsafe { libc::kill(pid, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+pub fn is_process_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_INFORMATION,
+    };
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_INFORMATION, 0, pid);
+        if handle == 0 {
+            return false;
+        }
+        let mut exit_code = 0u32;
+        let ok = GetExitCodeProcess(handle, &mut exit_code);
+        CloseHandle(handle);
+        ok != 0 && exit_code == STILL_ACTIVE as u32
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn is_process_alive(_pid: u32) -> bool {
+    false
+}
+
+/// Read a process's Linux start time as a stable PID identity token.
+///
+/// The value is field 22 of `/proc/<pid>/stat`, measured in clock ticks since
+/// boot. It distinguishes a recorded process from a later process that reused
+/// the same PID. Other platforms return `None` until they provide an equivalent
+/// stable token.
+#[cfg(target_os = "linux")]
+pub fn pid_start_time(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    linux_pid_start_time_from_stat(&stat)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn pid_start_time(_pid: u32) -> Option<u64> {
+    None
+}
+
+/// Check process liveness and, when recorded, its stable identity token.
+///
+/// Records created before PID identity tokens were introduced contain no
+/// expected start time and retain their legacy liveness behavior.
+pub fn is_process_alive_with_identity(pid: u32, expected_start_time: Option<u64>) -> bool {
+    if !is_process_alive(pid) {
+        return false;
+    }
+
+    match expected_start_time {
+        Some(expected) => pid_start_time(pid) == Some(expected),
+        None => true,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_pid_start_time_from_stat(stat: &str) -> Option<u64> {
+    // `comm` may contain spaces and parentheses, so fields begin after the
+    // final `)`. Field 3 is then token zero and field 22 is token 19.
+    let fields = stat.get(stat.rfind(')')? + 1..)?;
+    fields.split_whitespace().nth(19)?.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_process_is_alive() {
+        assert!(is_process_alive(std::process::id()));
+    }
+
+    #[test]
+    fn missing_process_is_not_alive() {
+        assert!(!is_process_alive(0x7fff_fffe));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parses_start_time_after_complex_command_name() {
+        let stat =
+            "123 (command (with) spaces) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 4242";
+        assert_eq!(linux_pid_start_time_from_stat(stat), Some(4242));
+        assert_eq!(linux_pid_start_time_from_stat("malformed"), None);
+        assert_eq!(linux_pid_start_time_from_stat("123 (short) S 1"), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn identity_rejects_a_reused_pid() {
+        let pid = std::process::id();
+        let start_time = pid_start_time(pid);
+        assert!(start_time.is_some());
+        assert!(is_process_alive_with_identity(pid, start_time));
+        assert!(!is_process_alive_with_identity(pid, Some(u64::MAX)));
+        assert!(is_process_alive_with_identity(pid, None));
+        assert!(!is_process_alive_with_identity(0x7fff_fffe, None));
+    }
+}

--- a/src/sdk/src/client/mod.rs
+++ b/src/sdk/src/client/mod.rs
@@ -20,13 +20,15 @@ use a3s_box_core::volume::VolumeConfig;
 use a3s_box_core::{ExecOutput, ExecRequest, FileRequest, FileResponse, StoredImage};
 use a3s_box_runtime::oci::BuildResult as RuntimeBuildResult;
 use a3s_box_runtime::{
-    BuildConfig as RuntimeBuildConfig, ImagePuller, ImageReference, ImageStore, NetworkStore,
-    OciImage, PushResult, RegistryAuth, RegistryProtocol, RegistryPusher, SignaturePolicy,
-    SnapshotStore, VolumeStore,
+    is_process_alive, is_process_alive_with_identity, BuildConfig as RuntimeBuildConfig,
+    ImagePuller, ImageReference, ImageStore, NetworkStore, OciImage, PushResult, RegistryAuth,
+    RegistryProtocol, RegistryPusher, SignaturePolicy, SnapshotStore, VolumeStore,
 };
 use serde::{Deserialize, Serialize};
 use sysinfo::{Pid, System};
 
+#[cfg(all(test, unix))]
+use a3s_box_runtime::pid_start_time;
 #[cfg(unix)]
 use a3s_box_runtime::{AttestationReport, AttestationRequest, ExecClient, PtyClient};
 

--- a/src/sdk/src/client/support.rs
+++ b/src/sdk/src/client/support.rs
@@ -410,38 +410,6 @@ fn require_live_pid(record: &BoxRecord, action: &str) -> Result<u32> {
     }
 }
 
-fn is_process_alive_with_identity(pid: u32, expected_start: Option<u64>) -> bool {
-    if !is_process_alive(pid) {
-        return false;
-    }
-    match expected_start {
-        Some(expected) => pid_start_time(pid) == Some(expected),
-        None => true,
-    }
-}
-
-#[cfg(unix)]
-fn is_process_alive(pid: u32) -> bool {
-    unsafe { libc::kill(pid as i32, 0) == 0 }
-}
-
-#[cfg(not(unix))]
-fn is_process_alive(_pid: u32) -> bool {
-    false
-}
-
-#[cfg(target_os = "linux")]
-fn pid_start_time(pid: u32) -> Option<u64> {
-    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-    let after_comm = stat.rsplit_once(") ")?.1;
-    after_comm.split_whitespace().nth(19)?.parse().ok()
-}
-
-#[cfg(not(target_os = "linux"))]
-fn pid_start_time(_pid: u32) -> Option<u64> {
-    None
-}
-
 #[cfg(unix)]
 fn send_host_signal(pid: u32, signal: i32) -> std::io::Result<()> {
     let result = unsafe { libc::kill(pid as i32, signal) };
@@ -940,4 +908,3 @@ fn file_size_or_zero(path: &Path) -> Result<u64> {
         Ok(metadata.len())
     }
 }
-


### PR DESCRIPTION
## Summary

- add one runtime-owned host process liveness and PID identity implementation
- make CLI and SDK reuse the runtime implementation
- preserve Windows liveness support and legacy records without identity tokens
- test Linux proc stat parsing with complex process names

## Validation

- cargo test -p a3s-box-runtime process::tests
- cargo test -p a3s-box-cli process::tests
- cargo test -p a3s-box-sdk --lib
- cargo clippy -p a3s-box-runtime -p a3s-box-cli -p a3s-box-sdk --all-targets -- -D warnings -A clippy::needless-return
- cargo fmt --all
- git diff --check

The Clippy allow applies only to an existing macOS-only warning in runtime/src/sandbox/capability.rs that this PR does not modify.