### PR TITLE
feat(runtime): add durable managed restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,11 @@ For CI-style one-shot commands, prefer foreground `run --rm --timeout <seconds>`
 
 The manager-backed `create` path treats `start` as first activation of its
 nonterminal reservation. Once that managed execution is stopped or failed,
-ordinary `start` rejects it instead of reusing a stale generation. The explicit
-generation-advancing managed restart operation is the next lifecycle slice;
-legacy records retain their existing stopped-box `start` behavior meanwhile.
+ordinary `start` rejects it instead of reusing a stale generation. Explicit
+managed restart persists separate teardown and startup phases, advances the
+generation only after the old runtime is terminal, and retains its operation ID
+for idempotent crash recovery. CLI `restart` uses that manager path for managed
+records; legacy records retain their existing stop-and-boot behavior.
 
 Health checks for detached `run`, Compose services, and boxes brought back by
 `start`/`restart` are owned by a generation-fenced background worker, not by the
@@ -337,8 +339,10 @@ canonical manager, and the first `start` of that reservation consumes its
 persisted generation through the same manager. The production backend prepares
 named-volume and network ownership idempotently and rolls back only resources
 acquired by a failed start attempt. Ordinary `start` does not revive a terminal
-managed execution; an explicit restart transition must advance its generation.
-CLI `restart`/`run` and the Rust SDK still need migration. The production HCL
+managed execution. CLI `restart` now uses a durable two-phase operation that
+terminates the old runtime before advancing the generation, recovers ambiguous
+kill/start responses from backend evidence, and rebinds local resources without
+duplicating ownership. CLI `run` and the Rust SDK still need migration. The production HCL
 service, encrypted credentials, generation-fenced route leases, wildcard TLS
 gateway, envd data plane, and real official-client Sandbox suite also remain
 open gates.

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,8 +1,8 @@
 # E2B Protocol Compatibility and SDK Design
 
 Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 3 complete;
-slice 4 runtime path and staged CLI create/start complete, remaining callers
-pending)**
+slice 4 runtime path and staged CLI create/start/restart complete, remaining
+callers pending)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -22,7 +22,7 @@ unversioned claim.
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, reaping, and startup reconciliation | Wire the repository and supervisor into the production service process and exercise restart and host-reboot recovery end to end |
-| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI staged `create` and first `start` use the same generation-fenced path with caller-policy parity tests, idempotent named-volume/network preparation, and start-failure rollback; an A3S OS smoke test proves reservation-only create, restart reconciliation, real `crun` start, explicit pause rejection, kill, and cleanup without MicroVM fallback | Add an explicit generation-advancing restart operation, then migrate CLI restart/run and the Rust SDK and add the remaining caller parity tests |
+| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI `create`, first `start`, and explicit two-phase `restart` use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery tests; an A3S OS smoke test proves reservation-only create, creation reconciliation, real `crun` start, explicit pause rejection, kill, and cleanup without MicroVM fallback | Validate managed restart on A3S OS, then migrate CLI run and the Rust SDK and add the remaining caller parity tests |
 | Credentials and routing | Injected verifier, token, cursor, and template interfaces isolate protocol logic from infrastructure | Add production credential hashing, token encryption and rotation, generation-fenced route leases, validated wildcard/direct routing, and the TLS data-plane gateway |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
@@ -784,8 +784,8 @@ Phase 2 is delivered as small, immediately merged changes:
 4. **Partially complete:** extract canonical A3S state and the runtime
    `ExecutionManager`; add the production backend and prove its real Sandbox
    lifecycle; switch CLI create to the same reservation path; switch CLI
-   start/run and the Rust SDK to the same implementation with behavior parity
-   tests.
+   start/restart/run and the Rust SDK to the same implementation with behavior
+   parity tests. Create, start, and restart are complete; run and the SDK remain.
 5. Add the production HCL-configured service binary, credential and token
    providers, generation-fenced route leases, and TLS data-plane gateway. Pull
    each merge commit on an A3S OS server and run the unmodified official clients
@@ -799,7 +799,8 @@ writes, and synchronous read-modify-write transactions protect that state. The
 managed-execution store reserves creation operations atomically, returns an
 existing record only when the full creation intent matches, persists
 transitional lifecycle claims, rejects stale state or generation comparisons,
-and advances the generation exactly once when pause or resume completes.
+and advances the generation exactly once when pause or resume completes or a
+restart moves from old-runtime teardown to new-runtime startup.
 Backend calls remain outside the state lock.
 
 `LocalExecutionManager` implements the backend-neutral lifecycle contract over
@@ -812,6 +813,19 @@ state-file work on Tokio blocking workers, and resolves ambiguous backend
 errors from runtime observations before publishing a result. Startup
 reconciliation can therefore distinguish an unstarted reservation from a
 runtime that became ready before its durable `running` publication.
+
+Explicit restart persists `restart_stopping` before terminating an active old
+runtime. Only confirmed terminal backend evidence and resource release permit
+the atomic transition to `restart_starting`, which increments the generation
+once. The restart operation ID, source generation, and source state survive a
+manager crash. A retry can therefore finish a lost kill response, start a
+generation that was advanced before the backend call, or replay a completed
+lease without starting another runtime. Start failure is recorded at the new
+generation and requires a new operation ID for any later restart. Graceful-stop
+timeout is part of the restart intent, so a retry cannot silently change it.
+Named-volume and network ownership is released and rebound once, while
+execution-owned anonymous volumes remain available to the replacement
+generation; a terminal kill still removes them.
 
 The production VM/Sandbox backend is also complete for this slice. It owns live
 runtime handles, reconstructs MicroVM processes with PID identity fencing,
@@ -832,8 +846,8 @@ managed request, including config-only values such as DNS and persistent
 filesystem policy. Named-volume bookkeeping remains attached only after the
 durable reservation succeeds and rolls the reservation back on failure.
 
-Slice 4 remains incomplete until CLI start/run and the Rust SDK call the same
-manager with behavior parity tests. The existing Rust SDK uses the canonical
+Slice 4 remains incomplete until CLI run and the Rust SDK call the same manager
+with behavior parity tests. The existing Rust SDK uses the canonical
 record store for management operations but still has a separate local
 lifecycle model and does not expose create/start/run.
 

--- a/docs/host-sandbox-backend-design.md
+++ b/docs/host-sandbox-backend-design.md
@@ -1,8 +1,15 @@
 # Host Sandbox Backend Design
 
-Status: **Proposed**
+Status: **Implementation in progress**
 
-Scope: architecture only; implementation has not started
+Scope: architecture, implemented OCI runtime foundation, and remaining
+lifecycle/security/performance gates
+
+The certified `crun` launch path, protected OCI bundle construction, managed
+create/start/kill lifecycle, exec, health, named volumes, shared memory, and
+durable two-phase managed restart are implemented. This document remains the
+source for unfinished hardening, lifecycle parity, and a3s-bench gates; it is
+not a claim that the complete validation matrix has passed.
 
 Target platform: Linux without `/dev/kvm`
 

--- a/src/cli/src/commands/restart.rs
+++ b/src/cli/src/commands/restart.rs
@@ -1,7 +1,12 @@
 //! `a3s-box restart` command — Restart one or more boxes.
 //!
-//! Equivalent to `a3s-box stop` followed by `a3s-box start`.
+//! Managed records use the durable lifecycle manager. Legacy records retain
+//! the equivalent of `a3s-box stop` followed by `a3s-box start`.
 
+use a3s_box_core::{
+    ExecutionGeneration, ExecutionId, ExecutionManager, OperationId, RestartExecutionOptions,
+};
+use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionOperation, ManagedExecutionState};
 use clap::Args;
 
 use crate::boot;
