### PR TITLE
refactor(cli): start managed reservations through manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ Important supported options:
 
 For CI-style one-shot commands, prefer foreground `run --rm --timeout <seconds>` and avoid `-i` unless the command truly needs stdin. A timed-out foreground run stops/removes the box according to the usual `--rm` behavior and exits with code 124. `a3s-box wait` prints a low-frequency stderr keepalive while it is blocking so long CI or SSH sessions do not look idle; use `--no-heartbeat` or `--heartbeat-interval <seconds>` to tune it.
 
+The manager-backed `create` path treats `start` as first activation of its
+nonterminal reservation. Once that managed execution is stopped or failed,
+ordinary `start` rejects it instead of reusing a stale generation. The explicit
+generation-advancing managed restart operation is the next lifecycle slice;
+legacy records retain their existing stopped-box `start` behavior meanwhile.
+
 Health checks for detached `run`, Compose services, and boxes brought back by
 `start`/`restart` are owned by a generation-fenced background worker, not by the
 short-lived creating CLI. The worker stops when that box generation stops or is
@@ -327,10 +333,15 @@ owns kill and cleanup without MicroVM fallback.
 
 Those protocol and runtime tests are not yet one end-to-end service path. CLI
 `create` now persists its reservation and complete caller policy through the
-canonical manager; CLI `start`/`run` and the Rust SDK still need migration. The
-production HCL service, encrypted credentials, generation-fenced route leases,
-wildcard TLS gateway, envd data plane, and real official-client Sandbox suite
-also remain open gates.
+canonical manager, and the first `start` of that reservation consumes its
+persisted generation through the same manager. The production backend prepares
+named-volume and network ownership idempotently and rolls back only resources
+acquired by a failed start attempt. Ordinary `start` does not revive a terminal
+managed execution; an explicit restart transition must advance its generation.
+CLI `restart`/`run` and the Rust SDK still need migration. The production HCL
+service, encrypted credentials, generation-fenced route leases, wildcard TLS
+gateway, envd data plane, and real official-client Sandbox suite also remain
+open gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,7 +1,8 @@
 # E2B Protocol Compatibility and SDK Design
 
 Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 3 complete;
-slice 4 runtime path proven, caller migration pending)**
+slice 4 runtime path and staged CLI create/start complete, remaining callers
+pending)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -21,7 +22,7 @@ unversioned claim.
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, reaping, and startup reconciliation | Wire the repository and supervisor into the production service process and exercise restart and host-reboot recovery end to end |
-| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI `create` uses the same reservation path with caller-policy parity tests; an A3S OS smoke test proves reservation-only create, restart reconciliation, real `crun` start, explicit pause rejection, kill, and cleanup without MicroVM fallback | Migrate CLI start/run and the Rust SDK to the same manager and add the remaining caller parity tests |
+| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI staged `create` and first `start` use the same generation-fenced path with caller-policy parity tests, idempotent named-volume/network preparation, and start-failure rollback; an A3S OS smoke test proves reservation-only create, restart reconciliation, real `crun` start, explicit pause rejection, kill, and cleanup without MicroVM fallback | Add an explicit generation-advancing restart operation, then migrate CLI restart/run and the Rust SDK and add the remaining caller parity tests |
 | Credentials and routing | Injected verifier, token, cursor, and template interfaces isolate protocol logic from infrastructure | Add production credential hashing, token encryption and rotation, generation-fenced route leases, validated wildcard/direct routing, and the TLS data-plane gateway |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 

