### PR TITLE
refactor(cli): reserve created boxes through manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,10 +326,11 @@ resources, then starts through certified `crun`, rejects pause explicitly, and
 owns kill and cleanup without MicroVM fallback.
 
 Those protocol and runtime tests are not yet one end-to-end service path. CLI
-create/start/run and the Rust SDK still need migration to the canonical manager,
-and the production HCL service, encrypted credentials, generation-fenced route
-leases, wildcard TLS gateway, envd data plane, and real official-client Sandbox
-suite remain open gates.
+`create` now persists its reservation and complete caller policy through the
+canonical manager; CLI `start`/`run` and the Rust SDK still need migration. The
+production HCL service, encrypted credentials, generation-fenced route leases,
+wildcard TLS gateway, envd data plane, and real official-client Sandbox suite
+also remain open gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -21,7 +21,7 @@ unversioned claim.
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, reaping, and startup reconciliation | Wire the repository and supervisor into the production service process and exercise restart and host-reboot recovery end to end |
-| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; an A3S OS smoke test proves reservation-only create, restart reconciliation, real `crun` start, explicit pause rejection, kill, and cleanup without MicroVM fallback | Migrate CLI create/start/run and the Rust SDK to the same manager and add caller parity tests |
+| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI `create` uses the same reservation path with caller-policy parity tests; an A3S OS smoke test proves reservation-only create, restart reconciliation, real `crun` start, explicit pause rejection, kill, and cleanup without MicroVM fallback | Migrate CLI start/run and the Rust SDK to the same manager and add the remaining caller parity tests |
 | Credentials and routing | Injected verifier, token, cursor, and template interfaces isolate protocol logic from infrastructure | Add production credential hashing, token encryption and rotation, generation-fenced route leases, validated wildcard/direct routing, and the TLS data-plane gateway |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
@@ -606,11 +606,12 @@ must not assume that the single-host limit is part of the upstream contract.
 ### Dependency direction
 
 The runtime now owns a canonical managed-execution store, a backend-neutral
