### PR TITLE
feat(runtime): add managed VM execution backend

### DIFF
--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -63,6 +63,8 @@ pub use box_record::{
     ManagedExecutionState,
 };
 pub use box_state::BoxStateStore;
+#[cfg(feature = "vm")]
+pub use local_execution::VmLocalExecutionBackend;
 pub use local_execution::{
     LocalExecutionBackend, LocalExecutionHandle, LocalExecutionManager, LocalExecutionObservation,
 };

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -8,6 +8,10 @@ mod record;
 mod recovery;
 mod store;
 mod support;
+#[cfg(feature = "vm")]
+mod vm_backend;
+#[cfg(feature = "vm")]
+mod vm_process;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -15,6 +19,8 @@ use std::sync::Arc;
 pub use backend::{LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation};
 use record::{build_managed_record, status_from_record};
 use store::RuntimeUpdate;
+#[cfg(feature = "vm")]
+pub use vm_backend::VmLocalExecutionBackend;
 
 use crate::{BoxRecord, ManagedExecutionOperation, ManagedExecutionState, ManagedExecutionStore};
 
@@ -41,6 +47,16 @@ impl LocalExecutionManager {
 
     pub fn state_path(&self) -> &std::path::Path {
         self.store.path()
+    }
+
+    #[cfg(feature = "vm")]
+    pub fn with_vm_backend(state_path: impl Into<PathBuf>, home_dir: impl Into<PathBuf>) -> Self {
+        let home_dir = home_dir.into();
+        Self::new(
+            state_path,
+            home_dir.clone(),
+            Arc::new(VmLocalExecutionBackend::new(home_dir)),
+        )
     }
 }
 

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -1,0 +1,599 @@
+//! Production local execution backend backed by [`crate::VmManager`].
+
+#[path = "vm_sandbox.rs"]
+mod sandbox;
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+#[cfg(unix)]
+use std::time::Duration;
+
+use a3s_box_core::{
+    EventEmitter, ExecutionBackend, ExecutionId, ExecutionManagerError, ExecutionManagerResult,
+    ExecutionState, KillOutcome,
+};
+use async_trait::async_trait;
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+use tokio::sync::Mutex;
+
+use super::vm_process::{locate_microvm_process, LocatedProcess};
+use super::{LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation};
+use crate::{BoxRecord, ManagedExecutionMetadata, ManagedExecutionState, VmManager};
+
+type SharedVm = Arc<Mutex<VmManager>>;
+
+/// Runtime adapter that owns live [`VmManager`] handles and reconstructs them
+/// from durable runtime evidence after a control-plane restart.
+#[derive(Clone)]
+pub struct VmLocalExecutionBackend {
+    home_dir: PathBuf,
+    managers: Arc<DashMap<String, SharedVm>>,
+}
+
+impl VmLocalExecutionBackend {
+    pub fn new(home_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            home_dir: home_dir.into(),
+            managers: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub fn home_dir(&self) -> &Path {
+        &self.home_dir
+    }
+
+    fn metadata<'a>(
+        &self,
+        record: &'a BoxRecord,
+    ) -> ExecutionManagerResult<&'a ManagedExecutionMetadata> {
+        uuid::Uuid::parse_str(&record.id).map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "managed execution has an invalid internal ID {}: {error}",
+                record.id
+            ))
+        })?;
+        let expected_box_dir = self.home_dir.join("boxes").join(&record.id);
+        if record.box_dir != expected_box_dir {
+            return Err(ExecutionManagerError::Internal(format!(
+                "managed execution {} has an unexpected host directory {}",
+                record.id,
+                record.box_dir.display()
+            )));
+        }
+        let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "execution {} lost managed lifecycle metadata",
+                record.id
+            ))
+        })?;
+        metadata
+            .validate()
+            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
+        if record.isolation != metadata.request.config.isolation {
+            return Err(ExecutionManagerError::Internal(format!(
+                "managed execution {} has inconsistent isolation metadata",
+                record.id
+            )));
+        }
+        Ok(metadata)
+    }
+
+    fn new_manager(&self, record: &BoxRecord) -> ExecutionManagerResult<VmManager> {
+        let metadata = self.metadata(record)?;
+        let mut manager = VmManager::with_box_id(
+            metadata.request.config.clone(),
+            EventEmitter::new(256),
+            record.id.clone(),
+        );
+        manager.home_dir = self.home_dir.clone();
+        manager.anonymous_volumes = record.anonymous_volumes.clone();
+        manager.set_log_config(record.log_config.clone());
+        manager.resolved_execution_plan = Some(metadata.plan.clone());
+        Ok(manager)
+    }
+
+    fn manager(&self, execution_id: &str) -> Option<SharedVm> {
+        self.managers
+            .get(execution_id)
+            .map(|entry| Arc::clone(entry.value()))
+    }
+
+    fn remove_manager(&self, execution_id: &str, expected: &SharedVm) {
+        if let Entry::Occupied(entry) = self.managers.entry(execution_id.to_string()) {
+            if Arc::ptr_eq(entry.get(), expected) {
+                entry.remove();
+            }
+        }
+    }
+
+    async fn handle_from_manager(
+        &self,
+        record: &BoxRecord,
+        manager: &VmManager,
+    ) -> ExecutionManagerResult<LocalExecutionHandle> {
+        let execution_id = execution_id(record)?;
+        let pid = manager.pid().await.ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "runtime returned no host PID for {execution_id}"
+            ))
+        })?;
+        let pid_start_time = crate::process::pid_start_time(pid);
+        #[cfg(target_os = "linux")]
+        if pid_start_time.is_none() {
+            return Err(ExecutionManagerError::NotFound(execution_id));
+        }
+        if !crate::process::is_process_alive_with_identity(pid, pid_start_time) {
+            return Err(ExecutionManagerError::NotFound(execution_id));
+        }
+        let exec_socket_path = manager
+            .exec_socket_path()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| {
+                ExecutionManagerError::Internal(format!(
+                    "runtime returned no exec socket for {}",
+                    record.id
+                ))
+            })?;
+        let anonymous_volumes = if manager.anonymous_volumes().is_empty() {
+            self.anonymous_volumes_for_record(record).await
+        } else {
+            manager.anonymous_volumes().to_vec()
+        };
+        Ok(LocalExecutionHandle {
+            started_at: record.started_at.unwrap_or_else(chrono::Utc::now),
+            pid: Some(pid),
+            pid_start_time,
+            exec_socket_path,
+            console_log: record.box_dir.join("logs/console.log"),
+            anonymous_volumes,
+        })
+    }
+
+    async fn inspect_registered(
+        &self,
+        record: &BoxRecord,
+        shared: SharedVm,
+    ) -> ExecutionManagerResult<LocalExecutionObservation> {
+        let mut manager = shared.lock().await;
+        let exit_code = manager
+            .try_wait_exit()
+            .await
+            .map_err(|error| runtime_error("inspect", record, error))?;
+        let mut state = manager.state().await;
+        let terminal = exit_code.is_some() || state == crate::BoxState::Stopped;
+        if terminal {
+            let cleanup = manager.destroy().await;
+            let exit_code = manager.exit_code().or(exit_code);
+            drop(manager);
+            self.remove_manager(&record.id, &shared);
+            cleanup.map_err(|error| runtime_error("clean up", record, error))?;
+            return Ok(LocalExecutionObservation {
+                state: ExecutionState::Stopped,
+                handle: None,
+                exit_code,
+            });
+        }
+
+        if state == crate::BoxState::Created {
+            if manager.has_exited().await {
+                let cleanup = manager.destroy().await;
+                let exit_code = manager.exit_code();
+                drop(manager);
+                self.remove_manager(&record.id, &shared);
+                cleanup.map_err(|error| runtime_error("clean up", record, error))?;
+                return Ok(LocalExecutionObservation {
+                    state: ExecutionState::Stopped,
+                    handle: None,
+                    exit_code,
+                });
+            }
+            if !self.promote_if_ready(record, &mut manager).await {
+                return Ok(LocalExecutionObservation {
+                    state: ExecutionState::Creating,
+                    handle: None,
+                    exit_code: None,
+                });
+            }
+            state = manager.state().await;
+        }
+
+        if !manager
+            .health_check()
+            .await
+            .map_err(|error| runtime_error("inspect", record, error))?
+        {
+            let cleanup = manager.destroy().await;
+            let exit_code = manager.exit_code();
+            drop(manager);
+            self.remove_manager(&record.id, &shared);
+            cleanup.map_err(|error| runtime_error("clean up", record, error))?;
+            return Ok(LocalExecutionObservation {
+                state: ExecutionState::Stopped,
+                handle: None,
+                exit_code,
+            });
+        }
+
+        if state != crate::BoxState::Ready
+            && state != crate::BoxState::Busy
+            && state != crate::BoxState::Compacting
+        {
+            return Err(ExecutionManagerError::Internal(format!(
+                "runtime manager for {} is in unexpected state {state:?}",
+                record.id
+            )));
+        }
+        if managed_state(record)? == ManagedExecutionState::Starting
+            && !exec_endpoint_ready(manager.exec_socket_path()).await
+        {
+            return Ok(LocalExecutionObservation {
+                state: ExecutionState::Creating,
+                handle: None,
+                exit_code: None,
+            });
+        }
+        let visible_state = visible_active_state(record)?;
+        let handle = self.handle_from_manager(record, &manager).await?;
+        Ok(LocalExecutionObservation {
+            state: visible_state,
+            handle: Some(handle),
+            exit_code: None,
+        })
+    }
+
+    async fn promote_if_ready(&self, record: &BoxRecord, manager: &mut VmManager) -> bool {
+        let socket_dir = crate::vm::runtime_socket_dir(&self.home_dir, &record.id);
+        let exec_socket = socket_dir.join("exec.sock");
+        if !exec_endpoint_ready(Some(&exec_socket)).await {
+            return false;
+        }
+        manager.exec_socket_path = Some(exec_socket);
+        manager.pty_socket_path = Some(socket_dir.join("pty.sock"));
+        manager.port_forward_socket_path = Some(socket_dir.join("portfwd.sock"));
+        *manager.state.write().await = crate::BoxState::Ready;
+        true
+    }
+
+    async fn recover_microvm(&self, record: &BoxRecord) -> ExecutionManagerResult<SharedVm> {
+        self.metadata(record)?;
+        let execution_id = execution_id(record)?;
+        let execution_id_label = record.id.clone();
+        let recorded = record.pid.map(|pid| (pid, record.pid_start_time));
+        let located = tokio::task::spawn_blocking(move || {
+            locate_microvm_process(&execution_id_label, recorded)
+        })
+        .await
+        .map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "MicroVM process discovery task failed for {}: {error}",
+                record.id
+            ))
+        })?
+        .map_err(ExecutionManagerError::Internal)?
+        .ok_or(ExecutionManagerError::NotFound(execution_id))?;
+        self.attach_microvm(record, located).await
+    }
+
+    async fn attach_microvm(
+        &self,
+        record: &BoxRecord,
+        located: LocatedProcess,
+    ) -> ExecutionManagerResult<SharedVm> {
+        let mut manager = self.new_manager(record)?;
+        let socket_dir = crate::vm::runtime_socket_dir(&self.home_dir, &record.id);
+        manager
+            .attach_running_process(
+                located.pid,
+                socket_dir.join("exec.sock"),
+                Some(socket_dir.join("pty.sock")),
+            )
+            .await
+            .map_err(|error| runtime_error("recover", record, error))?;
+        if located.start_time.is_some()
+            && crate::process::pid_start_time(located.pid) != located.start_time
+        {
+            return Err(ExecutionManagerError::NotFound(execution_id(record)?));
+        }
+        let recovered = Arc::new(Mutex::new(manager));
+        match self.managers.entry(record.id.clone()) {
+            Entry::Occupied(entry) => Ok(Arc::clone(entry.get())),
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::clone(&recovered));
+                Ok(recovered)
+            }
+        }
+    }
+
+    async fn require_microvm(&self, record: &BoxRecord) -> ExecutionManagerResult<SharedVm> {
+        match self.manager(&record.id) {
+            Some(manager) => Ok(manager),
+            None => self.recover_microvm(record).await,
+        }
+    }
+
+    async fn destroy_registered(
+        &self,
+        record: &BoxRecord,
+        shared: SharedVm,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        let mut manager = shared.lock().await;
+        let mut anonymous_volumes = if manager.anonymous_volumes().is_empty() {
+            record.anonymous_volumes.clone()
+        } else {
+            manager.anonymous_volumes().to_vec()
+        };
+        let result = manager.destroy().await;
+        drop(manager);
+        self.remove_manager(&record.id, &shared);
+        result.map_err(|error| runtime_error("kill", record, error))?;
+        if anonymous_volumes.is_empty() {
+            anonymous_volumes = self.anonymous_volumes_for_record(record).await;
+        }
+        self.cleanup_anonymous_volumes(anonymous_volumes).await;
+        Ok(KillOutcome::Killed)
+    }
+
+    async fn anonymous_volumes_for_record(&self, record: &BoxRecord) -> Vec<String> {
+        if !record.anonymous_volumes.is_empty() {
+            return record.anonymous_volumes.clone();
+        }
+        let home_dir = self.home_dir.clone();
+        let execution_id = record.id.clone();
+        let short_id = record.id.chars().take(8).collect::<String>();
+        let result = tokio::task::spawn_blocking(move || -> a3s_box_core::Result<Vec<String>> {
+            let store =
+                crate::VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"));
+            let prefix = format!("anon_{short_id}_");
+            let mut names = store
+                .load()?
+                .into_values()
+                .filter(|volume| {
+                    volume
+                        .labels
+                        .get("anonymous")
+                        .is_some_and(|value| value == "true")
+                        && (volume.in_use_by.iter().any(|id| id == &execution_id)
+                            || volume.name.starts_with(&prefix))
+                })
+                .map(|volume| volume.name)
+                .collect::<Vec<_>>();
+            names.sort();
+            Ok(names)
+        })
+        .await;
+        match result {
+            Ok(Ok(names)) => names,
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    execution_id = %record.id,
+                    %error,
+                    "Failed to load anonymous volumes during managed cleanup"
+                );
+                Vec::new()
+            }
+            Err(error) => {
+                tracing::warn!(
+                    execution_id = %record.id,
+                    %error,
+                    "Anonymous volume recovery task failed"
+                );
+                Vec::new()
+            }
+        }
+    }
+
+    async fn cleanup_anonymous_volumes(&self, names: Vec<String>) {
+        if names.is_empty() {
+            return;
+        }
+        let home_dir = self.home_dir.clone();
+        let task = tokio::task::spawn_blocking(move || {
+            let store = crate::VolumeStore::new(
+                home_dir.join("volumes.json"),
+                home_dir.join("volumes"),
+            );
+            for name in names {
+                if let Err(error) = store.remove(&name, true) {
+                    tracing::warn!(volume = %name, %error, "Failed to remove managed anonymous volume");
+                }
+            }
+        })
+        .await;
+        if let Err(error) = task {
+            tracing::warn!(%error, "Anonymous volume cleanup task failed");
+        }
+    }
+}
+
+#[async_trait]
+impl LocalExecutionBackend for VmLocalExecutionBackend {
+    async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
+        self.metadata(record)?;
+        let manager = Arc::new(Mutex::new(self.new_manager(record)?));
+        match self.managers.entry(record.id.clone()) {
+            Entry::Occupied(_) => {
+                return Err(ExecutionManagerError::Unavailable(format!(
+                    "execution {} already has an in-process runtime owner",
+                    record.id
+                )))
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::clone(&manager));
+            }
+        }
+
+        let mut guard = manager.lock().await;
+        if let Err(error) = guard.boot().await {
+            drop(guard);
+            self.remove_manager(&record.id, &manager);
+            return Err(runtime_error("start", record, error));
+        }
+        self.handle_from_manager(record, &guard).await
+    }
+
+    async fn inspect(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionObservation> {
+        let metadata = self.metadata(record)?;
+        if let Some(manager) = self.manager(&record.id) {
+            return self.inspect_registered(record, manager).await;
+        }
+        match metadata.plan.backend {
+            ExecutionBackend::Crun => self.inspect_sandbox(record).await,
+            ExecutionBackend::Krun => {
+                let manager = self.recover_microvm(record).await?;
+                self.inspect_registered(record, manager).await
+            }
+        }
+    }
+
+    async fn pause(
+        &self,
+        record: &BoxRecord,
+        keep_memory: bool,
+    ) -> ExecutionManagerResult<LocalExecutionHandle> {
+        let metadata = self.metadata(record)?;
+        if metadata.plan.backend == ExecutionBackend::Crun {
+            return Err(unsupported(record, "pause", "the Sandbox backend"));
+        }
+        if !keep_memory {
+            return Err(unsupported(
+                record,
+                "pause without memory retention",
+                "the local MicroVM backend",
+            ));
+        }
+        let shared = self.require_microvm(record).await?;
+        let manager = shared.lock().await;
+        require_recorded_pid(record, &manager).await?;
+        manager
+            .pause()
+            .await
+            .map_err(|error| runtime_error("pause", record, error))?;
+        self.handle_from_manager(record, &manager).await
+    }
+
+    async fn resume(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
+        let metadata = self.metadata(record)?;
+        if metadata.plan.backend == ExecutionBackend::Crun {
+            return Err(unsupported(record, "resume", "the Sandbox backend"));
+        }
+        let shared = self.require_microvm(record).await?;
+        let manager = shared.lock().await;
+        require_recorded_pid(record, &manager).await?;
+        manager
+            .resume()
+            .await
+            .map_err(|error| runtime_error("resume", record, error))?;
+        self.handle_from_manager(record, &manager).await
+    }
+
+    async fn kill(&self, record: &BoxRecord) -> ExecutionManagerResult<KillOutcome> {
+        let metadata = self.metadata(record)?;
+        if let Some(manager) = self.manager(&record.id) {
+            return self.destroy_registered(record, manager).await;
+        }
+        match metadata.plan.backend {
+            ExecutionBackend::Crun => self.destroy_detached_sandbox(record).await,
+            ExecutionBackend::Krun => {
+                let manager = self.recover_microvm(record).await?;
+                self.destroy_registered(record, manager).await
+            }
+        }
+    }
+}
+
+async fn require_recorded_pid(
+    record: &BoxRecord,
+    manager: &VmManager,
+) -> ExecutionManagerResult<()> {
+    let execution_id = execution_id(record)?;
+    let pid = manager
+        .pid()
+        .await
+        .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+    if record.pid != Some(pid)
+        || !crate::process::is_process_alive_with_identity(pid, record.pid_start_time)
+    {
+        return Err(ExecutionManagerError::NotFound(execution_id));
+    }
+    Ok(())
+}
+
+fn visible_active_state(record: &BoxRecord) -> ExecutionManagerResult<ExecutionState> {
+    match managed_state(record)? {
+        ManagedExecutionState::Paused | ManagedExecutionState::Resuming => {
+            Ok(ExecutionState::Paused)
+        }
+        ManagedExecutionState::Starting
+        | ManagedExecutionState::Running
+        | ManagedExecutionState::Pausing
+        | ManagedExecutionState::Killing => Ok(ExecutionState::Running),
+        state => Err(ExecutionManagerError::Internal(format!(
+            "execution {} has no active runtime in managed state {state}",
+            record.id
+        ))),
+    }
+}
+
+fn managed_state(record: &BoxRecord) -> ExecutionManagerResult<ManagedExecutionState> {
+    record
+        .managed_state()
+        .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?
+        .ok_or_else(|| {
+            ExecutionManagerError::Internal(format!("execution {} is not managed", record.id))
+        })
+}
+
+fn execution_id(record: &BoxRecord) -> ExecutionManagerResult<ExecutionId> {
+    ExecutionId::new(record.id.clone())
+        .map_err(|error| ExecutionManagerError::Internal(error.to_string()))
+}
+
+fn runtime_error(
+    action: &str,
+    record: &BoxRecord,
+    error: impl std::fmt::Display,
+) -> ExecutionManagerError {
+    ExecutionManagerError::Internal(format!(
+        "failed to {action} execution {}: {error}",
+        record.id
+    ))
+}
+
+fn unsupported(record: &BoxRecord, operation: &str, backend: &str) -> ExecutionManagerError {
+    match execution_id(record) {
+        Ok(execution_id) => ExecutionManagerError::Conflict {
+            execution_id,
+            message: format!("{operation} is not supported by {backend}"),
+        },
+        Err(error) => error,
+    }
+}
+
+#[cfg(unix)]
+async fn exec_endpoint_ready(path: Option<&Path>) -> bool {
+    let Some(path) = path else {
+        return false;
+    };
+    let attempt = async {
+        let client = crate::ExecClient::connect(path).await.ok()?;
+        client.heartbeat().await.ok().filter(|ready| *ready)
+    };
+    tokio::time::timeout(Duration::from_millis(500), attempt)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
+#[cfg(not(unix))]
+async fn exec_endpoint_ready(path: Option<&Path>) -> bool {
+    path.is_some()
+}
+
+#[cfg(test)]
+#[path = "vm_backend_tests.rs"]
+mod tests;

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -1,0 +1,112 @@
+use std::collections::BTreeMap;
+
+use a3s_box_core::{
+    BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionIsolation, OperationId,
+};
+
+use super::*;
+use crate::local_execution::record::build_managed_record;
+
+fn record(home_dir: &Path, isolation: ExecutionIsolation) -> BoxRecord {
+    let id = ExecutionId::new("11111111-1111-4111-8111-111111111111").unwrap();
+    let mut config = BoxConfig {
+        isolation,
+        image: "alpine:latest".to_string(),
+        dns: vec!["1.1.1.1".to_string()],
+        ..Default::default()
+    };
+    if isolation == ExecutionIsolation::Microvm {
+        config.sysctls = vec![("net.ipv4.ip_forward".to_string(), "1".to_string())];
+    }
+    config.resources.memory_mb = 256;
+    build_managed_record(
+        home_dir,
+        &id,
+        OperationId::new("operation-1").unwrap(),
+        CreateExecutionRequest {
+            external_sandbox_id: "external-untrusted-label".to_string(),
+            config,
+            labels: BTreeMap::new(),
+        },
+        chrono::Utc::now(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn manager_uses_the_full_persisted_request_config() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let record = record(temporary.path(), ExecutionIsolation::Microvm);
+
+    let manager = backend.new_manager(&record).unwrap();
+
+    assert_eq!(manager.config.dns, vec!["1.1.1.1"]);
+    assert_eq!(
+        manager.config.sysctls,
+        vec![("net.ipv4.ip_forward".to_string(), "1".to_string())]
+    );
+    assert_eq!(manager.config.resources.memory_mb, 256);
+    assert_eq!(manager.box_id(), record.id);
+    assert_eq!(manager.home_dir, temporary.path());
+}
+
+#[test]
+fn validation_rejects_a_host_path_derived_from_external_input() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let mut record = record(temporary.path(), ExecutionIsolation::Microvm);
+    record.box_dir = temporary.path().join("external-untrusted-label");
+
+    let error = backend.new_manager(&record).err().unwrap();
+
+    assert!(error.to_string().contains("unexpected host directory"));
+}
+
+#[test]
+fn transitional_states_retry_idempotent_pause_and_resume_operations() {
+    let temporary = tempfile::tempdir().unwrap();
+    let mut record = record(temporary.path(), ExecutionIsolation::Microvm);
+    record.status = ManagedExecutionState::Pausing.as_status().to_string();
+    record.managed_execution.as_mut().unwrap().pending_operation =
+        Some(crate::ManagedExecutionOperation::Pause { keep_memory: true });
+    assert_eq!(
+        visible_active_state(&record).unwrap(),
+        ExecutionState::Running
+    );
+
+    record.status = ManagedExecutionState::Resuming.as_status().to_string();
+    record.managed_execution.as_mut().unwrap().pending_operation =
+        Some(crate::ManagedExecutionOperation::Resume);
+    assert_eq!(
+        visible_active_state(&record).unwrap(),
+        ExecutionState::Paused
+    );
+}
+
+#[tokio::test]
+async fn unsupported_pause_modes_fail_before_starting_a_runtime() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let sandbox = record(temporary.path(), ExecutionIsolation::Sandbox);
+    let microvm = record(temporary.path(), ExecutionIsolation::Microvm);
+
+    let sandbox_error = backend.pause(&sandbox, true).await.unwrap_err();
+    let memory_error = backend.pause(&microvm, false).await.unwrap_err();
+
+    assert!(sandbox_error.to_string().contains("Sandbox backend"));
+    assert!(memory_error
+        .to_string()
+        .contains("pause without memory retention"));
+    assert!(backend.managers.is_empty());
+}
+
+#[test]
+fn visible_state_rejects_terminal_records() {
+    let temporary = tempfile::tempdir().unwrap();
+    let mut record = record(temporary.path(), ExecutionIsolation::Microvm);
+    record.status = ManagedExecutionState::Stopped.as_status().to_string();
+    record.managed_execution.as_mut().unwrap().generation = ExecutionGeneration::INITIAL;
+
+    assert!(visible_active_state(&record).is_err());
+}

--- a/src/runtime/src/local_execution/vm_process.rs
+++ b/src/runtime/src/local_execution/vm_process.rs
@@ -1,0 +1,131 @@
+//! Exact MicroVM shim discovery for managed restart recovery.
+
+use std::path::Path;
+
+use sysinfo::{Pid, System};
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct LocatedProcess {
+    pub(super) pid: u32,
+    pub(super) start_time: Option<u64>,
+}
+
+pub(super) fn locate_microvm_process(
+    execution_id: &str,
+    recorded: Option<(u32, Option<u64>)>,
+) -> Result<Option<LocatedProcess>, String> {
+    let system = System::new_all();
+
+    if let Some((pid, expected_start_time)) = recorded {
+        if !crate::process::is_process_alive_with_identity(pid, expected_start_time) {
+            return Ok(None);
+        }
+        let Some(process) = system.process(Pid::from_u32(pid)) else {
+            return Ok(None);
+        };
+        if !shim_command_targets_execution(process.cmd(), execution_id) {
+            return Ok(None);
+        }
+        return Ok(Some(LocatedProcess {
+            pid,
+            start_time: crate::process::pid_start_time(pid),
+        }));
+    }
+
+    let mut matches = system
+        .processes()
+        .values()
+        .filter(|process| shim_command_targets_execution(process.cmd(), execution_id))
+        .map(|process| LocatedProcess {
+            pid: process.pid().as_u32(),
+            start_time: crate::process::pid_start_time(process.pid().as_u32()),
+        });
+    let first = matches.next();
+    if matches.next().is_some() {
+        return Err(format!(
+            "multiple MicroVM shim processes claim execution {execution_id}"
+        ));
+    }
+    Ok(first)
+}
+
+fn shim_command_targets_execution(command: &[String], execution_id: &str) -> bool {
+    let Some(executable) = command.first() else {
+        return false;
+    };
+    let Some(file_name) = Path::new(executable)
+        .file_name()
+        .and_then(|name| name.to_str())
+    else {
+        return false;
+    };
+    if !matches!(file_name, "a3s-box-shim" | "a3s-box-shim.exe") {
+        return false;
+    }
+
+    let Some(config_index) = command.iter().position(|argument| argument == "--config") else {
+        return false;
+    };
+    let Some(config) = command.get(config_index + 1) else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(config)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("box_id")
+                .and_then(serde_json::Value::as_str)
+                .map(|box_id| box_id == execution_id)
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_match_requires_exact_binary_argument_and_internal_id() {
+        let command = vec![
+            "/usr/bin/a3s-box-shim".to_string(),
+            "--config".to_string(),
+            r#"{"box_id":"11111111-1111-4111-8111-111111111111"}"#.to_string(),
+        ];
+
+        assert!(shim_command_targets_execution(
+            &command,
+            "11111111-1111-4111-8111-111111111111"
+        ));
+        assert!(!shim_command_targets_execution(&command, "11111111"));
+    }
+
+    #[test]
+    fn command_match_rejects_lookalikes_and_malformed_json() {
+        let lookalike = vec![
+            "/tmp/not-a3s-box-shim".to_string(),
+            "--config".to_string(),
+            r#"{"box_id":"box-1"}"#.to_string(),
+        ];
+        let malformed = vec![
+            "a3s-box-shim".to_string(),
+            "--config".to_string(),
+            "not-json".to_string(),
+        ];
+
+        assert!(!shim_command_targets_execution(&lookalike, "box-1"));
+        assert!(!shim_command_targets_execution(&malformed, "box-1"));
+    }
+
+    #[test]
+    fn recorded_non_shim_process_is_never_accepted() {
+        let located = locate_microvm_process(
+            std::process::id().to_string().as_str(),
+            Some((
+                std::process::id(),
+                crate::process::pid_start_time(std::process::id()),
+            )),
+        )
+        .unwrap();
+        assert!(located.is_none());
+    }
+}

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -1,0 +1,193 @@
+//! Durable `crun` recovery for the production local execution backend.
+
+use super::*;
+
+impl VmLocalExecutionBackend {
+    pub(super) async fn inspect_sandbox(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionObservation> {
+        self.metadata(record)?;
+        let home_dir = self.home_dir.clone();
+        let box_dir = record.box_dir.clone();
+        let box_id = record.id.clone();
+        let execution_id = execution_id(record)?;
+        let state = tokio::task::spawn_blocking(move || {
+            inspect_recorded_sandbox(&home_dir, &box_dir, &box_id)
+        })
+        .await
+        .map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "Sandbox inspection task failed for {}: {error}",
+                record.id
+            ))
+        })?
+        .map_err(|error| runtime_error("inspect", record, error))?
+        .ok_or(ExecutionManagerError::NotFound(execution_id))?;
+
+        match state.status.as_str() {
+            "created" | "running" => {
+                if state.pid == 0 {
+                    return Err(ExecutionManagerError::Internal(format!(
+                        "Sandbox runtime returned PID zero for {}",
+                        record.id
+                    )));
+                }
+                let manager = self.attach_sandbox(record, state).await?;
+                self.inspect_registered(record, manager).await
+            }
+            "stopped" => {
+                self.cleanup_detached_sandbox(record).await?;
+                Ok(LocalExecutionObservation {
+                    state: ExecutionState::Stopped,
+                    handle: None,
+                    exit_code: None,
+                })
+            }
+            status => Err(ExecutionManagerError::Internal(format!(
+                "Sandbox runtime returned unknown state {status} for {}",
+                record.id
+            ))),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn attach_sandbox(
+        &self,
+        record: &BoxRecord,
+        inspection: SandboxInspection,
+    ) -> ExecutionManagerResult<SharedVm> {
+        let mut manager = self.new_manager(record)?;
+        let socket_dir = crate::vm::runtime_socket_dir(&self.home_dir, &record.id);
+        manager.exec_socket_path = Some(socket_dir.join("exec.sock"));
+        manager.pty_socket_path = Some(socket_dir.join("pty.sock"));
+        manager.port_forward_socket_path = Some(socket_dir.join("portfwd.sock"));
+        *manager.handler.write().await = Some(Box::new(
+            crate::sandbox::handler::CrunHandler::from_recorded_runtime(
+                inspection.runtime.runtime_path,
+                inspection.runtime.runtime_root,
+                record.id.clone(),
+                inspection.pid,
+                inspection.runtime.bundle_dir,
+                record.box_dir.join("sandbox/runtime.json"),
+            ),
+        ));
+        if managed_state(record)? != ManagedExecutionState::Starting {
+            *manager.state.write().await = crate::BoxState::Ready;
+        }
+
+        let recovered = Arc::new(Mutex::new(manager));
+        match self.managers.entry(record.id.clone()) {
+            Entry::Occupied(entry) => Ok(Arc::clone(entry.get())),
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::clone(&recovered));
+                Ok(recovered)
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    async fn attach_sandbox(
+        &self,
+        record: &BoxRecord,
+        _inspection: SandboxInspection,
+    ) -> ExecutionManagerResult<SharedVm> {
+        Err(unsupported(
+            record,
+            "recovery",
+            "the Sandbox backend on this host",
+        ))
+    }
+
+    pub(super) async fn destroy_detached_sandbox(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        self.inspect_sandbox(record).await?;
+        if let Some(manager) = self.manager(&record.id) {
+            return self.destroy_registered(record, manager).await;
+        }
+        Ok(KillOutcome::Killed)
+    }
+
+    async fn cleanup_detached_sandbox(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {
+        let home_dir = self.home_dir.clone();
+        let box_dir = record.box_dir.clone();
+        let box_id = record.id.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::vm::reap::cleanup_recorded_sandbox_runtime_in(&home_dir, &box_dir, &box_id)
+        })
+        .await
+        .map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "Sandbox cleanup task failed for {}: {error}",
+                record.id
+            ))
+        })?
+        .map_err(|error| runtime_error("kill", record, error))?;
+
+        let mut manager = self.new_manager(record)?;
+        manager
+            .destroy()
+            .await
+            .map_err(|error| runtime_error("clean up", record, error))?;
+        let anonymous_volumes = self.anonymous_volumes_for_record(record).await;
+        self.cleanup_anonymous_volumes(anonymous_volumes).await;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct SandboxInspection {
+    status: String,
+    pid: u32,
+    runtime: crate::vm::reap::RecordedSandboxRuntime,
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_recorded_sandbox(
+    home_dir: &Path,
+    box_dir: &Path,
+    box_id: &str,
+) -> a3s_box_core::Result<Option<SandboxInspection>> {
+    let Some(runtime) = crate::vm::reap::load_recorded_sandbox_runtime(home_dir, box_dir, box_id)?
+    else {
+        return Ok(None);
+    };
+    let state = crate::sandbox::handler::CrunHandler::query_state_at(
+        &runtime.runtime_path,
+        &runtime.runtime_root,
+        box_id,
+    )?;
+    let (status, pid) = match state {
+        Some(state) => (state.status, state.pid),
+        None => ("stopped".to_string(), 0),
+    };
+    if matches!(status.as_str(), "created" | "running") && pid != runtime.init_pid {
+        return Err(a3s_box_core::BoxError::StateError(format!(
+            "Sandbox runtime PID disagrees with its durable record for {box_id}"
+        )));
+    }
+    Ok(Some(SandboxInspection {
+        status,
+        pid,
+        runtime,
+    }))
+}
+
+#[cfg(not(target_os = "linux"))]
+struct SandboxInspection {
+    status: String,
+    pid: u32,
+}
+
+#[cfg(not(target_os = "linux"))]
+fn inspect_recorded_sandbox(
+    _home_dir: &Path,
+    _box_dir: &Path,
+    _box_id: &str,
+) -> a3s_box_core::Result<Option<SandboxInspection>> {
+    Err(a3s_box_core::BoxError::StateError(
+        "Sandbox execution requires Linux".to_string(),
+    ))
+}

--- a/src/runtime/src/sandbox/handler.rs
+++ b/src/runtime/src/sandbox/handler.rs
@@ -66,6 +66,29 @@ impl CrunHandler {
         }
     }
 
