### PR TITLE
feat(runtime): split managed execution create and start

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,9 +315,10 @@ generation-fenced transitions and restart reconciliation; and a canonical
 runtime `ExecutionManager` with a production VM/Sandbox backend. CI runs the
 pinned official Python sync/async, TypeScript, and Code Interpreter clients
 against the router through an in-memory repository and fake execution manager.
-Separately, an A3S OS smoke harness proves real `--isolation sandbox` create,
-inspect, manager restart recovery, explicit pause rejection, kill, and cleanup
-through certified `crun`, without MicroVM fallback.
+Separately, an A3S OS smoke harness proves that `--isolation sandbox` create
+persists a recoverable `created` reservation without allocating backend
+resources, then starts through certified `crun`, rejects pause explicitly, and
+owns kill and cleanup without MicroVM fallback.
 
 Those protocol and runtime tests are not yet one end-to-end service path. CLI
 create/start/run and the Rust SDK still need migration to the canonical manager,

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -21,7 +21,7 @@ unversioned claim.
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, reaping, and startup reconciliation | Wire the repository and supervisor into the production service process and exercise restart and host-reboot recovery end to end |
-| Runtime lifecycle | Canonical managed-execution store, backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; an A3S OS smoke test proves real `crun` create, inspect, manager restart recovery, explicit pause rejection, kill, and cleanup without MicroVM fallback | Migrate CLI create/start/run and the Rust SDK to the same manager and add caller parity tests |
+| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; an A3S OS smoke test proves reservation-only create, restart reconciliation, real `crun` start, explicit pause rejection, kill, and cleanup without MicroVM fallback | Migrate CLI create/start/run and the Rust SDK to the same manager and add caller parity tests |
 | Credentials and routing | Injected verifier, token, cursor, and template interfaces isolate protocol logic from infrastructure | Add production credential hashing, token encryption and rotation, generation-fenced route leases, validated wildcard/direct routing, and the TLS data-plane gateway |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
@@ -638,6 +638,8 @@ CLI or the public compatibility API:
 
 ```text
 ExecutionManager
+  create(request, operation_id)           -> ExecutionReservation
+  start(execution_id, generation)         -> ExecutionLease
   create_and_start(request, operation_id) -> ExecutionLease
   inspect(execution_id)                   -> ExecutionStatus
   pause(execution_id, generation, policy) -> ExecutionLease
@@ -646,10 +648,13 @@ ExecutionManager
   reconcile(operation_id)                 -> ReconcileOutcome
 ```
 
-`operation_id` makes create retryable after a service crash. `generation`
-prevents a delayed kill or route request from reaching a replacement
-execution. Runtime-specific handles, process IDs, socket paths, OCI bundle
-paths, and shim command lines never cross this interface.
+`create_and_start` is the default composition of `create` followed by `start`.
+The durable `created` state lets CLI/SDK callers create without booting and
+lets startup reconciliation distinguish a reservation from an in-flight
+backend start. `operation_id` makes create retryable after a service crash.
+`generation` prevents a delayed start, kill, or route request from reaching a
+replacement execution. Runtime-specific handles, process IDs, socket paths,
+OCI bundle paths, and shim command lines never cross this interface.
 
 ### Compatibility service modules
 
@@ -704,7 +709,11 @@ transaction: insert creating record
   plan digest, encrypted tokens, expiry, metadata
               |
               v
-ExecutionManager.create_and_start(operation_id)
+ExecutionManager.create(operation_id)
+  persist a generation-fenced created reservation
+              |
+              v
+ExecutionManager.start(execution_id, generation)
               |
               v
 transaction: compare generation and publish running + route lease
@@ -780,22 +789,26 @@ and advances the generation exactly once when pause or resume completes.
 Backend calls remain outside the state lock.
 
 `LocalExecutionManager` implements the backend-neutral lifecycle contract over
-that store and an injectable runtime backend. It persists a `starting` claim
-before launch, keeps pause policy with the corresponding transitional record,
-performs state-file work on Tokio blocking workers, and resolves ambiguous
-backend errors from runtime observations before publishing a result. Startup
-reconciliation can therefore distinguish an unstarted claim from a runtime
-that became ready before its durable `running` publication.
+that store and an injectable runtime backend. `create` persists a stable
+`created` reservation without backend side effects, `start` fences the caller
+by generation and persists a `starting` claim before launch, and
+`create_and_start` composes those operations for the compatibility service.
+It keeps pause policy with the corresponding transitional record, performs
+state-file work on Tokio blocking workers, and resolves ambiguous backend
+errors from runtime observations before publishing a result. Startup
+reconciliation can therefore distinguish an unstarted reservation from a
+runtime that became ready before its durable `running` publication.
 
 The production VM/Sandbox backend is also complete for this slice. It owns live
 runtime handles, reconstructs MicroVM processes with PID identity fencing,
 reconstructs Sandbox executions from validated durable `crun` evidence,
 rejects unsupported Sandbox pause/resume without falling back to MicroVM, and
-owns terminal cleanup. The opt-in A3S OS smoke harness has proven real Sandbox
-create, inspect, manager reconstruction, pause rollback, kill, and removal of
-the Box directory, runtime root, and sockets. Deterministic image-pull failure
-injection also proves that a failed start does not create those runtime
-resources.
+owns terminal cleanup. The opt-in A3S OS smoke harness has proven that Sandbox
+`create` persists a `created` reservation without allocating a Box directory,
+runtime root, or sockets; manager reconstruction reconciles the same unstarted
+reservation; and explicit `start` launches through `crun`. It also proves pause
+rollback, kill, and terminal cleanup. Deterministic image-pull failure injection
+proves that a failed start does not create those runtime resources.
 
 Slice 4 remains incomplete until CLI create/start/run and the Rust SDK call the
 same manager with behavior parity tests. The existing Rust SDK uses the

--- a/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
+++ b/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
@@ -17,8 +17,8 @@ use a3s_box_compat::http::{
 use a3s_box_core::{
     resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionId,
     ExecutionIsolation, ExecutionLease, ExecutionManager, ExecutionManagerError,
-    ExecutionManagerResult, ExecutionState, ExecutionStatus, KillOutcome, OperationId,
-    ReconcileOutcome, ResourceConfig,
+    ExecutionManagerResult, ExecutionReservation, ExecutionState, ExecutionStatus, KillOutcome,
+    OperationId, ReconcileOutcome, ResourceConfig,
 };
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
@@ -255,20 +255,30 @@ impl FixtureExecutionManager {
             ExecutionManagerError::Unavailable("fixture execution lock poisoned".into())
         })
     }