@@ -48,12 +53,45 @@ async fn restart_one(
 
     let box_id = record.id.clone();
     let name = record.name.clone();
-    let restart_plan = restart_plan(record)?;
+    let restart_plan = restart_plan(record, timeout)?;
     let box_dir = record.box_dir.clone();
     let exec_socket_path = record.exec_socket_path.clone();
 
+    if let RestartPlan::Managed {
+        execution_id,
+        generation,
+        operation_id,
+        stop_timeout_secs,
+    } = restart_plan
+    {
+        let operation_id = match operation_id {
+            Some(operation_id) => operation_id,
+            None => OperationId::new(format!("cli-restart-{}", uuid::Uuid::new_v4()))?,
+        };
+        let home = a3s_box_core::dirs_home();
+        let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+        manager
+            .restart_with_options(
+                &execution_id,
+                generation,
+                &operation_id,
+                RestartExecutionOptions { stop_timeout_secs },
+            )
+            .await?;
+        create_baseline_snapshot(&box_id, &box_dir).await;
+
+        let current = StateFile::load_default()?;
+        let record = current
+            .find_by_id(&box_id)
+            .ok_or_else(|| format!("{name} was removed during restart"))?;
+        crate::health::spawn_detached_health_checker(record)
+            .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
+        println!("{name}");
+        return Ok(());
+    }
+
     // Phase 1: Stop the box if it is active.
-    if restart_plan == RestartPlan::StopThenStart {
+    if restart_plan == RestartPlan::LegacyStopThenStart {
         let pid = lifecycle::require_live_pid(record, "restart")
             .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
         let stop_signal = record
@@ -107,19 +145,92 @@ async fn restart_one(
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RestartPlan {
-    StopThenStart,
-    StartOnly,
+async fn create_baseline_snapshot(box_id: &str, box_dir: &std::path::Path) {
+    let baseline_box_dir = box_dir.to_path_buf();
+    let baseline_box_id = box_id.to_string();
+    match tokio::task::spawn_blocking(move || {
+        crate::commands::diff::create_box_baseline_snapshot(&baseline_box_dir)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            tracing::warn!(
+                box_id = %baseline_box_id,
+                %error,
+                "Failed to create rootfs diff baseline snapshot after restart"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                box_id = %baseline_box_id,
+                %error,
+                "Rootfs diff baseline task failed after restart"
+            );
+        }
+    }
 }
 
-fn restart_plan(record: &crate::state::BoxRecord) -> Result<RestartPlan, String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RestartPlan {
+    LegacyStopThenStart,
+    LegacyStartOnly,
+    Managed {
+        execution_id: ExecutionId,
+        generation: ExecutionGeneration,
+        operation_id: Option<OperationId>,
+        stop_timeout_secs: Option<u64>,
+    },
+}
+
+fn restart_plan(record: &crate::state::BoxRecord, timeout: u64) -> Result<RestartPlan, String> {
+    if let Some(metadata) = record.managed_execution.as_ref() {
+        let execution_id =
+            ExecutionId::new(record.id.clone()).map_err(|error| error.to_string())?;
+        let state = record
+            .managed_state()
+            .map_err(|error| format!("Invalid managed state for box {}: {error}", record.name))?
+            .ok_or_else(|| format!("Box {} lost managed lifecycle metadata", record.name))?;
+        return match state {
+            ManagedExecutionState::Created
+            | ManagedExecutionState::Running
+            | ManagedExecutionState::Paused
+            | ManagedExecutionState::Stopped
+            | ManagedExecutionState::Failed => Ok(RestartPlan::Managed {
+                execution_id,
+                generation: metadata.generation,
+                operation_id: None,
+                stop_timeout_secs: Some(record.stop_timeout.unwrap_or(timeout)),
+            }),
+            ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting => {
+                match metadata.pending_operation.as_ref() {
+                    Some(ManagedExecutionOperation::Restart {
+                        operation_id,
+                        source_generation,
+                        stop_timeout_secs,
+                        ..
+                    }) => Ok(RestartPlan::Managed {
+                        execution_id,
+                        generation: *source_generation,
+                        operation_id: Some(operation_id.clone()),
+                        stop_timeout_secs: *stop_timeout_secs,
+                    }),
+                    _ => Err(format!(
+                        "Box {} has no persisted managed restart intent",
+                        record.name
+                    )),
+                }
+            }
+            other => Err(format!("Cannot restart box in state: {other}")),
+        };
+    }
     if status::is_active(record) {
-        return Ok(RestartPlan::StopThenStart);
+        return Ok(RestartPlan::LegacyStopThenStart);
     }
 
     match record.status.as_str() {
-        "created" | "stopped" | "dead" => Ok(RestartPlan::StartOnly),
+        "created" | "stopped" | "dead" => Ok(RestartPlan::LegacyStartOnly),
         other => Err(format!("Cannot restart box in state: {other}")),
     }
 }
@@ -127,33 +238,127 @@ fn restart_plan(record: &crate::state::BoxRecord) -> Result<RestartPlan, String>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use a3s_box_core::{BoxConfig, CreateExecutionRequest, ExecutionIsolation};
+    use a3s_box_runtime::ManagedExecutionMetadata;
+    use std::collections::BTreeMap;
+
     use crate::test_helpers::fixtures::make_record;
+
+    fn managed_record(state: ManagedExecutionState) -> crate::state::BoxRecord {
+        let id = "11111111-1111-4111-8111-111111111111";
+        let mut record = make_record(id, "managed", state.as_status(), None);
+        record.isolation = ExecutionIsolation::Sandbox;
+        let mut metadata = ManagedExecutionMetadata::new(
+            OperationId::new("operation-create").unwrap(),
+            ExecutionGeneration::INITIAL,
+            CreateExecutionRequest {
+                external_sandbox_id: "external-1".to_string(),
+                config: BoxConfig {
+                    isolation: ExecutionIsolation::Sandbox,
+                    image: record.image.clone(),
+                    ..Default::default()
+                },
+                labels: BTreeMap::new(),
+                policy: Default::default(),
+            },
+        )
+        .unwrap();
+        if matches!(
+            state,
+            ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting
+        ) {
+            metadata.pending_operation = Some(ManagedExecutionOperation::Restart {
+                operation_id: OperationId::new("operation-restart").unwrap(),
+                source_generation: ExecutionGeneration::INITIAL,
+                source_state: ManagedExecutionState::Running,
+                stop_timeout_secs: Some(7),
+            });
+        }
+        if state == ManagedExecutionState::RestartStarting {
+            metadata.generation = ExecutionGeneration::new(2).unwrap();
+        }
+        record.managed_execution = Some(metadata);
+        record
+    }
 
     #[test]
     fn test_restart_plan_stops_running_and_paused_first() {
         assert_eq!(
-            restart_plan(&make_record("id-1", "running", "running", Some(1))).unwrap(),
-            RestartPlan::StopThenStart
+            restart_plan(&make_record("id-1", "running", "running", Some(1)), 10).unwrap(),
+            RestartPlan::LegacyStopThenStart
         );
         assert_eq!(
-            restart_plan(&make_record("id-2", "paused", "paused", Some(1))).unwrap(),
-            RestartPlan::StopThenStart
+            restart_plan(&make_record("id-2", "paused", "paused", Some(1)), 10).unwrap(),
+            RestartPlan::LegacyStopThenStart
         );
     }
 
     #[test]
     fn test_restart_plan_starts_inactive_boxes_directly() {
         assert_eq!(
-            restart_plan(&make_record("id-1", "created", "created", None)).unwrap(),
-            RestartPlan::StartOnly
+            restart_plan(&make_record("id-1", "created", "created", None), 10).unwrap(),
+            RestartPlan::LegacyStartOnly
         );
         assert_eq!(
-            restart_plan(&make_record("id-2", "stopped", "stopped", None)).unwrap(),
-            RestartPlan::StartOnly
+            restart_plan(&make_record("id-2", "stopped", "stopped", None), 10).unwrap(),
+            RestartPlan::LegacyStartOnly
         );
         assert_eq!(
-            restart_plan(&make_record("id-3", "dead", "dead", None)).unwrap(),
-            RestartPlan::StartOnly
+            restart_plan(&make_record("id-3", "dead", "dead", None), 10).unwrap(),
+            RestartPlan::LegacyStartOnly
         );
+    }
+
+    #[test]
+    fn managed_restart_plan_uses_the_current_generation_for_stable_states() {
+        for state in [
+            ManagedExecutionState::Created,
+            ManagedExecutionState::Running,
+            ManagedExecutionState::Paused,
+            ManagedExecutionState::Stopped,
+            ManagedExecutionState::Failed,
+        ] {
+            assert_eq!(
+                restart_plan(&managed_record(state), 10).unwrap(),
+                RestartPlan::Managed {
+                    execution_id: ExecutionId::new("11111111-1111-4111-8111-111111111111").unwrap(),
+                    generation: ExecutionGeneration::INITIAL,
+                    operation_id: None,
+                    stop_timeout_secs: Some(10),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn managed_restart_plan_recovers_the_persisted_operation() {
+        for state in [
+            ManagedExecutionState::RestartStopping,
+            ManagedExecutionState::RestartStarting,
+        ] {
+            assert_eq!(
+                restart_plan(&managed_record(state), 10).unwrap(),
+                RestartPlan::Managed {
+                    execution_id: ExecutionId::new("11111111-1111-4111-8111-111111111111").unwrap(),
+                    generation: ExecutionGeneration::INITIAL,
+                    operation_id: Some(OperationId::new("operation-restart").unwrap()),
+                    stop_timeout_secs: Some(7),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn managed_restart_plan_uses_record_stop_timeout_before_cli_fallback() {
+        let mut record = managed_record(ManagedExecutionState::Running);
+        record.stop_timeout = Some(3);
+
+        let RestartPlan::Managed {
+            stop_timeout_secs, ..
+        } = restart_plan(&record, 10).unwrap()
+        else {
+            panic!("expected managed restart plan");
+        };
+        assert_eq!(stop_timeout_secs, Some(3));
     }
 }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -64,8 +64,8 @@ pub use traits::{
     ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionRecordPolicy,
     ExecutionReservation, ExecutionRestartPolicy, ExecutionState, ExecutionStatus, ImageRegistry,
     ImageStoreBackend, KillOutcome, MetricsCollector, NetworkStoreBackend, NoopMetrics,
-    OperationId, PulledImage, ReconcileOutcome, SnapshotStoreBackend, StoredImage,
-    VolumeStoreBackend,
+    OperationId, PulledImage, ReconcileOutcome, RestartExecutionOptions, SnapshotStoreBackend,
+    StoredImage, VolumeStoreBackend,
 };
 pub use vmm::{
     Entrypoint, FsMount, InstanceSpec, NetworkInstanceConfig, TeeInstanceConfig, VmHandler,

--- a/src/core/src/traits/execution.rs
+++ b/src/core/src/traits/execution.rs
@@ -333,6 +333,15 @@ pub enum KillOutcome {
     AlreadyStopped,
 }
 
+/// Per-operation controls persisted with an idempotent restart.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RestartExecutionOptions {
+    /// Graceful stop deadline for the old runtime. `None` uses persisted
+    /// execution policy or the backend default.
+    #[serde(default)]
+    pub stop_timeout_secs: Option<u64>,
+}
+
 /// Runtime evidence recovered after a service restart.
 #[derive(Debug, Clone)]
 pub enum ReconcileOutcome {
@@ -417,6 +426,36 @@ pub trait ExecutionManager: Send + Sync {
         execution_id: &ExecutionId,
         generation: ExecutionGeneration,
     ) -> ExecutionManagerResult<ExecutionLease>;
+
+    /// Terminate the current runtime, advance its generation exactly once,
+    /// and start it again under an idempotent operation identity.
+    async fn restart(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+        operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        self.restart_with_options(
+            execution_id,
+            generation,
+            operation_id,
+            RestartExecutionOptions::default(),
+        )
+        .await
+    }
+
+    /// Restart with controls that become part of the durable operation intent.
+    async fn restart_with_options(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        _operation_id: &OperationId,
+        _options: RestartExecutionOptions,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        Err(ExecutionManagerError::Unavailable(
+            "this execution manager does not support restart".to_string(),
+        ))
+    }
 
     async fn kill(
         &self,

--- a/src/core/src/traits/mod.rs
+++ b/src/core/src/traits/mod.rs
@@ -21,7 +21,7 @@ pub use execution::{
     CreateExecutionRequest, ExecutionGeneration, ExecutionHealthCheck, ExecutionId, ExecutionLease,
     ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionRecordPolicy,
     ExecutionReservation, ExecutionRestartPolicy, ExecutionState, ExecutionStatus, KillOutcome,
-    OperationId, ReconcileOutcome,
+    OperationId, ReconcileOutcome, RestartExecutionOptions,
 };
 pub use metrics::{MetricsCollector, NoopMetrics};
 pub use registry::{ImageRegistry, PulledImage};

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -214,7 +214,7 @@ impl BoxRecord {
             return Ok(None);
         };
         let state = ManagedExecutionState::from_status(&self.status)?;
-        validate_pending_operation(state, metadata.pending_operation.as_ref())?;
+        validate_pending_operation(state, metadata)?;
         Ok(Some(state))
     }
 
@@ -245,7 +245,8 @@ impl BoxRecord {
 /// Transitional states are persisted before backend side effects. This lets
 /// a restarted manager distinguish work that was never claimed from work that
 /// may already have reached the runtime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ManagedExecutionState {
     Creating,
     Created,
@@ -255,6 +256,8 @@ pub enum ManagedExecutionState {
     Paused,
     Resuming,
     Killing,
+    RestartStopping,
+    RestartStarting,
     Stopped,
     Failed,
 }
@@ -271,6 +274,8 @@ impl ManagedExecutionState {
             Self::Paused => "paused",
             Self::Resuming => "resuming",
             Self::Killing => "killing",
+            Self::RestartStopping => "restart_stopping",
+            Self::RestartStarting => "restart_starting",
             Self::Stopped => "stopped",
             Self::Failed => "failed",
         }
@@ -287,6 +292,8 @@ impl ManagedExecutionState {
             "paused" => Ok(Self::Paused),
             "resuming" => Ok(Self::Resuming),
             "killing" => Ok(Self::Killing),
+            "restart_stopping" => Ok(Self::RestartStopping),
+            "restart_starting" => Ok(Self::RestartStarting),
             "stopped" => Ok(Self::Stopped),
             "dead" | "failed" => Ok(Self::Failed),
             other => Err(a3s_box_core::BoxError::StateError(format!(
@@ -331,6 +338,9 @@ pub struct ManagedExecutionMetadata {
     /// Lifecycle side effect claimed before calling the backend.
     #[serde(default)]
     pub pending_operation: Option<ManagedExecutionOperation>,
+    /// Most recent completed restart retained for idempotent response replay.
+    #[serde(default)]
+    pub last_restart: Option<ManagedRestartCompletion>,
 }
 
 /// Recoverable backend operation associated with a transitional state.
@@ -338,9 +348,37 @@ pub struct ManagedExecutionMetadata {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ManagedExecutionOperation {
     Start,
-    Pause { keep_memory: bool },
+    Pause {
+        keep_memory: bool,
+    },
     Resume,
     Kill,
+    Restart {
+        operation_id: OperationId,
+        source_generation: ExecutionGeneration,
+        source_state: ManagedExecutionState,
+        #[serde(default)]
+        stop_timeout_secs: Option<u64>,
+    },
+}
+
+/// Durable result of the most recent restart operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagedRestartOutcome {
+    Running,
+    Failed,
+}
+
+/// Restart identity retained after its transitional state has completed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManagedRestartCompletion {
+    pub operation_id: OperationId,
+    pub source_generation: ExecutionGeneration,
+    pub target_generation: ExecutionGeneration,
+    pub outcome: ManagedRestartOutcome,
+    #[serde(default)]
+    pub stop_timeout_secs: Option<u64>,
 }
 
 impl ManagedExecutionMetadata {
@@ -362,6 +400,7 @@ impl ManagedExecutionMetadata {
             request,
             plan,
             pending_operation: None,
+            last_restart: None,
         })
     }
 
@@ -378,14 +417,25 @@ impl ManagedExecutionMetadata {
                 "managed execution plan does not match its persisted creation request".to_string(),
             ));
         }
+        if let Some(completed) = &self.last_restart {
+            let expected_target = next_generation(completed.source_generation)?;
+            if completed.target_generation != expected_target {
+                return Err(a3s_box_core::BoxError::StateError(format!(
+                    "completed restart {} has inconsistent generations",
+                    completed.operation_id
+                )));
+            }
+            validate_restart_timeout(completed.stop_timeout_secs)?;
+        }
         Ok(())
     }
 }
 
 fn validate_pending_operation(
     state: ManagedExecutionState,
-    operation: Option<&ManagedExecutionOperation>,
+    metadata: &ManagedExecutionMetadata,
 ) -> a3s_box_core::Result<()> {
+    let operation = metadata.pending_operation.as_ref();
     let consistent = matches!(
         (state, operation),
         (
@@ -401,6 +451,9 @@ fn validate_pending_operation(
             ManagedExecutionState::Killing,
             Some(ManagedExecutionOperation::Kill)
         ) | (
+            ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting,
+            Some(ManagedExecutionOperation::Restart { .. })
+        ) | (
             ManagedExecutionState::Creating
                 | ManagedExecutionState::Created
                 | ManagedExecutionState::Running
@@ -410,13 +463,69 @@ fn validate_pending_operation(
             None
         )
     );
-    if consistent {
-        Ok(())
-    } else {
-        Err(a3s_box_core::BoxError::StateError(format!(
+    if !consistent {
+        return Err(a3s_box_core::BoxError::StateError(format!(
             "managed execution state {state} has inconsistent pending operation"
-        )))
+        )));
     }
+
+    if let Some(ManagedExecutionOperation::Restart {
+        source_generation,
+        source_state,
+        stop_timeout_secs,
+        ..
+    }) = operation
+    {
+        if !matches!(
+            source_state,
+            ManagedExecutionState::Created
+                | ManagedExecutionState::Running
+                | ManagedExecutionState::Paused
+                | ManagedExecutionState::Stopped
+                | ManagedExecutionState::Failed
+        ) {
+            return Err(a3s_box_core::BoxError::StateError(
+                "restart source state is not stable".to_string(),
+            ));
+        }
+        let expected = match state {
+            ManagedExecutionState::RestartStopping => *source_generation,
+            ManagedExecutionState::RestartStarting => next_generation(*source_generation)?,
+            _ => {
+                return Err(a3s_box_core::BoxError::StateError(
+                    "restart operation is attached to a non-restart state".to_string(),
+                ))
+            }
+        };
+        if metadata.generation != expected {
+            return Err(a3s_box_core::BoxError::StateError(format!(
+                "restart state {state} has generation {}, expected {}",
+                metadata.generation.get(),
+                expected.get()
+            )));
+        }
+        validate_restart_timeout(*stop_timeout_secs)?;
+    }
+    Ok(())
+}
+
+fn validate_restart_timeout(timeout_secs: Option<u64>) -> a3s_box_core::Result<()> {
+    if timeout_secs.is_some_and(|timeout| timeout.checked_mul(1_000).is_none()) {
+        Err(a3s_box_core::BoxError::StateError(
+            "restart stop timeout is too large".to_string(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn next_generation(generation: ExecutionGeneration) -> a3s_box_core::Result<ExecutionGeneration> {
+    let value = generation.get().checked_add(1).ok_or_else(|| {
+        a3s_box_core::BoxError::StateError("execution generation is exhausted".to_string())
+    })?;
+    ExecutionGeneration::new(value).map_err(|error| {
+        a3s_box_core::BoxError::StateError(format!("invalid execution generation: {error}"))
+    })
 }
 
 fn default_restart_policy() -> String {

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -60,7 +60,7 @@ pub use audit::{read_audit_log, AuditLog, AuditQuery};
 // Canonical local execution metadata
 pub use box_record::{
     BoxRecord, HealthCheck, ManagedExecutionMetadata, ManagedExecutionOperation,
-    ManagedExecutionState,
+    ManagedExecutionState, ManagedRestartCompletion, ManagedRestartOutcome,
 };
 pub use box_state::BoxStateStore;
 #[cfg(feature = "vm")]

--- a/src/runtime/src/local_execution/api.rs
+++ b/src/runtime/src/local_execution/api.rs
@@ -1,7 +1,7 @@
 use a3s_box_core::{
     CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManager,
     ExecutionManagerError, ExecutionManagerResult, ExecutionReservation, ExecutionState,
-    ExecutionStatus, KillOutcome, OperationId, ReconcileOutcome,
+    ExecutionStatus, KillOutcome, OperationId, ReconcileOutcome, RestartExecutionOptions,
 };
 use async_trait::async_trait;
 
@@ -101,6 +101,21 @@ impl ExecutionManager for LocalExecutionManager {
         self.finish_resume(claimed).await
     }
 
+    async fn restart_with_options(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+        operation_id: &OperationId,
+        options: RestartExecutionOptions,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let record = self
+            .get(execution_id)
+            .await?
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        self.restart_record(record, expected_generation, operation_id, options)
+            .await
+    }
+
     async fn kill(
         &self,
         execution_id: &ExecutionId,
@@ -114,6 +129,12 @@ impl ExecutionManager for LocalExecutionManager {
         let state = managed_state(&record)?;
         if state.is_terminal() {
             return Ok(KillOutcome::AlreadyStopped);
+        }
+        if matches!(
+            state,
+            ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting
+        ) {
+            return Err(state_conflict(&record, execution_id, "kill"));
         }
         let claimed = if state == ManagedExecutionState::Killing {
             record
@@ -166,6 +187,10 @@ impl ExecutionManager for LocalExecutionManager {
                 self.finish_kill(record).await?;
                 Ok(ReconcileOutcome::Failed)
             }
+            ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting => self
+                .resume_restart(record)
+                .await
+                .map(ReconcileOutcome::Ready),
             _ => {
                 let (record, state) = self.observe_record(record).await?;
                 outcome_from_record(record, state)

--- a/src/runtime/src/local_execution/backend.rs
+++ b/src/runtime/src/local_execution/backend.rs
@@ -94,5 +94,15 @@ pub trait LocalExecutionBackend: Send + Sync {
 
     async fn resume(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle>;
 
+    /// Stop the current runtime while preserving execution-owned storage for
+    /// the replacement generation.
+    async fn stop_for_restart(
+        &self,
+        record: &BoxRecord,
+        _timeout_secs: Option<u64>,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        self.kill(record).await
+    }
+
     async fn kill(&self, record: &BoxRecord) -> ExecutionManagerResult<KillOutcome>;
 }

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -7,6 +7,7 @@ mod operations;
 mod record;
 mod recovery;
 mod resources;
+mod restart;
 mod store;
 mod support;
 #[cfg(feature = "vm")]

--- a/src/runtime/src/local_execution/record.rs
+++ b/src/runtime/src/local_execution/record.rs
@@ -116,6 +116,16 @@ pub(crate) fn apply_handle(record: &mut BoxRecord, handle: &LocalExecutionHandle
 
 pub(crate) fn apply_start_handle(record: &mut BoxRecord, handle: &LocalExecutionHandle) {
     apply_handle(record, handle);
+    initialize_health(record);
+    record.restart_count = 0;
+}
+
+pub(crate) fn apply_restart_handle(record: &mut BoxRecord, handle: &LocalExecutionHandle) {
+    apply_handle(record, handle);
+    initialize_health(record);
+}
+
+fn initialize_health(record: &mut BoxRecord) {
     record.health_status = if record.health_check.is_some() {
         "starting".to_string()
     } else {
@@ -124,7 +134,6 @@ pub(crate) fn apply_start_handle(record: &mut BoxRecord, handle: &LocalExecution
     record.health_retries = 0;
     record.health_last_check = None;
     record.stopped_by_user = false;
-    record.restart_count = 0;
 }
 
 pub(crate) fn clear_live_runtime(record: &mut BoxRecord, exit_code: Option<i32>) {

--- a/src/runtime/src/local_execution/recovery.rs
+++ b/src/runtime/src/local_execution/recovery.rs
@@ -3,7 +3,9 @@ use a3s_box_core::{
 };
 
 use super::record::{execution_id, lease_from_record};
-use super::support::{managed_state, outcome_from_record, required_handle};
+use super::support::{
+    managed_state, outcome_from_record, pending_restart_source_state, required_handle,
+};
 use super::{BoxRecord, LocalExecutionManager, ManagedExecutionState, RuntimeUpdate};
 
 impl LocalExecutionManager {
@@ -18,13 +20,29 @@ impl LocalExecutionManager {
             }
             ManagedExecutionState::Stopped => return Ok((record, ExecutionState::Stopped)),
             ManagedExecutionState::Failed => return Ok((record, ExecutionState::Failed)),
+            ManagedExecutionState::RestartStopping => {
+                let id = execution_id(&record)?;
+                if matches!(
+                    pending_restart_source_state(&record, &id)?,
+                    ManagedExecutionState::Created
+                        | ManagedExecutionState::Stopped
+                        | ManagedExecutionState::Failed
+                ) {
+                    return Ok((record, ExecutionState::Creating));
+                }
+            }
             _ => {}
         }
         let id = execution_id(&record)?;
         let observation = match self.backend.inspect(&record).await {
             Ok(observation) => observation,
             Err(ExecutionManagerError::NotFound(_)) => {
-                if internal == ManagedExecutionState::Starting {
+                if matches!(
+                    internal,
+                    ManagedExecutionState::Starting
+                        | ManagedExecutionState::RestartStopping
+                        | ManagedExecutionState::RestartStarting
+                ) {
                     return Ok((record, ExecutionState::Creating));
                 }
                 let terminal = if internal == ManagedExecutionState::Killing {
@@ -99,6 +117,44 @@ impl LocalExecutionManager {
             }
             (ManagedExecutionState::Killing, ExecutionState::Creating) => {
                 Ok((record, ExecutionState::Creating))
+            }
+            (
+                ManagedExecutionState::RestartStopping,
+                state @ (ExecutionState::Running | ExecutionState::Paused),
+            ) => Ok((record, state)),
+            (
+                ManagedExecutionState::RestartStopping,
+                ExecutionState::Created
+                | ExecutionState::Creating
+                | ExecutionState::Stopped
+                | ExecutionState::Failed,
+            ) => Ok((record, ExecutionState::Creating)),
+            (ManagedExecutionState::RestartStarting, ExecutionState::Running) => {
+                self.complete_restart_with_handle(&record, required_handle(&observation, &id)?)
+                    .await?;
+                let current = self
+                    .get(&id)
+                    .await?
+                    .ok_or_else(|| ExecutionManagerError::NotFound(id.clone()))?;
+                Ok((current, ExecutionState::Running))
+            }
+            (
+                ManagedExecutionState::RestartStarting,
+                ExecutionState::Created | ExecutionState::Creating,
+            ) => Ok((record, ExecutionState::Creating)),
+            (
+                ManagedExecutionState::RestartStarting,
+                ExecutionState::Stopped | ExecutionState::Failed,
+            ) => {
+                let record = self
+                    .transition(
+                        &record,
+                        ManagedExecutionState::RestartStarting,
+                        ManagedExecutionState::Failed,
+                        RuntimeUpdate::RestartFailed(observation.exit_code),
+                    )
+                    .await?;
+                Ok((record, ExecutionState::Failed))
             }
             (ManagedExecutionState::Running, ExecutionState::Running) => {
                 Ok((record, ExecutionState::Running))

--- a/src/runtime/src/local_execution/resources.rs
+++ b/src/runtime/src/local_execution/resources.rs
@@ -354,4 +354,33 @@ mod tests {
             .endpoints
             .contains_key(&record.id));
     }
+
+    #[test]
+    fn restart_release_and_prepare_rebind_resources_exactly_once() {
+        let temporary = tempfile::tempdir().unwrap();
+        let record = record(temporary.path());
+        let (volumes, networks) = stores(temporary.path());
+        ExecutionResourceGuard::prepare(temporary.path(), &record)
+            .unwrap()
+            .disarm();
+
+        release_resources(temporary.path(), &record).unwrap();
+        ExecutionResourceGuard::prepare(temporary.path(), &record)
+            .unwrap()
+            .disarm();
+
+        assert_eq!(
+            volumes.get("workspace").unwrap().unwrap().in_use_by,
+            vec![record.id.clone()]
+        );
+        let network = networks.get("dev").unwrap().unwrap();
+        assert_eq!(
+            network
+                .endpoints
+                .keys()
+                .filter(|execution_id| execution_id.as_str() == record.id)
+                .count(),
+            1
+        );
+    }
 }

--- a/src/runtime/src/local_execution/restart.rs
+++ b/src/runtime/src/local_execution/restart.rs
@@ -1,0 +1,479 @@
+use a3s_box_core::{
+    ExecutionGeneration, ExecutionLease, ExecutionManagerError, ExecutionManagerResult,
+    ExecutionState, OperationId, RestartExecutionOptions,
+};
+
+use super::record::{execution_id, lease_from_record};
+use super::store::RuntimeUpdate;
+use super::support::{generation, managed_state, require_generation, required_handle};
+use super::{
+    BoxRecord, LocalExecutionHandle, LocalExecutionManager, ManagedExecutionOperation,
+    ManagedExecutionState,
+};
+use crate::ManagedRestartOutcome;
+
+#[derive(Clone)]
+struct RestartIntent {
+    operation_id: OperationId,
+    source_generation: ExecutionGeneration,
+    source_state: ManagedExecutionState,
+    stop_timeout_secs: Option<u64>,
+}
+
+impl RestartIntent {
+    const fn options(&self) -> RestartExecutionOptions {
+        RestartExecutionOptions {
+            stop_timeout_secs: self.stop_timeout_secs,
+        }
+    }
+}
+
+impl LocalExecutionManager {
+    pub(super) async fn restart_record(
+        &self,
+        record: BoxRecord,
+        expected_generation: ExecutionGeneration,
+        operation_id: &OperationId,
+        options: RestartExecutionOptions,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        if let Some(result) =
+            completed_restart_result(&record, expected_generation, operation_id, options)?
+        {
+            return result;
+        }
+        if record
+            .managed_execution
+            .as_ref()
+            .is_some_and(|metadata| metadata.operation_id == *operation_id)
+        {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id(&record)?,
+                message: format!(
+                    "operation {operation_id} is already the execution creation identity"
+                ),
+            });
+        }
+
+        match managed_state(&record)? {
+            ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting => {
+                require_matching_restart(&record, expected_generation, operation_id, options)?;
+                self.continue_restart(record).await
+            }
+            state @ (ManagedExecutionState::Created
+            | ManagedExecutionState::Running
+            | ManagedExecutionState::Paused
+            | ManagedExecutionState::Stopped
+            | ManagedExecutionState::Failed) => {
+                let id = execution_id(&record)?;
+                require_generation(&record, &id, expected_generation)?;
+                ensure_restart_generation_available(&id, expected_generation)?;
+                ensure_restart_timeout_valid(
+                    &id,
+                    options.stop_timeout_secs.or(record.stop_timeout),
+                )?;
+                let claimed = match self
+                    .transition(
+                        &record,
+                        state,
+                        ManagedExecutionState::RestartStopping,
+                        RuntimeUpdate::RestartClaim {
+                            operation_id: operation_id.clone(),
+                            options,
+                        },
+                    )
+                    .await
+                {
+                    Ok(claimed) => claimed,
+                    Err(ExecutionManagerError::Conflict { .. }) => {
+                        let current = self
+                            .get(&id)
+                            .await?
+                            .ok_or_else(|| ExecutionManagerError::NotFound(id.clone()))?;
+                        if let Some(result) = completed_restart_result(
+                            &current,
+                            expected_generation,
+                            operation_id,
+                            options,
+                        )? {
+                            return result;
+                        }
+                        require_matching_restart(
+                            &current,
+                            expected_generation,
+                            operation_id,
+                            options,
+                        )?;
+                        return self.continue_restart(current).await;
+                    }
+                    Err(error) => return Err(error),
+                };
+                self.continue_restart(claimed).await
+            }
+            state => Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id(&record)?,
+                message: format!("cannot restart execution in state {state}"),
+            }),
+        }
+    }
+
+    pub(super) async fn resume_restart(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        restart_intent(&record)?;
+        self.continue_restart(record).await
+    }
+
+    async fn continue_restart(&self, record: BoxRecord) -> ExecutionManagerResult<ExecutionLease> {
+        match managed_state(&record)? {
+            ManagedExecutionState::RestartStopping => self.finish_restart_stop(record).await,
+            ManagedExecutionState::RestartStarting => self.finish_restart_start(record).await,
+            state => Err(ExecutionManagerError::Internal(format!(
+                "restart continuation reached state {state} for {}",
+                record.id
+            ))),
+        }
+    }
+
+    async fn finish_restart_stop(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let intent = restart_intent(&record)?;
+        if matches!(
+            intent.source_state,
+            ManagedExecutionState::Running | ManagedExecutionState::Paused
+        ) {
+            self.confirm_restart_kill(&record, intent.stop_timeout_secs)
+                .await?;
+        }
+        self.release_execution_resources(&record).await?;
+
+        let id = execution_id(&record)?;
+        let starting = match self
+            .transition(
+                &record,
+                ManagedExecutionState::RestartStopping,
+                ManagedExecutionState::RestartStarting,
+                RuntimeUpdate::RestartAdvance,
+            )
+            .await
+        {
+            Ok(starting) => starting,
+            Err(ExecutionManagerError::Conflict { .. }) => {
+                let current = self
+                    .get(&id)
+                    .await?
+                    .ok_or_else(|| ExecutionManagerError::NotFound(id.clone()))?;
+                if let Some(result) = completed_restart_result(
+                    &current,
+                    intent.source_generation,
+                    &intent.operation_id,
+                    intent.options(),
+                )? {
+                    return result;
+                }
+                require_matching_restart(
+                    &current,
+                    intent.source_generation,
+                    &intent.operation_id,
+                    intent.options(),
+                )?;
+                if managed_state(&current)? != ManagedExecutionState::RestartStarting {
+                    return Err(ExecutionManagerError::Unavailable(format!(
+                        "restart teardown for {id} is owned by another caller"
+                    )));
+                }
+                current
+            }
+            Err(error) => return Err(error),
+        };
+        self.finish_restart_start(starting).await
+    }
+
+    async fn confirm_restart_kill(
+        &self,
+        record: &BoxRecord,
+        stop_timeout_secs: Option<u64>,
+    ) -> ExecutionManagerResult<()> {
+        match self
+            .backend
+            .stop_for_restart(record, stop_timeout_secs)
+            .await
+        {
+            Ok(_) | Err(ExecutionManagerError::NotFound(_)) => Ok(()),
+            Err(error) => {
+                let terminal = match self.backend.inspect(record).await {
+                    Err(ExecutionManagerError::NotFound(_)) => true,
+                    Ok(observation) => matches!(
+                        observation.state,
+                        ExecutionState::Stopped | ExecutionState::Failed
+                    ),
+                    Err(_) => false,
+                };
+                if terminal {
+                    Ok(())
+                } else {
+                    Err(error)
+                }
+            }
+        }
+    }
+
+    async fn finish_restart_start(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let id = execution_id(&record)?;
+        match self.backend.start(&record).await {
+            Ok(handle) => {
+                handle.validate(&id)?;
+                self.complete_restart_with_handle(&record, handle).await
+            }
+            Err(error) => self.resolve_restart_start_error(record, error).await,
+        }
+    }
+
+    pub(super) async fn complete_restart_with_handle(
+        &self,
+        record: &BoxRecord,
+        handle: LocalExecutionHandle,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let intent = restart_intent(record)?;
+        let id = execution_id(record)?;
+        match self
+            .transition(
+                record,
+                ManagedExecutionState::RestartStarting,
+                ManagedExecutionState::Running,
+                RuntimeUpdate::RestartHandle(handle),
+            )
+            .await
+        {
+            Ok(running) => lease_from_record(&running),
+            Err(error @ ExecutionManagerError::Conflict { .. }) => {
+                let current = self
+                    .get(&id)
+                    .await?
+                    .ok_or_else(|| ExecutionManagerError::NotFound(id.clone()))?;
+                match completed_restart_result(
+                    &current,
+                    intent.source_generation,
+                    &intent.operation_id,
+                    intent.options(),
+                )? {
+                    Some(result) => result,
+                    None => Err(error),
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn resolve_restart_start_error(
+        &self,
+        record: BoxRecord,
+        start_error: ExecutionManagerError,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        let id = execution_id(&record)?;
+        match self.backend.inspect(&record).await {
+            Ok(observation) => {
+                observation.validate(&id)?;
+                match observation.state {
+                    ExecutionState::Running => {
+                        self.complete_restart_with_handle(
+                            &record,
+                            required_handle(&observation, &id)?,
+                        )
+                        .await
+                    }
+                    ExecutionState::Stopped | ExecutionState::Failed => {
+                        self.publish_restart_failure(&record, observation.exit_code)
+                            .await?;
+                        Err(start_error)
+                    }
+                    ExecutionState::Created | ExecutionState::Creating | ExecutionState::Paused => {
+                        Err(start_error)
+                    }
+                }
+            }
+            Err(ExecutionManagerError::NotFound(_)) => {
+                self.publish_restart_failure(&record, None).await?;
+                Err(start_error)
+            }
+            Err(_) => Err(start_error),
+        }
+    }
+
+    async fn publish_restart_failure(
+        &self,
+        record: &BoxRecord,
+        exit_code: Option<i32>,
+    ) -> ExecutionManagerResult<()> {
+        self.release_execution_resources(record).await?;
+        let intent = restart_intent(record)?;
+        let id = execution_id(record)?;
+        match self
+            .transition(
+                record,
+                ManagedExecutionState::RestartStarting,
+                ManagedExecutionState::Failed,
+                RuntimeUpdate::RestartFailed(exit_code),
+            )
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(error @ ExecutionManagerError::Conflict { .. }) => {
+                let current = self
+                    .get(&id)
+                    .await?
+                    .ok_or_else(|| ExecutionManagerError::NotFound(id.clone()))?;
+                if completed_restart_result(
+                    &current,
+                    intent.source_generation,
+                    &intent.operation_id,
+                    intent.options(),
+                )?
+                .is_some()
+                {
+                    Ok(())
+                } else {
+                    Err(error)
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn ensure_restart_generation_available(
+    execution_id: &a3s_box_core::ExecutionId,
+    generation: ExecutionGeneration,
+) -> ExecutionManagerResult<()> {
+    if generation.get().checked_add(1).is_some() {
+        Ok(())
+    } else {
+        Err(ExecutionManagerError::Conflict {
+            execution_id: execution_id.clone(),
+            message: "execution generation is exhausted".to_string(),
+        })
+    }
+}
+
+fn ensure_restart_timeout_valid(
+    execution_id: &a3s_box_core::ExecutionId,
+    timeout_secs: Option<u64>,
+) -> ExecutionManagerResult<()> {
+    if timeout_secs.is_some_and(|timeout| timeout.checked_mul(1_000).is_none()) {
+        Err(ExecutionManagerError::InvalidRequest(format!(
+            "restart timeout is too large for execution {execution_id}"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn restart_intent(record: &BoxRecord) -> ExecutionManagerResult<RestartIntent> {
+    let id = execution_id(record)?;
+    match record
+        .managed_execution
+        .as_ref()
+        .and_then(|metadata| metadata.pending_operation.as_ref())
+    {
+        Some(ManagedExecutionOperation::Restart {
+            operation_id,
+            source_generation,
+            source_state,
+            stop_timeout_secs,
+        }) => Ok(RestartIntent {
+            operation_id: operation_id.clone(),
+            source_generation: *source_generation,
+            source_state: *source_state,
+            stop_timeout_secs: *stop_timeout_secs,
+        }),
+        _ => Err(ExecutionManagerError::Internal(format!(
+            "restarting execution {id} has no persisted restart intent"
+        ))),
+    }
+}
+
+fn require_matching_restart(
+    record: &BoxRecord,
+    expected_generation: ExecutionGeneration,
+    operation_id: &OperationId,
+    options: RestartExecutionOptions,
+) -> ExecutionManagerResult<()> {
+    let id = execution_id(record)?;
+    let intent = restart_intent(record)?;
+    if intent.operation_id == *operation_id
+        && intent.source_generation == expected_generation
+        && intent.stop_timeout_secs == options.stop_timeout_secs
+    {
+        Ok(())
+    } else {
+        Err(ExecutionManagerError::Conflict {
+            execution_id: id,
+            message: format!(
+                "restart is already owned by operation {} from generation {}",
+                intent.operation_id,
+                intent.source_generation.get()
+            ),
+        })
+    }
+}
+
+fn completed_restart_result(
+    record: &BoxRecord,
+    expected_generation: ExecutionGeneration,
+    operation_id: &OperationId,
+    options: RestartExecutionOptions,
+) -> ExecutionManagerResult<Option<ExecutionManagerResult<ExecutionLease>>> {
+    let id = execution_id(record)?;
+    let Some(completed) = record
+        .managed_execution
+        .as_ref()
+        .and_then(|metadata| metadata.last_restart.as_ref())
+        .filter(|completed| completed.operation_id == *operation_id)
+    else {
+        return Ok(None);
+    };
+    if completed.source_generation != expected_generation {
+        return Ok(Some(Err(ExecutionManagerError::Conflict {
+            execution_id: id,
+            message: format!(
+                "restart operation {operation_id} belongs to generation {}, not {}",
+                completed.source_generation.get(),
+                expected_generation.get()
+            ),
+        })));
+    }
+    if completed.stop_timeout_secs != options.stop_timeout_secs {
+        return Ok(Some(Err(ExecutionManagerError::Conflict {
+            execution_id: id,
+            message: format!(
+                "restart operation {operation_id} was retried with different stop options"
+            ),
+        })));
+    }
+    if completed.outcome == ManagedRestartOutcome::Failed {
+        return Ok(Some(Err(ExecutionManagerError::Conflict {
+            execution_id: id,
+            message: format!(
+                "restart operation {operation_id} failed at generation {}",
+                completed.target_generation.get()
+            ),
+        })));
+    }
+    let current_generation = generation(record, &id)?;
+    if managed_state(record)? == ManagedExecutionState::Running
+        && current_generation == completed.target_generation
+    {
+        return Ok(Some(lease_from_record(record)));
+    }
+    Ok(Some(Err(ExecutionManagerError::Conflict {
+        execution_id: id,
+        message: format!(
+            "restart operation {operation_id} completed, but the execution has since moved"
+        ),
+    })))
+}

--- a/src/runtime/src/local_execution/store.rs
+++ b/src/runtime/src/local_execution/store.rs
@@ -1,8 +1,11 @@
 use a3s_box_core::{
     ExecutionGeneration, ExecutionId, ExecutionManagerError, ExecutionManagerResult, OperationId,
+    RestartExecutionOptions,
 };
 
-use super::record::{apply_handle, apply_start_handle, clear_live_runtime, execution_id};
+use super::record::{
+    apply_handle, apply_restart_handle, apply_start_handle, clear_live_runtime, execution_id,
+};
 use super::support::{generation, managed_state};
 use super::{LocalExecutionHandle, LocalExecutionManager};
 use crate::{
@@ -59,6 +62,22 @@ impl LocalExecutionManager {
                             Some(ManagedExecutionOperation::Pause { keep_memory });
                     }
                 }
+                RuntimeUpdate::RestartClaim {
+                    operation_id,
+                    options,
+                } => {
+                    if let Some(metadata) = record.managed_execution.as_mut() {
+                        metadata.pending_operation = Some(ManagedExecutionOperation::Restart {
+                            operation_id,
+                            source_generation: metadata.generation,
+                            source_state: from,
+                            stop_timeout_secs: options.stop_timeout_secs,
+                        });
+                    }
+                }
+                RuntimeUpdate::RestartAdvance => clear_live_runtime(record, None),
+                RuntimeUpdate::RestartHandle(handle) => apply_restart_handle(record, &handle),
+                RuntimeUpdate::RestartFailed(exit_code) => clear_live_runtime(record, exit_code),
             })
         })
         .await
@@ -122,6 +141,13 @@ pub(super) enum RuntimeUpdate {
     StartHandle(LocalExecutionHandle),
     Terminal(Option<i32>),
     PauseClaim(bool),
+    RestartClaim {
+        operation_id: OperationId,
+        options: RestartExecutionOptions,
+    },
+    RestartAdvance,
+    RestartHandle(LocalExecutionHandle),
+    RestartFailed(Option<i32>),
 }
 
 async fn run_store<T>(

--- a/src/runtime/src/local_execution/support.rs
+++ b/src/runtime/src/local_execution/support.rs
@@ -94,6 +94,22 @@ pub(super) fn pending_pause_policy(
     }
 }
 
+pub(super) fn pending_restart_source_state(
+    record: &BoxRecord,
+    execution_id: &ExecutionId,
+) -> ExecutionManagerResult<ManagedExecutionState> {
+    match record
+        .managed_execution
+        .as_ref()
+        .and_then(|metadata| metadata.pending_operation.as_ref())
+    {
+        Some(ManagedExecutionOperation::Restart { source_state, .. }) => Ok(*source_state),
+        _ => Err(ExecutionManagerError::Internal(format!(
+            "restarting execution {execution_id} has no persisted restart source state"
+        ))),
+    }
+}
+
 pub(super) fn outcome_from_record(
     record: BoxRecord,
     state: ExecutionState,

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -6,7 +6,7 @@ use a3s_box_core::{
     BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionHealthCheck, ExecutionId,
     ExecutionIsolation, ExecutionManager, ExecutionManagerError, ExecutionManagerResult,
     ExecutionRecordPolicy, ExecutionRestartPolicy, ExecutionState, KillOutcome, NetworkMode,
-    OperationId, ReconcileOutcome,
+    OperationId, ReconcileOutcome, RestartExecutionOptions,
 };
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
@@ -28,9 +28,13 @@ struct FakeBackend {
     pauses: AtomicUsize,
     resumes: AtomicUsize,
     kills: AtomicUsize,
+    fail_start: AtomicBool,
+    fail_start_after_effect: AtomicBool,
+    fail_kill_after_effect: AtomicBool,
     fail_pause: AtomicBool,
     fail_pause_after_effect: AtomicBool,
     last_keep_memory: Mutex<Option<bool>>,
+    last_restart_timeout: Mutex<Option<Option<u64>>>,
 }
 
 impl FakeBackend {
@@ -55,6 +59,13 @@ impl FakeBackend {
         execution.state = ExecutionState::Stopped;
         execution.exit_code = Some(exit_code);
     }
+
+    fn fail_externally(&self, execution_id: &ExecutionId, exit_code: i32) {
+        let mut executions = self.executions.lock().unwrap();
+        let execution = executions.get_mut(execution_id.as_str()).unwrap();
+        execution.state = ExecutionState::Failed;
+        execution.exit_code = Some(exit_code);
+    }
 }
 
 #[async_trait]
@@ -62,15 +73,20 @@ impl LocalExecutionBackend for FakeBackend {
     async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
         let mut executions = self.executions.lock().unwrap();
         if let Some(execution) = executions.get(&record.id) {
-            return match execution.state {
-                ExecutionState::Running | ExecutionState::Paused => Ok(execution.handle.clone()),
-                state => Err(ExecutionManagerError::Conflict {
-                    execution_id: Self::execution_id(record),
-                    message: format!("fake execution is {state:?}"),
-                }),
-            };
+            if matches!(
+                execution.state,
+                ExecutionState::Running | ExecutionState::Paused
+            ) {
+                return Ok(execution.handle.clone());
+            }
         }
         self.starts.fetch_add(1, Ordering::Relaxed);
+        if self.fail_start.load(Ordering::Relaxed) {
+            executions.remove(&record.id);
+            return Err(ExecutionManagerError::Unavailable(
+                "fake start is unavailable".to_string(),
+            ));
+        }
         let handle = Self::handle(record);
         executions.insert(
             record.id.clone(),
@@ -80,6 +96,11 @@ impl LocalExecutionBackend for FakeBackend {
                 exit_code: None,
             },
         );
+        if self.fail_start_after_effect.load(Ordering::Relaxed) {
+            return Err(ExecutionManagerError::Unavailable(
+                "fake start response was lost".to_string(),
+            ));
+        }
         Ok(handle)
     }
 
@@ -149,6 +170,15 @@ impl LocalExecutionBackend for FakeBackend {
         Ok(execution.handle.clone())
     }
 
+    async fn stop_for_restart(
+        &self,
+        record: &BoxRecord,
+        timeout_secs: Option<u64>,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        *self.last_restart_timeout.lock().unwrap() = Some(timeout_secs);
+        self.kill(record).await
+    }
+
     async fn kill(&self, record: &BoxRecord) -> ExecutionManagerResult<KillOutcome> {
         self.kills.fetch_add(1, Ordering::Relaxed);
         let mut executions = self.executions.lock().unwrap();
@@ -159,6 +189,11 @@ impl LocalExecutionBackend for FakeBackend {
             return Ok(KillOutcome::AlreadyStopped);
         }
         execution.state = ExecutionState::Stopped;
+        if self.fail_kill_after_effect.load(Ordering::Relaxed) {
+            return Err(ExecutionManagerError::Unavailable(
+                "fake kill response was lost".to_string(),
+            ));
+        }
         Ok(KillOutcome::Killed)
     }
 }
@@ -764,5 +799,471 @@ async fn inspection_persists_an_external_terminal_observation() {
     assert_eq!(
         record.managed_state().unwrap(),
         Some(ManagedExecutionState::Stopped)
+    );
+}
+
+#[tokio::test]
+async fn restart_running_execution_advances_generation_once_and_is_idempotent() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-create"))
+        .await
+        .unwrap();
+    let restart_operation = operation("operation-restart");
+
+    let restarted = manager
+        .restart(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+        )
+        .await
+        .unwrap();
+    let retry = manager
+        .restart(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(restarted.generation, ExecutionGeneration::new(2).unwrap());
+    assert_eq!(retry.generation, restarted.generation);
+    assert_eq!(backend.kills.load(Ordering::Relaxed), 1);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 2);
+    let record = persisted(&manager, &running.execution_id);
+    assert_eq!(
+        record.managed_state().unwrap(),
+        Some(ManagedExecutionState::Running)
+    );
+    let completed = record
+        .managed_execution
+        .unwrap()
+        .last_restart
+        .expect("completed restart must remain durable for idempotent retries");
+    assert_eq!(completed.operation_id, restart_operation);
+    assert_eq!(completed.source_generation, running.generation);
+    assert_eq!(completed.target_generation, restarted.generation);
+}
+
+#[tokio::test]
+async fn stale_restart_generation_has_no_backend_side_effects() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-create"))
+        .await
+        .unwrap();
+
+    let error = manager
+        .restart(
+            &running.execution_id,
+            ExecutionGeneration::new(2).unwrap(),
+            &operation("operation-stale-restart"),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ExecutionManagerError::Conflict { .. }));
+    assert_eq!(backend.kills.load(Ordering::Relaxed), 0);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn restart_persists_stop_options_and_rejects_retry_drift() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-create"))
+        .await
+        .unwrap();
+    let restart_operation = operation("operation-restart");
+    let options = RestartExecutionOptions {
+        stop_timeout_secs: Some(7),
+    };
+
+    manager
+        .restart_with_options(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+            options,
+        )
+        .await
+        .unwrap();
+    let starts_after_restart = backend.starts.load(Ordering::Relaxed);
+    let drift = manager
+        .restart_with_options(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+            RestartExecutionOptions {
+                stop_timeout_secs: Some(8),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(drift, ExecutionManagerError::Conflict { .. }));
+    assert_eq!(backend.starts.load(Ordering::Relaxed), starts_after_restart);
+    assert_eq!(*backend.last_restart_timeout.lock().unwrap(), Some(Some(7)));
+    assert_eq!(
+        persisted(&manager, &running.execution_id)
+            .managed_execution
+            .unwrap()
+            .last_restart
+            .unwrap()
+            .stop_timeout_secs,
+        Some(7)
+    );
+}
+
+#[tokio::test]
+async fn restart_supports_paused_stopped_and_failed_executions() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("paused"), &operation("create-paused"))
+        .await
+        .unwrap();
+    let paused = manager
+        .pause(&running.execution_id, running.generation, true)
+        .await
+        .unwrap();
+    let restarted_paused = manager
+        .restart(
+            &paused.execution_id,
+            paused.generation,
+            &operation("restart-paused"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        restarted_paused.generation,
+        ExecutionGeneration::new(3).unwrap()
+    );
+
+    let stopped = manager
+        .create_and_start(request("stopped"), &operation("create-stopped"))
+        .await
+        .unwrap();
+    manager
+        .kill(&stopped.execution_id, stopped.generation)
+        .await
+        .unwrap();
+    let kills_before_stopped_restart = backend.kills.load(Ordering::Relaxed);
+    let restarted_stopped = manager
+        .restart(
+            &stopped.execution_id,
+            stopped.generation,
+            &operation("restart-stopped"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        restarted_stopped.generation,
+        ExecutionGeneration::new(2).unwrap()
+    );
+    assert_eq!(
+        backend.kills.load(Ordering::Relaxed),
+        kills_before_stopped_restart
+    );
+
+    let failed = manager
+        .create_and_start(request("failed"), &operation("create-failed"))
+        .await
+        .unwrap();
+    backend.fail_externally(&failed.execution_id, 17);
+    assert_eq!(
+        manager.inspect(&failed.execution_id).await.unwrap().state,
+        ExecutionState::Failed
+    );
+    let kills_before_failed_restart = backend.kills.load(Ordering::Relaxed);
+    let restarted_failed = manager
+        .restart(
+            &failed.execution_id,
+            failed.generation,
+            &operation("restart-failed"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        restarted_failed.generation,
+        ExecutionGeneration::new(2).unwrap()
+    );
+    assert_eq!(
+        backend.kills.load(Ordering::Relaxed),
+        kills_before_failed_restart
+    );
+}
+
+#[tokio::test]
+async fn restart_of_an_unstarted_reservation_starts_generation_two_without_kill() {
+    let (_directory, manager, backend) = harness();
+    let created = manager
+        .create(request("created"), &operation("create-created"))
+        .await
+        .unwrap();
+
+    let restarted = manager
+        .restart(
+            &created.execution_id,
+            created.generation,
+            &operation("restart-created"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(restarted.generation, ExecutionGeneration::new(2).unwrap());
+    assert_eq!(backend.kills.load(Ordering::Relaxed), 0);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn restart_recovers_when_kill_succeeded_but_its_response_was_lost() {
+    let (directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-create"))
+        .await
+        .unwrap();
+    let restart_operation = operation("operation-restart");
+    let record = persisted(&manager, &running.execution_id);
+    let claimed = manager
+        .transition(
+            &record,
+            ManagedExecutionState::Running,
+            ManagedExecutionState::RestartStopping,
+            RuntimeUpdate::RestartClaim {
+                operation_id: restart_operation.clone(),
+                options: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+    backend
+        .fail_kill_after_effect
+        .store(true, Ordering::Relaxed);
+    assert!(backend.kill(&claimed).await.is_err());
+    backend
+        .fail_kill_after_effect
+        .store(false, Ordering::Relaxed);
+
+    let restarted_manager = LocalExecutionManager::new(
+        directory.path().join("boxes.json"),
+        directory.path().join("home"),
+        backend.clone(),
+    );
+    let restarted = restarted_manager
+        .restart(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(restarted.generation, ExecutionGeneration::new(2).unwrap());
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn restart_recovers_after_generation_advance_before_backend_start() {
+    let (directory, manager, backend) = harness();
+    let create_operation = operation("operation-create");
+    let running = manager
+        .create_and_start(request("sandbox-1"), &create_operation)
+        .await
+        .unwrap();
+    let restart_operation = operation("operation-restart");
+    let record = persisted(&manager, &running.execution_id);
+    let claimed = manager
+        .transition(
+            &record,
+            ManagedExecutionState::Running,
+            ManagedExecutionState::RestartStopping,
+            RuntimeUpdate::RestartClaim {
+                operation_id: restart_operation.clone(),
+                options: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+    backend.kill(&claimed).await.unwrap();
+    let restarting = manager
+        .transition(
+            &claimed,
+            ManagedExecutionState::RestartStopping,
+            ManagedExecutionState::RestartStarting,
+            RuntimeUpdate::RestartAdvance,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        restarting.managed_execution.as_ref().unwrap().generation,
+        ExecutionGeneration::new(2).unwrap()
+    );
+
+    let restarted_manager = LocalExecutionManager::new(
+        directory.path().join("boxes.json"),
+        directory.path().join("home"),
+        backend.clone(),
+    );
+    let ReconcileOutcome::Ready(restarted) = restarted_manager
+        .reconcile(&create_operation)
+        .await
+        .unwrap()
+    else {
+        panic!("expected restart reconciliation to return a ready lease");
+    };
+
+    assert_eq!(restarted.generation, ExecutionGeneration::new(2).unwrap());
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn concurrent_retries_of_one_restart_start_the_new_generation_once() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-create"))
+        .await
+        .unwrap();
+    let restart_operation = operation("operation-restart");
+
+    let (left, right) = tokio::join!(
+        manager.restart(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+        ),
+        manager.restart(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+        ),
+    );
+
+    let successes = [left, right]
+        .into_iter()
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+    assert_eq!(successes.len(), 2);
+    assert!(successes
+        .iter()
+        .all(|lease| lease.generation == ExecutionGeneration::new(2).unwrap()));
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn a_different_operation_cannot_take_over_an_in_progress_restart() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-create"))
+        .await
+        .unwrap();
+    let record = persisted(&manager, &running.execution_id);
+    manager
+        .transition(
+            &record,
+            ManagedExecutionState::Running,
+            ManagedExecutionState::RestartStopping,
+            RuntimeUpdate::RestartClaim {
+                operation_id: operation("restart-owner"),
+                options: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let error = manager
+        .restart(
+            &running.execution_id,
+            running.generation,
+            &operation("restart-contender"),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ExecutionManagerError::Conflict { .. }));
+    assert_eq!(backend.kills.load(Ordering::Relaxed), 0);
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn ambiguous_restart_start_error_uses_backend_evidence() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-create"))
+        .await
+        .unwrap();
+    backend
+        .fail_start_after_effect
+        .store(true, Ordering::Relaxed);
+
+    let restarted = manager
+        .restart(
+            &running.execution_id,
+            running.generation,
+            &operation("operation-restart"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(restarted.generation, ExecutionGeneration::new(2).unwrap());
+    assert_eq!(backend.starts.load(Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn failed_restart_start_is_terminal_at_the_new_generation() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(request("sandbox-1"), &operation("operation-create"))
+        .await
+        .unwrap();
+    manager
+        .kill(&running.execution_id, running.generation)
+        .await
+        .unwrap();
+    backend.fail_start.store(true, Ordering::Relaxed);
+    let restart_operation = operation("operation-restart");
+
+    let error = manager
+        .restart(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+        )
+        .await
+        .unwrap_err();
+    let attempts_after_failure = backend.starts.load(Ordering::Relaxed);
+    let retry = manager
+        .restart(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ExecutionManagerError::Unavailable(_)));
+    assert!(matches!(retry, ExecutionManagerError::Conflict { .. }));
+    assert_eq!(
+        backend.starts.load(Ordering::Relaxed),
+        attempts_after_failure
+    );
+    let record = persisted(&manager, &running.execution_id);
+    assert_eq!(
+        record.managed_state().unwrap(),
+        Some(ManagedExecutionState::Failed)
+    );
+    assert_eq!(
+        record.managed_execution.as_ref().unwrap().generation,
+        ExecutionGeneration::new(2).unwrap()
+    );
+    assert_eq!(
+        record
+            .managed_execution
+            .unwrap()
+            .last_restart
+            .unwrap()
+            .outcome,
+        crate::ManagedRestartOutcome::Failed
     );
 }

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -20,7 +20,10 @@ use tokio::sync::Mutex;
 use super::resources::ExecutionResourceGuard;
 use super::vm_process::{locate_microvm_process, LocatedProcess};
 use super::{LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation};
-use crate::{BoxRecord, ManagedExecutionMetadata, ManagedExecutionState, VmManager};
+use crate::{
+    BoxRecord, ManagedExecutionMetadata, ManagedExecutionOperation, ManagedExecutionState,
+    VmManager,
+};
 
 type SharedVm = Arc<Mutex<VmManager>>;
 
@@ -231,8 +234,10 @@ impl VmLocalExecutionBackend {
                 record.id
             )));
         }
-        if managed_state(record)? == ManagedExecutionState::Starting
-            && !exec_endpoint_ready(manager.exec_socket_path()).await
+        if matches!(
+            managed_state(record)?,
+            ManagedExecutionState::Starting | ManagedExecutionState::RestartStarting
+        ) && !exec_endpoint_ready(manager.exec_socket_path()).await
         {
             return Ok(LocalExecutionObservation {
                 state: ExecutionState::Creating,
@@ -323,6 +328,8 @@ impl VmLocalExecutionBackend {
         &self,
         record: &BoxRecord,
         shared: SharedVm,
+        remove_anonymous_volumes: bool,
+        timeout_secs: Option<u64>,
     ) -> ExecutionManagerResult<KillOutcome> {
         let mut manager = shared.lock().await;
         let mut anonymous_volumes = if manager.anonymous_volumes().is_empty() {
@@ -330,14 +337,31 @@ impl VmLocalExecutionBackend {
         } else {
             manager.anonymous_volumes().to_vec()
         };
-        let result = manager.destroy().await;
+        let result = if let Some(timeout_secs) = timeout_secs {
+            let timeout_ms = timeout_secs.checked_mul(1_000).ok_or_else(|| {
+                ExecutionManagerError::InvalidRequest(format!(
+                    "restart timeout is too large for execution {}",
+                    record.id
+                ))
+            })?;
+            let signal = record
+                .stop_signal
+                .as_deref()
+                .map(a3s_box_core::vmm::parse_signal_name)
+                .unwrap_or(libc::SIGTERM);
+            manager.destroy_with_options(signal, timeout_ms).await
+        } else {
+            manager.destroy().await
+        };
         drop(manager);
         self.remove_manager(&record.id, &shared);
         result.map_err(|error| runtime_error("kill", record, error))?;
-        if anonymous_volumes.is_empty() {
-            anonymous_volumes = self.anonymous_volumes_for_record(record).await;
+        if remove_anonymous_volumes {
+            if anonymous_volumes.is_empty() {
+                anonymous_volumes = self.anonymous_volumes_for_record(record).await;
+            }
+            self.cleanup_anonymous_volumes(anonymous_volumes).await;
         }
-        self.cleanup_anonymous_volumes(anonymous_volumes).await;
         Ok(KillOutcome::Killed)
     }
 
@@ -531,13 +555,38 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
     async fn kill(&self, record: &BoxRecord) -> ExecutionManagerResult<KillOutcome> {
         let metadata = self.metadata(record)?;
         if let Some(manager) = self.manager(&record.id) {
-            return self.destroy_registered(record, manager).await;
+            return self.destroy_registered(record, manager, true, None).await;
         }
         match metadata.plan.backend {
-            ExecutionBackend::Crun => self.destroy_detached_sandbox(record).await,
+            ExecutionBackend::Crun => self.destroy_detached_sandbox(record, true, None).await,
             ExecutionBackend::Krun => {
                 let manager = self.recover_microvm(record).await?;
-                self.destroy_registered(record, manager).await
+                self.destroy_registered(record, manager, true, None).await
+            }
+        }
+    }
+
+    async fn stop_for_restart(
+        &self,
+        record: &BoxRecord,
+        timeout_secs: Option<u64>,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        let metadata = self.metadata(record)?;
+        let timeout_secs = timeout_secs.or(record.stop_timeout);
+        if let Some(manager) = self.manager(&record.id) {
+            return self
+                .destroy_registered(record, manager, false, timeout_secs)
+                .await;
+        }
+        match metadata.plan.backend {
+            ExecutionBackend::Crun => {
+                self.destroy_detached_sandbox(record, false, timeout_secs)
+                    .await
+            }
+            ExecutionBackend::Krun => {
+                let manager = self.recover_microvm(record).await?;
+                self.destroy_registered(record, manager, false, timeout_secs)
+                    .await
             }
         }
     }
@@ -566,9 +615,28 @@ fn visible_active_state(record: &BoxRecord) -> ExecutionManagerResult<ExecutionS
             Ok(ExecutionState::Paused)
         }
         ManagedExecutionState::Starting
+        | ManagedExecutionState::RestartStarting
         | ManagedExecutionState::Running
         | ManagedExecutionState::Pausing
         | ManagedExecutionState::Killing => Ok(ExecutionState::Running),
+        ManagedExecutionState::RestartStopping => match record
+            .managed_execution
+            .as_ref()
+            .and_then(|metadata| metadata.pending_operation.as_ref())
+        {
+            Some(ManagedExecutionOperation::Restart {
+                source_state: ManagedExecutionState::Paused,
+                ..
+            }) => Ok(ExecutionState::Paused),
+            Some(ManagedExecutionOperation::Restart {
+                source_state: ManagedExecutionState::Running,
+                ..
+            }) => Ok(ExecutionState::Running),
+            _ => Err(ExecutionManagerError::Internal(format!(
+                "execution {} has invalid restart teardown metadata",
+                record.id
+            ))),
+        },
         state => Err(ExecutionManagerError::Internal(format!(
             "execution {} has no active runtime in managed state {state}",
             record.id

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 
 use a3s_box_core::{
-    BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionIsolation, OperationId,
+    volume::VolumeConfig, BoxConfig, CreateExecutionRequest, ExecutionGeneration,
+    ExecutionIsolation, OperationId,
 };
 
 use super::*;
@@ -108,6 +109,35 @@ fn transitional_states_retry_idempotent_pause_and_resume_operations() {
     );
 }
 
+#[test]
+fn restart_teardown_preserves_old_runtime_visibility_until_generation_advance() {
+    let temporary = tempfile::tempdir().unwrap();
+    let mut record = record(temporary.path(), ExecutionIsolation::Microvm);
+    record.status = ManagedExecutionState::RestartStopping
+        .as_status()
+        .to_string();
+    record.managed_execution.as_mut().unwrap().pending_operation =
+        Some(crate::ManagedExecutionOperation::Restart {
+            operation_id: OperationId::new("operation-restart").unwrap(),
+            source_generation: ExecutionGeneration::INITIAL,
+            source_state: ManagedExecutionState::Paused,
+            stop_timeout_secs: None,
+        });
+    assert_eq!(
+        visible_active_state(&record).unwrap(),
+        ExecutionState::Paused
+    );
+
+    record.status = ManagedExecutionState::RestartStarting
+        .as_status()
+        .to_string();
+    record.managed_execution.as_mut().unwrap().generation = ExecutionGeneration::new(2).unwrap();
+    assert_eq!(
+        visible_active_state(&record).unwrap(),
+        ExecutionState::Running
+    );
+}
+
 #[tokio::test]
 async fn unsupported_pause_modes_fail_before_starting_a_runtime() {
     let temporary = tempfile::tempdir().unwrap();
@@ -123,6 +153,30 @@ async fn unsupported_pause_modes_fail_before_starting_a_runtime() {
         .to_string()
         .contains("pause without memory retention"));
     assert!(backend.managers.is_empty());
+}
+
+#[tokio::test]
+async fn restart_stop_preserves_anonymous_volumes_but_terminal_kill_removes_them() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let mut record = record(temporary.path(), ExecutionIsolation::Microvm);
+    let volume_name = "anonymous-restart-volume";
+    let volumes = crate::VolumeStore::new(
+        temporary.path().join("volumes.json"),
+        temporary.path().join("volumes"),
+    );
+    volumes.create(VolumeConfig::new(volume_name, "")).unwrap();
+    record.anonymous_volumes = vec![volume_name.to_string()];
+
+    let manager = Arc::new(Mutex::new(backend.new_manager(&record).unwrap()));
+    backend.managers.insert(record.id.clone(), manager);
+    backend.stop_for_restart(&record, Some(0)).await.unwrap();
+    assert!(volumes.get(volume_name).unwrap().is_some());
+
+    let manager = Arc::new(Mutex::new(backend.new_manager(&record).unwrap()));
+    backend.managers.insert(record.id.clone(), manager);
+    backend.kill(&record).await.unwrap();
+    assert!(volumes.get(volume_name).unwrap().is_none());
 }
 
 #[test]

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -72,7 +72,10 @@ impl VmLocalExecutionBackend {
                 record.box_dir.join("sandbox/runtime.json"),
             ),
         ));
-        if managed_state(record)? != ManagedExecutionState::Starting {
+        if !matches!(
+            managed_state(record)?,
+            ManagedExecutionState::Starting | ManagedExecutionState::RestartStarting
+        ) {
             *manager.state.write().await = crate::BoxState::Ready;
         }
 
@@ -102,10 +105,18 @@ impl VmLocalExecutionBackend {
     pub(super) async fn destroy_detached_sandbox(
         &self,
         record: &BoxRecord,
+        remove_anonymous_volumes: bool,
+        timeout_secs: Option<u64>,
     ) -> ExecutionManagerResult<KillOutcome> {
         self.inspect_sandbox(record).await?;
         if let Some(manager) = self.manager(&record.id) {
-            return self.destroy_registered(record, manager).await;
+            return self
+                .destroy_registered(record, manager, remove_anonymous_volumes, timeout_secs)
+                .await;
+        }
+        if remove_anonymous_volumes {
+            let anonymous_volumes = self.anonymous_volumes_for_record(record).await;
+            self.cleanup_anonymous_volumes(anonymous_volumes).await;
         }
         Ok(KillOutcome::Killed)
     }
@@ -131,8 +142,6 @@ impl VmLocalExecutionBackend {
             .destroy()
             .await
             .map_err(|error| runtime_error("clean up", record, error))?;
-        let anonymous_volumes = self.anonymous_volumes_for_record(record).await;
-        self.cleanup_anonymous_volumes(anonymous_volumes).await;
         Ok(())
     }
 }

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 use a3s_box_core::{ExecutionGeneration, ExecutionId, OperationId};
 use thiserror::Error;
 
-use crate::{BoxRecord, BoxStateStore, ManagedExecutionOperation, ManagedExecutionState};
+use crate::{
+    BoxRecord, BoxStateStore, ManagedExecutionOperation, ManagedExecutionState,
+    ManagedRestartCompletion, ManagedRestartOutcome,
+};
 
 /// Strict durable repository used by the local `ExecutionManager`.
 #[derive(Debug, Clone)]
@@ -154,9 +157,9 @@ impl ManagedExecutionStore {
 
     /// Atomically compare generation and state, then persist one legal edge.
     ///
-    /// Completing pause and resume advances the runtime generation exactly
-    /// once. Claim, rollback, terminal, and kill transitions retain the current
-    /// generation.
+    /// Completing pause and resume, and advancing a restart from teardown to
+    /// startup, increments the runtime generation exactly once. Other edges
+    /// retain the current generation.
     pub fn transition(
         &self,
         execution_id: &ExecutionId,
@@ -242,6 +245,35 @@ impl ManagedExecutionStore {
                 .as_mut()
                 .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
             metadata.generation = next_generation;
+            if expected_state == ManagedExecutionState::RestartStarting
+                && matches!(
+                    next_state,
+                    ManagedExecutionState::Running | ManagedExecutionState::Failed
+                )
+            {
+                let Some(ManagedExecutionOperation::Restart {
+                    operation_id,
+                    source_generation,
+                    stop_timeout_secs,
+                    ..
+                }) = metadata.pending_operation.as_ref()
+                else {
+                    return Err(ManagedExecutionStoreError::InvalidRecord(format!(
+                        "restart completion for {execution_id} has no persisted restart intent"
+                    )));
+                };
+                metadata.last_restart = Some(ManagedRestartCompletion {
+                    operation_id: operation_id.clone(),
+                    source_generation: *source_generation,
+                    target_generation: next_generation,
+                    outcome: if next_state == ManagedExecutionState::Running {
+                        ManagedRestartOutcome::Running
+                    } else {
+                        ManagedRestartOutcome::Failed
+                    },
+                    stop_timeout_secs: *stop_timeout_secs,
+                });
+            }
             metadata.pending_operation = match next_state {
                 ManagedExecutionState::Starting => Some(ManagedExecutionOperation::Start),
                 ManagedExecutionState::Pausing => match metadata.pending_operation.take() {
@@ -250,6 +282,18 @@ impl ManagedExecutionStore {
                 },
                 ManagedExecutionState::Resuming => Some(ManagedExecutionOperation::Resume),
                 ManagedExecutionState::Killing => Some(ManagedExecutionOperation::Kill),
+                ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting => {
+                    match metadata.pending_operation.take() {
+                        Some(operation @ ManagedExecutionOperation::Restart { .. }) => {
+                            Some(operation)
+                        }
+                        _ => {
+                            return Err(ManagedExecutionStoreError::InvalidRecord(format!(
+                            "restart transition for {execution_id} has no persisted restart intent"
+                        )))
+                        }
+                    }
+                }
                 ManagedExecutionState::Creating
                 | ManagedExecutionState::Created
                 | ManagedExecutionState::Running
@@ -308,22 +352,35 @@ fn transition_generation(
     current: ExecutionGeneration,
 ) -> ManagedExecutionStoreResult<ExecutionGeneration> {
     use ManagedExecutionState::{
-        Created, Creating, Failed, Killing, Paused, Pausing, Resuming, Running, Starting, Stopped,
+        Created, Creating, Failed, Killing, Paused, Pausing, RestartStarting, RestartStopping,
+        Resuming, Running, Starting, Stopped,
     };
 
     let legal = matches!(
         (from, to),
         (Creating, Created | Starting | Killing | Stopped | Failed)
-            | (Created, Starting | Killing | Stopped | Failed)
+            | (
+                Created,
+                Starting | Killing | RestartStopping | Stopped | Failed
+            )
             | (
                 Starting,
                 Created | Creating | Running | Killing | Stopped | Failed
             )
-            | (Running, Pausing | Killing | Stopped | Failed)
+            | (
+                Running,
+                Pausing | Killing | RestartStopping | Stopped | Failed
+            )
             | (Pausing, Paused | Running | Killing | Stopped | Failed)
-            | (Paused, Resuming | Killing | Stopped | Failed)
+            | (
+                Paused,
+                Resuming | Killing | RestartStopping | Stopped | Failed
+            )
             | (Resuming, Running | Paused | Killing | Stopped | Failed)
             | (Killing, Stopped | Failed)
+            | (Stopped | Failed, RestartStopping)
+            | (RestartStopping, RestartStarting)
+            | (RestartStarting, Running | Failed)
     );
     if !legal {
         return Err(ManagedExecutionStoreError::InvalidTransition {
@@ -333,7 +390,10 @@ fn transition_generation(
         });
     }
 
-    if matches!((from, to), (Pausing, Paused) | (Resuming, Running)) {
+    if matches!(
+        (from, to),
+        (Pausing, Paused) | (Resuming, Running) | (RestartStopping, RestartStarting)
+    ) {
         let value = current.get().checked_add(1).ok_or_else(|| {
             ManagedExecutionStoreError::InvalidRecord(format!(
                 "execution {execution_id} generation is exhausted"
@@ -505,6 +565,85 @@ mod tests {
             resumed.managed_execution.unwrap().generation,
             ExecutionGeneration::new(3).unwrap()
         );
+    }
+
+    #[test]
+    fn restart_advances_generation_between_durable_teardown_and_startup() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = ManagedExecutionStore::new(directory.path().join("boxes.json"));
+        let id = ExecutionId::new("execution-1").unwrap();
+        store
+            .reserve(managed_record(id.as_str(), "operation-create"))
+            .unwrap();
+        store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Created,
+                ManagedExecutionState::Starting,
+            )
+            .unwrap();
+        store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Starting,
+                ManagedExecutionState::Running,
+            )
+            .unwrap();
+        let restart_operation = OperationId::new("operation-restart").unwrap();
+        let stopping = store
+            .transition_with(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::Running,
+                ManagedExecutionState::RestartStopping,
+                |record| {
+                    record.managed_execution.as_mut().unwrap().pending_operation =
+                        Some(ManagedExecutionOperation::Restart {
+                            operation_id: restart_operation.clone(),
+                            source_generation: ExecutionGeneration::INITIAL,
+                            source_state: ManagedExecutionState::Running,
+                            stop_timeout_secs: Some(10),
+                        });
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            stopping.managed_execution.as_ref().unwrap().generation,
+            ExecutionGeneration::INITIAL
+        );
+
+        let starting = store
+            .transition(
+                &id,
+                ExecutionGeneration::INITIAL,
+                ManagedExecutionState::RestartStopping,
+                ManagedExecutionState::RestartStarting,
+            )
+            .unwrap();
+        let generation_two = ExecutionGeneration::new(2).unwrap();
+        assert_eq!(
+            starting.managed_execution.as_ref().unwrap().generation,
+            generation_two
+        );
+        let running = store
+            .transition(
+                &id,
+                generation_two,
+                ManagedExecutionState::RestartStarting,
+                ManagedExecutionState::Running,
+            )
+            .unwrap();
+        let metadata = running.managed_execution.unwrap();
+        assert_eq!(metadata.generation, generation_two);
+        assert!(metadata.pending_operation.is_none());
+        let completed = metadata.last_restart.unwrap();
+        assert_eq!(completed.operation_id, restart_operation);
+        assert_eq!(completed.source_generation, ExecutionGeneration::INITIAL);
+        assert_eq!(completed.target_generation, generation_two);
+        assert_eq!(completed.outcome, ManagedRestartOutcome::Running);
+        assert_eq!(completed.stop_timeout_secs, Some(10));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add generation-fenced, operation-idempotent managed restart with durable teardown/startup phases
- recover lost kill/start responses and control-process restarts without duplicate generations
- migrate CLI restart while preserving legacy records, stop timeout, health startup, resource ownership, and anonymous volumes
- update runtime/E2B architecture status documentation

## Validation
- cargo fmt --all -- --check
- cargo test -p a3s-box-core
- cargo test -p a3s-box-runtime
- cargo test -p a3s-box-cli
- cargo test -p a3s-box-compat
- cargo clippy -p a3s-box-core -p a3s-box-runtime -p a3s-box-cli --all-targets -- -D warnings -A clippy::needless-return

Strict clippy without the final allow is currently blocked by the pre-existing runtime/src/sandbox/capability.rs:158 needless_return warning.