-`LocalExecutionManager`, and a production VM/Sandbox backend. The current CLI
-still owns a separate complete `create` and `start` orchestration path, while
-the Rust SDK intentionally omits those operations. The compatibility service
-must not work around that caller gap by spawning `a3s-box`, importing CLI
-modules, or editing `boxes.json`. Phase 2 completes this dependency direction:
+`LocalExecutionManager`, and a production VM/Sandbox backend. CLI `create`
+reserves through that manager, while CLI `start`/`run` still own separate boot
+paths and the Rust SDK intentionally omits those operations. The compatibility
+service must not work around the remaining caller gap by spawning `a3s-box`,
+importing CLI modules, or editing `boxes.json`. Phase 2 completes this
+dependency direction:
 
 ```text
 a3s-box-core
@@ -781,8 +782,9 @@ Phase 2 is delivered as small, immediately merged changes:
    startup reconciliation, and corruption/crash/concurrency tests.
 4. **Partially complete:** extract canonical A3S state and the runtime
    `ExecutionManager`; add the production backend and prove its real Sandbox
-   lifecycle; switch CLI create/start/run and the Rust SDK to the same
-   implementation with behavior parity tests.
+   lifecycle; switch CLI create to the same reservation path; switch CLI
+   start/run and the Rust SDK to the same implementation with behavior parity
+   tests.
 5. Add the production HCL-configured service binary, credential and token
    providers, generation-fenced route leases, and TLS data-plane gateway. Pull
    each merge commit on an A3S OS server and run the unmodified official clients
@@ -821,10 +823,18 @@ reservation; and explicit `start` launches through `crun`. It also proves pause
 rollback, kill, and terminal cleanup. Deterministic image-pull failure injection
 proves that a failed start does not create those runtime resources.
 
-Slice 4 remains incomplete until CLI create/start/run and the Rust SDK call the
-same manager with behavior parity tests. The existing Rust SDK uses the
-canonical record store for management operations but still has a separate
-local lifecycle model and does not expose create/start/run.
+CLI `create` now converts its validated arguments into `BoxConfig` and
+`ExecutionRecordPolicy`, then calls `LocalExecutionManager::create`. It no
+longer pre-allocates the Box directory, log directory, or socket directory.
+Caller parity coverage verifies both the legacy inspection fields and the full
+managed request, including config-only values such as DNS and persistent
+filesystem policy. Named-volume bookkeeping remains attached only after the
+durable reservation succeeds and rolls the reservation back on failure.
+
+Slice 4 remains incomplete until CLI start/run and the Rust SDK call the same
+manager with behavior parity tests. The existing Rust SDK uses the canonical
+record store for management operations but still has a separate local
+lifecycle model and does not expose create/start/run.
 
 Each slice must pass its focused tests and repository CI before merge. The
 Phase 2 gate remains closed until slice 5 composes the durable repository,

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -1,10 +1,15 @@
 //! `a3s-box create` command — Create without starting.
 
+use a3s_box_core::{
+    BoxConfig, CreateExecutionRequest, ExecutionManager, ExecutionRecordPolicy,
+    ExecutionRestartPolicy, OperationId, ResourceConfig,
+};
+use a3s_box_runtime::LocalExecutionManager;
 use clap::Args;
 
 use super::common::{self, CommonBoxArgs};
 use crate::output::parse_memory;
-use crate::state::{generate_name, BoxRecord, StateFile};
+use crate::state::{generate_name, StateFile};
 
 #[derive(Args)]
 pub struct CreateArgs {
@@ -24,6 +29,7 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
     let (restart_policy, max_restart_count) =
         crate::state::parse_restart_policy(&args.common.restart)
             .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let restart_policy = execution_restart_policy(&restart_policy)?;
 
     let memory_mb =
         parse_memory(&args.common.memory).map_err(|e| format!("Invalid --memory: {e}"))?;
@@ -35,7 +41,9 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
     let env = common::build_env_map(&args.common)?;
     let labels = common::parse_env_vars(&args.common.labels)
-        .map_err(|e| e.replace("environment variable", "label"))?;
+        .map_err(|e| e.replace("environment variable", "label"))?
+        .into_iter()
+        .collect();
     if let Some(network) = args.common.network.as_deref() {
         ensure_network_exists(network)?;
     }
@@ -64,22 +72,7 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         None => None,
     };
 
-    let box_id = uuid::Uuid::new_v4().to_string();
-    let short_id = BoxRecord::make_short_id(&box_id);
-
     let home = a3s_box_core::dirs_home();
-    let box_dir = home.join("boxes").join(&box_id);
-
-    // Arm cleanup for the pre-registration section: create_dir_all and volume
-    // resolution below can fail with `?` after the box dir already exists, and
-    // until the box is registered it's invisible to `prune`/`rm`. The guard
-    // removes the orphaned dir on any early return; it is disarmed right before
-    // the add_record block, after which cleanup_partial_box_record takes over.
-    let mut dir_guard = crate::cleanup::BoxDirGuard::new(box_dir.clone());
-
-    // Create box directory structure
-    std::fs::create_dir_all(box_dir.join("sockets"))?;
-    std::fs::create_dir_all(box_dir.join("logs"))?;
 
     // Resolve named volumes
     let mut resolved_volumes = Vec::new();
@@ -105,90 +98,80 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         },
         None => a3s_box_core::NetworkMode::Tsi,
     };
+    let mut extra_env = env.into_iter().collect::<Vec<_>>();
+    extra_env.sort_by(|left, right| left.0.cmp(&right.0));
 
-    let record = BoxRecord {
-        id: box_id.clone(),
-        short_id: short_id.clone(),
-        name: name.clone(),
-        image: args.common.image.clone(),
+    let config = BoxConfig {
         isolation,
-        managed_execution: None,
-        status: "created".to_string(),
-        pid: None,
-        pid_start_time: None,
-        cpus: args.common.cpus,
-        memory_mb,
+        image: args.common.image.clone(),
+        resources: ResourceConfig {
+            vcpus: args.common.cpus,
+            memory_mb,
+            ..Default::default()
+        },
+        cmd: args.cmd.clone(),
+        entrypoint_override: entrypoint,
+        user: args.common.user.clone(),
+        workdir: args.common.workdir.clone(),
+        hostname: args.common.hostname.clone(),
         volumes: resolved_volumes,
         virtiofs_cache: args
             .common
             .virtiofs_cache
             .map(|mode| mode.as_guest_value().to_string()),
-        env,
-        cmd: args.cmd.clone(),
-        entrypoint,
-        box_dir: box_dir.clone(),
-        exec_socket_path: box_dir.join("sockets").join("exec.sock"),
-        console_log: box_dir.join("logs").join("console.log"),
-        created_at: chrono::Utc::now(),
-        started_at: None,
-        auto_remove: false,
-        hostname: args.common.hostname,
-        user: args.common.user,
-        workdir: args.common.workdir,
-        restart_policy,
+        extra_env,
         port_map,
-        labels,
-        stopped_by_user: false,
-        restart_count: 0,
+        dns: args.common.dns.clone(),
+        add_hosts: args.common.add_host.clone(),
+        network: network_mode,
+        tmpfs: args.common.tmpfs.clone(),
+        resource_limits,
+        read_only: args.common.read_only,
+        cap_add: args.common.cap_add.clone(),
+        cap_drop: args.common.cap_drop.clone(),
+        security_opt: args.common.security_opt.clone(),
+        privileged: args.common.privileged,
+        // A created box is restartable and therefore retains its writable
+        // filesystem until an explicit remove.
+        persistent: true,
+        ..Default::default()
+    };
+    let policy = ExecutionRecordPolicy {
+        name: Some(name.clone()),
+        auto_remove: false,
+        restart_policy,
         max_restart_count,
-        exit_code: None,
         health_check,
         healthcheck_disabled: args.common.no_healthcheck,
-        health_status: "none".to_string(),
-        health_retries: 0,
-        health_last_check: None,
-        network_mode,
-        network_name: args.common.network,
-        volume_names: volume_names.clone(),
-        tmpfs: args.common.tmpfs,
-        anonymous_volumes: vec![],
-        resource_limits,
         log_config: a3s_box_core::log::LogConfig::default(),
-        add_host: args.common.add_host,
-        platform: args.common.platform,
+        volume_names: volume_names.clone(),
+        platform: args.common.platform.clone(),
         init: args.common.init,
-        read_only: args.common.read_only,
-        cap_add: args.common.cap_add,
-        cap_drop: args.common.cap_drop,
-        security_opt: args.common.security_opt,
-        privileged: args.common.privileged,
-        devices: args.common.device,
-        gpus: args.common.gpus,
+        devices: args.common.device.clone(),
+        gpus: args.common.gpus.clone(),
         shm_size,
         stop_signal: effective_stop_signal,
         stop_timeout: args.common.stop_timeout,
         oom_kill_disable: args.common.oom_kill_disable,
         oom_score_adj: args.common.oom_score_adj,
     };
-
-    let record_for_cleanup = record.clone();
-    // Past the fallible pre-registration section: hand box-dir ownership to the
-    // record-level cleanup below (cleanup_partial_box_record), which also clears
-    // state + attached resources.
-    dir_guard.disarm();
-
-    // Atomic append under the state lock so concurrent `create`/`run` cannot
-    // lose records (load_default()+add() is a lost-update race).
-    if let Err(error) = StateFile::add_record(record) {
-        let mut state = StateFile::load_default()?;
-        crate::cleanup::cleanup_partial_box_record(&record_for_cleanup, Some(&mut state));
-        return Err(error.into());
-    }
+    let operation_id = OperationId::new(format!("cli-create-{}", uuid::Uuid::new_v4()))?;
+    let request = CreateExecutionRequest {
+        external_sandbox_id: operation_id.as_str().to_string(),
+        config,
+        labels,
+        policy,
+    };
+    let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), home);
+    let reservation = manager.create(request, &operation_id).await?;
+    let box_id = reservation.execution_id.to_string();
 
     // Attach named volumes to this box
     if let Err(error) = super::volume::attach_volumes(&volume_names, &box_id) {
         let mut state = StateFile::load_default()?;
-        crate::cleanup::cleanup_partial_box_record(&record_for_cleanup, Some(&mut state));
+        if let Some(record) = state.find_by_id(&box_id).cloned() {
+            crate::cleanup::cleanup_partial_box_record(&record, Some(&mut state));
+        }
         return Err(error);
     }
 
@@ -202,6 +185,16 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
+fn execution_restart_policy(value: &str) -> Result<ExecutionRestartPolicy, String> {
+    match value {
+        "no" => Ok(ExecutionRestartPolicy::No),
+        "always" => Ok(ExecutionRestartPolicy::Always),
+        "on-failure" => Ok(ExecutionRestartPolicy::OnFailure),
+        "unless-stopped" => Ok(ExecutionRestartPolicy::UnlessStopped),
+        other => Err(format!("Invalid normalized restart policy: {other}")),
+    }
+}
+
 fn ensure_network_exists(network: &str) -> Result<(), Box<dyn std::error::Error>> {
     let store = a3s_box_runtime::NetworkStore::default_path()?;
     let config = store
@@ -210,4 +203,30 @@ fn ensure_network_exists(network: &str) -> Result<(), Box<dyn std::error::Error>
     super::network::validate_attachable_network(&config)
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalized_restart_policies_map_to_typed_creation_policy() {
+        assert_eq!(
+            execution_restart_policy("no").unwrap(),
+            ExecutionRestartPolicy::No
+        );
+        assert_eq!(
+            execution_restart_policy("always").unwrap(),
+            ExecutionRestartPolicy::Always
+        );
+        assert_eq!(
+            execution_restart_policy("on-failure").unwrap(),
+            ExecutionRestartPolicy::OnFailure
+        );
+        assert_eq!(
+            execution_restart_policy("unless-stopped").unwrap(),
+            ExecutionRestartPolicy::UnlessStopped
+        );
+        assert!(execution_restart_policy("on-failure:3").is_err());
+    }
 }

--- a/src/cli/tests/command_coverage.rs
+++ b/src/cli/tests/command_coverage.rs
@@ -388,6 +388,8 @@ fn test_create_persists_rich_runtime_options() {
         "4",
         "--memory",
         "768m",
+        "--dns",
+        "1.1.1.1",
         "--volume",
         "covrichdata:/data:ro",
         "--env-file",
@@ -531,6 +533,44 @@ fn test_create_persists_rich_runtime_options() {
     assert_eq!(inspect["stop_timeout"], 12);
     assert_eq!(inspect["oom_kill_disable"], true);
     assert_eq!(inspect["oom_score_adj"], 100);
+    assert!(
+        !std::path::Path::new(inspect["box_dir"].as_str().expect("box directory path")).exists(),
+        "reservation-only create must not allocate a runtime directory"
+    );
+
+    let managed = &inspect["managed_execution"];
+    assert_eq!(managed["generation"], 1);
+    assert!(managed["pending_operation"].is_null());
+    assert!(managed["operation_id"]
+        .as_str()
+        .expect("managed operation ID")
+        .starts_with("cli-create-"));
+    assert!(managed["request"]["external_sandbox_id"]
+        .as_str()
+        .expect("external diagnostic ID")
+        .starts_with("cli-create-"));
+    assert_eq!(
+        managed["request"]["config"]["image"],
+        "docker.io/library/alpine:latest"
+    );
+    assert_eq!(
+        managed["request"]["config"]["dns"],
+        serde_json::json!(["1.1.1.1"])
+    );
+    assert_eq!(
+        managed["request"]["config"]["extra_env"],
+        serde_json::json!([
+            ["FROM_FILE", "kept"],
+            ["INLINE", "present"],
+            ["OVERRIDE", "cli"]
+        ])
+    );
+    assert_eq!(managed["request"]["config"]["persistent"], true);
+    assert_eq!(managed["request"]["policy"]["name"], "cov-rich");
+    assert_eq!(managed["request"]["policy"]["restart_policy"], "on-failure");
+    assert_eq!(managed["request"]["policy"]["max_restart_count"], 3);
+    assert_eq!(managed["request"]["policy"]["stop_timeout"], 12);
+    assert_eq!(managed["request"]["labels"]["purpose"], "coverage");
 
     let volume = cli.ok(&["volume", "inspect", "covrichdata"]);
     assert!(volume.contains("covrichdata"));


### PR DESCRIPTION

## Summary

- route CLI create through LocalExecutionManager and persist the canonical managed request and caller policy
- preserve CLI parity for DNS, persistence, health checks, restart/logging/stop policy, volume identity, and deterministic environment ordering
- defer Box, log, and socket allocation until start; roll back the reservation if named-volume attachment fails

## Validation

- 731 CLI unit tests passed
- all 11 command coverage tests passed
- cargo fmt --check passed
- Clippy passed with warnings denied, retaining only the existing macOS needless_return allowance
- A3S OS production smoke passed at 0ee8302: OCI image load, create --isolation sandbox, managed metadata validation, runtime-directory absence before start, crun start, guest exec, kill, and rm
- server test used an isolated A3S_HOME and Git-fetched worktree; temporary resources were removed after validation