+
+    fn reservation(execution: &FixtureExecution) -> ExecutionReservation {
+        ExecutionReservation {
+            execution_id: execution.lease.execution_id.clone(),
+            generation: execution.lease.generation,
+            plan: execution.lease.plan.clone(),
+            resources: execution.lease.resources.clone(),
+            created_at: execution.lease.started_at,
+        }
+    }
 }
 
 #[async_trait]
 impl ExecutionManager for FixtureExecutionManager {
-    async fn create_and_start(
+    async fn create(
         &self,
         request: CreateExecutionRequest,
         operation_id: &OperationId,
-    ) -> ExecutionManagerResult<ExecutionLease> {
+    ) -> ExecutionManagerResult<ExecutionReservation> {
         if let Some(execution_id) = self.operations()?.get(operation_id.as_str()).cloned() {
             return self
                 .executions()?
                 .get(&execution_id)
-                .map(|execution| execution.lease.clone())
+                .map(Self::reservation)
                 .ok_or_else(|| {
                     ExecutionManagerError::Internal(
                         "fixture operation references a missing execution".into(),
@@ -290,12 +300,46 @@ impl ExecutionManager for FixtureExecutionManager {
             execution_id.to_string(),
             FixtureExecution {
                 lease: lease.clone(),
-                state: ExecutionState::Running,
+                state: ExecutionState::Created,
             },
         );
         self.operations()?
             .insert(operation_id.as_str().to_string(), execution_id.to_string());
-        Ok(lease)
+        Ok(ExecutionReservation {
+            execution_id,
+            generation: lease.generation,
+            plan: lease.plan,
+            resources: lease.resources,
+            created_at: lease.started_at,
+        })
+    }
+
+    async fn start(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let mut executions = self.executions()?;
+        let execution = executions
+            .get_mut(execution_id.as_str())
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        if execution.lease.generation != generation {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id.clone(),
+                message: "stale fixture start".to_string(),
+            });
+        }
+        match execution.state {
+            ExecutionState::Created => execution.state = ExecutionState::Running,
+            ExecutionState::Running => {}
+            state => {
+                return Err(ExecutionManagerError::Conflict {
+                    execution_id: execution_id.clone(),
+                    message: format!("cannot start fixture execution in state {state:?}"),
+                });
+            }
+        }
+        Ok(execution.lease.clone())
     }
 
     async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
@@ -394,6 +438,7 @@ impl ExecutionManager for FixtureExecutionManager {
             )
         })?;
         Ok(match execution.state {
+            ExecutionState::Created => ReconcileOutcome::Created(Self::reservation(execution)),
             ExecutionState::Creating => ReconcileOutcome::Creating,
             ExecutionState::Running | ExecutionState::Paused => {
                 ReconcileOutcome::Ready(execution.lease.clone())

--- a/src/compat/src/control/supervisor.rs
+++ b/src/compat/src/control/supervisor.rs
@@ -2,7 +2,8 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use a3s_box_core::{
-    ExecutionLease, ExecutionManager, ExecutionManagerError, ExecutionState, ReconcileOutcome,
+    ExecutionLease, ExecutionManager, ExecutionManagerError, ExecutionReservation, ExecutionState,
+    ReconcileOutcome,
 };
 use thiserror::Error;
 
@@ -140,6 +141,9 @@ impl LifecycleSupervisor {
             ReconcileOutcome::Absent | ReconcileOutcome::Failed => {
                 self.finish_missing(record).await
             }
+            ReconcileOutcome::Created(reservation) => {
+                self.reconcile_created(record, reservation).await
+            }
             ReconcileOutcome::Creating => match record.state() {
                 LifecycleState::Creating | LifecycleState::Killing => {
                     Ok(MaintenanceDisposition::Deferred)
@@ -149,6 +153,42 @@ impl LifecycleSupervisor {
                 ))),
             },
             ReconcileOutcome::Ready(lease) => self.reconcile_ready(record, lease).await,
+        }
+    }
+
+    async fn reconcile_created(
+        &self,
+        record: SandboxRecord,
+        reservation: ExecutionReservation,
+    ) -> MaintenanceItemResult<MaintenanceDisposition> {
+        ensure_created_reservation(&record, &reservation)?;
+        match record.state() {
+            LifecycleState::Creating => {
+                let lease = self
+                    .executions
+                    .start(&reservation.execution_id, reservation.generation)
+                    .await?;
+                if lease.execution_id != reservation.execution_id
+                    || lease.generation != reservation.generation
+                    || lease.plan != reservation.plan
+                    || !same_resources(&lease.resources, &reservation.resources)
+                {
+                    return Err(MaintenanceItemError::Inconsistent(
+                        "created reservation and started execution disagree".to_string(),
+                    ));
+                }
+                self.publish_running(record, lease).await
+            }
+            LifecycleState::Killing => {
+                self.finish_kill_with_target(
+                    record,
+                    Some((reservation.execution_id, reservation.generation)),
+                )
+                .await
+            }
+            state => Err(MaintenanceItemError::Inconsistent(format!(
+                "persisted state {state:?} disagrees with a created runtime reservation"
+            ))),
         }
     }
 
@@ -172,6 +212,9 @@ impl LifecycleSupervisor {
         }
 
         match status.state {
+            ExecutionState::Created => Err(MaintenanceItemError::Inconsistent(
+                "ready reconciliation inspected a created execution".to_string(),
+            )),
             ExecutionState::Creating => match record.state() {
                 LifecycleState::Creating | LifecycleState::Killing => {
                     Ok(MaintenanceDisposition::Deferred)
@@ -366,6 +409,44 @@ impl LifecycleSupervisor {
             },
         )
     }
+}
+
+fn ensure_created_reservation(
+    record: &SandboxRecord,
+    reservation: &ExecutionReservation,
+) -> MaintenanceItemResult<()> {
+    if record.plan() != &reservation.plan {
+        return Err(MaintenanceItemError::Inconsistent(
+            "created reservation plan differs from persisted sandbox".to_string(),
+        ));
+    }
+    if !same_resources(record.resources(), &reservation.resources) {
+        return Err(MaintenanceItemError::Inconsistent(
+            "created reservation resources differ from persisted sandbox".to_string(),
+        ));
+    }
+    match (record.execution_id(), record.execution_generation()) {
+        (None, None) => Ok(()),
+        (Some(execution_id), Some(generation))
+            if execution_id == &reservation.execution_id
+                && generation == reservation.generation =>
+        {
+            Ok(())
+        }
+        _ => Err(MaintenanceItemError::Inconsistent(
+            "created reservation differs from persisted execution mapping".to_string(),
+        )),
+    }
+}
+
+fn same_resources(
+    left: &a3s_box_core::ResourceConfig,
+    right: &a3s_box_core::ResourceConfig,
+) -> bool {
+    left.vcpus == right.vcpus
+        && left.memory_mb == right.memory_mb
+        && left.disk_mb == right.disk_mb
+        && left.timeout == right.timeout
 }
 
 impl LifecycleMaintenanceReport {

--- a/src/compat/src/control/supervisor_tests.rs
+++ b/src/compat/src/control/supervisor_tests.rs
@@ -81,6 +81,60 @@ async fn start_runtime(
         .unwrap()
 }
 
+async fn create_runtime(
+    manager: &RecordingExecutionManager,
+    record: &SandboxRecord,
+    config: BoxConfig,
+) -> a3s_box_core::ExecutionReservation {
+    manager
+        .create(
+            CreateExecutionRequest {
+                external_sandbox_id: record.sandbox_id().to_string(),
+                config,
+                labels: BTreeMap::new(),
+            },
+            record.operation_id(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn assert_created_reservation_drift_is_rejected(
+    sandbox_id: &str,
+    record: SandboxRecord,
+    runtime_config: BoxConfig,
+    expected_failure: &str,
+) {
+    let repository = Arc::new(MemorySandboxRepository::default());
+    let clock: Arc<dyn Clock> = Arc::new(FixedClock(instant(20)));
+    let executions = Arc::new(RecordingExecutionManager::new(clock.clone()));
+    repository.insert(record.clone()).await.unwrap();
+    let reservation = create_runtime(&executions, &record, runtime_config).await;
+
+    let report = supervisor(repository, executions.clone(), clock)
+        .reconcile_startup(NonZeroU32::new(10).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(report.examined, 1, "{sandbox_id}");
+    assert_eq!(report.completed, 0, "{sandbox_id}");
+    assert_eq!(report.failures.len(), 1, "{sandbox_id}");
+    assert!(
+        report.failures[0].message.contains(expected_failure),
+        "unexpected reconciliation failure for {sandbox_id}: {}",
+        report.failures[0].message
+    );
+    assert_eq!(
+        executions
+            .inspect(&reservation.execution_id)
+            .await
+            .unwrap()
+            .state,
+        ExecutionState::Created,
+        "reconciliation must reject drift before starting {sandbox_id}"
+    );
+}
+
 fn supervisor(
     repository: Arc<dyn SandboxRepository>,
     executions: Arc<RecordingExecutionManager>,
@@ -175,6 +229,64 @@ async fn startup_recovers_create_committed_only_in_runtime() {
 }
 
 #[tokio::test]
+async fn startup_starts_a_durable_runtime_reservation_before_publishing_running() {
+    let repository = Arc::new(MemorySandboxRepository::default());
+    let clock: Arc<dyn Clock> = Arc::new(FixedClock(instant(20)));
+    let executions = Arc::new(RecordingExecutionManager::new(clock.clone()));
+    let (record, config) = creating_record("sandbox-1", OnTimeoutAction::Kill);
+    repository.insert(record.clone()).await.unwrap();
+    let reservation = create_runtime(&executions, &record, config).await;
+
+    let report = supervisor(repository.clone(), executions.clone(), clock)
+        .reconcile_startup(NonZeroU32::new(10).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(report.examined, 1);
+    assert_eq!(report.completed, 1);
+    assert!(report.failures.is_empty());
+    let recovered = repository.get(record.sandbox_id()).await.unwrap().unwrap();
+    assert_eq!(recovered.state(), LifecycleState::Running);
+    assert_eq!(recovered.execution_id(), Some(&reservation.execution_id));
+    assert_eq!(
+        executions
+            .inspect(&reservation.execution_id)
+            .await
+            .unwrap()
+            .state,
+        ExecutionState::Running
+    );
+}
+
+#[tokio::test]
+async fn startup_rejects_created_plan_drift_before_starting_the_runtime() {
+    let (record, mut runtime_config) = creating_record("plan-drift", OnTimeoutAction::Kill);
+    runtime_config.isolation = ExecutionIsolation::Microvm;
+
+    assert_created_reservation_drift_is_rejected(
+        "plan-drift",
+        record,
+        runtime_config,
+        "reservation plan differs",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn startup_rejects_created_resource_drift_before_starting_the_runtime() {
+    let (record, mut runtime_config) = creating_record("resource-drift", OnTimeoutAction::Kill);
+    runtime_config.resources.memory_mb += 1;
+
+    assert_created_reservation_drift_is_rejected(
+        "resource-drift",
+        record,
+        runtime_config,
+        "reservation resources differ",
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn startup_marks_an_absent_incomplete_runtime_as_failed() {
     let repository = Arc::new(MemorySandboxRepository::default());
     let clock: Arc<dyn Clock> = Arc::new(FixedClock(instant(20)));
@@ -233,6 +345,42 @@ async fn startup_kills_a_runtime_created_after_its_record_was_claimed() {
     );
     assert_eq!(
         executions.inspect(&lease.execution_id).await.unwrap().state,
+        ExecutionState::Stopped
+    );
+}
+
+#[tokio::test]
+async fn startup_kills_a_created_reservation_without_starting_it() {
+    let repository = Arc::new(MemorySandboxRepository::default());
+    let clock: Arc<dyn Clock> = Arc::new(FixedClock(instant(20)));
+    let executions = Arc::new(RecordingExecutionManager::new(clock.clone()));
+    let (mut record, config) = creating_record("sandbox-1", OnTimeoutAction::Kill);
+    let reservation = create_runtime(&executions, &record, config).await;
+    record.begin_kill().unwrap();
+    repository.insert(record.clone()).await.unwrap();
+
+    let report = supervisor(repository.clone(), executions.clone(), clock)
+        .reconcile_startup(NonZeroU32::new(10).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(report.completed, 1);
+    assert!(report.failures.is_empty());
+    assert_eq!(
+        repository
+            .get(record.sandbox_id())
+            .await
+            .unwrap()
+            .unwrap()
+            .state(),
+        LifecycleState::Killed
+    );
+    assert_eq!(
+        executions
+            .inspect(&reservation.execution_id)
+            .await
+            .unwrap()
+            .state,
         ExecutionState::Stopped
     );
 }

--- a/src/compat/src/control/test_support.rs
+++ b/src/compat/src/control/test_support.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Mutex};
 use a3s_box_core::{
     resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionId,
     ExecutionIsolation, ExecutionLease, ExecutionManager, ExecutionManagerError,
-    ExecutionManagerResult, ExecutionState, ExecutionStatus, KillOutcome, NetworkMode, OperationId,
-    ReconcileOutcome, ResourceConfig,
+    ExecutionManagerResult, ExecutionReservation, ExecutionState, ExecutionStatus, KillOutcome,
+    NetworkMode, OperationId, ReconcileOutcome, ResourceConfig,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
@@ -180,17 +180,40 @@ impl RecordingExecutionManager {
     pub fn fail_create(&self) {
         self.fail_create.store(true, Ordering::Relaxed);
     }
+
+    fn reservation(execution: &TestExecution) -> ExecutionReservation {
+        ExecutionReservation {
+            execution_id: execution.lease.execution_id.clone(),
+            generation: execution.lease.generation,
+            plan: execution.lease.plan.clone(),
+            resources: execution.lease.resources.clone(),
+            created_at: execution.lease.started_at,
+        }
+    }
 }
 
 #[async_trait]
 impl ExecutionManager for RecordingExecutionManager {
-    async fn create_and_start(
+    async fn create(
         &self,
         request: CreateExecutionRequest,
         operation_id: &OperationId,
-    ) -> ExecutionManagerResult<ExecutionLease> {
+    ) -> ExecutionManagerResult<ExecutionReservation> {
         if self.fail_create.load(Ordering::Relaxed) {
             return Err(ExecutionManagerError::Unavailable("test failure".into()));
+        }
+        if let Some(execution_id) = self
+            .operations
+            .lock()
+            .unwrap()
+            .get(operation_id.as_str())
+            .cloned()
+        {
+            let executions = self.executions.lock().unwrap();
+            let execution = executions.get(&execution_id).ok_or_else(|| {
+                ExecutionManagerError::Internal("missing test execution".to_string())
+            })?;
+            return Ok(Self::reservation(execution));
         }
         self.requests.lock().unwrap().push(request.clone());
         let plan = resolve_execution(&request.config)
@@ -211,10 +234,44 @@ impl ExecutionManager for RecordingExecutionManager {
             execution_id.to_string(),
             TestExecution {
                 lease: lease.clone(),
-                state: ExecutionState::Running,
+                state: ExecutionState::Created,
             },
         );
-        Ok(lease)
+        Ok(ExecutionReservation {
+            execution_id,
+            generation: lease.generation,
+            plan: lease.plan,
+            resources: lease.resources,
+            created_at: lease.started_at,
+        })
+    }
+
+    async fn start(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let mut executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get_mut(execution_id.as_str())
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        if execution.lease.generation != generation {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id.clone(),
+                message: "stale test start".to_string(),
+            });
+        }
+        match execution.state {
+            ExecutionState::Created => execution.state = ExecutionState::Running,
+            ExecutionState::Running => {}
+            state => {
+                return Err(ExecutionManagerError::Conflict {
+                    execution_id: execution_id.clone(),
+                    message: format!("cannot start test execution in state {state:?}"),
+                });
+            }
+        }
+        Ok(execution.lease.clone())
     }
 
     async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
@@ -318,6 +375,7 @@ impl ExecutionManager for RecordingExecutionManager {
             .get(&execution_id)
             .ok_or_else(|| ExecutionManagerError::Internal("missing test execution".to_string()))?;
         Ok(match execution.state {
+            ExecutionState::Created => ReconcileOutcome::Created(Self::reservation(execution)),
             ExecutionState::Creating => ReconcileOutcome::Creating,
             ExecutionState::Running | ExecutionState::Paused => {
                 ReconcileOutcome::Ready(execution.lease.clone())

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -61,10 +61,10 @@ pub use tee::{detect_tee, is_tee_available, TeeCapability, TeeType};
 pub use traits::{
     AuditSink, CacheBackend, CacheEntry, CacheStats, CreateExecutionRequest, CredentialProvider,
     EventBus, ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManager,
-    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ExecutionStatus, ImageRegistry,
-    ImageStoreBackend, KillOutcome, MetricsCollector, NetworkStoreBackend, NoopMetrics,
-    OperationId, PulledImage, ReconcileOutcome, SnapshotStoreBackend, StoredImage,
-    VolumeStoreBackend,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionReservation, ExecutionState,
+    ExecutionStatus, ImageRegistry, ImageStoreBackend, KillOutcome, MetricsCollector,
+    NetworkStoreBackend, NoopMetrics, OperationId, PulledImage, ReconcileOutcome,
+    SnapshotStoreBackend, StoredImage, VolumeStoreBackend,
 };
 pub use vmm::{
     Entrypoint, FsMount, InstanceSpec, NetworkInstanceConfig, TeeInstanceConfig, VmHandler,

--- a/src/core/src/traits/execution.rs
+++ b/src/core/src/traits/execution.rs
@@ -139,6 +139,16 @@ pub struct CreateExecutionRequest {
     pub labels: BTreeMap<String, String>,
 }
 
+/// Durable evidence returned after an execution is created but not started.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionReservation {
+    pub execution_id: ExecutionId,
+    pub generation: ExecutionGeneration,
+    pub plan: ResolvedExecutionPlan,
+    pub resources: ResourceConfig,
+    pub created_at: DateTime<Utc>,
+}
+
 /// Evidence returned when a runtime execution is ready.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionLease {
@@ -153,6 +163,7 @@ pub struct ExecutionLease {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecutionState {
+    Created,
     Creating,
     Running,
     Paused,
@@ -180,6 +191,7 @@ pub enum KillOutcome {
 #[derive(Debug, Clone)]
 pub enum ReconcileOutcome {
     Absent,
+    Created(ExecutionReservation),
     Creating,
     Ready(ExecutionLease),
     Failed,
@@ -208,12 +220,41 @@ pub type ExecutionManagerResult<T> = std::result::Result<T, ExecutionManagerErro
 /// Backend-neutral lifecycle facade shared by the CLI, SDK, and remote service.
 #[async_trait]
 pub trait ExecutionManager: Send + Sync {
+    /// Persist exactly one unstarted execution reservation for `operation_id`.
+    async fn create(
+        &self,
+        _request: CreateExecutionRequest,
+        _operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ExecutionReservation> {
+        Err(ExecutionManagerError::Unavailable(
+            "this execution manager does not support staged create".to_string(),
+        ))
+    }
+
+    /// Start one created execution after fencing stale callers by generation.
+    async fn start(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        Err(ExecutionManagerError::Unavailable(
+            "this execution manager does not support staged start".to_string(),
+        ))
+    }
+
     /// Create and start exactly one execution for `operation_id`.
+    ///
+    /// Retrying after a crash reuses the durable reservation and continues its
+    /// start instead of allocating a second execution.
     async fn create_and_start(
         &self,
         request: CreateExecutionRequest,
         operation_id: &OperationId,
-    ) -> ExecutionManagerResult<ExecutionLease>;
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let reservation = self.create(request, operation_id).await?;
+        self.start(&reservation.execution_id, reservation.generation)
+            .await
+    }
 
     async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus>;
 

--- a/src/core/src/traits/mod.rs
+++ b/src/core/src/traits/mod.rs
@@ -19,8 +19,8 @@ pub use credential::CredentialProvider;
 pub use event::EventBus;
 pub use execution::{
     CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManager,
-    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ExecutionStatus, KillOutcome,
-    OperationId, ReconcileOutcome,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionReservation, ExecutionState,
+    ExecutionStatus, KillOutcome, OperationId, ReconcileOutcome,
 };
 pub use metrics::{MetricsCollector, NoopMetrics};
 pub use registry::{ImageRegistry, PulledImage};

--- a/src/runtime/examples/managed_sandbox_smoke.rs
+++ b/src/runtime/examples/managed_sandbox_smoke.rs
@@ -29,7 +29,7 @@ mod linux {
     use a3s_box_core::{
         BoxConfig, CreateExecutionRequest, ExecutionBackend, ExecutionId, ExecutionIsolation,
         ExecutionManager, ExecutionManagerError, ExecutionState, IsolationClass, KillOutcome,
-        NetworkMode, OperationId,
+        NetworkMode, OperationId, ReconcileOutcome, ResourceConfig,
     };
     use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionStore};
 
@@ -108,38 +108,75 @@ mod linux {
         };
 
         let manager = LocalExecutionManager::with_vm_backend(state_path, home_dir);
-        let lease = manager.create_and_start(request, operation_id).await?;
+        let reservation = manager.create(request, operation_id).await?;
         require(
-            lease.plan.backend == ExecutionBackend::Crun
-                && lease.plan.isolation_class == IsolationClass::SharedKernel,
+            reservation.plan.backend == ExecutionBackend::Crun
+                && reservation.plan.isolation_class == IsolationClass::SharedKernel,
             "Sandbox request did not resolve exclusively to the crun shared-kernel backend",
         )?;
-        let execution_id = lease.execution_id.clone();
+        let execution_id = reservation.execution_id.clone();
         let status = manager.inspect(&execution_id).await?;
         require(
-            status.state == ExecutionState::Running,
-            "new managed Sandbox is not running",
+            status.state == ExecutionState::Created,
+            "new managed Sandbox reservation is not created",
+        )?;
+        require(
+            status.generation == reservation.generation && status.plan == reservation.plan,
+            "created Sandbox inspection disagrees with its reservation",
         )?;
 
         let box_dir = home_dir.join("boxes").join(execution_id.as_str());
-        validate_runtime_record(home_dir, &box_dir, &execution_id)?;
+        validate_runtime_absent(home_dir, &execution_id)?;
         println!(
-            "created execution={} backend=crun state=running",
+            "created execution={} backend=crun state=created",
             execution_id
         );
 
         drop(manager);
-        let recovered = LocalExecutionManager::with_vm_backend(state_path, home_dir);
-        let recovered_status = recovered.inspect(&execution_id).await?;
+        let restarted = LocalExecutionManager::with_vm_backend(state_path, home_dir);
+        let recovered_reservation = match restarted.reconcile(operation_id).await? {
+            ReconcileOutcome::Created(reservation) => reservation,
+            _ => {
+                return Err(failure(
+                    "restarted manager did not recover a created reservation",
+                ))
+            }
+        };
         require(
-            recovered_status.state == ExecutionState::Running,
-            "restarted manager did not recover the running Sandbox",
+            recovered_reservation.execution_id == reservation.execution_id
+                && recovered_reservation.generation == reservation.generation
+                && recovered_reservation.plan == reservation.plan
+                && same_resources(&recovered_reservation.resources, &reservation.resources),
+            "recovered Sandbox reservation differs from the durable reservation",
+        )?;
+        let recovered_status = restarted.inspect(&execution_id).await?;
+        require(
+            recovered_status.state == ExecutionState::Created,
+            "restarted manager did not preserve the created Sandbox state",
+        )?;
+        validate_runtime_absent(home_dir, &execution_id)?;
+        println!("recovered execution={} state=created", execution_id);
+
+        let lease = restarted
+            .start(&execution_id, recovered_reservation.generation)
+            .await?;
+        require(
+            lease.execution_id == reservation.execution_id
+                && lease.generation == reservation.generation
+                && lease.plan == reservation.plan
+                && same_resources(&lease.resources, &reservation.resources),
+            "started Sandbox lease differs from its reservation",
+        )?;
+        let running_status = restarted.inspect(&execution_id).await?;
+        require(
+            running_status.state == ExecutionState::Running,
+            "started managed Sandbox is not running",
         )?;
         validate_runtime_record(home_dir, &box_dir, &execution_id)?;
-        println!("recovered execution={} state=running", execution_id);
+        println!("started execution={} state=running", execution_id);
 
-        let pause_error = match recovered
-            .pause(&execution_id, recovered_status.generation, true)
+        let pause_error = match restarted
+            .pause(&execution_id, running_status.generation, true)
             .await
         {
             Ok(_) => return Err(failure("Sandbox pause unexpectedly succeeded")),
@@ -149,22 +186,22 @@ mod linux {
             matches!(pause_error, ExecutionManagerError::Conflict { .. }),
             "Sandbox pause did not return a conflict",
         )?;
-        let rolled_back = recovered.inspect(&execution_id).await?;
+        let rolled_back = restarted.inspect(&execution_id).await?;
         require(
             rolled_back.state == ExecutionState::Running
-                && rolled_back.generation == recovered_status.generation,
+                && rolled_back.generation == running_status.generation,
             "failed Sandbox pause did not roll back to the running generation",
         )?;
         println!("pause-rejected execution={} state=running", execution_id);
 
-        let outcome = recovered
+        let outcome = restarted
             .kill(&execution_id, rolled_back.generation)
             .await?;
         require(
             outcome == KillOutcome::Killed,
             "managed Sandbox kill did not own runtime cleanup",
         )?;
-        let stopped = recovered.inspect(&execution_id).await?;
+        let stopped = restarted.inspect(&execution_id).await?;
         require(
             stopped.state == ExecutionState::Stopped,
             "managed Sandbox did not persist a stopped state",
@@ -185,6 +222,36 @@ mod linux {
         )?;
         println!("killed execution={} state=stopped cleanup=ok", execution_id);
         Ok(())
+    }
+
+    fn validate_runtime_absent(
+        home_dir: &Path,
+        execution_id: &ExecutionId,
+    ) -> Result<(), AnyError> {
+        require(
+            !home_dir.join("boxes").join(execution_id.as_str()).exists(),
+            "created Sandbox unexpectedly allocated a box directory",
+        )?;
+        require(
+            !home_dir
+                .join("run/crun")
+                .join(execution_id.as_str())
+                .exists(),
+            "created Sandbox unexpectedly allocated a crun state directory",
+        )?;
+        require(
+            !Path::new("/tmp/a3s-box-sockets")
+                .join(execution_id.as_str())
+                .exists(),
+            "created Sandbox unexpectedly allocated a socket directory",
+        )
+    }
+
+    fn same_resources(left: &ResourceConfig, right: &ResourceConfig) -> bool {
+        left.vcpus == right.vcpus
+            && left.memory_mb == right.memory_mb
+            && left.disk_mb == right.disk_mb
+            && left.timeout == right.timeout
     }
 
     fn validate_runtime_record(

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -246,6 +246,7 @@ impl BoxRecord {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManagedExecutionState {
     Creating,
+    Created,
     Starting,
     Running,
     Pausing,
@@ -261,6 +262,7 @@ impl ManagedExecutionState {
     pub const fn as_status(self) -> &'static str {
         match self {
             Self::Creating => "creating",
+            Self::Created => "created",
             Self::Starting => "starting",
             Self::Running => "running",
             Self::Pausing => "pausing",
@@ -275,9 +277,8 @@ impl ManagedExecutionState {
     /// Parse a persisted managed lifecycle state.
     pub fn from_status(status: &str) -> a3s_box_core::Result<Self> {
         match status {
-            // Accept the legacy pre-start and terminal spellings so records
-            // created during the state-schema migration remain recoverable.
-            "created" | "creating" => Ok(Self::Creating),
+            "creating" => Ok(Self::Creating),
+            "created" => Ok(Self::Created),
             "starting" => Ok(Self::Starting),
             "running" => Ok(Self::Running),
             "pausing" => Ok(Self::Pausing),
@@ -294,7 +295,10 @@ impl ManagedExecutionState {
 
     /// Whether host resources may still belong to this execution.
     pub const fn keeps_resources(self) -> bool {
-        !matches!(self, Self::Stopped | Self::Failed)
+        !matches!(
+            self,
+            Self::Creating | Self::Created | Self::Stopped | Self::Failed
+        )
     }
 
     /// Whether no further lifecycle operation can revive this execution.
@@ -415,6 +419,7 @@ fn validate_pending_operation(
             Some(ManagedExecutionOperation::Kill)
         ) | (
             ManagedExecutionState::Creating
+                | ManagedExecutionState::Created
                 | ManagedExecutionState::Running
                 | ManagedExecutionState::Paused
                 | ManagedExecutionState::Stopped
@@ -519,9 +524,9 @@ mod tests {
         let encoded = serde_json::to_value(&record).unwrap();
         assert_eq!(
             record.managed_state().unwrap(),
-            Some(ManagedExecutionState::Creating)
+            Some(ManagedExecutionState::Created)
         );
-        assert!(record.is_active());
+        assert!(!record.is_active());
         let managed = record.managed_execution.unwrap();
 
         assert_eq!(managed.operation_id.as_str(), "create-op-1");

--- a/src/runtime/src/local_execution/api.rs
+++ b/src/runtime/src/local_execution/api.rs
@@ -1,7 +1,7 @@
 use a3s_box_core::{
     CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManager,
-    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ExecutionStatus, KillOutcome,
-    OperationId, ReconcileOutcome,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionReservation, ExecutionState,
+    ExecutionStatus, KillOutcome, OperationId, ReconcileOutcome,
 };
 use async_trait::async_trait;
 
@@ -13,11 +13,11 @@ use super::{
 
 #[async_trait]
 impl ExecutionManager for LocalExecutionManager {
-    async fn create_and_start(
+    async fn create(
         &self,
         request: CreateExecutionRequest,
         operation_id: &OperationId,
-    ) -> ExecutionManagerResult<ExecutionLease> {
+    ) -> ExecutionManagerResult<ExecutionReservation> {
         let execution_id = ExecutionId::new(uuid::Uuid::new_v4().to_string())?;
         let record = build_managed_record(
             &self.home_dir,
@@ -27,7 +27,20 @@ impl ExecutionManager for LocalExecutionManager {
             chrono::Utc::now(),
         )?;
         let reservation = self.reserve(record).await?;
-        self.ensure_started(reservation.into_record()).await
+        super::record::reservation_from_record(reservation.record())
+    }
+
+    async fn start(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let record = self
+            .get(execution_id)
+            .await?
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        require_generation(&record, execution_id, expected_generation)?;
+        self.ensure_started(record).await
     }
 
     async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
@@ -124,9 +137,10 @@ impl ExecutionManager for LocalExecutionManager {
             return Ok(ReconcileOutcome::Absent);
         };
         match managed_state(&record)? {
-            ManagedExecutionState::Creating | ManagedExecutionState::Starting => {
-                self.recover_start(record).await
-            }
+            ManagedExecutionState::Creating | ManagedExecutionState::Created => Ok(
+                ReconcileOutcome::Created(super::record::reservation_from_record(&record)?),
+            ),
+            ManagedExecutionState::Starting => self.recover_start(record).await,
             ManagedExecutionState::Pausing => {
                 let (record, state) = self.observe_record(record).await?;
                 if managed_state(&record)? == ManagedExecutionState::Pausing

--- a/src/runtime/src/local_execution/backend.rs
+++ b/src/runtime/src/local_execution/backend.rs
@@ -61,7 +61,10 @@ impl LocalExecutionObservation {
                     ))
                 })?;
             }
-            ExecutionState::Creating | ExecutionState::Stopped | ExecutionState::Failed => {}
+            ExecutionState::Created
+            | ExecutionState::Creating
+            | ExecutionState::Stopped
+            | ExecutionState::Failed => {}
         }
         if let Some(handle) = &self.handle {
             handle.validate(execution_id)?;

--- a/src/runtime/src/local_execution/create.rs
+++ b/src/runtime/src/local_execution/create.rs
@@ -11,7 +11,9 @@ impl LocalExecutionManager {
         record: BoxRecord,
     ) -> ExecutionManagerResult<ExecutionLease> {
         match managed_state(&record)? {
-            ManagedExecutionState::Creating => self.claim_and_start(record).await,
+            state @ (ManagedExecutionState::Creating | ManagedExecutionState::Created) => {
+                self.claim_and_start(record, state).await
+            }
             ManagedExecutionState::Starting => {
                 let execution_id = execution_id(&record)?;
                 match self.backend.inspect(&record).await {
@@ -33,6 +35,11 @@ impl LocalExecutionManager {
                             ExecutionState::Creating => Err(ExecutionManagerError::Unavailable(
                                 format!("execution {execution_id} is still starting"),
                             )),
+                            ExecutionState::Created => {
+                                Err(ExecutionManagerError::Internal(format!(
+                                    "backend reported created state while starting {execution_id}"
+                                )))
+                            }
                             ExecutionState::Stopped | ExecutionState::Failed => {
                                 self.transition(
                                     &record,
@@ -60,9 +67,7 @@ impl LocalExecutionManager {
                     Err(error) => Err(error),
                 }
             }
-            ManagedExecutionState::Running | ManagedExecutionState::Paused => {
-                lease_from_record(&record)
-            }
+            ManagedExecutionState::Running => lease_from_record(&record),
             state => Err(ExecutionManagerError::Conflict {
                 execution_id: execution_id(&record)?,
                 message: format!("creation operation is {state}"),
@@ -73,11 +78,12 @@ impl LocalExecutionManager {
     pub(super) async fn claim_and_start(
         &self,
         record: BoxRecord,
+        expected_state: ManagedExecutionState,
     ) -> ExecutionManagerResult<ExecutionLease> {
         let claimed = match self
             .transition(
                 &record,
-                ManagedExecutionState::Creating,
+                expected_state,
                 ManagedExecutionState::Starting,
                 RuntimeUpdate::None,
             )
@@ -118,8 +124,12 @@ impl LocalExecutionManager {
         record: BoxRecord,
     ) -> ExecutionManagerResult<ExecutionLease> {
         match managed_state(&record)? {
-            ManagedExecutionState::Running | ManagedExecutionState::Paused => {
-                lease_from_record(&record)
+            ManagedExecutionState::Running => lease_from_record(&record),
+            ManagedExecutionState::Creating | ManagedExecutionState::Created => {
+                Err(ExecutionManagerError::Unavailable(format!(
+                    "execution {} startup claim was released; retry the request",
+                    execution_id(&record)?
+                )))
             }
             ManagedExecutionState::Starting => {
                 let id = execution_id(&record)?;
@@ -183,7 +193,9 @@ impl LocalExecutionManager {
                             .await;
                         Err(start_error)
                     }
-                    ExecutionState::Creating | ExecutionState::Paused => Err(start_error),
+                    ExecutionState::Created | ExecutionState::Creating | ExecutionState::Paused => {
+                        Err(start_error)
+                    }
                 }
             }
             Err(ExecutionManagerError::NotFound(_)) => {

--- a/src/runtime/src/local_execution/record.rs
+++ b/src/runtime/src/local_execution/record.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use a3s_box_core::log::LogConfig;
 use a3s_box_core::{
     CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionLease,
-    ExecutionManagerError, ExecutionManagerResult, ExecutionState, ExecutionStatus, NetworkMode,
-    OperationId,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionReservation, ExecutionState,
+    ExecutionStatus, NetworkMode, OperationId,
 };
 use chrono::{DateTime, Utc};
 
@@ -45,7 +45,7 @@ pub(crate) fn build_managed_record(
         image: config.image.clone(),
         isolation: config.isolation,
         managed_execution: Some(metadata),
-        status: ManagedExecutionState::Creating.as_status().to_string(),
+        status: ManagedExecutionState::Created.as_status().to_string(),
         pid: None,
         pid_start_time: None,
         cpus: config.resources.vcpus,
@@ -117,6 +117,20 @@ pub(crate) fn clear_live_runtime(record: &mut BoxRecord, exit_code: Option<i32>)
     record.exit_code = exit_code;
     record.health_status = "none".to_string();
     record.health_retries = 0;
+}
+
+pub(crate) fn reservation_from_record(
+    record: &BoxRecord,
+) -> ExecutionManagerResult<ExecutionReservation> {
+    let execution_id = execution_id(record)?;
+    let metadata = metadata(record, &execution_id)?;
+    Ok(ExecutionReservation {
+        execution_id,
+        generation: metadata.generation,
+        plan: metadata.plan.clone(),
+        resources: metadata.request.config.resources.clone(),
+        created_at: record.created_at,
+    })
 }
 
 pub(crate) fn lease_from_record(record: &BoxRecord) -> ExecutionManagerResult<ExecutionLease> {

--- a/src/runtime/src/local_execution/recovery.rs
+++ b/src/runtime/src/local_execution/recovery.rs
@@ -13,7 +13,9 @@ impl LocalExecutionManager {
     ) -> ExecutionManagerResult<(BoxRecord, ExecutionState)> {
         let internal = managed_state(&record)?;
         match internal {
-            ManagedExecutionState::Creating => return Ok((record, ExecutionState::Creating)),
+            ManagedExecutionState::Creating | ManagedExecutionState::Created => {
+                return Ok((record, ExecutionState::Created));
+            }
             ManagedExecutionState::Stopped => return Ok((record, ExecutionState::Stopped)),
             ManagedExecutionState::Failed => return Ok((record, ExecutionState::Failed)),
             _ => {}
@@ -138,7 +140,7 @@ impl LocalExecutionManager {
                     self.transition(
                         &record,
                         ManagedExecutionState::Starting,
-                        ManagedExecutionState::Creating,
+                        ManagedExecutionState::Created,
                         RuntimeUpdate::None,
                     )
                     .await?
@@ -175,7 +177,7 @@ impl LocalExecutionManager {
         } else {
             record
         };
-        self.claim_and_start(record)
+        self.claim_and_start(record, ManagedExecutionState::Created)
             .await
             .map(ReconcileOutcome::Ready)
     }

--- a/src/runtime/src/local_execution/support.rs
+++ b/src/runtime/src/local_execution/support.rs
@@ -3,7 +3,7 @@ use a3s_box_core::{
     ExecutionState, ReconcileOutcome,
 };
 
-use super::record::lease_from_record;
+use super::record::{lease_from_record, reservation_from_record};
 use super::{
     BoxRecord, LocalExecutionHandle, LocalExecutionObservation, ManagedExecutionOperation,
     ManagedExecutionState,
@@ -99,6 +99,7 @@ pub(super) fn outcome_from_record(
     state: ExecutionState,
 ) -> ExecutionManagerResult<ReconcileOutcome> {
     match state {
+        ExecutionState::Created => Ok(ReconcileOutcome::Created(reservation_from_record(&record)?)),
         ExecutionState::Creating => Ok(ReconcileOutcome::Creating),
         ExecutionState::Running | ExecutionState::Paused => {
             Ok(ReconcileOutcome::Ready(lease_from_record(&record)?))

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -222,7 +222,7 @@ async fn reserve_starting(
     manager
         .transition(
             &record,
-            ManagedExecutionState::Creating,
+            ManagedExecutionState::Created,
             ManagedExecutionState::Starting,
             RuntimeUpdate::None,
         )
@@ -260,6 +260,121 @@ async fn create_persists_trusted_identity_and_returns_running_lease() {
         .starts_with(directory.path().join("home/boxes")));
     assert_eq!(record.pid, Some(4242));
     assert_eq!(record.anonymous_volumes, vec!["anonymous-1"]);
+}
+
+#[tokio::test]
+async fn create_reserves_without_start_and_start_is_generation_fenced() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+    let create_request = request("sandbox-1");
+
+    let reservation = manager
+        .create(create_request.clone(), &operation_id)
+        .await
+        .unwrap();
+    let retry = manager.create(create_request, &operation_id).await.unwrap();
+    let status = manager.inspect(&reservation.execution_id).await.unwrap();
+    let record = persisted(&manager, &reservation.execution_id);
+
+    assert_eq!(retry.execution_id, reservation.execution_id);
+    assert_eq!(status.state, ExecutionState::Created);
+    assert_eq!(record.status, "created");
+    assert_eq!(
+        record.managed_state().unwrap(),
+        Some(ManagedExecutionState::Created)
+    );
+    assert!(!record.is_active());
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 0);
+
+    let stale = manager
+        .start(
+            &reservation.execution_id,
+            ExecutionGeneration::new(2).unwrap(),
+        )
+        .await;
+    assert!(matches!(stale, Err(ExecutionManagerError::Conflict { .. })));
+
+    let lease = manager
+        .start(&reservation.execution_id, reservation.generation)
+        .await
+        .unwrap();
+    let repeated = manager
+        .start(&reservation.execution_id, reservation.generation)
+        .await
+        .unwrap();
+
+    assert_eq!(lease.execution_id, reservation.execution_id);
+    assert_eq!(repeated.execution_id, reservation.execution_id);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        manager
+            .inspect(&reservation.execution_id)
+            .await
+            .unwrap()
+            .state,
+        ExecutionState::Running
+    );
+}
+
+#[tokio::test]
+async fn reconciliation_reports_created_reservation_without_starting_it() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+    let reservation = manager
+        .create(request("sandbox-1"), &operation_id)
+        .await
+        .unwrap();
+
+    let outcome = manager.reconcile(&operation_id).await.unwrap();
+
+    let ReconcileOutcome::Created(recovered) = outcome else {
+        panic!("expected created reconciliation");
+    };
+    assert_eq!(recovered.execution_id, reservation.execution_id);
+    assert_eq!(recovered.generation, reservation.generation);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn legacy_creating_reservation_remains_recoverable_after_upgrade() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-1");
+    let reservation = manager
+        .create(request("sandbox-1"), &operation_id)
+        .await
+        .unwrap();
+    let created = persisted(&manager, &reservation.execution_id);
+    let starting = manager
+        .transition(
+            &created,
+            ManagedExecutionState::Created,
+            ManagedExecutionState::Starting,
+            RuntimeUpdate::None,
+        )
+        .await
+        .unwrap();
+    manager
+        .transition(
+            &starting,
+            ManagedExecutionState::Starting,
+            ManagedExecutionState::Creating,
+            RuntimeUpdate::None,
+        )
+        .await
+        .unwrap();
+
+    let outcome = manager.reconcile(&operation_id).await.unwrap();
+    let ReconcileOutcome::Created(recovered) = outcome else {
+        panic!("expected legacy creating reservation to reconcile as created");
+    };
+    assert_eq!(recovered.execution_id, reservation.execution_id);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 0);
+
+    manager
+        .start(&recovered.execution_id, recovered.generation)
+        .await
+        .unwrap();
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
 }
 
 #[tokio::test]

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -109,7 +109,7 @@ impl ManagedExecutionStore {
         mut record: BoxRecord,
     ) -> ManagedExecutionStoreResult<ManagedExecutionReservation> {
         let execution_id = validate_new_record(&record)?;
-        record.status = ManagedExecutionState::Creating.as_status().to_string();
+        record.status = ManagedExecutionState::Created.as_status().to_string();
         let incoming_metadata = record
             .managed_execution
             .as_ref()
@@ -251,6 +251,7 @@ impl ManagedExecutionStore {
                 ManagedExecutionState::Resuming => Some(ManagedExecutionOperation::Resume),
                 ManagedExecutionState::Killing => Some(ManagedExecutionOperation::Kill),
                 ManagedExecutionState::Creating
+                | ManagedExecutionState::Created
                 | ManagedExecutionState::Running
                 | ManagedExecutionState::Paused
                 | ManagedExecutionState::Stopped
@@ -275,9 +276,9 @@ fn validate_new_record(record: &BoxRecord) -> ManagedExecutionStoreResult<Execut
         .managed_state()
         .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?
         .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
-    if state != ManagedExecutionState::Creating {
+    if state != ManagedExecutionState::Created {
         return Err(ManagedExecutionStoreError::InvalidRecord(format!(
-            "new execution {execution_id} must be creating, found {state}"
+            "new execution {execution_id} must be created, found {state}"
         )));
     }
     if metadata.generation != ExecutionGeneration::INITIAL {
@@ -307,13 +308,17 @@ fn transition_generation(
     current: ExecutionGeneration,
 ) -> ManagedExecutionStoreResult<ExecutionGeneration> {
     use ManagedExecutionState::{
-        Creating, Failed, Killing, Paused, Pausing, Resuming, Running, Starting, Stopped,
+        Created, Creating, Failed, Killing, Paused, Pausing, Resuming, Running, Starting, Stopped,
     };
 
     let legal = matches!(
         (from, to),
-        (Creating, Starting | Killing | Stopped | Failed)
-            | (Starting, Creating | Running | Killing | Stopped | Failed)
+        (Creating, Created | Starting | Killing | Stopped | Failed)
+            | (Created, Starting | Killing | Stopped | Failed)
+            | (
+                Starting,
+                Created | Creating | Running | Killing | Stopped | Failed
+            )
             | (Running, Pausing | Killing | Stopped | Failed)
             | (Pausing, Paused | Running | Killing | Stopped | Failed)
             | (Paused, Resuming | Killing | Stopped | Failed)
@@ -356,7 +361,7 @@ mod tests {
             "name": format!("box-{id}"),
             "image": "alpine:latest",
             "isolation": "sandbox",
-            "status": "creating",
+            "status": "created",
             "pid": null,
             "cpus": 1,
             "memory_mb": 128,
@@ -445,7 +450,7 @@ mod tests {
             .transition(
                 &id,
                 ExecutionGeneration::INITIAL,
-                ManagedExecutionState::Creating,
+                ManagedExecutionState::Created,
                 ManagedExecutionState::Starting,
             )
             .unwrap();
@@ -513,7 +518,7 @@ mod tests {
             .transition(
                 &id,
                 ExecutionGeneration::INITIAL,
-                ManagedExecutionState::Creating,
+                ManagedExecutionState::Created,
                 ManagedExecutionState::Starting,
             )
             .unwrap();
@@ -573,7 +578,7 @@ mod tests {
             .transition(
                 &id,
                 ExecutionGeneration::INITIAL,
-                ManagedExecutionState::Creating,
+                ManagedExecutionState::Created,
                 ManagedExecutionState::Starting,
             )
             .unwrap();

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -84,12 +84,13 @@ The client reads the shared `boxes.json` state format through an SDK-local model
 so it does not depend on the CLI crate. Image, volume, network, snapshot, build,
 registry, exec, PTY, and attestation operations use `a3s-box-runtime` directly.
 
-Container lifecycle orchestration for `run`, `create`, `start`, and `restart`
-still needs stable runtime facades before it can be exposed as default SDK API.
-Pause, unpause, Unix stop, and box removal are already exposed directly because
-they can be implemented with PID identity checks, runtime guest-control sockets,
-host process signals, cleanup, and locked state updates. The default SDK does
-not shell out for lifecycle commands.
+The runtime now provides generation-fenced `create`, `start`, and
+`create_and_start` operations over the canonical managed-execution store.
+Container lifecycle orchestration is not exposed by this SDK yet: the SDK
+adapter and the CLI-specific record-policy mapping still need behavior-parity
+coverage before becoming default APIs. Pause, unpause, Unix stop, and box
+removal remain available through the existing direct management surface. The
+default SDK does not shell out for lifecycle commands.
 
 ## Maintenance Calls
 


### PR DESCRIPTION
## Summary

- add a durable `Created` execution reservation and generation-fenced two-stage `create` / `start` lifecycle
- preserve one-stage `create_and_start` compatibility and recover legacy `creating` reservations
- reconcile control records without starting drifted reservations, and kill unstarted reservations without booting them
- extend the A3S OS smoke harness to prove create has no backend side effects before explicit start

## Validation

- `cargo test -p a3s-box-core -p a3s-box-runtime -p a3s-box-compat --all-targets`
- `cargo check -p a3s-box-cli -p a3s-box-sdk --all-targets`
- focused `clippy -D warnings` for core/runtime/compat/CLI/SDK (allowing the existing macOS-only `needless_return` baseline lint)
- E2B contract verification and unchanged official Python sync/async, TypeScript, and Code Interpreter fixtures
- A3S OS production host smoke at commit `23c98174b87e16d57e43fb3b6b9e9399395fb20b` using certified crun 1.28 and an offline OCI archive: `created -> recovered(created) -> started(running) -> pause rejected -> killed(stopped), cleanup=ok`

The production host test used a Git-fetched detached worktree and isolated `A3S_HOME`; it left the existing server worktree and production home unchanged.