+    #[cfg(target_os = "linux")]
+    pub(crate) fn from_recorded_runtime(
+        runtime_path: PathBuf,
+        runtime_root: PathBuf,
+        container_id: String,
+        init_pid: u32,
+        bundle_dir: PathBuf,
+        runtime_record: PathBuf,
+    ) -> Self {
+        Self {
+            runtime_path,
+            runtime_root,
+            container_id,
+            init_pid,
+            process: None,
+            metrics_sys: Mutex::new(System::new()),
+            exit_code: None,
+            bundle_dir,
+            runtime_record,
+            cleaned: false,
+        }
+    }
+
     pub(crate) fn query_state_at(
         runtime_path: &Path,
         runtime_root: &Path,
@@ -344,6 +367,33 @@ fn remove_dir_if_exists(path: &Path) {
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recorded_runtime_handler_attaches_without_owning_a_wrapper_process() {
+        let temporary = tempfile::tempdir().unwrap();
+        let runtime_path = PathBuf::from("/bin/true");
+        let runtime_root = temporary.path().join("runtime");
+        let bundle_dir = temporary.path().join("bundle");
+        let runtime_record = temporary.path().join("runtime.json");
+
+        let handler = CrunHandler::from_recorded_runtime(
+            runtime_path.clone(),
+            runtime_root.clone(),
+            "recorded-test".to_string(),
+            42,
+            bundle_dir.clone(),
+            runtime_record.clone(),
+        );
+
+        assert_eq!(handler.runtime_path, runtime_path);
+        assert_eq!(handler.runtime_root, runtime_root);
+        assert_eq!(handler.container_id, "recorded-test");
+        assert_eq!(handler.pid(), 42);
+        assert!(handler.process.is_none());
+        assert_eq!(handler.bundle_dir, bundle_dir);
+        assert_eq!(handler.runtime_record, runtime_record);
+        assert!(!handler.cleaned);
+    }
 
     #[test]
     fn dropping_handler_detaches_from_live_runtime_process() {

--- a/src/runtime/src/sandbox/handler.rs
+++ b/src/runtime/src/sandbox/handler.rs
@@ -66,7 +66,7 @@ impl CrunHandler {
         }
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "vm"))]
     pub(crate) fn from_recorded_runtime(
         runtime_path: PathBuf,
         runtime_root: PathBuf,
@@ -368,6 +368,7 @@ fn remove_dir_if_exists(path: &Path) {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "vm")]
     #[test]
     fn recorded_runtime_handler_attaches_without_owning_a_wrapper_process() {
         let temporary = tempfile::tempdir().unwrap();

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -10,6 +10,27 @@ use a3s_box_core::error::{BoxError, Result};
 
 use super::{BoxLayout, VmManager};
 
+pub(crate) fn runtime_socket_dir(home_dir: &Path, box_id: &str) -> PathBuf {
+    #[cfg(all(unix, target_os = "macos"))]
+    {
+        let _ = home_dir;
+        PathBuf::from("/private/tmp")
+            .join("a3s-box-sockets")
+            .join(box_id)
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let _ = home_dir;
+        PathBuf::from("/tmp").join("a3s-box-sockets").join(box_id)
+    }
+
+    #[cfg(not(unix))]
+    {
+        home_dir.join("boxes").join(box_id).join("sockets")
+    }
+}
+
 impl VmManager {
     pub(crate) async fn prepare_layout(&self) -> Result<BoxLayout> {
         // Create box-specific directories
@@ -297,29 +318,7 @@ impl VmManager {
     }
 
     pub(crate) fn socket_dir(&self) -> PathBuf {
-        #[cfg(all(unix, target_os = "macos"))]
-        {
-            // Use the canonical short temp path so macOS HVF runs can bind
-            // Unix sockets without relying on the /tmp symlink.
-            PathBuf::from("/private/tmp")
-                .join("a3s-box-sockets")
-                .join(&self.box_id)
-        }
-
-        #[cfg(all(unix, not(target_os = "macos")))]
-        {
-            PathBuf::from("/tmp")
-                .join("a3s-box-sockets")
-                .join(&self.box_id)
-        }
-
-        #[cfg(not(unix))]
-        {
-            self.home_dir
-                .join("boxes")
-                .join(&self.box_id)
-                .join("sockets")
-        }
+        runtime_socket_dir(&self.home_dir, &self.box_id)
     }
 
     /// Try to get a cached rootfs and copy it to the target path.

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -7,6 +7,8 @@ pub mod reap;
 mod sandbox;
 mod spec;
 
+pub(crate) use layout::runtime_socket_dir;
+
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -454,6 +456,29 @@ impl VmManager {
         self.exec_socket_path = Some(exec_socket_path);
         self.pty_socket_path = pty_socket_path;
         self.port_forward_socket_path = Some(port_forward_socket_path);
+        *self.handler.write().await = Some(Box::new(handler));
+        *self.state.write().await = BoxState::Ready;
+        Ok(())
+    }
+
+    /// Attach this manager to an already-running Windows shim process.
+    #[cfg(windows)]
+    pub async fn attach_running_process(
+        &mut self,
+        pid: u32,
+        exec_socket_path: PathBuf,
+        pty_socket_path: Option<PathBuf>,
+    ) -> Result<()> {
+        let handler = crate::vmm::ShimHandler::from_pid(pid, self.box_id.clone());
+        if !handler.is_running() {
+            return Err(BoxError::StateError(format!(
+                "Cannot attach to non-running VM process {pid}"
+            )));
+        }
+
+        self.exec_socket_path = Some(exec_socket_path);
+        self.pty_socket_path = pty_socket_path;
+        self.port_forward_socket_path = None;
         *self.handler.write().await = Some(Box::new(handler));
         *self.state.write().await = BoxState::Ready;
         Ok(())

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -31,7 +31,7 @@ pub fn cleanup_recorded_sandbox_runtime(box_dir: &Path, box_id: &str) -> a3s_box
 }
 
 #[cfg(target_os = "linux")]
-fn cleanup_recorded_sandbox_runtime_in(
+pub(crate) fn cleanup_recorded_sandbox_runtime_in(
     home_dir: &Path,
     box_dir: &Path,
     box_id: &str,
@@ -103,7 +103,7 @@ fn reap_orphaned_box_in(home_dir: &Path, box_id: &str) {
 }
 
 #[cfg(target_os = "linux")]
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
 struct SandboxRuntimeRecord {
     schema: String,
     container_id: String,
@@ -111,6 +111,72 @@ struct SandboxRuntimeRecord {
     runtime_root: std::path::PathBuf,
     bundle_dir: std::path::PathBuf,
     init_pid: u32,
+}
+
+/// Validated durable evidence for one live or stopped Sandbox generation.
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+pub(crate) struct RecordedSandboxRuntime {
+    pub(crate) runtime_path: std::path::PathBuf,
+    pub(crate) runtime_root: std::path::PathBuf,
+    pub(crate) bundle_dir: std::path::PathBuf,
+    pub(crate) init_pid: u32,
+}
+
+/// Load and validate the runtime-owned Sandbox record for one internal box ID.
+///
+/// Every persisted path is checked against the expected internal layout and
+/// the recorded runtime binary is re-certified before callers may execute it.
+#[cfg(target_os = "linux")]
+pub(crate) fn load_recorded_sandbox_runtime(
+    home_dir: &Path,
+    box_dir: &Path,
+    box_id: &str,
+) -> a3s_box_core::Result<Option<RecordedSandboxRuntime>> {
+    let expected_box_dir = home_dir.join("boxes").join(box_id);
+    if box_dir != expected_box_dir {
+        return Err(a3s_box_core::BoxError::StateError(format!(
+            "Sandbox runtime record has an unexpected host directory for {box_id}"
+        )));
+    }
+    let record_path = box_dir.join("sandbox/runtime.json");
+    let bytes = match std::fs::read(&record_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(a3s_box_core::BoxError::IoError(error)),
+    };
+    let record: SandboxRuntimeRecord = serde_json::from_slice(&bytes).map_err(|error| {
+        a3s_box_core::BoxError::StateError(format!(
+            "Invalid Sandbox runtime record at {}: {error}",
+            record_path.display()
+        ))
+    })?;
+    let expected_runtime_root = home_dir.join("run/crun").join(box_id);
+    let expected_bundle = box_dir.join("sandbox/bundle");
+    if record.schema != "a3s.box.sandbox-runtime.v1"
+        || record.container_id != box_id
+        || record.runtime_root != expected_runtime_root
+        || record.bundle_dir != expected_bundle
+        || record.init_pid == 0
+    {
+        return Err(a3s_box_core::BoxError::StateError(format!(
+            "Sandbox runtime record failed path or identity validation for {box_id}"
+        )));
+    }
+
+    let capabilities = crate::sandbox::probe_sandbox_capabilities(Some(&record.runtime_path));
+    let runtime = capabilities.runtime.ok_or_else(|| {
+        a3s_box_core::BoxError::StateError(format!(
+            "Cannot verify the recorded Sandbox runtime for {box_id}: {:?}",
+            capabilities.failures
+        ))
+    })?;
+    Ok(Some(RecordedSandboxRuntime {
+        runtime_path: runtime.path,
+        runtime_root: record.runtime_root,
+        bundle_dir: record.bundle_dir,
+        init_pid: record.init_pid,
+    }))
 }
 
 #[cfg(target_os = "linux")]
@@ -128,59 +194,16 @@ fn reap_orphaned_crun(home_dir: &Path, box_dir: &Path, box_id: &str) -> SandboxR
     use std::process::Command;
 
     let record_path = box_dir.join("sandbox/runtime.json");
-    let bytes = match std::fs::read(&record_path) {
-        Ok(bytes) => bytes,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return SandboxReap::NotPresent;
-        }
+    let record = match load_recorded_sandbox_runtime(home_dir, box_dir, box_id) {
+        Ok(Some(record)) => record,
+        Ok(None) => return SandboxReap::NotPresent,
         Err(error) => {
-            tracing::error!(
-                box_id,
-                path = %record_path.display(),
-                %error,
-                "Failed to read Sandbox runtime record during crash recovery"
-            );
+            tracing::error!(box_id, %error, "Invalid Sandbox runtime record during crash recovery");
             return SandboxReap::Failed;
         }
-    };
-    let record: SandboxRuntimeRecord = match serde_json::from_slice(&bytes) {
-        Ok(record) => record,
-        Err(error) => {
-            tracing::error!(
-                box_id,
-                path = %record_path.display(),
-                %error,
-                "Invalid Sandbox runtime record during crash recovery"
-            );
-            return SandboxReap::Failed;
-        }
-    };
-    let expected_runtime_root = home_dir.join("run/crun").join(box_id);
-    let expected_bundle = box_dir.join("sandbox/bundle");
-    if record.schema != "a3s.box.sandbox-runtime.v1"
-        || record.container_id != box_id
-        || record.runtime_root != expected_runtime_root
-        || record.bundle_dir != expected_bundle
-        || record.init_pid == 0
-    {
-        tracing::error!(
-            box_id,
-            "Sandbox runtime record failed path or identity validation"
-        );
-        return SandboxReap::Failed;
-    }
-
-    let capabilities = crate::sandbox::probe_sandbox_capabilities(Some(&record.runtime_path));
-    let Some(runtime) = capabilities.runtime else {
-        tracing::error!(
-            box_id,
-            failures = ?capabilities.failures,
-            "Cannot verify the recorded Sandbox runtime during crash recovery"
-        );
-        return SandboxReap::Failed;
     };
     let state = match crate::sandbox::handler::CrunHandler::query_state_at(
-        &runtime.path,
+        &record.runtime_path,
         &record.runtime_root,
         box_id,
     ) {
@@ -191,7 +214,7 @@ fn reap_orphaned_crun(home_dir: &Path, box_dir: &Path, box_id: &str) -> SandboxR
         }
     };
     if state.is_some_and(|state| state.status != "stopped") {
-        let output = Command::new(&runtime.path)
+        let output = Command::new(&record.runtime_path)
             .arg("--root")
             .arg(&record.runtime_root)
             .arg("kill")
@@ -205,7 +228,7 @@ fn reap_orphaned_crun(home_dir: &Path, box_dir: &Path, box_id: &str) -> SandboxR
         }
     }
 
-    let output = Command::new(&runtime.path)
+    let output = Command::new(&record.runtime_path)
         .arg("--root")
         .arg(&record.runtime_root)
         .arg("delete")
@@ -217,7 +240,7 @@ fn reap_orphaned_crun(home_dir: &Path, box_dir: &Path, box_id: &str) -> SandboxR
         Ok(output) if output.status.success() => {}
         Ok(output) => {
             match crate::sandbox::handler::CrunHandler::query_state_at(
-                &runtime.path,
+                &record.runtime_path,
                 &record.runtime_root,
                 box_id,
             ) {
@@ -277,6 +300,15 @@ pub fn cleanup_recorded_sandbox_runtime(
     Ok(())
 }
 
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn cleanup_recorded_sandbox_runtime_in(
+    _home_dir: &std::path::Path,
+    _box_dir: &std::path::Path,
+    _box_id: &str,
+) -> a3s_box_core::Result<()> {
+    Ok(())
+}
+
 #[cfg(all(test, not(target_os = "linux")))]
 mod tests {
     use super::*;
@@ -326,6 +358,29 @@ fn kill_orphaned_shim(box_id: &str) -> Vec<i32> {
 mod tests {
     use super::*;
 
+    fn write_runtime_record(
+        home_dir: &Path,
+        box_dir: &Path,
+        box_id: &str,
+        mutate: impl FnOnce(&mut SandboxRuntimeRecord),
+    ) {
+        let mut record = SandboxRuntimeRecord {
+            schema: "a3s.box.sandbox-runtime.v1".to_string(),
+            container_id: box_id.to_string(),
+            runtime_path: Path::new("/definitely/missing/certified-crun").to_path_buf(),
+            runtime_root: home_dir.join("run/crun").join(box_id),
+            bundle_dir: box_dir.join("sandbox/bundle"),
+            init_pid: 42,
+        };
+        mutate(&mut record);
+        std::fs::create_dir_all(box_dir.join("sandbox")).unwrap();
+        std::fs::write(
+            box_dir.join("sandbox/runtime.json"),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+    }
+
     #[test]
     fn test_reap_removes_box_dir() {
         // A box dir with no live shim / mount (e.g. left by a crash) is removed.
@@ -357,5 +412,33 @@ mod tests {
         cleanup_recorded_sandbox_runtime_in(home.path(), &box_dir, box_id).unwrap();
 
         assert!(box_dir.exists());
+    }
+
+    #[test]
+    fn recorded_sandbox_runtime_rejects_an_unexpected_box_directory() {
+        let home = tempfile::tempdir().unwrap();
+        let box_id = "recorded-sandbox-unexpected-directory";
+        let box_dir = home.path().join("external").join(box_id);
+        write_runtime_record(home.path(), &box_dir, box_id, |_| {});
+
+        let error = load_recorded_sandbox_runtime(home.path(), &box_dir, box_id).unwrap_err();
+
+        assert!(error.to_string().contains("unexpected host directory"));
+    }
+
+    #[test]
+    fn recorded_sandbox_runtime_rejects_invalid_paths_before_certification() {
+        let home = tempfile::tempdir().unwrap();
+        let box_id = "recorded-sandbox-invalid-paths";
+        let box_dir = home.path().join("boxes").join(box_id);
+        write_runtime_record(home.path(), &box_dir, box_id, |record| {
+            record.runtime_root = home.path().join("run/crun/another-box");
+        });
+
+        let error = load_recorded_sandbox_runtime(home.path(), &box_dir, box_id).unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("path or identity validation"));
+        assert!(!message.contains("Cannot verify the recorded Sandbox runtime"));
     }
 }


### PR DESCRIPTION
## Summary

- add a production `VmLocalExecutionBackend` for managed MicroVM and Sandbox executions
- recover MicroVM shims using exact command identity and PID start-time fencing
- recover certified `crun` runtimes from validated durable records
- preserve explicit Sandbox pause/resume rejection and clean anonymous volumes

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p a3s-box-runtime`
- `cargo check -p a3s-box-runtime --no-default-features`
- `cargo test -p a3s-box-runtime local_execution::vm_` (Linux: 8 passed)
- `cargo test -p a3s-box-runtime vm::reap` (Linux: 5 passed)
- `cargo test -p a3s-box-runtime sandbox::handler` (Linux: 2 passed)
- `cargo clippy -p a3s-box-runtime --all-targets -- -D warnings`

Linux validation ran from a detached Git worktree on the A3S OS server.