--- a/src/cli/src/commands/mod.rs
+++ b/src/cli/src/commands/mod.rs
@@ -84,7 +84,7 @@ pub enum Command {
     Run(run::RunArgs),
     /// Create a new box without starting it
     Create(create::CreateArgs),
-    /// Start one or more stopped or created boxes
+    /// Start one or more eligible boxes
     Start(start::StartArgs),
     /// Gracefully stop one or more running boxes
     Stop(stop::StopArgs),

--- a/src/cli/src/commands/network.rs
+++ b/src/cli/src/commands/network.rs
@@ -286,12 +286,7 @@ fn subnets_overlap(a: &str, b: &str) -> bool {
 }
 
 pub(crate) fn validate_attachable_network(config: &NetworkConfig) -> Result<(), String> {
-    validate_network_driver(&config.driver)?;
-    config
-        .policy
-        .validate()
-        .map_err(|e| format!("Unsupported network isolation mode: {e}"))?;
-    Ok(())
+    config.validate_runtime()
 }
 
 pub(crate) fn validate_network_driver(driver: &str) -> Result<(), String> {

--- a/src/cli/src/commands/start.rs
+++ b/src/cli/src/commands/start.rs
@@ -1,5 +1,7 @@
-//! `a3s-box start` command — Start one or more created/stopped boxes.
+//! `a3s-box start` command — Start one or more eligible boxes.
 
+use a3s_box_core::{ExecutionGeneration, ExecutionId, ExecutionManager};
+use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionState};
 use clap::Args;
 
 use crate::boot;
@@ -32,25 +34,66 @@ pub async fn execute(args: StartArgs) -> Result<(), Box<dyn std::error::Error>> 
 
 async fn start_one(state: &StateFile, query: &str) -> Result<(), Box<dyn std::error::Error>> {
     let record = resolve::resolve(state, query)?;
-
-    validate_start_status(&record.name, &record.status)
-        .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
+    let plan =
+        start_plan(record).map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
 
     let box_id = record.id.clone();
     let name = record.name.clone();
 
     println!("Starting box {name}...");
-    let result = boot::boot_from_record(record).await?;
+    let started_record = match plan {
+        StartPlan::Legacy => {
+            let result = boot::boot_from_record(record).await?;
 
-    // Persist the boot result atomically (load-fresh + mutate + save under the
-    // state lock) so it cannot clobber a concurrent writer with our pre-boot
-    // snapshot.
-    let started_record = StateFile::modify(move |s| {
-        Ok::<_, std::io::Error>(s.find_by_id_mut(&box_id).map(|record| {
-            boot::apply_boot_result(record, result, boot::RestartCountUpdate::Reset);
-            record.clone()
-        }))
-    })?;
+            // Persist the boot result atomically (load-fresh + mutate + save under the
+            // state lock) so it cannot clobber a concurrent writer with our pre-boot
+            // snapshot.
+            StateFile::modify({
+                let box_id = box_id.clone();
+                move |state| {
+                    Ok::<_, std::io::Error>(state.find_by_id_mut(&box_id).map(|record| {
+                        boot::apply_boot_result(record, result, boot::RestartCountUpdate::Reset);
+                        record.clone()
+                    }))
+                }
+            })?
+        }
+        StartPlan::Managed {
+            execution_id,
+            generation,
+        } => {
+            let home = a3s_box_core::dirs_home();
+            let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+            manager.start(&execution_id, generation).await?;
+
+            let baseline_box_dir = record.box_dir.clone();
+            let baseline_box_id = record.id.clone();
+            match tokio::task::spawn_blocking(move || {
+                crate::commands::diff::create_box_baseline_snapshot(&baseline_box_dir)
+                    .map_err(|error| error.to_string())
+            })
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        box_id = %baseline_box_id,
+                        %error,
+                        "Failed to create rootfs diff baseline snapshot"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        box_id = %baseline_box_id,
+                        %error,
+                        "Rootfs diff baseline task failed"
+                    );
+                }
+            }
+
+            StateFile::load_default()?.find_by_id(&box_id).cloned()
+        }
+    };
     if let Some(record) = started_record {
         crate::health::spawn_detached_health_checker(&record)
             .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
@@ -58,6 +101,41 @@ async fn start_one(state: &StateFile, query: &str) -> Result<(), Box<dyn std::er
 
     println!("{name}");
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StartPlan {
+    Legacy,
+    Managed {
+        execution_id: ExecutionId,
+        generation: ExecutionGeneration,
+    },
+}
+
+fn start_plan(record: &crate::state::BoxRecord) -> Result<StartPlan, String> {
+    let Some(metadata) = record.managed_execution.as_ref() else {
+        validate_start_status(&record.name, &record.status)?;
+        return Ok(StartPlan::Legacy);
+    };
+    let state = record
+        .managed_state()
+        .map_err(|error| format!("Invalid managed state for box {}: {error}", record.name))?
+        .ok_or_else(|| format!("Box {} lost managed lifecycle metadata", record.name))?;
+
+    match state {
+        ManagedExecutionState::Creating
+        | ManagedExecutionState::Created
+        | ManagedExecutionState::Starting => Ok(StartPlan::Managed {
+            execution_id: ExecutionId::new(record.id.clone()).map_err(|error| error.to_string())?,
+            generation: metadata.generation,
+        }),
+        ManagedExecutionState::Running => Err(format!("Box {} is already running", record.name)),
+        ManagedExecutionState::Stopped | ManagedExecutionState::Failed => Err(format!(
+            "Box {} is {state}; ordinary start cannot revive a terminal managed execution without advancing its generation",
+            record.name
+        )),
+        other => Err(format!("Cannot start box in state: {other}")),
+    }
 }
 
 fn validate_start_status(name: &str, status: &str) -> Result<(), String> {
@@ -71,6 +149,37 @@ fn validate_start_status(name: &str, status: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use a3s_box_core::{BoxConfig, CreateExecutionRequest, ExecutionIsolation, OperationId};
+    use a3s_box_runtime::{ManagedExecutionMetadata, ManagedExecutionOperation};
+    use std::collections::BTreeMap;
+
+    use crate::test_helpers::fixtures::make_record;
+
+    fn managed_record(status: ManagedExecutionState) -> crate::state::BoxRecord {
+        let id = "11111111-1111-4111-8111-111111111111";
+        let mut record = make_record(id, "web", status.as_status(), None);
+        record.isolation = ExecutionIsolation::Sandbox;
+        let mut metadata = ManagedExecutionMetadata::new(
+            OperationId::new("operation-1").unwrap(),
+            ExecutionGeneration::INITIAL,
+            CreateExecutionRequest {
+                external_sandbox_id: "external-1".to_string(),
+                config: BoxConfig {
+                    isolation: ExecutionIsolation::Sandbox,
+                    image: record.image.clone(),
+                    ..Default::default()
+                },
+                labels: BTreeMap::new(),
+                policy: Default::default(),
+            },
+        )
+        .unwrap();
+        if status == ManagedExecutionState::Starting {
+            metadata.pending_operation = Some(ManagedExecutionOperation::Start);
+        }
+        record.managed_execution = Some(metadata);
+        record
+    }
 
     #[test]
     fn validate_start_status_accepts_startable_states() {
@@ -92,6 +201,43 @@ mod tests {
         assert_eq!(
             validate_start_status("web", "paused").unwrap_err(),
             "Cannot start box in state: paused"
+        );
+    }
+
+    #[test]
+    fn managed_start_plan_uses_the_persisted_generation() {
+        for status in [
+            ManagedExecutionState::Creating,
+            ManagedExecutionState::Created,
+            ManagedExecutionState::Starting,
+        ] {
+            assert_eq!(
+                start_plan(&managed_record(status)).unwrap(),
+                StartPlan::Managed {
+                    execution_id: ExecutionId::new("11111111-1111-4111-8111-111111111111").unwrap(),
+                    generation: ExecutionGeneration::INITIAL,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn managed_start_plan_rejects_terminal_resurrection() {
+        for status in [
+            ManagedExecutionState::Stopped,
+            ManagedExecutionState::Failed,
+        ] {
+            let error = start_plan(&managed_record(status)).unwrap_err();
+            assert!(error.contains("cannot revive a terminal managed execution"));
+            assert!(error.contains("advancing its generation"));
+        }
+    }
+
+    #[test]
+    fn legacy_stopped_box_keeps_legacy_start_behavior() {
+        assert_eq!(
+            start_plan(&make_record("legacy", "legacy", "stopped", None)).unwrap(),
+            StartPlan::Legacy
         );
     }
 }

--- a/src/core/src/network.rs
+++ b/src/core/src/network.rs
@@ -443,6 +443,19 @@ impl NetworkConfig {
         })
     }
 
+    /// Validate the driver and policy that the runtime can enforce today.
+    pub fn validate_runtime(&self) -> Result<(), String> {
+        if self.driver != "bridge" {
+            return Err(format!(
+                "Unsupported network driver '{}'. Only 'bridge' is currently supported",
+                self.driver
+            ));
+        }
+        self.policy
+            .validate()
+            .map_err(|error| format!("Unsupported network isolation mode: {error}"))
+    }
+
     /// Allocate an IP and register a new endpoint for a box.
     pub fn connect(&mut self, box_id: &str, box_name: &str) -> Result<NetworkEndpoint, String> {
         self.connect_with_aliases(box_id, box_name, &[])
@@ -1178,6 +1191,23 @@ mod tests {
         let err = policy.validate().unwrap_err();
         assert!(err.contains("custom"));
         assert!(err.contains("not yet enforced"));
+    }
+
+    #[test]
+    fn test_network_config_runtime_validation_accepts_supported_configuration() {
+        let network = NetworkConfig::new("mynet", "10.88.0.0/24").unwrap();
+
+        assert!(network.validate_runtime().is_ok());
+    }
+
+    #[test]
+    fn test_network_config_runtime_validation_rejects_unsupported_driver() {
+        let mut network = NetworkConfig::new("mynet", "10.88.0.0/24").unwrap();
+        network.driver = "overlay".to_string();
+
+        let error = network.validate_runtime().unwrap_err();
+
+        assert!(error.contains("Unsupported network driver"));
     }
 
     // --- NetworkConfig::set_policy tests ---

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -6,6 +6,7 @@ mod create;
 mod operations;
 mod record;
 mod recovery;
+mod resources;
 mod store;
 mod support;
 #[cfg(feature = "vm")]

--- a/src/runtime/src/local_execution/operations.rs
+++ b/src/runtime/src/local_execution/operations.rs
@@ -137,6 +137,7 @@ impl LocalExecutionManager {
     ) -> ExecutionManagerResult<KillOutcome> {
         match self.backend.kill(&record).await {
             Ok(outcome) => {
+                self.release_execution_resources(&record).await?;
                 self.transition(
                     &record,
                     ManagedExecutionState::Killing,
@@ -147,6 +148,7 @@ impl LocalExecutionManager {
                 Ok(outcome)
             }
             Err(ExecutionManagerError::NotFound(_)) => {
+                self.release_execution_resources(&record).await?;
                 self.transition(
                     &record,
                     ManagedExecutionState::Killing,
@@ -177,6 +179,9 @@ impl LocalExecutionManager {
             _ => false,
         };
         if !terminal {
+            return None;
+        }
+        if self.release_execution_resources(&record).await.is_err() {
             return None;
         }
         self.transition(

--- a/src/runtime/src/local_execution/record.rs
+++ b/src/runtime/src/local_execution/record.rs
@@ -114,6 +114,19 @@ pub(crate) fn apply_handle(record: &mut BoxRecord, handle: &LocalExecutionHandle
     record.exit_code = None;
 }
 
+pub(crate) fn apply_start_handle(record: &mut BoxRecord, handle: &LocalExecutionHandle) {
+    apply_handle(record, handle);
+    record.health_status = if record.health_check.is_some() {
+        "starting".to_string()
+    } else {
+        "none".to_string()
+    };
+    record.health_retries = 0;
+    record.health_last_check = None;
+    record.stopped_by_user = false;
+    record.restart_count = 0;
+}
+
 pub(crate) fn clear_live_runtime(record: &mut BoxRecord, exit_code: Option<i32>) {
     record.pid = None;
     record.pid_start_time = None;

--- a/src/runtime/src/local_execution/resources.rs
+++ b/src/runtime/src/local_execution/resources.rs
@@ -1,0 +1,357 @@
+//! Host resource preparation for managed local execution startup.
+
+use std::path::{Path, PathBuf};
+
+use a3s_box_core::{BoxError, ExecutionManagerError, ExecutionManagerResult, NetworkMode};
+
+use crate::{BoxRecord, LocalExecutionManager, NetworkStore, VolumeStore};
+
+/// Rolls back only the resource ownership acquired by one start attempt.
+pub(super) struct ExecutionResourceGuard {
+    home_dir: PathBuf,
+    execution_id: String,
+    attached_volumes: Vec<String>,
+    connected_network: Option<String>,
+    armed: bool,
+}
+
+impl ExecutionResourceGuard {
+    pub(super) fn prepare(home_dir: &Path, record: &BoxRecord) -> ExecutionManagerResult<Self> {
+        let mut guard = Self {
+            home_dir: home_dir.to_path_buf(),
+            execution_id: record.id.clone(),
+            attached_volumes: Vec::new(),
+            connected_network: None,
+            armed: true,
+        };
+
+        let volume_store =
+            VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"));
+        for volume_name in &record.volume_names {
+            let volume = volume_store
+                .get(volume_name)
+                .map_err(|error| resource_error(record, "load named volume", error))?
+                .ok_or_else(|| {
+                    ExecutionManagerError::Unavailable(format!(
+                        "named volume '{volume_name}' required by execution {} was not found",
+                        record.id
+                    ))
+                })?;
+            if volume.in_use_by.iter().any(|id| id == &record.id) {
+                continue;
+            }
+            let attached = volume_store
+                .modify(volume_name, |volume| volume.attach(&record.id))
+                .map_err(|error| resource_error(record, "attach named volume", error))?;
+            if !attached {
+                return Err(ExecutionManagerError::Unavailable(format!(
+                    "named volume '{volume_name}' required by execution {} disappeared during startup",
+                    record.id
+                )));
+            }
+            guard.attached_volumes.push(volume_name.clone());
+        }
+
+        if let Some(network_name) = network_name(record) {
+            let network_store = NetworkStore::new(home_dir.join("networks.json"));
+            let connected = network_store
+                .with_write_lock(|networks| -> Result<bool, BoxError> {
+                    let network = networks.get_mut(network_name).ok_or_else(|| {
+                        BoxError::NetworkError(format!("network '{network_name}' not found"))
+                    })?;
+                    network.validate_runtime().map_err(BoxError::NetworkError)?;
+                    if network.endpoints.contains_key(&record.id) {
+                        return Ok(false);
+                    }
+                    network
+                        .connect(&record.id, &record.name)
+                        .map_err(BoxError::NetworkError)?;
+                    Ok(true)
+                })
+                .map_err(|error| resource_error(record, "connect network", error))?;
+            if connected {
+                guard.connected_network = Some(network_name.to_string());
+            }
+        }
+
+        Ok(guard)
+    }
+
+    pub(super) fn disarm(mut self) {
+        self.armed = false;
+    }
+
+    pub(super) fn rollback(mut self) {
+        self.rollback_inner();
+    }
+
+    fn rollback_inner(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let volume_store = VolumeStore::new(
+            self.home_dir.join("volumes.json"),
+            self.home_dir.join("volumes"),
+        );
+        for volume_name in &self.attached_volumes {
+            if let Err(error) = volume_store.modify(volume_name, |volume| {
+                volume.detach(&self.execution_id);
+            }) {
+                tracing::warn!(
+                    execution_id = %self.execution_id,
+                    volume = %volume_name,
+                    %error,
+                    "Failed to roll back managed volume attachment"
+                );
+            }
+        }
+
+        if let Some(network_name) = self.connected_network.as_deref() {
+            let network_store = NetworkStore::new(self.home_dir.join("networks.json"));
+            if let Err(error) = network_store.with_write_lock(|networks| -> Result<(), BoxError> {
+                if let Some(network) = networks.get_mut(network_name) {
+                    let _ = network.disconnect(&self.execution_id);
+                }
+                Ok(())
+            }) {
+                tracing::warn!(
+                    execution_id = %self.execution_id,
+                    network = %network_name,
+                    %error,
+                    "Failed to roll back managed network attachment"
+                );
+            }
+        }
+
+        self.armed = false;
+    }
+}
+
+impl Drop for ExecutionResourceGuard {
+    fn drop(&mut self) {
+        self.rollback_inner();
+    }
+}
+
+impl LocalExecutionManager {
+    pub(super) async fn release_execution_resources(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<()> {
+        let home_dir = self.home_dir.clone();
+        let execution_id = record.id.clone();
+        let record = record.clone();
+        tokio::task::spawn_blocking(move || release_resources(&home_dir, &record))
+            .await
+            .map_err(|error| {
+                ExecutionManagerError::Internal(format!(
+                    "managed resource cleanup task failed for {}: {error}",
+                    execution_id
+                ))
+            })?
+    }
+}
+
+fn release_resources(home_dir: &Path, record: &BoxRecord) -> ExecutionManagerResult<()> {
+    let volume_store = VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"));
+    for volume_name in &record.volume_names {
+        volume_store
+            .modify(volume_name, |volume| volume.detach(&record.id))
+            .map_err(|error| resource_error(record, "detach named volume", error))?;
+    }
+
+    if let Some(network_name) = network_name(record) {
+        let network_store = NetworkStore::new(home_dir.join("networks.json"));
+        network_store
+            .with_write_lock(|networks| -> Result<(), BoxError> {
+                if let Some(network) = networks.get_mut(network_name) {
+                    let _ = network.disconnect(&record.id);
+                }
+                Ok(())
+            })
+            .map_err(|error| resource_error(record, "disconnect network", error))?;
+    }
+    Ok(())
+}
+
+fn network_name(record: &BoxRecord) -> Option<&str> {
+    record
+        .network_name
+        .as_deref()
+        .or(match &record.network_mode {
+            NetworkMode::Bridge { network } => Some(network.as_str()),
+            NetworkMode::Tsi | NetworkMode::None => None,
+        })
+}
+
+fn resource_error(
+    record: &BoxRecord,
+    operation: &str,
+    error: impl std::fmt::Display,
+) -> ExecutionManagerError {
+    ExecutionManagerError::Unavailable(format!(
+        "failed to {operation} for execution {}: {error}",
+        record.id
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use a3s_box_core::{network::NetworkConfig, volume::VolumeConfig};
+
+    use super::*;
+
+    fn record(home_dir: &Path) -> BoxRecord {
+        let id = "11111111-1111-4111-8111-111111111111";
+        let mut record: BoxRecord = serde_json::from_value(serde_json::json!({
+            "id": id,
+            "short_id": "11111111",
+            "name": "managed-resources",
+            "image": "alpine:latest",
+            "status": "created",
+            "pid": null,
+            "cpus": 1,
+            "memory_mb": 128,
+            "volumes": [],
+            "env": {},
+            "cmd": ["sleep", "60"],
+            "box_dir": home_dir.join("boxes").join(id),
+            "console_log": home_dir.join("boxes").join(id).join("logs/console.log"),
+            "created_at": "2026-07-15T00:00:00Z",
+            "started_at": null,
+            "auto_remove": false
+        }))
+        .unwrap();
+        record.volume_names = vec!["workspace".to_string()];
+        record.network_mode = NetworkMode::Bridge {
+            network: "dev".to_string(),
+        };
+        record.network_name = Some("dev".to_string());
+        record
+    }
+
+    fn stores(home_dir: &Path) -> (VolumeStore, NetworkStore) {
+        let volumes = VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"));
+        volumes.create(VolumeConfig::new("workspace", "")).unwrap();
+        let networks = NetworkStore::new(home_dir.join("networks.json"));
+        networks
+            .create(NetworkConfig::new("dev", "10.88.0.0/24").unwrap())
+            .unwrap();
+        (volumes, networks)
+    }
+
+    #[test]
+    fn failed_start_rolls_back_only_resources_acquired_by_that_attempt() {
+        let temporary = tempfile::tempdir().unwrap();
+        let record = record(temporary.path());
+        let (volumes, networks) = stores(temporary.path());
+
+        let guard = ExecutionResourceGuard::prepare(temporary.path(), &record).unwrap();
+        assert_eq!(
+            volumes.get("workspace").unwrap().unwrap().in_use_by,
+            vec![record.id.clone()]
+        );
+        assert!(networks
+            .get("dev")
+            .unwrap()
+            .unwrap()
+            .endpoints
+            .contains_key(&record.id));
+
+        drop(guard);
+
+        assert!(volumes
+            .get("workspace")
+            .unwrap()
+            .unwrap()
+            .in_use_by
+            .is_empty());
+        assert!(!networks
+            .get("dev")
+            .unwrap()
+            .unwrap()
+            .endpoints
+            .contains_key(&record.id));
+    }
+
+    #[test]
+    fn preexisting_resource_ownership_survives_start_rollback() {
+        let temporary = tempfile::tempdir().unwrap();
+        let record = record(temporary.path());
+        let (volumes, networks) = stores(temporary.path());
+        volumes
+            .modify("workspace", |volume| volume.attach(&record.id))
+            .unwrap();
+        networks
+            .with_write_lock(|entries| -> Result<(), BoxError> {
+                entries
+                    .get_mut("dev")
+                    .unwrap()
+                    .connect(&record.id, &record.name)
+                    .map_err(BoxError::NetworkError)?;
+                Ok(())
+            })
+            .unwrap();
+
+        drop(ExecutionResourceGuard::prepare(temporary.path(), &record).unwrap());
+
+        assert_eq!(
+            volumes.get("workspace").unwrap().unwrap().in_use_by,
+            vec![record.id.clone()]
+        );
+        assert!(networks
+            .get("dev")
+            .unwrap()
+            .unwrap()
+            .endpoints
+            .contains_key(&record.id));
+    }
+
+    #[test]
+    fn successful_start_keeps_prepared_resources() {
+        let temporary = tempfile::tempdir().unwrap();
+        let record = record(temporary.path());
+        let (volumes, networks) = stores(temporary.path());
+
+        ExecutionResourceGuard::prepare(temporary.path(), &record)
+            .unwrap()
+            .disarm();
+
+        assert_eq!(
+            volumes.get("workspace").unwrap().unwrap().in_use_by,
+            vec![record.id.clone()]
+        );
+        assert!(networks
+            .get("dev")
+            .unwrap()
+            .unwrap()
+            .endpoints
+            .contains_key(&record.id));
+    }
+
+    #[test]
+    fn terminal_release_detaches_all_record_resources() {
+        let temporary = tempfile::tempdir().unwrap();
+        let record = record(temporary.path());
+        let (volumes, networks) = stores(temporary.path());
+        ExecutionResourceGuard::prepare(temporary.path(), &record)
+            .unwrap()
+            .disarm();
+
+        release_resources(temporary.path(), &record).unwrap();
+
+        assert!(volumes
+            .get("workspace")
+            .unwrap()
+            .unwrap()
+            .in_use_by
+            .is_empty());
+        assert!(!networks
+            .get("dev")
+            .unwrap()
+            .unwrap()
+            .endpoints
+            .contains_key(&record.id));
+    }
+}

--- a/src/runtime/src/local_execution/store.rs
+++ b/src/runtime/src/local_execution/store.rs
@@ -2,7 +2,7 @@ use a3s_box_core::{
     ExecutionGeneration, ExecutionId, ExecutionManagerError, ExecutionManagerResult, OperationId,
 };
 
-use super::record::{apply_handle, clear_live_runtime, execution_id};
+use super::record::{apply_handle, apply_start_handle, clear_live_runtime, execution_id};
 use super::support::{generation, managed_state};
 use super::{LocalExecutionHandle, LocalExecutionManager};
 use crate::{
@@ -51,6 +51,7 @@ impl LocalExecutionManager {
             store.transition_with(&execution_id, generation, from, to, |record| match update {
                 RuntimeUpdate::None => {}
                 RuntimeUpdate::Handle(handle) => apply_handle(record, &handle),
+                RuntimeUpdate::StartHandle(handle) => apply_start_handle(record, &handle),
                 RuntimeUpdate::Terminal(exit_code) => clear_live_runtime(record, exit_code),
                 RuntimeUpdate::PauseClaim(keep_memory) => {
                     if let Some(metadata) = record.managed_execution.as_mut() {
@@ -90,10 +91,13 @@ impl LocalExecutionManager {
         } else {
             current_generation
         };
-        match self
-            .transition(record, from, to, RuntimeUpdate::Handle(handle))
-            .await
-        {
+        let update =
+            if from == ManagedExecutionState::Starting && to == ManagedExecutionState::Running {
+                RuntimeUpdate::StartHandle(handle)
+            } else {
+                RuntimeUpdate::Handle(handle)
+            };
+        match self.transition(record, from, to, update).await {
             Ok(record) => Ok(record),
             Err(error @ ExecutionManagerError::Conflict { .. }) => {
                 let Some(current) = self.get(&execution_id).await? else {
@@ -115,6 +119,7 @@ impl LocalExecutionManager {
 pub(super) enum RuntimeUpdate {
     None,
     Handle(LocalExecutionHandle),
+    StartHandle(LocalExecutionHandle),
     Terminal(Option<i32>),
     PauseClaim(bool),
 }

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -381,6 +381,64 @@ async fn create_preserves_complete_caller_record_policy() {
 }
 
 #[tokio::test]
+async fn first_start_initializes_health_state_from_persisted_policy() {
+    let (_directory, manager, _backend) = harness();
+    let mut create_request = request("sandbox-1");
+    create_request.policy.health_check = Some(ExecutionHealthCheck {
+        cmd: vec!["test".to_string(), "-f".to_string(), "/ready".to_string()],
+        interval_secs: 11,
+        timeout_secs: 3,
+        retries: 7,
+        start_period_secs: 5,
+    });
+    let reservation = manager
+        .create(create_request, &operation("operation-health"))
+        .await
+        .unwrap();
+
+    manager
+        .start(&reservation.execution_id, reservation.generation)
+        .await
+        .unwrap();
+
+    let record = persisted(&manager, &reservation.execution_id);
+    assert_eq!(record.health_status, "starting");
+    assert_eq!(record.health_retries, 0);
+    assert!(record.health_last_check.is_none());
+}
+
+#[tokio::test]
+async fn ordinary_start_never_revives_a_terminal_managed_execution() {
+    let (_directory, manager, backend) = harness();
+    let reservation = manager
+        .create(request("sandbox-1"), &operation("operation-terminal"))
+        .await
+        .unwrap();
+    let lease = manager
+        .start(&reservation.execution_id, reservation.generation)
+        .await
+        .unwrap();
+    manager
+        .kill(&lease.execution_id, lease.generation)
+        .await
+        .unwrap();
+
+    let error = manager
+        .start(&lease.execution_id, lease.generation)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ExecutionManagerError::Conflict { .. }));
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        persisted(&manager, &lease.execution_id)
+            .managed_state()
+            .unwrap(),
+        Some(ManagedExecutionState::Stopped)
+    );
+}
+
+#[tokio::test]
 async fn repeated_create_rejects_caller_policy_drift() {
     let (_directory, manager, backend) = harness();
     let operation_id = operation("operation-policy-drift");

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -17,6 +17,7 @@ use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use tokio::sync::Mutex;
 
+use super::resources::ExecutionResourceGuard;
 use super::vm_process::{locate_microvm_process, LocatedProcess};
 use super::{LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation};
 use crate::{BoxRecord, ManagedExecutionMetadata, ManagedExecutionState, VmManager};
@@ -81,11 +82,17 @@ impl VmLocalExecutionBackend {
 
     fn new_manager(&self, record: &BoxRecord) -> ExecutionManagerResult<VmManager> {
         let metadata = self.metadata(record)?;
-        let mut manager = VmManager::with_box_id(
-            metadata.request.config.clone(),
-            EventEmitter::new(256),
-            record.id.clone(),
-        );
+        let mut config = metadata.request.config.clone();
+        if let Some(shm_size) = metadata.request.policy.shm_size {
+            let has_shared_memory_mount = config
+                .tmpfs
+                .iter()
+                .any(|entry| entry.split(':').next() == Some("/dev/shm"));
+            if !has_shared_memory_mount {
+                config.tmpfs.push(format!("/dev/shm:size={shm_size}"));
+            }
+        }
+        let mut manager = VmManager::with_box_id(config, EventEmitter::new(256), record.id.clone());
         manager.home_dir = self.home_dir.clone();
         manager.anonymous_volumes = record.anonymous_volumes.clone();
         manager.set_log_config(record.log_config.clone());
@@ -424,11 +431,42 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
         }
 
         let mut guard = manager.lock().await;
+        let resource_home = self.home_dir.clone();
+        let resource_record = record.clone();
+        let resources = match tokio::task::spawn_blocking(move || {
+            ExecutionResourceGuard::prepare(&resource_home, &resource_record)
+        })
+        .await
+        {
+            Ok(Ok(resources)) => resources,
+            Ok(Err(error)) => {
+                drop(guard);
+                self.remove_manager(&record.id, &manager);
+                return Err(error);
+            }
+            Err(error) => {
+                drop(guard);
+                self.remove_manager(&record.id, &manager);
+                return Err(ExecutionManagerError::Internal(format!(
+                    "managed resource preparation task failed for {}: {error}",
+                    record.id
+                )));
+            }
+        };
         if let Err(error) = guard.boot().await {
             drop(guard);
             self.remove_manager(&record.id, &manager);
+            let rollback = tokio::task::spawn_blocking(move || resources.rollback()).await;
+            if let Err(rollback_error) = rollback {
+                tracing::warn!(
+                    execution_id = %record.id,
+                    %rollback_error,
+                    "Managed resource rollback task failed"
+                );
+            }
             return Err(runtime_error("start", record, error));
         }
+        resources.disarm();
         self.handle_from_manager(record, &guard).await
     }
 

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -53,6 +53,29 @@ fn manager_uses_the_full_persisted_request_config() {
 }
 
 #[test]
+fn manager_applies_persisted_shared_memory_policy_to_runtime_config() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let mut record = record(temporary.path(), ExecutionIsolation::Microvm);
+    let shm_size = 64 * 1024 * 1024;
+    record.shm_size = Some(shm_size);
+    record
+        .managed_execution
+        .as_mut()
+        .unwrap()
+        .request
+        .policy
+        .shm_size = Some(shm_size);
+
+    let manager = backend.new_manager(&record).unwrap();
+
+    assert!(manager
+        .config
+        .tmpfs
+        .contains(&format!("/dev/shm:size={shm_size}")));
+}
+
+#[test]
 fn validation_rejects_a_host_path_derived_from_external_input() {
     let temporary = tempfile::tempdir().unwrap();
     let backend = VmLocalExecutionBackend::new(temporary.path());

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -573,9 +573,10 @@ fn compile_mounts(user_mounts: &[SandboxMount], user_tmpfs: &[SandboxTmpfs]) -> 
                 tmpfs.destination.display()
             )));
         }
+        let is_shared_memory = tmpfs.destination == Path::new("/dev/shm");
         if path_is_or_below(&tmpfs.destination, Path::new("/proc"))
             || path_is_or_below(&tmpfs.destination, Path::new("/sys"))
-            || path_is_or_below(&tmpfs.destination, Path::new("/dev"))
+            || (path_is_or_below(&tmpfs.destination, Path::new("/dev")) && !is_shared_memory)
             || path_is_or_below(&tmpfs.destination, Path::new("/run/a3s-box"))
             || tmpfs.destination == Path::new("/")
         {
@@ -590,7 +591,10 @@ fn compile_mounts(user_mounts: &[SandboxMount], user_tmpfs: &[SandboxTmpfs]) -> 
             .iter()
             .position(|mount| mount.destination() == &tmpfs.destination)
         {
-            if !matches!(tmpfs.destination.to_str(), Some("/tmp" | "/run")) {
+            if !matches!(
+                tmpfs.destination.to_str(),
+                Some("/tmp" | "/run" | "/dev/shm")
+            ) {
                 return Err(BoxError::ConfigError(format!(
                     "Duplicate Sandbox mount destination {}",
                     tmpfs.destination.display()
@@ -605,17 +609,21 @@ fn compile_mounts(user_mounts: &[SandboxMount], user_tmpfs: &[SandboxTmpfs]) -> 
                 tmpfs.destination.display()
             )));
         }
+        let mut options = vec![
+            "nosuid".to_string(),
+            "nodev".to_string(),
+            "mode=1777".to_string(),
+            format!("size={}", tmpfs.size_bytes),
+        ];
+        if is_shared_memory {
+            options.push("noexec".to_string());
+        }
         mounts.push(
             MountBuilder::default()
                 .destination(tmpfs.destination.clone())
                 .typ("tmpfs".to_string())
                 .source(PathBuf::from("tmpfs"))
-                .options(vec![
-                    "nosuid".to_string(),
-                    "nodev".to_string(),
-                    "mode=1777".to_string(),
-                    format!("size={}", tmpfs.size_bytes),
-                ])
+                .options(options)
                 .build()
                 .map_err(oci_error)?,
         );
@@ -1336,6 +1344,30 @@ mod tests {
 
         let mut input = sample_input();
         input.mounts.push(input.mounts[0].clone());
+        assert!(compile_oci_spec(&input).is_err());
+    }
+
+    #[test]
+    fn compiler_allows_only_the_exact_shared_memory_tmpfs_override() {
+        let mut input = sample_input();
+        input.tmpfs.push(SandboxTmpfs {
+            destination: PathBuf::from("/dev/shm"),
+            size_bytes: 128 * 1024 * 1024,
+        });
+
+        let value = as_json(&compile_oci_spec(&input).unwrap());
+        let shared_memory = value["mounts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|mount| mount["destination"] == "/dev/shm")
+            .collect::<Vec<_>>();
+        assert_eq!(shared_memory.len(), 1);
+        let options = shared_memory[0]["options"].as_array().unwrap();
+        assert!(options.iter().any(|option| option == "size=134217728"));
+        assert!(options.iter().any(|option| option == "noexec"));
+
+        input.tmpfs[0].destination = PathBuf::from("/dev/shm/nested");
         assert!(compile_oci_spec(&input).is_err());
     }
 

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -272,27 +272,7 @@ impl VmManager {
         mounts: &[SandboxMount],
         id_mappings: &crate::sandbox::SandboxIdMappingPlan,
     ) -> Result<()> {
-        let mut managed = HashSet::new();
-        if self.config.workspace.as_os_str().is_empty() {
-            managed.insert(layout.workspace_path.clone());
-        }
-        let volume_store = crate::volume::VolumeStore::new(
-            self.home_dir.join("volumes.json"),
-            self.home_dir.join("volumes"),
-        );
-        for name in &self.anonymous_volumes {
-            let volume = volume_store
-                .get(name)?
-                .ok_or_else(|| BoxError::BoxBootError {
-                    message: format!("Sandbox anonymous volume {name} disappeared during boot"),
-                    hint: None,
-                })?;
-            managed.insert(
-                PathBuf::from(volume.mount_point)
-                    .canonicalize()
-                    .map_err(BoxError::IoError)?,
-            );
-        }
+        let managed = self.managed_sandbox_mount_sources(&layout.workspace_path, mounts)?;
 
         for mount in mounts {
             if managed.contains(&mount.source) {
@@ -302,6 +282,51 @@ impl VmManager {
             }
         }
         Ok(())
+    }
+
+    fn managed_sandbox_mount_sources(
+        &self,
+        workspace_path: &Path,
+        mounts: &[SandboxMount],
+    ) -> Result<HashSet<PathBuf>> {
+        let mut managed = HashSet::new();
+        if self.config.workspace.as_os_str().is_empty() {
+            managed.insert(workspace_path.to_path_buf());
+        }
+        let volume_store = crate::volume::VolumeStore::new(
+            self.home_dir.join("volumes.json"),
+            self.home_dir.join("volumes"),
+        );
+        let volumes = volume_store.load()?;
+        for name in &self.anonymous_volumes {
+            let volume = volumes.get(name).ok_or_else(|| BoxError::BoxBootError {
+                message: format!("Sandbox anonymous volume {name} disappeared during boot"),
+                hint: None,
+            })?;
+            managed.insert(
+                PathBuf::from(&volume.mount_point)
+                    .canonicalize()
+                    .map_err(BoxError::IoError)?,
+            );
+        }
+
+        // Named volumes are resolved to host paths before VmManager boots, so
+        // their names are not present in BoxConfig. Match only mount roots that
+        // are registered in A3S's volume store; arbitrary bind mounts remain
+        // external and are never chowned implicitly.
+        for volume in volumes.values() {
+            let Ok(source) = PathBuf::from(&volume.mount_point).canonicalize() else {
+                // A stale, unused volume entry must not prevent unrelated boxes
+                // from starting. A mounted missing path already fails while the
+                // Sandbox volume specification is canonicalized.
+                continue;
+            };
+            if mounts.iter().any(|mount| mount.source == source) {
+                managed.insert(source);
+            }
+        }
+
+        Ok(managed)
     }
 }
 
@@ -543,6 +568,8 @@ fn digest_json(value: &impl serde::Serialize) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use a3s_box_core::{volume::VolumeConfig, BoxConfig, EventEmitter};
+
     use super::*;
 
     #[test]
@@ -564,5 +591,45 @@ mod tests {
         let error =
             ensure_mount_destination(rootfs.path(), Path::new("/escape/host"), false).unwrap_err();
         assert!(error.to_string().contains("symlink"));
+    }
+
+    #[test]
+    fn named_volume_mounts_are_classified_as_a3s_managed() {
+        let home = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        let store = crate::volume::VolumeStore::new(
+            home.path().join("volumes.json"),
+            home.path().join("volumes"),
+        );
+        let volume = store.create(VolumeConfig::new("sandbox-data", "")).unwrap();
+        let named_source = PathBuf::from(volume.mount_point).canonicalize().unwrap();
+        let external_source = external.path().canonicalize().unwrap();
+        let mounts = vec![
+            SandboxMount {
+                source: named_source.clone(),
+                destination: PathBuf::from("/data"),
+                read_only: false,
+            },
+            SandboxMount {
+                source: external_source.clone(),
+                destination: PathBuf::from("/external"),
+                read_only: false,
+            },
+        ];
+        let mut manager = VmManager::with_box_id(
+            BoxConfig::default(),
+            EventEmitter::new(16),
+            "sandbox-managed-volume-test".to_string(),
+        );
+        manager.home_dir = home.path().to_path_buf();
+        let workspace = home.path().join("boxes/test/workspace");
+
+        let managed = manager
+            .managed_sandbox_mount_sources(&workspace, &mounts)
+            .unwrap();
+
+        assert!(managed.contains(&workspace));
+        assert!(managed.contains(&named_source));
+        assert!(!managed.contains(&external_source));
     }
 }


### PR DESCRIPTION
## Summary

- route the first CLI start of a managed reservation through LocalExecutionManager with its persisted generation
- prepare and release named volumes and networks at the production backend boundary
- preserve the full creation policy, shared-memory size, health state, and runtime evidence
- keep ordinary start from reviving stopped or failed managed generations
- classify A3S named volumes as managed Sandbox mounts while keeping arbitrary bind mounts external
- safely replace only the exact /dev/shm tmpfs for persisted shared-memory sizing

## Validation

- cargo test --workspace --lib
- cargo clippy --workspace --all-targets -- -D warnings (with the existing macOS needless-return allowance)
- cargo fmt --all -- --check
- E2B contract and official Python, TypeScript, and Code Interpreter fixtures
- A3S OS production smoke: create, managed start, exec, 64 MiB shared memory, named-volume write, health transition, kill, terminal start rejection, and full cleanup