### PR TITLE
feat(runtime): persist managed execution caller policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,11 @@ generation-fenced transitions and restart reconciliation; and a canonical
 runtime `ExecutionManager` with a production VM/Sandbox backend. CI runs the
 pinned official Python sync/async, TypeScript, and Code Interpreter clients
 against the router through an in-memory repository and fake execution manager.
+Managed creation requests also persist a typed caller policy for names,
+restart and health behavior, logging, stop behavior, and local resource
+metadata. An idempotent retry therefore cannot silently reuse a reservation
+with different policy, and the canonical record mapper does not replace caller
+choices with runtime defaults.
 Separately, an A3S OS smoke harness proves that `--isolation sandbox` create
 persists a recoverable `created` reservation without allocating backend
 resources, then starts through certified `crun`, rejects pause explicitly, and

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -614,7 +614,7 @@ modules, or editing `boxes.json`. Phase 2 completes this dependency direction:
 
 ```text
 a3s-box-core
-  typed execution request + resolved execution plan
+  typed execution request + caller record policy + resolved execution plan
           ^
           |
 a3s-box-runtime
@@ -655,6 +655,17 @@ backend start. `operation_id` makes create retryable after a service crash.
 `generation` prevents a delayed start, kill, or route request from reaching a
 replacement execution. Runtime-specific handles, process IDs, socket paths,
 OCI bundle paths, and shim command lines never cross this interface.
+
+`CreateExecutionRequest` keeps backend launch requirements in `BoxConfig` and
+keeps caller-owned lifecycle and local resource metadata in a typed
+`ExecutionRecordPolicy`. The policy includes the user-visible name, automatic
+removal and restart behavior, health and log configuration, named-volume
+identity, stop behavior, and host-facing inspection fields. It is part of the
+durable creation intent rather than an encoded label. Consequently, retrying
+one operation ID with policy drift fails as a conflict, while records written
+before the policy field was added deserialize to explicit safe defaults. A
+single runtime mapper projects the request and policy into `BoxRecord`; CLI,
+SDK, and compatibility adapters must not construct a parallel record shape.
 
 ### Compatibility service modules
 

--- a/src/compat/src/control/service.rs
+++ b/src/compat/src/control/service.rs
@@ -163,6 +163,7 @@ impl ControlService {
             external_sandbox_id: record.sandbox_id().to_string(),
             config,
             labels: request.metadata,
+            policy: Default::default(),
         };
         let lease = match self
             .executions

--- a/src/compat/src/control/supervisor_tests.rs
+++ b/src/compat/src/control/supervisor_tests.rs
@@ -74,6 +74,7 @@ async fn start_runtime(
                 external_sandbox_id: record.sandbox_id().to_string(),
                 config,
                 labels: BTreeMap::new(),
+                policy: Default::default(),
             },
             record.operation_id(),
         )
@@ -92,6 +93,7 @@ async fn create_runtime(
                 external_sandbox_id: record.sandbox_id().to_string(),
                 config,
                 labels: BTreeMap::new(),
+                policy: Default::default(),
             },
             record.operation_id(),
         )

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -60,11 +60,12 @@ pub use tee::ATTEST_VSOCK_PORT;
 pub use tee::{detect_tee, is_tee_available, TeeCapability, TeeType};
 pub use traits::{
     AuditSink, CacheBackend, CacheEntry, CacheStats, CreateExecutionRequest, CredentialProvider,
-    EventBus, ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManager,
-    ExecutionManagerError, ExecutionManagerResult, ExecutionReservation, ExecutionState,
-    ExecutionStatus, ImageRegistry, ImageStoreBackend, KillOutcome, MetricsCollector,
-    NetworkStoreBackend, NoopMetrics, OperationId, PulledImage, ReconcileOutcome,
-    SnapshotStoreBackend, StoredImage, VolumeStoreBackend,
+    EventBus, ExecutionGeneration, ExecutionHealthCheck, ExecutionId, ExecutionLease,
+    ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionRecordPolicy,
+    ExecutionReservation, ExecutionRestartPolicy, ExecutionState, ExecutionStatus, ImageRegistry,
+    ImageStoreBackend, KillOutcome, MetricsCollector, NetworkStoreBackend, NoopMetrics,
+    OperationId, PulledImage, ReconcileOutcome, SnapshotStoreBackend, StoredImage,
+    VolumeStoreBackend,
 };
 pub use vmm::{
     Entrypoint, FsMount, InstanceSpec, NetworkInstanceConfig, TeeInstanceConfig, VmHandler,

--- a/src/core/src/log.rs
+++ b/src/core/src/log.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Logging driver type.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum LogDriver {
     /// Docker-compatible JSON lines format (default).
@@ -48,7 +48,7 @@ impl std::str::FromStr for LogDriver {
 }
 
 /// Logging configuration for a box.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LogConfig {
     pub driver: LogDriver,
     #[serde(default)]

--- a/src/core/src/traits/execution.rs
+++ b/src/core/src/traits/execution.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 
 use crate::config::{BoxConfig, ResourceConfig};
 use crate::execution::ResolvedExecutionPlan;
+use crate::log::LogConfig;
 
 /// Stable identifier assigned to one runtime execution.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -128,6 +129,148 @@ impl From<ExecutionGeneration> for u64 {
     }
 }
 
+/// Restart behavior persisted with a local execution.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ExecutionRestartPolicy {
+    /// Never restart automatically.
+    #[default]
+    No,
+    /// Restart after every exit.
+    Always,
+    /// Restart only after an unsuccessful exit.
+    OnFailure,
+    /// Restart unless a user explicitly stopped the execution.
+    UnlessStopped,
+}
+
+impl ExecutionRestartPolicy {
+    /// Canonical value stored in the backwards-compatible local record.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::No => "no",
+            Self::Always => "always",
+            Self::OnFailure => "on-failure",
+            Self::UnlessStopped => "unless-stopped",
+        }
+    }
+}
+
+/// Health-check behavior persisted with a local execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionHealthCheck {
+    /// Command executed by the health check.
+    pub cmd: Vec<String>,
+    /// Interval between checks in seconds.
+    #[serde(default = "default_health_interval")]
+    pub interval_secs: u64,
+    /// Per-check timeout in seconds.
+    #[serde(default = "default_health_timeout")]
+    pub timeout_secs: u64,
+    /// Consecutive failures before the execution is unhealthy.
+    #[serde(default = "default_health_retries")]
+    pub retries: u32,
+    /// Grace period after startup in seconds.
+    #[serde(default)]
+    pub start_period_secs: u64,
+}
+
+/// Caller-owned policy projected into the canonical local execution record.
+///
+/// The complete value is persisted with the creation request so retries cannot
+/// silently reuse an execution with different lifecycle or local resource
+/// policy. Runtime launch requirements remain in [`BoxConfig`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionRecordPolicy {
+    /// User-visible local name. `None` lets the runtime assign a safe name.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Remove the execution automatically after it stops.
+    #[serde(default)]
+    pub auto_remove: bool,
+    /// Automatic restart behavior.
+    #[serde(default)]
+    pub restart_policy: ExecutionRestartPolicy,
+    /// Maximum automatic restart count, where zero means unlimited.
+    #[serde(default)]
+    pub max_restart_count: u32,
+    /// Effective caller or cached-image health check.
+    #[serde(default)]
+    pub health_check: Option<ExecutionHealthCheck>,
+    /// Prevent a later image-defined health check from being enabled.
+    #[serde(default)]
+    pub healthcheck_disabled: bool,
+    /// Runtime log driver policy.
+    #[serde(default)]
+    pub log_config: LogConfig,
+    /// Named volumes represented by the resolved mounts in [`BoxConfig`].
+    #[serde(default)]
+    pub volume_names: Vec<String>,
+    /// Requested OCI platform retained for inspection and image selection.
+    #[serde(default)]
+    pub platform: Option<String>,
+    /// Whether the caller requested an init process.
+    #[serde(default)]
+    pub init: bool,
+    /// Requested host device mappings.
+    #[serde(default)]
+    pub devices: Vec<String>,
+    /// Requested GPU selection.
+    #[serde(default)]
+    pub gpus: Option<String>,
+    /// Shared-memory size in bytes.
+    #[serde(default)]
+    pub shm_size: Option<u64>,
+    /// Signal used for graceful stop.
+    #[serde(default)]
+    pub stop_signal: Option<String>,
+    /// Graceful stop timeout in seconds.
+    #[serde(default)]
+    pub stop_timeout: Option<u64>,
+    /// Whether the caller requested OOM-killer suppression.
+    #[serde(default)]
+    pub oom_kill_disable: bool,
+    /// Requested host OOM score adjustment.
+    #[serde(default)]
+    pub oom_score_adj: Option<i32>,
+}
+
+impl Default for ExecutionRecordPolicy {
+    fn default() -> Self {
+        Self {
+            name: None,
+            auto_remove: false,
+            restart_policy: ExecutionRestartPolicy::No,
+            max_restart_count: 0,
+            health_check: None,
+            healthcheck_disabled: false,
+            log_config: LogConfig::default(),
+            volume_names: Vec::new(),
+            platform: None,
+            init: false,
+            devices: Vec::new(),
+            gpus: None,
+            shm_size: None,
+            stop_signal: None,
+            stop_timeout: None,
+            oom_kill_disable: false,
+            oom_score_adj: None,
+        }
+    }
+}
+
+fn default_health_interval() -> u64 {
+    30
+}
+
+fn default_health_timeout() -> u64 {
+    5
+}
+
+fn default_health_retries() -> u32 {
+    3
+}
+
 /// A fully resolved request submitted to the runtime lifecycle facade.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateExecutionRequest {
@@ -137,6 +280,9 @@ pub struct CreateExecutionRequest {
     pub config: BoxConfig,
     /// Labels persisted with the internal execution.
     pub labels: BTreeMap<String, String>,
+    /// Caller-owned lifecycle and local record policy.
+    #[serde(default)]
+    pub policy: ExecutionRecordPolicy,
 }
 
 /// Durable evidence returned after an execution is created but not started.
@@ -314,5 +460,33 @@ mod tests {
     fn identifier_deserialization_preserves_invariants() {
         assert!(serde_json::from_str::<ExecutionId>("\"\"").is_err());
         assert!(serde_json::from_str::<OperationId>("\" \"").is_err());
+    }
+
+    #[test]
+    fn legacy_creation_requests_default_record_policy() {
+        let request: CreateExecutionRequest = serde_json::from_value(serde_json::json!({
+            "external_sandbox_id": "sandbox-1",
+            "config": BoxConfig::default(),
+            "labels": {"purpose": "compatibility"}
+        }))
+        .unwrap();
+
+        assert_eq!(request.policy, ExecutionRecordPolicy::default());
+        assert_eq!(request.policy.restart_policy, ExecutionRestartPolicy::No);
+    }
+
+    #[test]
+    fn restart_policy_has_stable_record_values() {
+        assert_eq!(ExecutionRestartPolicy::No.as_str(), "no");
+        assert_eq!(ExecutionRestartPolicy::Always.as_str(), "always");
+        assert_eq!(ExecutionRestartPolicy::OnFailure.as_str(), "on-failure");
+        assert_eq!(
+            ExecutionRestartPolicy::UnlessStopped.as_str(),
+            "unless-stopped"
+        );
+        assert_eq!(
+            serde_json::to_value(ExecutionRestartPolicy::OnFailure).unwrap(),
+            "on-failure"
+        );
     }
 }

--- a/src/core/src/traits/mod.rs
+++ b/src/core/src/traits/mod.rs
@@ -18,9 +18,10 @@ pub use cache::{CacheBackend, CacheEntry, CacheStats};
 pub use credential::CredentialProvider;
 pub use event::EventBus;
 pub use execution::{
-    CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManager,
-    ExecutionManagerError, ExecutionManagerResult, ExecutionReservation, ExecutionState,
-    ExecutionStatus, KillOutcome, OperationId, ReconcileOutcome,
+    CreateExecutionRequest, ExecutionGeneration, ExecutionHealthCheck, ExecutionId, ExecutionLease,
+    ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionRecordPolicy,
+    ExecutionReservation, ExecutionRestartPolicy, ExecutionState, ExecutionStatus, KillOutcome,
+    OperationId, ReconcileOutcome,
 };
 pub use metrics::{MetricsCollector, NoopMetrics};
 pub use registry::{ImageRegistry, PulledImage};

--- a/src/runtime/examples/managed_sandbox_smoke.rs
+++ b/src/runtime/examples/managed_sandbox_smoke.rs
@@ -105,6 +105,7 @@ mod linux {
                 ..Default::default()
             },
             labels: BTreeMap::from([("purpose".to_string(), "managed-sandbox-smoke".to_string())]),
+            policy: Default::default(),
         };
 
         let manager = LocalExecutionManager::with_vm_backend(state_path, home_dir);

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -12,6 +12,8 @@ use a3s_box_core::{
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+pub use a3s_box_core::ExecutionHealthCheck as HealthCheck;
+
 /// Metadata record for a single local box execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BoxRecord {
@@ -313,25 +315,6 @@ impl std::fmt::Display for ManagedExecutionState {
     }
 }
 
-/// Health-check configuration persisted with a box record.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HealthCheck {
-    /// Command executed by the health check.
-    pub cmd: Vec<String>,
-    /// Interval between checks in seconds.
-    #[serde(default = "default_health_interval")]
-    pub interval_secs: u64,
-    /// Per-check timeout in seconds.
-    #[serde(default = "default_health_timeout")]
-    pub timeout_secs: u64,
-    /// Consecutive failures before the execution is unhealthy.
-    #[serde(default = "default_health_retries")]
-    pub retries: u32,
-    /// Grace period after startup in seconds.
-    #[serde(default)]
-    pub start_period_secs: u64,
-}
-
 /// Durable lifecycle metadata for an execution owned by [`ExecutionManager`].
 ///
 /// [`ExecutionManager`]: a3s_box_core::ExecutionManager
@@ -444,18 +427,6 @@ fn default_health_status() -> String {
     "none".to_string()
 }
 
-fn default_health_interval() -> u64 {
-    30
-}
-
-fn default_health_timeout() -> u64 {
-    5
-}
-
-fn default_health_retries() -> u32 {
-    3
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -514,6 +485,7 @@ mod tests {
                 external_sandbox_id: "sandbox-1".to_string(),
                 config,
                 labels: Default::default(),
+                policy: Default::default(),
             },
         )
         .unwrap();
@@ -553,6 +525,7 @@ mod tests {
                 external_sandbox_id: "sandbox-1".to_string(),
                 config,
                 labels: Default::default(),
+                policy: Default::default(),
             },
         )
         .unwrap();

--- a/src/runtime/src/box_state.rs
+++ b/src/runtime/src/box_state.rs
@@ -309,6 +309,7 @@ mod tests {
                     external_sandbox_id: format!("sandbox-{id}"),
                     config,
                     labels: Default::default(),
+                    policy: Default::default(),
                 },
             )
             .unwrap(),

--- a/src/runtime/src/local_execution/record.rs
+++ b/src/runtime/src/local_execution/record.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use a3s_box_core::log::LogConfig;
 use a3s_box_core::{
     CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionLease,
     ExecutionManagerError, ExecutionManagerResult, ExecutionReservation, ExecutionState,
@@ -25,6 +24,7 @@ pub(crate) fn build_managed_record(
         ManagedExecutionMetadata::new(operation_id, ExecutionGeneration::INITIAL, request.clone())
             .map_err(|error| ExecutionManagerError::InvalidRequest(error.to_string()))?;
     let config = &request.config;
+    let policy = &request.policy;
     let short_id = BoxRecord::make_short_id(execution_id.as_str());
     let box_dir = home_dir.join("boxes").join(execution_id.as_str());
     let network_name = match &config.network {
@@ -41,7 +41,10 @@ pub(crate) fn build_managed_record(
     Ok(BoxRecord {
         id: execution_id.to_string(),
         short_id: short_id.clone(),
-        name: format!("managed-{short_id}"),
+        name: policy
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("managed-{short_id}")),
         image: config.image.clone(),
         isolation: config.isolation,
         managed_execution: Some(metadata),
@@ -60,44 +63,44 @@ pub(crate) fn build_managed_record(
         console_log: box_dir.join("logs/console.log"),
         created_at: now,
         started_at: None,
-        auto_remove: false,
+        auto_remove: policy.auto_remove,
         hostname: config.hostname.clone(),
         user: config.user.clone(),
         workdir: config.workdir.clone(),
-        restart_policy: "no".to_string(),
+        restart_policy: policy.restart_policy.as_str().to_string(),
         port_map: config.port_map.clone(),
         labels,
         stopped_by_user: false,
         restart_count: 0,
-        max_restart_count: 0,
+        max_restart_count: policy.max_restart_count,
         exit_code: None,
-        health_check: None,
-        healthcheck_disabled: false,
+        health_check: policy.health_check.clone(),
+        healthcheck_disabled: policy.healthcheck_disabled,
         health_status: "none".to_string(),
         health_retries: 0,
         health_last_check: None,
         network_mode: config.network.clone(),
         network_name,
-        volume_names: Vec::new(),
+        volume_names: policy.volume_names.clone(),
         tmpfs: config.tmpfs.clone(),
         anonymous_volumes: Vec::new(),
         resource_limits: config.resource_limits.clone(),
-        log_config: LogConfig::default(),
+        log_config: policy.log_config.clone(),
         add_host: config.add_hosts.clone(),
-        platform: None,
-        init: false,
+        platform: policy.platform.clone(),
+        init: policy.init,
         read_only: config.read_only,
         cap_add: config.cap_add.clone(),
         cap_drop: config.cap_drop.clone(),
         security_opt: config.security_opt.clone(),
         privileged: config.privileged,
-        devices: Vec::new(),
-        gpus: None,
-        shm_size: None,
-        stop_signal: None,
-        stop_timeout: None,
-        oom_kill_disable: false,
-        oom_score_adj: None,
+        devices: policy.devices.clone(),
+        gpus: policy.gpus.clone(),
+        shm_size: policy.shm_size,
+        stop_signal: policy.stop_signal.clone(),
+        stop_timeout: policy.stop_timeout,
+        oom_kill_disable: policy.oom_kill_disable,
+        oom_score_adj: policy.oom_score_adj,
     })
 }
 

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -3,9 +3,10 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use a3s_box_core::{
-    BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionIsolation,
-    ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionState, KillOutcome,
-    NetworkMode, OperationId, ReconcileOutcome,
+    BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionHealthCheck, ExecutionId,
+    ExecutionIsolation, ExecutionManager, ExecutionManagerError, ExecutionManagerResult,
+    ExecutionRecordPolicy, ExecutionRestartPolicy, ExecutionState, KillOutcome, NetworkMode,
+    OperationId, ReconcileOutcome,
 };
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
@@ -191,6 +192,7 @@ fn request(external_id: &str) -> CreateExecutionRequest {
             ..Default::default()
         },
         labels,
+        policy: Default::default(),
     }
 }
 
@@ -314,6 +316,86 @@ async fn create_reserves_without_start_and_start_is_generation_fenced() {
             .state,
         ExecutionState::Running
     );
+}
+
+#[tokio::test]
+async fn create_preserves_complete_caller_record_policy() {
+    let (_directory, manager, backend) = harness();
+    let mut create_request = request("sandbox-1");
+    create_request.policy = ExecutionRecordPolicy {
+        name: Some("sdk-worker".to_string()),
+        auto_remove: true,
+        restart_policy: ExecutionRestartPolicy::OnFailure,
+        max_restart_count: 4,
+        health_check: Some(ExecutionHealthCheck {
+            cmd: vec!["test".to_string(), "-f".to_string(), "/ready".to_string()],
+            interval_secs: 11,
+            timeout_secs: 3,
+            retries: 7,
+            start_period_secs: 5,
+        }),
+        healthcheck_disabled: false,
+        log_config: a3s_box_core::log::LogConfig {
+            driver: a3s_box_core::log::LogDriver::None,
+            options: HashMap::from([("tag".to_string(), "worker".to_string())]),
+        },
+        volume_names: vec!["workspace".to_string()],
+        platform: Some("linux/arm64".to_string()),
+        init: true,
+        devices: vec!["/dev/fuse:/dev/fuse".to_string()],
+        gpus: Some("all".to_string()),
+        shm_size: Some(64 * 1024 * 1024),
+        stop_signal: Some("SIGINT".to_string()),
+        stop_timeout: Some(12),
+        oom_kill_disable: true,
+        oom_score_adj: Some(100),
+    };
+
+    let reservation = manager
+        .create(create_request.clone(), &operation("operation-policy"))
+        .await
+        .unwrap();
+    let record = persisted(&manager, &reservation.execution_id);
+
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 0);
+    assert_eq!(record.name, "sdk-worker");
+    assert!(record.auto_remove);
+    assert_eq!(record.restart_policy, "on-failure");
+    assert_eq!(record.max_restart_count, 4);
+    assert_eq!(record.health_check, create_request.policy.health_check);
+    assert_eq!(record.log_config, create_request.policy.log_config);
+    assert_eq!(record.volume_names, vec!["workspace"]);
+    assert_eq!(record.platform.as_deref(), Some("linux/arm64"));
+    assert!(record.init);
+    assert_eq!(record.devices, vec!["/dev/fuse:/dev/fuse"]);
+    assert_eq!(record.gpus.as_deref(), Some("all"));
+    assert_eq!(record.shm_size, Some(64 * 1024 * 1024));
+    assert_eq!(record.stop_signal.as_deref(), Some("SIGINT"));
+    assert_eq!(record.stop_timeout, Some(12));
+    assert!(record.oom_kill_disable);
+    assert_eq!(record.oom_score_adj, Some(100));
+    assert_eq!(
+        record.managed_execution.as_ref().unwrap().request.policy,
+        create_request.policy
+    );
+}
+
+#[tokio::test]
+async fn repeated_create_rejects_caller_policy_drift() {
+    let (_directory, manager, backend) = harness();
+    let operation_id = operation("operation-policy-drift");
+    let create_request = request("sandbox-1");
+    manager
+        .create(create_request.clone(), &operation_id)
+        .await
+        .unwrap();
+    let mut drifted = create_request;
+    drifted.policy.stop_timeout = Some(30);
+
+    let error = manager.create(drifted, &operation_id).await.unwrap_err();
+
+    assert!(matches!(error, ExecutionManagerError::Conflict { .. }));
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 0);
 }
 
 #[tokio::test]

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -27,6 +27,7 @@ fn record(home_dir: &Path, isolation: ExecutionIsolation) -> BoxRecord {
             external_sandbox_id: "external-untrusted-label".to_string(),
             config,
             labels: BTreeMap::new(),
+            policy: Default::default(),
         },
         chrono::Utc::now(),
     )

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -388,6 +388,7 @@ mod tests {
                     external_sandbox_id: "sandbox-1".to_string(),
                     config,
                     labels: Default::default(),
+                    policy: Default::default(),
                 },
             )
             .unwrap(),


### PR DESCRIPTION
## Summary

- add a typed caller-owned record policy to managed creation requests
- preserve names, restart and health behavior, logging, stop behavior, named-volume identity, and host-facing metadata in the canonical BoxRecord mapper
- include the policy in durable idempotency intent so operation retries reject policy drift
- retain backwards compatibility by defaulting the policy for older serialized requests

## Validation

- cargo test -p a3s-box-core -p a3s-box-runtime --lib
- cargo test -p a3s-box-compat --all-targets
- cargo check -p a3s-box-cli -p a3s-box-sdk --all-targets
- focused clippy with warnings denied, allowing only the existing macOS needless-return baseline
- pinned E2B contract verification
- official Python sync/async, TypeScript, and Code Interpreter fixtures against the Rust server
- A3S OS production-host smoke at 206105095ef8e4948e2bddf12047b30aef7df228 using Git-fetched code, isolated A3S_HOME, crun 1.28, and an offline OCI archive: created -> recovered(created) -> started(running) -> pause rejected -> killed(stopped), cleanup=ok