### PR TITLE
refactor(cli): run through managed execution manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,10 +342,13 @@ acquired by a failed start attempt. Ordinary `start` does not revive a terminal
 managed execution. CLI `restart` now uses a durable two-phase operation that
 terminates the old runtime before advancing the generation, recovers ambiguous
 kill/start responses from backend evidence, and rebinds local resources without
-duplicating ownership. CLI `run` and the Rust SDK still need migration. The production HCL
-service, encrypted credentials, generation-fenced route leases, wildcard TLS
-gateway, envd data plane, and real official-client Sandbox suite also remain
-open gates.
+duplicating ownership. CLI `run` now reserves and starts through the same
+manager, freezes image-defined health and stop defaults into the durable
+request, and leaves network, volume, rootfs, stop, and auto-remove ownership to
+the managed backend. The Rust SDK still needs migration. The production
+HCL service, encrypted credentials, generation-fenced route leases, wildcard
+TLS gateway, envd data plane, and real official-client Sandbox suite also
+remain open gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,8 +1,8 @@
 # E2B Protocol Compatibility and SDK Design
 
 Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 3 complete;
-slice 4 runtime path and staged CLI create/start/restart complete, remaining
-callers pending)**
+slice 4 runtime path and CLI create/start/restart/run complete, Rust SDK
+pending)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -22,7 +22,7 @@ unversioned claim.
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, reaping, and startup reconciliation | Wire the repository and supervisor into the production service process and exercise restart and host-reboot recovery end to end |
-| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI `create`, first `start`, and explicit two-phase `restart` use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery tests; an A3S OS smoke test proves reservation-only create, creation reconciliation, real `crun` start, explicit pause rejection, kill, and cleanup without MicroVM fallback | Validate managed restart on A3S OS, then migrate CLI run and the Rust SDK and add the remaining caller parity tests |
+| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI `create`, first `start`, `run`, and explicit two-phase `restart` use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery tests; A3S OS smoke tests prove reservation-only create, creation reconciliation, real `crun` start, managed restart, explicit pause rejection, kill, and cleanup without MicroVM fallback | Validate managed CLI `run` on A3S OS, migrate the Rust SDK, and add its caller parity tests |
 | Credentials and routing | Injected verifier, token, cursor, and template interfaces isolate protocol logic from infrastructure | Add production credential hashing, token encryption and rotation, generation-fenced route leases, validated wildcard/direct routing, and the TLS data-plane gateway |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
@@ -607,12 +607,11 @@ must not assume that the single-host limit is part of the upstream contract.
 ### Dependency direction
 
 The runtime now owns a canonical managed-execution store, a backend-neutral
-`LocalExecutionManager`, and a production VM/Sandbox backend. CLI `create`
-reserves through that manager, while CLI `start`/`run` still own separate boot
-paths and the Rust SDK intentionally omits those operations. The compatibility
-service must not work around the remaining caller gap by spawning `a3s-box`,
-importing CLI modules, or editing `boxes.json`. Phase 2 completes this
-dependency direction:
+`LocalExecutionManager`, and a production VM/Sandbox backend. CLI
+`create`/`start`/`restart`/`run` use that manager, while the Rust SDK
+intentionally omits those lifecycle operations. The compatibility service must
+not work around the remaining SDK gap by spawning `a3s-box`, importing CLI
+modules, or editing `boxes.json`. Phase 2 completes this dependency direction:
 
 ```text
 a3s-box-core
@@ -785,7 +784,8 @@ Phase 2 is delivered as small, immediately merged changes:
    `ExecutionManager`; add the production backend and prove its real Sandbox
    lifecycle; switch CLI create to the same reservation path; switch CLI
    start/restart/run and the Rust SDK to the same implementation with behavior
-   parity tests. Create, start, and restart are complete; run and the SDK remain.
+   parity tests. CLI create, start, restart, and run are complete; the SDK
+   remains.
 5. Add the production HCL-configured service binary, credential and token
    providers, generation-fenced route leases, and TLS data-plane gateway. Pull
    each merge commit on an A3S OS server and run the unmodified official clients
@@ -825,7 +825,8 @@ generation and requires a new operation ID for any later restart. Graceful-stop
 timeout is part of the restart intent, so a retry cannot silently change it.
 Named-volume and network ownership is released and rebound once, while
 execution-owned anonymous volumes remain available to the replacement
-generation; a terminal kill still removes them.
+generation. Retained terminal stops preserve those anonymous volumes for a
+later restart; auto-remove terminal kills remove them.
 
 The production VM/Sandbox backend is also complete for this slice. It owns live
 runtime handles, reconstructs MicroVM processes with PID identity fencing,
@@ -846,10 +847,18 @@ managed request, including config-only values such as DNS and persistent
 filesystem policy. Named-volume bookkeeping remains attached only after the
 durable reservation succeeds and rolls the reservation back on failure.
 
-Slice 4 remains incomplete until CLI run and the Rust SDK call the same manager
-with behavior parity tests. The existing Rust SDK uses the canonical
-record store for management operations but still has a separate local
-lifecycle model and does not expose create/start/run.
+CLI `run` now submits the complete caller policy to the same manager, starts
+under generation fencing, and reloads the canonical record before foreground
+or detached handling. It resolves image health and stop defaults before
+reservation, reuses the cache during backend start, and delegates network,
+volume, rootfs, stop, and auto-remove ownership to the managed backend. Caller
+parity tests cover isolation, DNS, environment, security, limits, TEE/sidecar,
+logs, health, stop policy, shared memory, persistence, and resource metadata.
+
+Slice 4 remains incomplete until the Rust SDK calls the same manager with
+behavior parity tests. The existing Rust SDK uses the canonical record store
+for management operations but still has a separate local lifecycle model and
+does not expose create/start/run.
 
 Each slice must pass its focused tests and repository CI before merge. The
 Phase 2 gate remains closed until slice 5 composes the durable repository,

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -4,9 +4,11 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use a3s_box_core::config::{BoxConfig, ResourceConfig, SidecarConfig, TeeConfig};
-use a3s_box_core::event::EventEmitter;
-use a3s_box_core::vmm::{parse_signal_name, DEFAULT_SHUTDOWN_TIMEOUT_MS};
-use a3s_box_runtime::VmManager;
+use a3s_box_core::{
+    CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionManager,
+    ExecutionRecordPolicy, ExecutionRestartPolicy, ExecutionState, OperationId,
+};
+use a3s_box_runtime::{LocalExecutionManager, VmLocalExecutionBackend};
 use clap::{Args, ValueEnum};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -137,7 +139,9 @@ pub struct RunArgs {
 
 /// Intermediate state produced by the setup phase, consumed by the run phase.
 struct RunContext {
-    vm: VmManager,
+    manager: LocalExecutionManager,
+    execution_id: ExecutionId,
+    generation: ExecutionGeneration,
     box_id: String,
     box_dir: PathBuf,
     name: String,
@@ -145,11 +149,8 @@ struct RunContext {
     exec_socket_path: PathBuf,
     #[cfg_attr(windows, allow(dead_code))]
     pty_socket_path: PathBuf,
-    volume_names: Vec<String>,
     anonymous_volumes: Vec<String>,
     health_checker: Option<tokio::task::JoinHandle<()>>,
-    stop_signal: i32,
-    stop_timeout_ms: u64,
 }
 
 pub async fn execute(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -389,465 +390,14 @@ fn build_pool_client_run(
     })
 }
 
-// ============================================================================
-// Phase 1: Parse args, build config, boot VM, save state
-// ============================================================================
+mod setup;
 
-async fn setup_and_boot(args: &RunArgs) -> Result<RunContext, Box<dyn std::error::Error>> {
-    common::validate_runtime_options(&args.common)
-        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    let (restart_policy, max_restart_count) =
-        crate::state::parse_restart_policy(&args.common.restart)
-            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-
-    let memory_mb =
-        parse_memory(&args.common.memory).map_err(|e| format!("Invalid --memory: {e}"))?;
-    let resource_limits = common::build_resource_limits(&args.common)?;
-
-    let log_driver: a3s_box_core::log::LogDriver = args
-        .log_driver
-        .parse()
-        .map_err(|e: String| format!("Invalid --log-driver: {e}"))?;
-    let log_opts = common::parse_env_vars(&args.log_opts)
-        .map_err(|e| e.replace("environment variable", "log option"))?;
-    let log_config = a3s_box_core::log::LogConfig {
-        driver: log_driver,
-        options: log_opts,
-    };
-
-    let name = args.common.name.clone().unwrap_or_else(generate_name);
-    let mut env = common::build_env_map(&args.common)?;
-    let port_map = common::normalize_port_maps(&args.common.publish)
-        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    let labels = common::parse_env_vars(&args.common.labels)
-        .map_err(|e| e.replace("environment variable", "label"))?;
-    let entrypoint_override = args
-        .common
-        .entrypoint
-        .as_ref()
-        .map(|ep| ep.split_whitespace().map(String::from).collect::<Vec<_>>());
-    let mut volume_specs = args.common.volumes.clone();
-    apply_package_caches(&args.package_cache, &mut volume_specs, &mut env);
-    let (resolved_volumes, volume_names) = resolve_volumes(&volume_specs)?;
-
-    // Parse --shm-size once; reuse for both tmpfs entry and the box record.
-    let shm_size = match &args.common.shm_size {
-        Some(s) => {
-            Some(common::parse_memory_bytes(s).map_err(|e| format!("Invalid --shm-size: {e}"))?)
-        }
-        None => None,
-    };
-    let mut tmpfs = args.common.tmpfs.clone();
-    if let Some(size_bytes) = shm_size {
-        tmpfs.push(format!("/dev/shm:size={}", size_bytes));
-    }
-
-    let network_mode = match &args.common.network {
-        Some(name) => a3s_box_core::NetworkMode::Bridge {
-            network: name.clone(),
-        },
-        None => a3s_box_core::NetworkMode::Tsi,
-    };
-
-    // Default (TSI) networking proxies guest sockets to the host, so a container
-    // cannot reach its own services over the guest loopback. A health check that
-    // probes localhost would always fail — point the user at bridge networking.
-    if matches!(network_mode, a3s_box_core::NetworkMode::Tsi) {
-        if let Some(cmd) = &args.common.health_cmd {
-            let lc = cmd.to_lowercase();
-            if lc.contains("localhost") || lc.contains("127.0.0.1") {
-                eprintln!(
-                    "warning: the health check probes localhost, but default (TSI) networking \
-                     cannot reach a container's own services over loopback, so the check will fail. \
-                     For a working localhost, create and attach a bridge network: \
-                     `a3s-box network create mynet` then run with `--network mynet`."
-                );
-            }
-        }
-    }
-
-    let tee = build_tee_config(args);
-
-    let config = build_box_config(
-        args,
-        memory_mb,
-        resource_limits.clone(),
-        entrypoint_override.clone(),
-        resolved_volumes.clone(),
-        env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-        port_map.clone(),
-        network_mode.clone(),
-        tmpfs,
-        tee,
-    )
-    .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    a3s_box_core::resolve_execution(&config)?;
-
-    let emitter = EventEmitter::new(256);
-    let mut vm = VmManager::new(config, emitter);
-    // The shim runs the log processor for the box's lifetime (so detached boxes
-    // keep logging after this CLI exits).
-    vm.set_log_config(log_config.clone());
-    let box_id = vm.box_id().to_string();
-    println!(
-        "Creating box {} ({})...",
-        name,
-        BoxRecord::make_short_id(&box_id)
-    );
-
-    let image_name = args.common.image.clone();
-    vm.set_pull_progress_fn(std::sync::Arc::new(move |current, total, digest, size| {
-        if current == 1 && size > 0 {
-            println!("Pulling {}...", image_name);
-        }
-        let short = &digest[digest.len().saturating_sub(12)..];
-        if size < 0 {
-            // Negative size signals completion
-            let actual_size = -size;
-            let size_str = if actual_size >= 1_048_576 {
-                format!("{:.1} MB", actual_size as f64 / 1_048_576.0)
-            } else if actual_size >= 1024 {
-                format!("{:.1} KB", actual_size as f64 / 1024.0)
-            } else {
-                format!("{} B", actual_size)
-            };
-            println!("  [{current}/{total}] {short}: {size_str} ✓");
-        } else {
-            // Positive size means downloading - just show once
-            let size_str = if size >= 1_048_576 {
-                format!("{:.1} MB", size as f64 / 1_048_576.0)
-            } else if size >= 1024 {
-                format!("{:.1} KB", size as f64 / 1024.0)
-            } else {
-                format!("{} B", size)
-            };
-            println!("  [{current}/{total}] {short}: Pulling {size_str}...");
-        }
-    }));
-
-    connect_network(args.common.network.as_deref(), &box_id, &name)?;
-    if let Err(error) = vm.boot().await {
-        crate::cleanup::cleanup_box_resources(
-            &box_id,
-            &volume_names,
-            args.common.network.as_deref(),
-        );
-        return Err(error.into());
-    }
-
-    let image_health_check = vm
-        .image_config()
-        .and_then(|config| config.health_check.clone());
-    let image_stop_signal = vm
-        .image_config()
-        .and_then(|config| config.stop_signal.clone());
-    let health_check = common::effective_health_check(&args.common, image_health_check.as_ref());
-    let effective_stop_signal = common::effective_stop_signal(
-        args.common.stop_signal.as_deref(),
-        image_stop_signal.as_deref(),
-    );
-
-    let pid = vm.pid().await;
-    let box_dir = a3s_box_core::dirs_home().join("boxes").join(&box_id);
-    let exec_socket_path = vm
-        .exec_socket_path()
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| box_dir.join("sockets").join("exec.sock"));
-    let pty_socket_path = vm
-        .pty_socket_path()
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| box_dir.join("sockets").join("pty.sock"));
-
-    let health_status = if health_check.is_some() {
-        "starting"
-    } else {
-        "none"
-    };
-    let record = BoxRecord {
-        id: box_id.clone(),
-        short_id: BoxRecord::make_short_id(&box_id),
-        name: name.clone(),
-        image: args.common.image.clone(),
-        isolation: common::execution_isolation(&args.common),
-        managed_execution: None,
-        status: "running".to_string(),
-        pid,
-        pid_start_time: pid.and_then(crate::process::pid_start_time),
-        cpus: args.common.cpus,
-        memory_mb,
-        volumes: resolved_volumes,
-        virtiofs_cache: args
-            .common
-            .virtiofs_cache
-            .map(|mode| mode.as_guest_value().to_string()),
-        env,
-        cmd: args.cmd.clone(),
-        entrypoint: entrypoint_override.clone(),
-        box_dir: box_dir.clone(),
-        exec_socket_path: exec_socket_path.clone(),
-        console_log: box_dir.join("logs").join("console.log"),
-        created_at: chrono::Utc::now(),
-        started_at: Some(chrono::Utc::now()),
-        auto_remove: args.rm,
-        hostname: args.common.hostname.clone(),
-        user: args.common.user.clone(),
-        workdir: args.common.workdir.clone(),
-        restart_policy,
-        port_map: port_map.clone(),
-        labels,
-        stopped_by_user: false,
-        restart_count: 0,
-        health_check: health_check.clone(),
-        healthcheck_disabled: args.common.no_healthcheck,
-        health_status: health_status.to_string(),
-        health_retries: 0,
-        health_last_check: None,
-        network_mode: network_mode.clone(),
-        network_name: args.common.network.clone(),
-        volume_names: volume_names.clone(),
-        tmpfs: args.common.tmpfs.clone(),
-        anonymous_volumes: vm.anonymous_volumes().to_vec(),
-        resource_limits,
-        log_config: log_config.clone(),
-        add_host: args.common.add_host.clone(),
-        platform: args.common.platform.clone(),
-        init: args.common.init,
-        read_only: args.common.read_only,
-        cap_add: args.common.cap_add.clone(),
-        cap_drop: args.common.cap_drop.clone(),
-        security_opt: args.common.security_opt.clone(),
-        privileged: args.common.privileged,
-        devices: args.common.device.clone(),
-        gpus: args.common.gpus.clone(),
-        shm_size,
-        stop_signal: effective_stop_signal.clone(),
-        stop_timeout: args.common.stop_timeout,
-        oom_kill_disable: args.common.oom_kill_disable,
-        oom_score_adj: args.common.oom_score_adj,
-        max_restart_count,
-        exit_code: None,
-    };
-
-    let stop_signal = effective_stop_signal
-        .as_deref()
-        .map(parse_signal_name)
-        .unwrap_or(15); // SIGTERM = 15
-    let stop_timeout_ms = args
-        .common
-        .stop_timeout
-        .map(|secs| secs.saturating_mul(1000)) // absurd --stop-timeout must not overflow ms
-        .unwrap_or(DEFAULT_SHUTDOWN_TIMEOUT_MS);
-    let anonymous_volumes = vm.anonymous_volumes().to_vec();
-    // Register atomically (load-fresh-under-lock → push → write). A stale
-    // `load_default()` + `state.add()` (save the in-memory snapshot) is a
-    // lost-update race: concurrent fork registrations clobber each other's records,
-    // so a burst of N forks would leave only a fraction registered.
-    if let Err(error) = StateFile::add_record(record.clone()) {
-        rollback_booted_setup(&mut vm, &record, stop_signal, stop_timeout_ms, None).await;
-        return Err(error.into());
-    }
-
-    if should_create_diff_baseline(args) {
-        if let Err(error) = super::diff::create_box_baseline_snapshot(&box_dir) {
-            tracing::warn!(
-                box_id = %box_id,
-                error = %error,
-                "Failed to create rootfs diff baseline snapshot"
-            );
-        }
-    } else {
-        tracing::debug!(
-            box_id = %box_id,
-            "Skipping rootfs diff baseline snapshot for foreground --rm box"
-        );
-    }
-
-    if let Err(error) = super::volume::attach_volumes(&volume_names, &box_id) {
-        // The record was registered atomically above; un-register it the same way.
-        let _ = StateFile::remove_record(&record.id);
-        rollback_booted_setup(&mut vm, &record, stop_signal, stop_timeout_ms, None).await;
-        return Err(error);
-    }
-
-    let log_dir = box_dir.join("logs");
-    if let Err(error) = std::fs::create_dir_all(&log_dir) {
-        let _ = StateFile::remove_record(&record.id);
-        rollback_booted_setup(&mut vm, &record, stop_signal, stop_timeout_ms, None).await;
-        return Err(error.into());
-    }
-    // Log processing now runs in the shim for the box's lifetime; see
-    // VmManager::set_log_config above. (log_dir is still created so the shim's
-    // container.json has a home.)
-    let _ = &log_dir;
-
-    Ok(RunContext {
-        vm,
-        box_id,
-        box_dir,
-        name,
-        record,
-        exec_socket_path,
-        pty_socket_path,
-        volume_names,
-        anonymous_volumes,
-        health_checker: None,
-        stop_signal,
-        stop_timeout_ms,
-    })
-}
-
-/// Build TeeConfig from run args.
-fn build_tee_config(args: &RunArgs) -> TeeConfig {
-    if args.tee || args.tee_simulate {
-        TeeConfig::SevSnp {
-            workload_id: args
-                .tee_workload_id
-                .clone()
-                .unwrap_or_else(|| args.common.image.clone()),
-            generation: Default::default(),
-            simulate: args.tee_simulate,
-        }
-    } else {
-        TeeConfig::None
-    }
-}
-
-/// Build BoxConfig from parsed run arguments.
-#[allow(clippy::too_many_arguments)]
-fn build_box_config(
-    args: &RunArgs,
-    memory_mb: u32,
-    resource_limits: a3s_box_core::config::ResourceLimits,
-    entrypoint_override: Option<Vec<String>>,
-    resolved_volumes: Vec<String>,
-    extra_env: Vec<(String, String)>,
-    port_map: Vec<String>,
-    network: a3s_box_core::NetworkMode,
-    tmpfs: Vec<String>,
-    tee: TeeConfig,
-) -> Result<BoxConfig, String> {
-    let (cmd, entrypoint_override) = if args.tty {
-        (
-            vec!["a3s-box-pty-keepalive".to_string()],
-            Some(interactive_keepalive_entrypoint()),
-        )
-    } else {
-        (args.cmd.clone(), entrypoint_override)
-    };
-
-    Ok(BoxConfig {
-        isolation: common::execution_isolation(&args.common),
-        image: args.common.image.clone(),
-        resources: ResourceConfig {
-            vcpus: args.common.cpus,
-            memory_mb,
-            ..Default::default()
-        },
-        cmd,
-        stdin_open: args.interactive && !args.no_stdin,
-        entrypoint_override,
-        user: common::normalize_user_option(args.common.user.as_deref())?,
-        workdir: args.common.workdir.clone(),
-        hostname: args.common.hostname.clone(),
-        volumes: resolved_volumes,
-        virtiofs_cache: args
-            .common
-            .virtiofs_cache
-            .map(|mode| mode.as_guest_value().to_string()),
-        extra_env,
-        port_map,
-        dns: args.common.dns.clone(),
-        add_hosts: args.common.add_host.clone(),
-        network,
-        tmpfs,
-        resource_limits,
-        tee,
-        read_only: args.common.read_only,
-        cap_add: args.common.cap_add.clone(),
-        cap_drop: args.common.cap_drop.clone(),
-        security_opt: args.common.security_opt.clone(),
-        privileged: args.common.privileged,
-        sidecar: args.sidecar.as_ref().map(|image| SidecarConfig {
-            image: image.clone(),
-            vsock_port: args.sidecar_vsock_port,
-            env: vec![],
-        }),
-        // A box without `--rm` survives its stop like a Docker stopped
-        // container: keep its dir (logs + overlay upper) so `logs`/`start` work
-        // afterwards. `--rm` boxes and CRI pods stay non-persistent (removed on
-        // teardown). `rm` force-removes either way (cleanup_removed_box).
-        persistent: args.common.persistent || !args.rm,
-        ..Default::default()
-    })
-}
-
-fn should_create_diff_baseline(args: &RunArgs) -> bool {
-    !args.rm || args.detach
-}
-
-/// Initial process used only to keep the guest init alive for `run -it`.
-///
-/// The actual user command is executed over the PTY after guest control sockets
-/// are ready, so short-lived interactive commands do not race the VM shutdown.
-fn interactive_keepalive_entrypoint() -> Vec<String> {
-    vec![
-        "/bin/sh".to_string(),
-        "-c".to_string(),
-        "trap 'exit 0' TERM INT; while :; do sleep 3600; done".to_string(),
-    ]
-}
-
-/// Register a network endpoint for the box before booting.
-fn connect_network(
-    net_name: Option<&str>,
-    box_id: &str,
-    name: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let Some(net_name) = net_name else {
-        return Ok(());
-    };
-    let net_store = a3s_box_runtime::NetworkStore::default_path()?;
-    let endpoint = connect_box_to_network(&net_store, net_name, box_id, name)?;
-    println!(
-        "Connected to network {} (IP: {})",
-        net_name, endpoint.ip_address
-    );
-    Ok(())
-}
-
-/// Allocate a network endpoint for a box atomically under the store's
-/// cross-process lock.
-///
-/// A plain `get → connect → update` reads the network outside the lock, so two
-/// concurrent `run --network` could allocate the same IP and drop one endpoint
-/// (#70 fixed the `network`/`start` paths but not this one). Split out from
-/// [`connect_network`] so the lost-update behavior is unit-testable with an
-/// explicit store — `NetworkStore::default_path` reads the process-global
-/// `A3S_HOME`, which cannot be raced safely across tests.
-fn connect_box_to_network(
-    net_store: &a3s_box_runtime::NetworkStore,
-    net_name: &str,
-    box_id: &str,
-    name: &str,
-) -> Result<a3s_box_core::network::NetworkEndpoint, Box<dyn std::error::Error>> {
-    net_store.with_write_lock(
-        |networks| -> Result<a3s_box_core::network::NetworkEndpoint, Box<dyn std::error::Error>> {
-            let net_config =
-                networks
-                    .get_mut(net_name)
-                    .ok_or_else(|| -> Box<dyn std::error::Error> {
-                        format!("network '{}' not found", net_name).into()
-                    })?;
-            super::network::validate_attachable_network(net_config)
-                .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-            net_config
-                .connect(box_id, name)
-                .map_err(|e| -> Box<dyn std::error::Error> {
-                    format!("Failed to connect to network: {e}").into()
-                })
-        },
-    )
-}
+use setup::setup_and_boot;
+#[cfg(test)]
+use setup::{
+    build_box_config, build_execution_request, interactive_keepalive_entrypoint,
+    should_create_diff_baseline, RunRecordPolicy,
+};
 
 // ============================================================================
 // Phase 2a: Interactive PTY mode
@@ -903,13 +453,7 @@ async fn run_tty(mut ctx: RunContext, args: &RunArgs) -> Result<(), Box<dyn std:
     };
 
     // Cleanup
-    cleanup_box(
-        &mut ctx,
-        args.common.network.as_deref(),
-        args.rm,
-        Some(exit_code),
-    )
-    .await;
+    cleanup_box(&mut ctx, args.rm, Some(exit_code)).await?;
 
     if exit_code != 0 {
         std::process::exit(exit_code);
@@ -1043,20 +587,12 @@ async fn run_foreground(
                 break ForegroundStopReason::TimedOut;
             }
             _ = exit_poll.tick() => {
-                if ctx.vm.try_wait_exit().await?.is_some() {
-                    break ForegroundStopReason::ProcessExited;
-                }
-                if ctx.vm.has_exited().await {
-                    // The shim can exit between the reap attempt above and the
-                    // liveness check. Reap once more after observing exit; the
-                    // provider-specific persisted guest status is refreshed
-                    // after the final log drain below.
-                    let _ = ctx.vm.try_wait_exit().await?;
+                if !managed_process_alive(&ctx) {
                     break ForegroundStopReason::ProcessExited;
                 }
             }
             _ = health_poll.tick() => {
-                if !ctx.vm.health_check().await.unwrap_or(false) {
+                if !managed_runtime_healthy(&ctx).await {
                     break ForegroundStopReason::VmUnhealthy;
                 }
             }
@@ -1067,37 +603,17 @@ async fn run_foreground(
         .await;
     log_handle.abort();
 
-    if stop_reason == ForegroundStopReason::ProcessExited {
-        // guest-init syncs the authoritative container exit code into the
-        // writable rootfs before halt. Refresh after draining the final console
-        // bytes so a fast shim exit cannot leave the foreground CLI with its
-        // process-level fallback status.
-        let _ = ctx.vm.try_wait_exit().await?;
-    }
-
-    let exit_code = foreground_exit_code(stop_reason, ctx.vm.exit_code());
+    let persisted_exit_code = a3s_box_runtime::rootfs::read_persisted_exit_code(&ctx.box_dir);
+    let exit_code = foreground_exit_code(stop_reason, persisted_exit_code);
     archive_auto_removed_logs(&ctx, args.rm, exit_code, stop_reason.stopped_by_user());
-
-    // Best-effort teardown: a stop failure (wedged VM, transient store error)
-    // must not orphan the box's other resources, so every step runs regardless
-    // of whether an earlier one failed.
-    if let Some(ref handle) = ctx.health_checker {
-        handle.abort();
-    }
-    if let Err(error) = ctx
-        .vm
-        .destroy_with_options(ctx.stop_signal, ctx.stop_timeout_ms)
-        .await
-    {
-        tracing::warn!(box_id = %ctx.box_id, %error, "Failed to destroy VM on stop; continuing teardown");
-    }
-    teardown_box_resources(
-        &ctx,
-        args.common.network.as_deref(),
+    cleanup_managed_execution(
+        &mut ctx,
         args.rm,
         exit_code,
         stop_reason.stopped_by_user(),
-    );
+        stop_reason == ForegroundStopReason::ProcessExited,
+    )
+    .await?;
     println!(
         "{}",
         foreground_completion_message(stop_reason, args.rm, &ctx.name)
@@ -1161,12 +677,41 @@ fn foreground_log_lengths(paths: &[(&std::path::Path, &AtomicU64)]) -> Vec<u64> 
 }
 
 fn foreground_exit_code(reason: ForegroundStopReason, vm_exit_code: Option<i32>) -> Option<i32> {
-    vm_exit_code.or(match reason {
-        ForegroundStopReason::ProcessExited => None,
-        ForegroundStopReason::UserInterrupted(signal) => Some(128 + signal),
-        ForegroundStopReason::VmUnhealthy => Some(1),
+    match reason {
+        ForegroundStopReason::ProcessExited => vm_exit_code,
+        ForegroundStopReason::UserInterrupted(signal) => vm_exit_code.or(Some(128 + signal)),
+        ForegroundStopReason::VmUnhealthy => vm_exit_code.or(Some(1)),
         ForegroundStopReason::TimedOut => Some(124),
+    }
+}
+
+fn managed_process_alive(ctx: &RunContext) -> bool {
+    ctx.record.pid.is_some_and(|pid| {
+        a3s_box_runtime::is_process_alive_with_identity(pid, ctx.record.pid_start_time)
     })
+}
+
+#[cfg(unix)]
+async fn managed_runtime_healthy(ctx: &RunContext) -> bool {
+    if !managed_process_alive(ctx) {
+        return false;
+    }
+    let probe = async {
+        let client = a3s_box_runtime::ExecClient::connect(&ctx.exec_socket_path)
+            .await
+            .ok()?;
+        client.heartbeat().await.ok().filter(|ready| *ready)
+    };
+    tokio::time::timeout(std::time::Duration::from_millis(500), probe)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
+#[cfg(not(unix))]
+async fn managed_runtime_healthy(ctx: &RunContext) -> bool {
+    managed_process_alive(ctx)
 }
 
 fn foreground_completion_message(
@@ -1199,24 +744,6 @@ fn foreground_completion_message(
 // ============================================================================
 // Shared helpers
 // ============================================================================
-
-async fn rollback_booted_setup(
-    vm: &mut VmManager,
-    record: &BoxRecord,
-    stop_signal: i32,
-    stop_timeout_ms: u64,
-    state: Option<&mut StateFile>,
-) {
-    if let Err(error) = vm.destroy_with_options(stop_signal, stop_timeout_ms).await {
-        tracing::debug!(
-            box_id = %record.id,
-            error = %error,
-            "Failed to destroy VM while rolling back run setup"
-        );
-    }
-
-    crate::cleanup::cleanup_partial_box_record(record, state);
-}
 
 /// Parse health check config from common args.
 #[cfg(test)]
@@ -1283,80 +810,90 @@ fn ensure_package_cache_volume(volume_specs: &mut Vec<String>, volume_spec: &str
     }
 }
 
-/// Disconnect from network if connected.
-fn disconnect_network(
-    box_id: &str,
-    net_name: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(net_name) = net_name {
-        let net_store = a3s_box_runtime::NetworkStore::default_path()?;
-        // Release the endpoint under the lock with a fresh read, so a
-        // concurrent connect to the same network is not clobbered.
-        net_store.with_write_lock(|networks| -> Result<(), Box<dyn std::error::Error>> {
-            if let Some(net_config) = networks.get_mut(net_name) {
-                net_config.disconnect(box_id).ok();
-            }
-            Ok(())
-        })?;
-    }
-    Ok(())
-}
-
-/// Shared cleanup: abort health checker, destroy VM, detach volumes, disconnect network, update state.
+/// Shared cleanup: stop the managed execution and update retained state.
 #[cfg(not(windows))]
 async fn cleanup_box(
     ctx: &mut RunContext,
-    net_name: Option<&str>,
     auto_remove: bool,
     exit_code: Option<i32>,
-) {
-    if let Some(ref handle) = ctx.health_checker {
-        handle.abort();
-    }
+) -> Result<(), Box<dyn std::error::Error>> {
     archive_auto_removed_logs(ctx, auto_remove, exit_code, false);
-    if let Err(error) = ctx
-        .vm
-        .destroy_with_options(ctx.stop_signal, ctx.stop_timeout_ms)
-        .await
-    {
-        tracing::warn!(box_id = %ctx.box_id, %error, "Failed to destroy VM on stop; continuing teardown");
-    }
-    teardown_box_resources(ctx, net_name, auto_remove, exit_code, false);
+    cleanup_managed_execution(ctx, auto_remove, exit_code, false, false).await
 }
 
-/// Best-effort teardown of a box's host + state resources after its VM has been
-/// destroyed. Every step runs even if an earlier one failed, so a wedged VM or a
-/// transient store error never orphans the box's other resources — volume
-/// attachment, network IP, the `boxes.json` record, and the box directory.
-///
-/// State writes go through the atomic primitives (`remove_record`/`modify`) so a
-/// concurrent writer (the monitor, or another box's stop) is not clobbered by a
-/// stale load → mutate → full-vector save.
-fn teardown_box_resources(
-    ctx: &RunContext,
-    net_name: Option<&str>,
+async fn cleanup_managed_execution(
+    ctx: &mut RunContext,
     auto_remove: bool,
     exit_code: Option<i32>,
     stopped_by_user: bool,
-) {
-    super::volume::detach_volumes(&ctx.volume_names, &ctx.box_id);
-    if let Err(error) = disconnect_network(&ctx.box_id, net_name) {
-        tracing::warn!(box_id = %ctx.box_id, %error, "Failed to disconnect network during teardown");
+    natural_exit: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(ref handle) = ctx.health_checker {
+        handle.abort();
     }
-    crate::cleanup::cleanup_external_socket_dir(&ctx.box_dir, &ctx.exec_socket_path);
+
+    let cleanup_result = if natural_exit {
+        match ctx.manager.inspect(&ctx.execution_id).await {
+            Ok(status)
+                if matches!(
+                    status.state,
+                    ExecutionState::Stopped | ExecutionState::Failed
+                ) =>
+            {
+                Ok(())
+            }
+            Ok(_) => ctx
+                .manager
+                .kill(&ctx.execution_id, ctx.generation)
+                .await
+                .map(|_| ()),
+            Err(_) => ctx
+                .manager
+                .kill(&ctx.execution_id, ctx.generation)
+                .await
+                .map(|_| ()),
+        }
+    } else {
+        ctx.manager
+            .kill(&ctx.execution_id, ctx.generation)
+            .await
+            .map(|_| ())
+    };
+
+    cleanup_result.map_err(|error| {
+        format!(
+            "failed to stop managed execution {}; state was preserved for recovery: {error}",
+            ctx.box_id
+        )
+    })?;
 
     if auto_remove {
-        crate::cleanup::cleanup_anonymous_volumes(&ctx.anonymous_volumes);
-        if let Err(error) = remove_auto_removed_record(&ctx.box_id, exit_code, stopped_by_user) {
-            tracing::warn!(box_id = %ctx.box_id, %error, "Failed to remove box record during teardown");
+        StateFile::remove_record(&ctx.box_id)
+            .map_err(|error| format!("failed to remove box {} state: {error}", ctx.box_id))?;
+        if natural_exit {
+            // Explicit managed kills remove auto-remove anonymous volumes in the
+            // backend. Natural exit has no kill path, so the CLI owns cleanup.
+            crate::cleanup::cleanup_anonymous_volumes(&ctx.anonymous_volumes);
         }
-        let _ = std::fs::remove_dir_all(&ctx.box_dir);
-    } else if let Err(error) = StateFile::modify(|s| {
-        mark_record_stopped(s, &ctx.box_id, exit_code, stopped_by_user);
-        Ok::<(), std::io::Error>(())
-    }) {
-        tracing::warn!(box_id = %ctx.box_id, %error, "Failed to mark box stopped during teardown");
+        if let Err(error) = std::fs::remove_dir_all(&ctx.box_dir) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                return Err(format!(
+                    "removed box {} state but failed to remove {}: {error}",
+                    ctx.box_id,
+                    ctx.box_dir.display()
+                )
+                .into());
+            }
+        }
+    } else {
+        StateFile::modify(|s| {
+            mark_record_stopped(s, &ctx.box_id, exit_code, stopped_by_user);
+            Ok::<(), std::io::Error>(())
+        })
+        .map_err(|error| format!("failed to mark box {} stopped: {error}", ctx.box_id))?;
     }
+
+    Ok(())
 }
 
 fn archive_auto_removed_logs(
@@ -1396,16 +933,6 @@ fn should_print_retained_log_hint(exit_code: Option<i32>, stopped_by_user: bool)
     matches!(exit_code, Some(code) if code != 0) && !stopped_by_user
 }
 
-fn remove_auto_removed_record(
-    box_id: &str,
-    exit_code: Option<i32>,
-    stopped_by_user: bool,
-) -> Result<Option<BoxRecord>, std::io::Error> {
-    StateFile::take_record(box_id).map(|record| {
-        record.map(|record| stopped_record_for_archive(&record, exit_code, stopped_by_user))
-    })
-}
-
 fn stopped_record_for_archive(
     record: &BoxRecord,
     exit_code: Option<i32>,
@@ -1434,933 +961,5 @@ fn mark_record_stopped(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Regression for the `run --network` lost-update race: connect_box_to_network
-    // must allocate a distinct IP per concurrent caller. A get → connect → update
-    // (the pre-fix code) would dup IPs and drop endpoints. The advisory lock is
-    // per-open-file-description, so separate FileLock::acquire calls serialize
-    // even across threads in one process — which exercises the fix in-process.
-    #[test]
-    fn concurrent_connect_box_to_network_allocates_distinct_ips() {
-        use a3s_box_core::network::NetworkConfig;
-        use a3s_box_runtime::NetworkStore;
-        use std::collections::HashSet;
-        use std::sync::Arc;
-
-        let dir = tempfile::tempdir().unwrap();
-        let store = Arc::new(NetworkStore::new(dir.path().join("networks.json")));
-        store
-            .create(NetworkConfig::new("dev", "10.88.0.0/24").unwrap())
-            .unwrap();
-
-        let handles: Vec<_> = (0..16)
-            .map(|i| {
-                let store = Arc::clone(&store);
-                std::thread::spawn(move || {
-                    connect_box_to_network(&store, "dev", &format!("box-{i}"), &format!("name-{i}"))
-                        .unwrap()
-                        .ip_address
-                })
-            })
-            .collect();
-        let ips: HashSet<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
-        assert_eq!(
-            ips.len(),
-            16,
-            "every concurrent connect must get a distinct IP (no lost update)"
-        );
-    }
-
-    // --- build_resource_limits tests (using new struct layout) ---
-
-    fn default_run_args() -> RunArgs {
-        RunArgs {
-            common: common::CommonBoxArgs {
-                image: "test".to_string(),
-                isolation: None,
-                name: None,
-                cpus: 2,
-                memory: "512m".to_string(),
-                volumes: vec![],
-                env: vec![],
-                publish: vec![],
-                dns: vec![],
-                entrypoint: None,
-                hostname: None,
-                user: None,
-                workdir: None,
-                restart: "no".to_string(),
-                labels: vec![],
-                tmpfs: vec![],
-                virtiofs_cache: None,
-                network: None,
-                health_cmd: None,
-                health_interval: 30,
-                health_timeout: 5,
-                health_retries: 3,
-                health_start_period: 0,
-                pids_limit: None,
-                cpuset_cpus: None,
-                ulimits: vec![],
-                cpu_shares: None,
-                cpu_quota: None,
-                cpu_period: None,
-                memory_reservation: None,
-                memory_swap: None,
-                env_file: vec![],
-                add_host: vec![],
-                platform: None,
-                init: false,
-                read_only: false,
-                cap_add: vec![],
-                cap_drop: vec![],
-                security_opt: vec![],
-                privileged: false,
-                device: vec![],
-                gpus: None,
-                shm_size: None,
-                stop_signal: None,
-                stop_timeout: None,
-                no_healthcheck: false,
-                oom_kill_disable: false,
-                oom_score_adj: None,
-                persistent: false,
-            },
-            detach: false,
-            interactive: false,
-            no_stdin: false,
-            tty: false,
-            timeout: None,
-            rm: false,
-            pool: false,
-            pool_socket: DEFAULT_SOCKET.to_string(),
-            pool_autostart: false,
-            pool_exec: false,
-            package_cache: vec![],
-            cmd: vec![],
-            log_driver: "json-file".to_string(),
-            log_opts: vec![],
-            tee: false,
-            tee_workload_id: None,
-            tee_simulate: false,
-            sidecar: None,
-            sidecar_vsock_port: 4092,
-        }
-    }
-
-    fn default_pool_run_args() -> RunArgs {
-        let mut args = default_run_args();
-        args.pool = true;
-        args.rm = true;
-        args.cmd = vec!["echo".to_string(), "hello".to_string()];
-        args
-    }
-
-    #[test]
-    fn test_foreground_auto_remove_skips_diff_baseline() {
-        let mut args = default_run_args();
-        args.rm = true;
-
-        assert!(!should_create_diff_baseline(&args));
-    }
-
-    #[test]
-    fn test_detached_auto_remove_keeps_diff_baseline_while_running() {
-        let mut args = default_run_args();
-        args.rm = true;
-        args.detach = true;
-
-        assert!(should_create_diff_baseline(&args));
-    }
-
-    #[test]
-    fn test_persistent_run_keeps_diff_baseline() {
-        let args = default_run_args();
-
-        assert!(should_create_diff_baseline(&args));
-    }
-
-    #[test]
-    fn test_build_resource_limits_defaults() {
-        let args = default_run_args();
-        let limits = common::build_resource_limits(&args.common).unwrap();
-        assert!(limits.pids_limit.is_none());
-        assert!(limits.cpuset_cpus.is_none());
-        assert!(limits.cpu_shares.is_none());
-        assert!(limits.memory_reservation.is_none());
-        assert!(limits.memory_swap.is_none());
-    }
-
-    #[test]
-    fn test_build_resource_limits_with_values() {
-        let mut args = default_run_args();
-        args.common.pids_limit = Some(100);
-        args.common.cpuset_cpus = Some("0-3".to_string());
-        args.common.ulimits = vec!["nofile=1024:4096".to_string()];
-        args.common.cpu_shares = Some(512);
-        args.common.cpu_quota = Some(50000);
-        args.common.cpu_period = Some(100000);
-        args.common.memory_reservation = Some("256m".to_string());
-        args.common.memory_swap = Some("-1".to_string());
-
-        let limits = common::build_resource_limits(&args.common).unwrap();
-        assert_eq!(limits.pids_limit, Some(100));
-        assert_eq!(limits.cpuset_cpus, Some("0-3".to_string()));
-        assert_eq!(limits.cpu_shares, Some(512));
-        assert_eq!(limits.cpu_quota, Some(50000));
-        assert_eq!(limits.cpu_period, Some(100000));
-        assert_eq!(limits.memory_reservation, Some(256 * 1024 * 1024));
-        assert_eq!(limits.memory_swap, Some(-1));
-    }
-
-    #[test]
-    fn test_build_resource_limits_memory_swap_value() {
-        let mut args = default_run_args();
-        args.common.memory_swap = Some("1g".to_string());
-
-        let limits = common::build_resource_limits(&args.common).unwrap();
-        assert_eq!(limits.memory_swap, Some(1024 * 1024 * 1024));
-    }
-
-    #[test]
-    fn test_parse_health_check_none() {
-        let args = default_run_args();
-        assert!(parse_health_check(&args.common).is_none());
-    }
-
-    #[test]
-    fn test_parse_health_check_disabled() {
-        let mut args = default_run_args();
-        args.common.health_cmd = Some("curl localhost".to_string());
-        args.common.no_healthcheck = true;
-        assert!(parse_health_check(&args.common).is_none());
-    }
-
-    #[test]
-    fn test_parse_health_check_configured() {
-        let mut args = default_run_args();
-        args.common.health_cmd = Some("curl localhost".to_string());
-        args.common.health_interval = 10;
-        args.common.health_retries = 5;
-        let hc = parse_health_check(&args.common).unwrap();
-        assert_eq!(hc.cmd, vec!["sh", "-c", "curl localhost"]);
-        assert_eq!(hc.interval_secs, 10);
-        assert_eq!(hc.retries, 5);
-    }
-
-    #[test]
-    fn test_validate_run_mode_rejects_detached_tty_before_boot() {
-        let mut args = default_run_args();
-        args.detach = true;
-        args.tty = true;
-
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("Cannot use -t"));
-    }
-
-    #[test]
-    fn test_validate_run_mode_rejects_tty_without_terminal_before_boot() {
-        let mut args = default_run_args();
-        args.tty = true;
-
-        let err = validate_run_mode(&args, false).unwrap_err();
-        assert!(err.contains("requires a terminal"));
-    }
-
-    #[test]
-    fn test_validate_run_mode_allows_detached_without_tty() {
-        let mut args = default_run_args();
-        args.detach = true;
-
-        assert!(validate_run_mode(&args, false).is_ok());
-    }
-
-    #[test]
-    fn test_validate_run_mode_rejects_no_stdin_with_interactive() {
-        let mut args = default_run_args();
-        args.interactive = true;
-        args.no_stdin = true;
-
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("--interactive"));
-    }
-
-    #[test]
-    fn test_validate_run_mode_rejects_invalid_timeout_modes() {
-        let mut args = default_run_args();
-        args.timeout = Some(0);
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("greater than zero"));
-
-        let mut args = default_run_args();
-        args.timeout = Some(30);
-        args.detach = true;
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("--timeout"));
-        assert!(err.contains("detach"));
-
-        let mut args = default_run_args();
-        args.timeout = Some(30);
-        args.tty = true;
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("--timeout"));
-        assert!(err.contains("tty"));
-    }
-
-    #[test]
-    fn test_validate_pool_run_mode_requires_auto_remove_and_command() {
-        let mut args = default_pool_run_args();
-        args.rm = false;
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("requires --rm"));
-
-        let mut args = default_pool_run_args();
-        args.cmd = vec![];
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("explicit command"));
-    }
-
-    #[test]
-    fn test_validate_pool_run_mode_rejects_unsupported_modes() {
-        let mut args = default_pool_run_args();
-        args.detach = true;
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("--pool"));
-        assert!(err.contains("detach"));
-
-        let mut args = default_pool_run_args();
-        args.interactive = true;
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("--interactive"));
-
-        let mut args = default_pool_run_args();
-        args.common.publish = vec!["8080:80".to_string()];
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("currently supports only"));
-
-        let mut args = default_pool_run_args();
-        args.common.name = Some("named-pool-run".to_string());
-        let err = validate_run_mode(&args, true).unwrap_err();
-        assert!(err.contains("currently supports only"));
-    }
-
-    #[test]
-    fn test_validate_pool_run_mode_allows_timeout() {
-        let mut args = default_pool_run_args();
-        args.timeout = Some(30);
-
-        assert!(validate_run_mode(&args, true).is_ok());
-    }
-
-    #[test]
-    fn test_selected_pool_socket_prefers_explicit_pool_socket() {
-        let mut args = default_pool_run_args();
-        args.pool_socket = "/tmp/explicit.sock".to_string();
-
-        assert_eq!(
-            selected_pool_socket(&args, Some("/tmp/env.sock")).as_deref(),
-            Some("/tmp/explicit.sock")
-        );
-    }
-
-    #[test]
-    fn test_selected_pool_socket_uses_env_for_compatible_foreground_run() {
-        let mut args = default_run_args();
-        args.rm = true;
-        args.cmd = vec!["bash".to_string(), "-lc".to_string(), "echo ok".to_string()];
-        args.package_cache = vec![PackageCache::Pnpm];
-        args.common.volumes = vec!["/host/work:/workspace:rw".to_string()];
-        args.common.workdir = Some("/workspace".to_string());
-
-        assert_eq!(
-            selected_pool_socket(&args, Some(" /tmp/runtime.sock ")).as_deref(),
-            Some("/tmp/runtime.sock")
-        );
-    }
-
-    #[test]
-    fn test_selected_pool_socket_ignores_env_for_incompatible_run() {
-        let mut args = default_run_args();
-        args.rm = true;
-        args.detach = true;
-        args.cmd = vec!["echo".to_string(), "ok".to_string()];
-
-        assert!(selected_pool_socket(&args, Some("/tmp/runtime.sock")).is_none());
-
-        let mut named = default_run_args();
-        named.rm = true;
-        named.common.name = Some("named-run".to_string());
-        named.cmd = vec!["echo".to_string(), "ok".to_string()];
-        assert!(selected_pool_socket(&named, Some("/tmp/runtime.sock")).is_none());
-        assert!(selected_pool_socket(&args, Some("")).is_none());
-    }
-
-    #[test]
-    fn test_selected_pool_socket_uses_autostart_flag() {
-        let mut args = default_pool_run_args();
-        args.pool = false;
-        args.pool_autostart = true;
-        args.pool_socket = "/tmp/autostart.sock".to_string();
-
-        assert_eq!(
-            selected_pool_socket(&args, None).as_deref(),
-            Some("/tmp/autostart.sock")
-        );
-    }
-
-    #[test]
-    fn test_pool_autostart_config_prewarms_simple_run() {
-        let args = default_pool_run_args();
-        let config = pool_autostart_config_for_run(&args, "/tmp/pool.sock").unwrap();
-
-        assert_eq!(config.socket, "/tmp/pool.sock");
-        assert_eq!(config.image.as_deref(), Some("test"));
-    }
-
-    #[test]
-    fn test_pool_autostart_config_skips_prewarm_for_volume_shape() {
-        let mut args = default_pool_run_args();
-        args.common.volumes = vec!["/host:/work:ro".to_string()];
-        let config = pool_autostart_config_for_run(&args, "/tmp/pool.sock").unwrap();
-
-        assert!(config.image.is_none());
-    }
-
-    #[test]
-    fn test_build_pool_client_run_plumbs_supported_options() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env_file = tmp.path().join("env.list");
-        std::fs::write(&env_file, "B=file\nC=file\n").unwrap();
-        let bind = format!("{}:/workspace:ro", tmp.path().display());
-
-        let mut args = default_pool_run_args();
-        args.common.image = "node:24-bookworm".to_string();
-        args.common.cpus = 4;
-        args.common.memory = "2g".to_string();
-        args.common.volumes = vec![bind.clone()];
-        args.common.env = vec!["A=cli".to_string(), "B=cli".to_string()];
-        args.common.env_file = vec![env_file.display().to_string()];
-        args.common.user = Some("root".to_string());
-        args.common.workdir = Some("/workspace".to_string());
-        args.pool_socket = "/tmp/a3s-box-test-pool.sock".to_string();
-        args.pool_exec = true;
-        args.timeout = Some(45);
-
-        let req = build_pool_client_run(&args, &args.pool_socket).unwrap();
-
-        assert_eq!(req.socket, "/tmp/a3s-box-test-pool.sock");
-        assert_eq!(req.image.as_deref(), Some("node:24-bookworm"));
-        assert_eq!(req.user.as_deref(), Some("0"));
-        assert_eq!(req.workdir.as_deref(), Some("/workspace"));
-        assert_eq!(req.volumes, vec![bind]);
-        assert_eq!(req.vcpus, 4);
-        assert_eq!(req.memory_mb, 2048);
-        assert!(req.exec);
-        assert_eq!(req.timeout_ns, Some(45_000_000_000));
-        assert_eq!(req.cmd, vec!["echo", "hello"]);
-        assert_eq!(req.env, vec!["A=cli", "B=cli", "C=file"]);
-    }
-
-    #[test]
-    fn test_apply_package_caches_adds_pnpm_volume_and_env() {
-        let mut volumes = Vec::new();
-        let mut env = std::collections::HashMap::new();
-
-        apply_package_caches(&[PackageCache::Pnpm], &mut volumes, &mut env);
-
-        assert_eq!(volumes, vec![PNPM_CACHE_VOLUME_SPEC.to_string()]);
-        assert_eq!(
-            env.get(PNPM_CONFIG_STORE_ENV).map(String::as_str),
-            Some(PNPM_STORE_DIR)
-        );
-        assert_eq!(
-            env.get(PNPM_STORE_ENV).map(String::as_str),
-            Some(PNPM_STORE_DIR)
-        );
-        assert_eq!(
-            env.get(PNPM_COREPACK_HOME_ENV).map(String::as_str),
-            Some(PNPM_COREPACK_HOME_DIR)
-        );
-        assert_eq!(
-            env.get(PNPM_HOME_ENV).map(String::as_str),
-            Some(PNPM_HOME_DIR)
-        );
-        assert_eq!(
-            env.get(PNPM_NPM_CACHE_ENV).map(String::as_str),
-            Some(PNPM_NPM_CACHE_DIR)
-        );
-        assert_eq!(
-            env.get(PNPM_CONFIG_PREFER_OFFLINE_ENV).map(String::as_str),
-            Some(PNPM_PREFER_OFFLINE_VALUE)
-        );
-        assert_eq!(
-            env.get(PNPM_PREFER_OFFLINE_ENV).map(String::as_str),
-            Some(PNPM_PREFER_OFFLINE_VALUE)
-        );
-        assert_eq!(
-            env.get(COREPACK_DOWNLOAD_PROMPT_ENV).map(String::as_str),
-            Some(COREPACK_DOWNLOAD_PROMPT_VALUE)
-        );
-    }
-
-    #[test]
-    fn test_apply_package_caches_preserves_user_pnpm_env() {
-        let mut volumes = Vec::new();
-        let mut env = std::collections::HashMap::from([
-            (
-                PNPM_CONFIG_STORE_ENV.to_string(),
-                "/custom/pnpm-config-store".to_string(),
-            ),
-            (PNPM_STORE_ENV.to_string(), "/custom/pnpm-store".to_string()),
-            (
-                PNPM_COREPACK_HOME_ENV.to_string(),
-                "/custom/corepack".to_string(),
-            ),
-            (PNPM_HOME_ENV.to_string(), "/custom/pnpm-home".to_string()),
-            (
-                PNPM_NPM_CACHE_ENV.to_string(),
-                "/custom/npm-cache".to_string(),
-            ),
-            (
-                PNPM_CONFIG_PREFER_OFFLINE_ENV.to_string(),
-                "false".to_string(),
-            ),
-            (PNPM_PREFER_OFFLINE_ENV.to_string(), "false".to_string()),
-            (COREPACK_DOWNLOAD_PROMPT_ENV.to_string(), "1".to_string()),
-        ]);
-
-        apply_package_caches(&[PackageCache::Pnpm], &mut volumes, &mut env);
-
-        assert_eq!(
-            env.get(PNPM_CONFIG_STORE_ENV).map(String::as_str),
-            Some("/custom/pnpm-config-store")
-        );
-        assert_eq!(
-            env.get(PNPM_STORE_ENV).map(String::as_str),
-            Some("/custom/pnpm-store")
-        );
-        assert_eq!(
-            env.get(PNPM_COREPACK_HOME_ENV).map(String::as_str),
-            Some("/custom/corepack")
-        );
-        assert_eq!(
-            env.get(PNPM_HOME_ENV).map(String::as_str),
-            Some("/custom/pnpm-home")
-        );
-        assert_eq!(
-            env.get(PNPM_NPM_CACHE_ENV).map(String::as_str),
-            Some("/custom/npm-cache")
-        );
-        assert_eq!(
-            env.get(PNPM_CONFIG_PREFER_OFFLINE_ENV).map(String::as_str),
-            Some("false")
-        );
-        assert_eq!(
-            env.get(PNPM_PREFER_OFFLINE_ENV).map(String::as_str),
-            Some("false")
-        );
-        assert_eq!(
-            env.get(COREPACK_DOWNLOAD_PROMPT_ENV).map(String::as_str),
-            Some("1")
-        );
-    }
-
-    #[test]
-    fn test_apply_package_caches_deduplicates_pnpm_volume() {
-        let mut volumes = vec![PNPM_CACHE_VOLUME_SPEC.to_string()];
-        let mut env = std::collections::HashMap::new();
-
-        apply_package_caches(
-            &[PackageCache::Pnpm, PackageCache::Pnpm],
-            &mut volumes,
-            &mut env,
-        );
-
-        assert_eq!(volumes, vec![PNPM_CACHE_VOLUME_SPEC.to_string()]);
-    }
-
-    #[test]
-    fn test_apply_package_caches_adds_npm_volume_and_env() {
-        let mut volumes = Vec::new();
-        let mut env = std::collections::HashMap::new();
-
-        apply_package_caches(&[PackageCache::Npm], &mut volumes, &mut env);
-
-        assert_eq!(volumes, vec![NPM_CACHE_VOLUME_SPEC.to_string()]);
-        assert_eq!(
-            env.get(NPM_CACHE_ENV).map(String::as_str),
-            Some(NPM_CACHE_DIR)
-        );
-        assert_eq!(
-            env.get(NPM_PREFER_OFFLINE_ENV).map(String::as_str),
-            Some(NPM_PREFER_OFFLINE_VALUE)
-        );
-        assert!(!env.contains_key(PNPM_STORE_ENV));
-        assert!(!env.contains_key(PNPM_COREPACK_HOME_ENV));
-        assert!(!env.contains_key(PNPM_HOME_ENV));
-    }
-
-    #[test]
-    fn test_apply_package_caches_preserves_user_npm_env() {
-        let mut volumes = Vec::new();
-        let mut env = std::collections::HashMap::from([
-            (NPM_CACHE_ENV.to_string(), "/custom/npm-cache".to_string()),
-            (NPM_PREFER_OFFLINE_ENV.to_string(), "false".to_string()),
-        ]);
-
-        apply_package_caches(&[PackageCache::Npm], &mut volumes, &mut env);
-
-        assert_eq!(
-            env.get(NPM_CACHE_ENV).map(String::as_str),
-            Some("/custom/npm-cache")
-        );
-        assert_eq!(
-            env.get(NPM_PREFER_OFFLINE_ENV).map(String::as_str),
-            Some("false")
-        );
-    }
-
-    #[test]
-    fn test_apply_package_caches_deduplicates_npm_volume() {
-        let mut volumes = vec![NPM_CACHE_VOLUME_SPEC.to_string()];
-        let mut env = std::collections::HashMap::new();
-
-        apply_package_caches(
-            &[PackageCache::Npm, PackageCache::Npm],
-            &mut volumes,
-            &mut env,
-        );
-
-        assert_eq!(volumes, vec![NPM_CACHE_VOLUME_SPEC.to_string()]);
-    }
-
-    #[test]
-    fn test_build_box_config_uses_keepalive_for_interactive_tty_boot() {
-        let mut args = default_run_args();
-        args.tty = true;
-        args.cmd = vec!["/bin/echo".to_string(), "hello".to_string()];
-
-        let config = build_box_config(
-            &args,
-            512,
-            Default::default(),
-            None,
-            vec![],
-            vec![],
-            vec![],
-            a3s_box_core::NetworkMode::Tsi,
-            vec![],
-            TeeConfig::None,
-        )
-        .unwrap();
-
-        assert_eq!(config.cmd, vec!["a3s-box-pty-keepalive"]);
-        assert_eq!(
-            config.entrypoint_override,
-            Some(interactive_keepalive_entrypoint())
-        );
-    }
-
-    #[test]
-    fn test_build_box_config_plumbs_virtiofs_cache_mode() {
-        let mut args = default_run_args();
-        args.common.virtiofs_cache = Some(common::VirtiofsCacheMode::Always);
-
-        let config = build_box_config(
-            &args,
-            512,
-            Default::default(),
-            None,
-            vec![],
-            vec![],
-            vec![],
-            a3s_box_core::NetworkMode::Tsi,
-            vec![],
-            TeeConfig::None,
-        )
-        .unwrap();
-
-        assert_eq!(config.virtiofs_cache.as_deref(), Some("always"));
-    }
-
-    #[test]
-    fn test_build_box_config_preserves_non_tty_command() {
-        let mut args = default_run_args();
-        args.cmd = vec!["/bin/echo".to_string(), "hello".to_string()];
-        let entrypoint = Some(vec!["/custom-entrypoint".to_string()]);
-
-        let config = build_box_config(
-            &args,
-            512,
-            Default::default(),
-            entrypoint.clone(),
-            vec![],
-            vec![],
-            vec![],
-            a3s_box_core::NetworkMode::Tsi,
-            vec![],
-            TeeConfig::None,
-        )
-        .unwrap();
-
-        assert_eq!(config.cmd, args.cmd);
-        assert_eq!(config.entrypoint_override, entrypoint);
-    }
-
-    #[test]
-    fn test_build_box_config_controls_stdin_open() {
-        let args = default_run_args();
-        let config = build_box_config(
-            &args,
-            512,
-            Default::default(),
-            None,
-            vec![],
-            vec![],
-            vec![],
-            a3s_box_core::NetworkMode::Tsi,
-            vec![],
-            TeeConfig::None,
-        )
-        .unwrap();
-        assert!(!config.stdin_open);
-
-        let mut args = default_run_args();
-        args.interactive = true;
-        let config = build_box_config(
-            &args,
-            512,
-            Default::default(),
-            None,
-            vec![],
-            vec![],
-            vec![],
-            a3s_box_core::NetworkMode::Tsi,
-            vec![],
-            TeeConfig::None,
-        )
-        .unwrap();
-        assert!(config.stdin_open);
-
-        let mut args = default_run_args();
-        args.no_stdin = true;
-        let config = build_box_config(
-            &args,
-            512,
-            Default::default(),
-            None,
-            vec![],
-            vec![],
-            vec![],
-            a3s_box_core::NetworkMode::Tsi,
-            vec![],
-            TeeConfig::None,
-        )
-        .unwrap();
-        assert!(!config.stdin_open);
-    }
-
-    #[test]
-    fn test_mark_record_stopped_persists_exit_context() {
-        let record = crate::test_helpers::fixtures::make_record(
-            "550e8400-e29b-41d4-a716-446655440000",
-            "run-exit",
-            "running",
-            Some(1234),
-        );
-        let (_tmp, mut state) = crate::test_helpers::fixtures::setup_state(vec![record]);
-
-        mark_record_stopped(
-            &mut state,
-            "550e8400-e29b-41d4-a716-446655440000",
-            Some(42),
-            true,
-        );
-
-        let record = state
-            .find_by_id("550e8400-e29b-41d4-a716-446655440000")
-            .unwrap();
-        assert_eq!(record.status, "stopped");
-        assert_eq!(record.pid, None);
-        assert_eq!(record.exit_code, Some(42));
-        assert!(record.stopped_by_user);
-    }
-
-    #[test]
-    fn test_foreground_exit_code_preserves_vm_code() {
-        assert_eq!(
-            foreground_exit_code(
-                ForegroundStopReason::UserInterrupted(FOREGROUND_SIGTERM),
-                Some(143)
-            ),
-            Some(143)
-        );
-        assert_eq!(
-            foreground_exit_code(ForegroundStopReason::VmUnhealthy, Some(2)),
-            Some(2)
-        );
-    }
-
-    #[test]
-    fn test_foreground_exit_code_has_deterministic_fallbacks() {
-        assert_eq!(
-            foreground_exit_code(ForegroundStopReason::ProcessExited, None),
-            None
-        );
-        assert_eq!(
-            foreground_exit_code(
-                ForegroundStopReason::UserInterrupted(FOREGROUND_SIGINT),
-                None
-            ),
-            Some(130)
-        );
-        assert_eq!(
-            foreground_exit_code(
-                ForegroundStopReason::UserInterrupted(FOREGROUND_SIGTERM),
-                None
-            ),
-            Some(143)
-        );
-        assert_eq!(
-            foreground_exit_code(ForegroundStopReason::VmUnhealthy, None),
-            Some(1)
-        );
-        assert_eq!(
-            foreground_exit_code(ForegroundStopReason::TimedOut, None),
-            Some(124)
-        );
-    }
-
-    #[test]
-    fn test_foreground_stop_reason_user_flag() {
-        assert!(ForegroundStopReason::UserInterrupted(FOREGROUND_SIGINT).stopped_by_user());
-        assert!(!ForegroundStopReason::ProcessExited.stopped_by_user());
-        assert!(!ForegroundStopReason::VmUnhealthy.stopped_by_user());
-        assert!(!ForegroundStopReason::TimedOut.stopped_by_user());
-    }
-
-    #[test]
-    fn test_foreground_poll_cadence_avoids_fixed_startup_delay() {
-        assert!(FOREGROUND_EXIT_POLL <= std::time::Duration::from_millis(20));
-        assert!(FOREGROUND_EXIT_POLL < FOREGROUND_HEALTH_POLL);
-        assert!(FOREGROUND_LOG_DRAIN_QUIET <= std::time::Duration::from_millis(50));
-        assert!(FOREGROUND_LOG_DRAIN_POLL < FOREGROUND_LOG_DRAIN_QUIET);
-    }
-
-    #[test]
-    fn test_retained_log_hint_only_for_non_user_failures() {
-        assert!(should_print_retained_log_hint(Some(1), false));
-        assert!(!should_print_retained_log_hint(Some(0), false));
-        assert!(!should_print_retained_log_hint(None, false));
-        assert!(!should_print_retained_log_hint(Some(130), true));
-    }
-
-    #[test]
-    fn test_foreground_completion_messages() {
-        assert_eq!(
-            foreground_completion_message(ForegroundStopReason::ProcessExited, true, "box"),
-            "Box box exited and was removed."
-        );
-        assert_eq!(
-            foreground_completion_message(
-                ForegroundStopReason::UserInterrupted(FOREGROUND_SIGINT),
-                false,
-                "box"
-            ),
-            "Box box stopped."
-        );
-        assert_eq!(
-            foreground_completion_message(ForegroundStopReason::VmUnhealthy, true, "box"),
-            "Box box stopped after VM health check failed and was removed."
-        );
-        assert_eq!(
-            foreground_completion_message(ForegroundStopReason::TimedOut, false, "box"),
-            "Box box stopped after --timeout expired."
-        );
-    }
-
-    #[test]
-    fn test_build_box_config_passes_security_options() {
-        let mut args = default_run_args();
-        args.common.cap_add = vec!["NET_ADMIN".to_string()];
-        args.common.cap_drop = vec!["NET_RAW".to_string()];
-        args.common.security_opt = vec!["seccomp=unconfined".to_string()];
-        args.common.privileged = true;
-
-        let config = build_box_config(
-            &args,
-            512,
-            a3s_box_core::config::ResourceLimits::default(),
-            None,
-            vec![],
-            vec![],
-            vec![],
-            a3s_box_core::NetworkMode::Tsi,
-            vec![],
-            TeeConfig::None,
-        )
-        .unwrap();
-
-        assert_eq!(config.cap_add, vec!["NET_ADMIN"]);
-        assert_eq!(config.cap_drop, vec!["NET_RAW"]);
-        assert_eq!(config.security_opt, vec!["seccomp=unconfined"]);
-        assert!(config.privileged);
-    }
-
-    #[test]
-    fn test_build_box_config_passes_user_and_workdir() {
-        let mut args = default_run_args();
-        args.common.user = Some("root:root".to_string());
-        args.common.workdir = Some("/app".to_string());
-
-        let config = build_box_config(
-            &args,
-            512,
-            a3s_box_core::config::ResourceLimits::default(),
-            None,
-            vec![],
-            vec![],
-            vec![],
-            a3s_box_core::NetworkMode::Tsi,
-            vec![],
-            TeeConfig::None,
-        )
-        .unwrap();
-
-        assert_eq!(config.user.as_deref(), Some("0:0"));
-        assert_eq!(config.workdir.as_deref(), Some("/app"));
-    }
-
-    #[test]
-    fn test_build_box_config_passes_hostname_and_add_hosts() {
-        let mut args = default_run_args();
-        args.common.hostname = Some("web".to_string());
-        args.common.add_host = vec!["db.local:10.88.0.10".to_string()];
-
-        let config = build_box_config(
-            &args,
-            512,
-            a3s_box_core::config::ResourceLimits::default(),
-            None,
-            vec![],
-            vec![],
-            vec![],
-            a3s_box_core::NetworkMode::Tsi,
-            vec![],
-            TeeConfig::None,
-        )
-        .unwrap();
-
-        assert_eq!(config.hostname.as_deref(), Some("web"));
-        assert_eq!(config.add_hosts, vec!["db.local:10.88.0.10"]);
-    }
-
-    #[test]
-    fn test_resolve_volumes_empty() {
-        let (resolved, names) = resolve_volumes(&[]).unwrap();
-        assert!(resolved.is_empty());
-        assert!(names.is_empty());
-    }
-}
+#[path = "run/tests.rs"]
+mod tests;

--- a/src/cli/src/commands/run/request_tests.rs
+++ b/src/cli/src/commands/run/request_tests.rs
@@ -1,0 +1,163 @@
+use super::*;
+
+#[test]
+fn test_build_box_config_selects_requested_sandbox_isolation() {
+    let mut args = default_run_args();
+    args.common.isolation = Some(common::IsolationArg::Sandbox);
+
+    let config = build_box_config(
+        &args,
+        512,
+        Default::default(),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+
+    assert_eq!(config.isolation, a3s_box_core::ExecutionIsolation::Sandbox);
+}
+
+#[test]
+fn test_managed_run_request_preserves_complete_caller_intent() {
+    let mut args = default_run_args();
+    args.common.image = "registry.example/worker:v2".to_string();
+    args.common.cpus = 6;
+    args.common.dns = vec!["1.1.1.1".to_string(), "8.8.8.8".to_string()];
+    args.common.hostname = Some("worker".to_string());
+    args.common.user = Some("root".to_string());
+    args.common.workdir = Some("/workspace".to_string());
+    args.common.virtiofs_cache = Some(common::VirtiofsCacheMode::Always);
+    args.common.tmpfs = vec!["/tmp:size=16m".to_string()];
+    args.common.add_host = vec!["db.internal:10.0.0.2".to_string()];
+    args.common.read_only = true;
+    args.common.cap_add = vec!["NET_ADMIN".to_string()];
+    args.common.cap_drop = vec!["NET_RAW".to_string()];
+    args.common.security_opt = vec!["no-new-privileges".to_string()];
+    args.common.privileged = true;
+    args.common.pids_limit = Some(128);
+    args.common.cpuset_cpus = Some("0-2".to_string());
+    args.common.cpu_shares = Some(1024);
+    args.common.memory_reservation = Some("512m".to_string());
+    args.common.memory_swap = Some("2g".to_string());
+    args.common.platform = Some("linux/arm64".to_string());
+    args.common.init = true;
+    args.common.device = vec!["/dev/fuse:/dev/fuse".to_string()];
+    args.common.gpus = Some("all".to_string());
+    args.common.stop_timeout = Some(9);
+    args.common.oom_kill_disable = true;
+    args.common.oom_score_adj = Some(125);
+    args.common.persistent = true;
+    args.rm = true;
+    args.cmd = vec!["python".to_string(), "worker.py".to_string()];
+    args.sidecar = Some("registry.example/proxy:v1".to_string());
+    args.sidecar_vsock_port = 5001;
+
+    let resource_limits = common::build_resource_limits(&args.common).unwrap();
+    let tee = TeeConfig::SevSnp {
+        workload_id: "worker-v2".to_string(),
+        generation: Default::default(),
+        simulate: true,
+    };
+    let config = build_box_config(
+        &args,
+        4096,
+        resource_limits.clone(),
+        Some(vec!["/entrypoint".to_string()]),
+        vec!["/host/workspace:/workspace:rw".to_string()],
+        vec![("MODE".to_string(), "test".to_string())],
+        vec!["8080:80".to_string()],
+        a3s_box_core::NetworkMode::Bridge {
+            network: "dev".to_string(),
+        },
+        args.common.tmpfs.clone(),
+        tee.clone(),
+    )
+    .unwrap();
+    let health_check = crate::state::HealthCheck {
+        cmd: vec!["test".to_string(), "-f".to_string(), "/ready".to_string()],
+        interval_secs: 11,
+        timeout_secs: 3,
+        retries: 7,
+        start_period_secs: 5,
+    };
+    let log_config = a3s_box_core::log::LogConfig {
+        driver: a3s_box_core::log::LogDriver::None,
+        options: std::collections::HashMap::from([("tag".to_string(), "worker".to_string())]),
+    };
+    let operation_id = OperationId::new("cli-run-request-test").unwrap();
+    let labels = std::collections::BTreeMap::from([("team".to_string(), "sandbox".to_string())]);
+    let request = build_execution_request(
+        &args,
+        &operation_id,
+        config,
+        labels.clone(),
+        RunRecordPolicy {
+            name: "managed-worker".to_string(),
+            restart_policy: ExecutionRestartPolicy::OnFailure,
+            max_restart_count: 4,
+            health_check: Some(health_check.clone()),
+            log_config: log_config.clone(),
+            volume_names: vec!["workspace".to_string()],
+            shm_size: Some(64 * 1024 * 1024),
+            stop_signal: Some("SIGINT".to_string()),
+        },
+    );
+
+    assert_eq!(request.external_sandbox_id, operation_id.as_str());
+    assert_eq!(request.labels, labels);
+    assert_eq!(request.config.image, "registry.example/worker:v2");
+    assert_eq!(request.config.resources.vcpus, 6);
+    assert_eq!(request.config.resources.memory_mb, 4096);
+    assert_eq!(
+        serde_json::to_value(&request.config.resource_limits).unwrap(),
+        serde_json::to_value(&resource_limits).unwrap()
+    );
+    assert_eq!(request.config.cmd, vec!["python", "worker.py"]);
+    assert_eq!(
+        request.config.entrypoint_override,
+        Some(vec!["/entrypoint".to_string()])
+    );
+    assert_eq!(
+        request.config.extra_env,
+        vec![("MODE".to_string(), "test".to_string())]
+    );
+    assert_eq!(request.config.dns, vec!["1.1.1.1", "8.8.8.8"]);
+    assert_eq!(request.config.cap_add, vec!["NET_ADMIN"]);
+    assert_eq!(request.config.cap_drop, vec!["NET_RAW"]);
+    assert_eq!(request.config.security_opt, vec!["no-new-privileges"]);
+    assert!(request.config.privileged);
+    assert_eq!(request.config.tee, tee);
+    assert_eq!(
+        request
+            .config
+            .sidecar
+            .as_ref()
+            .map(|sidecar| (sidecar.image.as_str(), sidecar.vsock_port)),
+        Some(("registry.example/proxy:v1", 5001))
+    );
+    assert!(request.config.persistent);
+    assert_eq!(request.policy.name.as_deref(), Some("managed-worker"));
+    assert!(request.policy.auto_remove);
+    assert_eq!(
+        request.policy.restart_policy,
+        ExecutionRestartPolicy::OnFailure
+    );
+    assert_eq!(request.policy.max_restart_count, 4);
+    assert_eq!(request.policy.health_check, Some(health_check));
+    assert_eq!(request.policy.log_config, log_config);
+    assert_eq!(request.policy.volume_names, vec!["workspace"]);
+    assert_eq!(request.policy.platform.as_deref(), Some("linux/arm64"));
+    assert!(request.policy.init);
+    assert_eq!(request.policy.devices, vec!["/dev/fuse:/dev/fuse"]);
+    assert_eq!(request.policy.gpus.as_deref(), Some("all"));
+    assert_eq!(request.policy.shm_size, Some(64 * 1024 * 1024));
+    assert_eq!(request.policy.stop_signal.as_deref(), Some("SIGINT"));
+    assert_eq!(request.policy.stop_timeout, Some(9));
+    assert!(request.policy.oom_kill_disable);
+    assert_eq!(request.policy.oom_score_adj, Some(125));
+}

--- a/src/cli/src/commands/run/setup.rs
+++ b/src/cli/src/commands/run/setup.rs
@@ -1,0 +1,404 @@
+use super::*;
+
+pub(super) struct RunRecordPolicy {
+    pub(super) name: String,
+    pub(super) restart_policy: ExecutionRestartPolicy,
+    pub(super) max_restart_count: u32,
+    pub(super) health_check: Option<crate::state::HealthCheck>,
+    pub(super) log_config: a3s_box_core::log::LogConfig,
+    pub(super) volume_names: Vec<String>,
+    pub(super) shm_size: Option<u64>,
+    pub(super) stop_signal: Option<String>,
+}
+
+// ============================================================================
+// Phase 1: Parse args, build config, boot VM, save state
+// ============================================================================
+
+pub(super) async fn setup_and_boot(
+    args: &RunArgs,
+) -> Result<RunContext, Box<dyn std::error::Error>> {
+    common::validate_runtime_options(&args.common)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let (restart_policy, max_restart_count) =
+        crate::state::parse_restart_policy(&args.common.restart)
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let restart_policy = execution_restart_policy(&restart_policy)?;
+
+    let memory_mb =
+        parse_memory(&args.common.memory).map_err(|e| format!("Invalid --memory: {e}"))?;
+    let resource_limits = common::build_resource_limits(&args.common)?;
+
+    let log_driver: a3s_box_core::log::LogDriver = args
+        .log_driver
+        .parse()
+        .map_err(|e: String| format!("Invalid --log-driver: {e}"))?;
+    let log_opts = common::parse_env_vars(&args.log_opts)
+        .map_err(|e| e.replace("environment variable", "log option"))?;
+    let log_config = a3s_box_core::log::LogConfig {
+        driver: log_driver,
+        options: log_opts,
+    };
+
+    let name = args.common.name.clone().unwrap_or_else(generate_name);
+    let mut env = common::build_env_map(&args.common)?;
+    let port_map = common::normalize_port_maps(&args.common.publish)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let labels = common::parse_env_vars(&args.common.labels)
+        .map_err(|e| e.replace("environment variable", "label"))?
+        .into_iter()
+        .collect();
+    let entrypoint_override = args
+        .common
+        .entrypoint
+        .as_ref()
+        .map(|ep| ep.split_whitespace().map(String::from).collect::<Vec<_>>());
+    let mut volume_specs = args.common.volumes.clone();
+    apply_package_caches(&args.package_cache, &mut volume_specs, &mut env);
+    let (resolved_volumes, volume_names) = resolve_volumes(&volume_specs)?;
+
+    // Parse --shm-size once; reuse for both tmpfs entry and the box record.
+    let shm_size = match &args.common.shm_size {
+        Some(s) => {
+            Some(common::parse_memory_bytes(s).map_err(|e| format!("Invalid --shm-size: {e}"))?)
+        }
+        None => None,
+    };
+    let network_mode = match &args.common.network {
+        Some(name) => a3s_box_core::NetworkMode::Bridge {
+            network: name.clone(),
+        },
+        None => a3s_box_core::NetworkMode::Tsi,
+    };
+
+    // Default (TSI) networking proxies guest sockets to the host, so a container
+    // cannot reach its own services over the guest loopback. A health check that
+    // probes localhost would always fail — point the user at bridge networking.
+    if matches!(network_mode, a3s_box_core::NetworkMode::Tsi) {
+        if let Some(cmd) = &args.common.health_cmd {
+            let lc = cmd.to_lowercase();
+            if lc.contains("localhost") || lc.contains("127.0.0.1") {
+                eprintln!(
+                    "warning: the health check probes localhost, but default (TSI) networking \
+                     cannot reach a container's own services over loopback, so the check will fail. \
+                     For a working localhost, create and attach a bridge network: \
+                     `a3s-box network create mynet` then run with `--network mynet`."
+                );
+            }
+        }
+    }
+
+    let tee = build_tee_config(args);
+
+    let config = build_box_config(
+        args,
+        memory_mb,
+        resource_limits.clone(),
+        entrypoint_override.clone(),
+        resolved_volumes.clone(),
+        env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+        port_map.clone(),
+        network_mode.clone(),
+        args.common.tmpfs.clone(),
+        tee,
+    )
+    .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    a3s_box_core::resolve_execution(&config)?;
+
+    // Freeze image-defined lifecycle defaults into the managed creation
+    // request. Pulling is cache-first, and happens only after the pure backend
+    // compatibility check above, so an invalid Sandbox request has no registry
+    // or runtime side effects.
+    let pull_progress_fn = pull_progress_callback(args.common.image.clone());
+    let image_config = pull_image_config(args, std::sync::Arc::clone(&pull_progress_fn)).await?;
+    let health_check =
+        common::effective_health_check(&args.common, image_config.health_check.as_ref());
+    let effective_stop_signal = common::effective_stop_signal(
+        args.common.stop_signal.as_deref(),
+        image_config.stop_signal.as_deref(),
+    );
+
+    let operation_id = OperationId::new(format!("cli-run-{}", uuid::Uuid::new_v4()))?;
+    let request = build_execution_request(
+        args,
+        &operation_id,
+        config,
+        labels,
+        RunRecordPolicy {
+            name: name.clone(),
+            restart_policy,
+            max_restart_count,
+            health_check,
+            log_config,
+            volume_names,
+            shm_size,
+            stop_signal: effective_stop_signal,
+        },
+    );
+    let home = a3s_box_core::dirs_home();
+    let backend = VmLocalExecutionBackend::new(&home).with_pull_progress_fn(pull_progress_fn);
+    let manager =
+        LocalExecutionManager::new(home.join("boxes.json"), &home, std::sync::Arc::new(backend));
+    let reservation = manager.create(request, &operation_id).await?;
+    let execution_id = reservation.execution_id.clone();
+    let box_id = execution_id.to_string();
+    println!(
+        "Creating box {} ({})...",
+        name,
+        BoxRecord::make_short_id(&box_id)
+    );
+    let lease = match manager.start(&execution_id, reservation.generation).await {
+        Ok(lease) => lease,
+        Err(error) => {
+            cleanup_failed_managed_run(&box_id);
+            return Err(error.into());
+        }
+    };
+    // A short-lived command can exit between `start` and this reload. Use the
+    // side-effect-free snapshot so legacy PID reconciliation cannot auto-remove
+    // the just-created managed record before foreground cleanup observes it.
+    let record = StateFile::load_readonly()?
+        .find_by_id(&box_id)
+        .cloned()
+        .ok_or_else(|| format!("managed run {box_id} disappeared after startup"))?;
+    let box_dir = record.box_dir.clone();
+    let exec_socket_path = record.exec_socket_path.clone();
+    let pty_socket_path = exec_socket_path
+        .parent()
+        .map(|parent| parent.join("pty.sock"))
+        .unwrap_or_else(|| box_dir.join("sockets/pty.sock"));
+    let anonymous_volumes = record.anonymous_volumes.clone();
+
+    if should_create_diff_baseline(args) {
+        if let Err(error) = crate::commands::diff::create_box_baseline_snapshot(&box_dir) {
+            tracing::warn!(
+                box_id = %box_id,
+                error = %error,
+                "Failed to create rootfs diff baseline snapshot"
+            );
+        }
+    } else {
+        tracing::debug!(
+            box_id = %box_id,
+            "Skipping rootfs diff baseline snapshot for foreground --rm box"
+        );
+    }
+
+    Ok(RunContext {
+        manager,
+        execution_id,
+        generation: lease.generation,
+        box_id,
+        box_dir,
+        name,
+        record,
+        exec_socket_path,
+        pty_socket_path,
+        anonymous_volumes,
+        health_checker: None,
+    })
+}
+
+fn pull_progress_callback(image_name: String) -> a3s_box_runtime::PullProgressFn {
+    std::sync::Arc::new(move |current, total, digest, size| {
+        if current == 1 && size > 0 {
+            println!("Pulling {}...", image_name);
+        }
+        let short = &digest[digest.len().saturating_sub(12)..];
+        if size < 0 {
+            // Negative size signals completion
+            let actual_size = -size;
+            let size_str = if actual_size >= 1_048_576 {
+                format!("{:.1} MB", actual_size as f64 / 1_048_576.0)
+            } else if actual_size >= 1024 {
+                format!("{:.1} KB", actual_size as f64 / 1024.0)
+            } else {
+                format!("{} B", actual_size)
+            };
+            println!("  [{current}/{total}] {short}: {size_str} ✓");
+        } else {
+            // Positive size means downloading - just show once
+            let size_str = if size >= 1_048_576 {
+                format!("{:.1} MB", size as f64 / 1_048_576.0)
+            } else if size >= 1024 {
+                format!("{:.1} KB", size as f64 / 1024.0)
+            } else {
+                format!("{} B", size)
+            };
+            println!("  [{current}/{total}] {short}: Pulling {size_str}...");
+        }
+    })
+}
+
+async fn pull_image_config(
+    args: &RunArgs,
+    progress: a3s_box_runtime::PullProgressFn,
+) -> Result<a3s_box_runtime::oci::OciImageConfig, Box<dyn std::error::Error>> {
+    let store = std::sync::Arc::new(crate::commands::open_image_store()?);
+    let reference = a3s_box_runtime::ImageReference::parse(&args.common.image)?;
+    let auth = a3s_box_runtime::RegistryAuth::from_credential_store(&reference.registry);
+    let puller =
+        a3s_box_runtime::ImagePuller::with_platform(store, auth, args.common.platform.clone())
+            .with_progress_fn(progress);
+    Ok(puller.pull(&args.common.image).await?.config().clone())
+}
+
+fn cleanup_failed_managed_run(box_id: &str) {
+    let Ok(state) = StateFile::load_default() else {
+        return;
+    };
+    let Some(record) = state.find_by_id(box_id).cloned() else {
+        return;
+    };
+    if let Err(error) = crate::cleanup::cleanup_removed_box(&record) {
+        tracing::warn!(box_id, %error, "Failed to roll back managed run startup");
+        return;
+    }
+    if let Err(error) = StateFile::remove_record(box_id) {
+        tracing::warn!(box_id, %error, "Failed to remove rolled-back managed run record");
+    }
+}
+
+fn execution_restart_policy(value: &str) -> Result<ExecutionRestartPolicy, String> {
+    match value {
+        "no" => Ok(ExecutionRestartPolicy::No),
+        "always" => Ok(ExecutionRestartPolicy::Always),
+        "on-failure" => Ok(ExecutionRestartPolicy::OnFailure),
+        "unless-stopped" => Ok(ExecutionRestartPolicy::UnlessStopped),
+        other => Err(format!("Invalid normalized restart policy: {other}")),
+    }
+}
+
+pub(super) fn build_execution_request(
+    args: &RunArgs,
+    operation_id: &OperationId,
+    config: BoxConfig,
+    labels: std::collections::BTreeMap<String, String>,
+    record: RunRecordPolicy,
+) -> CreateExecutionRequest {
+    CreateExecutionRequest {
+        external_sandbox_id: operation_id.as_str().to_string(),
+        config,
+        labels,
+        policy: ExecutionRecordPolicy {
+            name: Some(record.name),
+            auto_remove: args.rm,
+            restart_policy: record.restart_policy,
+            max_restart_count: record.max_restart_count,
+            health_check: record.health_check,
+            healthcheck_disabled: args.common.no_healthcheck,
+            log_config: record.log_config,
+            volume_names: record.volume_names,
+            platform: args.common.platform.clone(),
+            init: args.common.init,
+            devices: args.common.device.clone(),
+            gpus: args.common.gpus.clone(),
+            shm_size: record.shm_size,
+            stop_signal: record.stop_signal,
+            stop_timeout: args.common.stop_timeout,
+            oom_kill_disable: args.common.oom_kill_disable,
+            oom_score_adj: args.common.oom_score_adj,
+        },
+    }
+}
+
+/// Build TeeConfig from run args.
+fn build_tee_config(args: &RunArgs) -> TeeConfig {
+    if args.tee || args.tee_simulate {
+        TeeConfig::SevSnp {
+            workload_id: args
+                .tee_workload_id
+                .clone()
+                .unwrap_or_else(|| args.common.image.clone()),
+            generation: Default::default(),
+            simulate: args.tee_simulate,
+        }
+    } else {
+        TeeConfig::None
+    }
+}
+
+/// Build BoxConfig from parsed run arguments.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn build_box_config(
+    args: &RunArgs,
+    memory_mb: u32,
+    resource_limits: a3s_box_core::config::ResourceLimits,
+    entrypoint_override: Option<Vec<String>>,
+    resolved_volumes: Vec<String>,
+    extra_env: Vec<(String, String)>,
+    port_map: Vec<String>,
+    network: a3s_box_core::NetworkMode,
+    tmpfs: Vec<String>,
+    tee: TeeConfig,
+) -> Result<BoxConfig, String> {
+    let (cmd, entrypoint_override) = if args.tty {
+        (
+            vec!["a3s-box-pty-keepalive".to_string()],
+            Some(interactive_keepalive_entrypoint()),
+        )
+    } else {
+        (args.cmd.clone(), entrypoint_override)
+    };
+
+    Ok(BoxConfig {
+        isolation: common::execution_isolation(&args.common),
+        image: args.common.image.clone(),
+        resources: ResourceConfig {
+            vcpus: args.common.cpus,
+            memory_mb,
+            ..Default::default()
+        },
+        cmd,
+        stdin_open: args.interactive && !args.no_stdin,
+        entrypoint_override,
+        user: common::normalize_user_option(args.common.user.as_deref())?,
+        workdir: args.common.workdir.clone(),
+        hostname: args.common.hostname.clone(),
+        volumes: resolved_volumes,
+        virtiofs_cache: args
+            .common
+            .virtiofs_cache
+            .map(|mode| mode.as_guest_value().to_string()),
+        extra_env,
+        port_map,
+        dns: args.common.dns.clone(),
+        add_hosts: args.common.add_host.clone(),
+        network,
+        tmpfs,
+        resource_limits,
+        tee,
+        read_only: args.common.read_only,
+        cap_add: args.common.cap_add.clone(),
+        cap_drop: args.common.cap_drop.clone(),
+        security_opt: args.common.security_opt.clone(),
+        privileged: args.common.privileged,
+        sidecar: args.sidecar.as_ref().map(|image| SidecarConfig {
+            image: image.clone(),
+            vsock_port: args.sidecar_vsock_port,
+            env: vec![],
+        }),
+        // A box without `--rm` survives its stop like a Docker stopped
+        // container: keep its dir (logs + overlay upper) so `logs`/`start` work
+        // afterwards. `--rm` boxes and CRI pods stay non-persistent (removed on
+        // teardown). `rm` force-removes either way (cleanup_removed_box).
+        persistent: args.common.persistent || !args.rm,
+        ..Default::default()
+    })
+}
+
+pub(super) fn should_create_diff_baseline(args: &RunArgs) -> bool {
+    !args.rm || args.detach
+}
+
+/// Initial process used only to keep the guest init alive for `run -it`.
+///
+/// The actual user command is executed over the PTY after guest control sockets
+/// are ready, so short-lived interactive commands do not race the VM shutdown.
+pub(super) fn interactive_keepalive_entrypoint() -> Vec<String> {
+    vec![
+        "/bin/sh".to_string(),
+        "-c".to_string(),
+        "trap 'exit 0' TERM INT; while :; do sleep 3600; done".to_string(),
+    ]
+}

--- a/src/cli/src/commands/run/tests.rs
+++ b/src/cli/src/commands/run/tests.rs
@@ -1,0 +1,939 @@
+use super::*;
+
+// --- build_resource_limits tests (using new struct layout) ---
+
+fn default_run_args() -> RunArgs {
+    RunArgs {
+        common: common::CommonBoxArgs {
+            image: "test".to_string(),
+            isolation: None,
+            name: None,
+            cpus: 2,
+            memory: "512m".to_string(),
+            volumes: vec![],
+            env: vec![],
+            publish: vec![],
+            dns: vec![],
+            entrypoint: None,
+            hostname: None,
+            user: None,
+            workdir: None,
+            restart: "no".to_string(),
+            labels: vec![],
+            tmpfs: vec![],
+            virtiofs_cache: None,
+            network: None,
+            health_cmd: None,
+            health_interval: 30,
+            health_timeout: 5,
+            health_retries: 3,
+            health_start_period: 0,
+            pids_limit: None,
+            cpuset_cpus: None,
+            ulimits: vec![],
+            cpu_shares: None,
+            cpu_quota: None,
+            cpu_period: None,
+            memory_reservation: None,
+            memory_swap: None,
+            env_file: vec![],
+            add_host: vec![],
+            platform: None,
+            init: false,
+            read_only: false,
+            cap_add: vec![],
+            cap_drop: vec![],
+            security_opt: vec![],
+            privileged: false,
+            device: vec![],
+            gpus: None,
+            shm_size: None,
+            stop_signal: None,
+            stop_timeout: None,
+            no_healthcheck: false,
+            oom_kill_disable: false,
+            oom_score_adj: None,
+            persistent: false,
+        },
+        detach: false,
+        interactive: false,
+        no_stdin: false,
+        tty: false,
+        timeout: None,
+        rm: false,
+        pool: false,
+        pool_socket: DEFAULT_SOCKET.to_string(),
+        pool_autostart: false,
+        pool_exec: false,
+        package_cache: vec![],
+        cmd: vec![],
+        log_driver: "json-file".to_string(),
+        log_opts: vec![],
+        tee: false,
+        tee_workload_id: None,
+        tee_simulate: false,
+        sidecar: None,
+        sidecar_vsock_port: 4092,
+    }
+}
+
+fn default_pool_run_args() -> RunArgs {
+    let mut args = default_run_args();
+    args.pool = true;
+    args.rm = true;
+    args.cmd = vec!["echo".to_string(), "hello".to_string()];
+    args
+}
+
+#[test]
+fn test_foreground_auto_remove_skips_diff_baseline() {
+    let mut args = default_run_args();
+    args.rm = true;
+
+    assert!(!should_create_diff_baseline(&args));
+}
+
+#[test]
+fn test_detached_auto_remove_keeps_diff_baseline_while_running() {
+    let mut args = default_run_args();
+    args.rm = true;
+    args.detach = true;
+
+    assert!(should_create_diff_baseline(&args));
+}
+
+#[test]
+fn test_persistent_run_keeps_diff_baseline() {
+    let args = default_run_args();
+
+    assert!(should_create_diff_baseline(&args));
+}
+
+#[test]
+fn test_build_resource_limits_defaults() {
+    let args = default_run_args();
+    let limits = common::build_resource_limits(&args.common).unwrap();
+    assert!(limits.pids_limit.is_none());
+    assert!(limits.cpuset_cpus.is_none());
+    assert!(limits.cpu_shares.is_none());
+    assert!(limits.memory_reservation.is_none());
+    assert!(limits.memory_swap.is_none());
+}
+
+#[test]
+fn test_build_resource_limits_with_values() {
+    let mut args = default_run_args();
+    args.common.pids_limit = Some(100);
+    args.common.cpuset_cpus = Some("0-3".to_string());
+    args.common.ulimits = vec!["nofile=1024:4096".to_string()];
+    args.common.cpu_shares = Some(512);
+    args.common.cpu_quota = Some(50000);
+    args.common.cpu_period = Some(100000);
+    args.common.memory_reservation = Some("256m".to_string());
+    args.common.memory_swap = Some("-1".to_string());
+
+    let limits = common::build_resource_limits(&args.common).unwrap();
+    assert_eq!(limits.pids_limit, Some(100));
+    assert_eq!(limits.cpuset_cpus, Some("0-3".to_string()));
+    assert_eq!(limits.cpu_shares, Some(512));
+    assert_eq!(limits.cpu_quota, Some(50000));
+    assert_eq!(limits.cpu_period, Some(100000));
+    assert_eq!(limits.memory_reservation, Some(256 * 1024 * 1024));
+    assert_eq!(limits.memory_swap, Some(-1));
+}
+
+#[test]
+fn test_build_resource_limits_memory_swap_value() {
+    let mut args = default_run_args();
+    args.common.memory_swap = Some("1g".to_string());
+
+    let limits = common::build_resource_limits(&args.common).unwrap();
+    assert_eq!(limits.memory_swap, Some(1024 * 1024 * 1024));
+}
+
+#[test]
+fn test_parse_health_check_none() {
+    let args = default_run_args();
+    assert!(parse_health_check(&args.common).is_none());
+}
+
+#[test]
+fn test_parse_health_check_disabled() {
+    let mut args = default_run_args();
+    args.common.health_cmd = Some("curl localhost".to_string());
+    args.common.no_healthcheck = true;
+    assert!(parse_health_check(&args.common).is_none());
+}
+
+#[test]
+fn test_parse_health_check_configured() {
+    let mut args = default_run_args();
+    args.common.health_cmd = Some("curl localhost".to_string());
+    args.common.health_interval = 10;
+    args.common.health_retries = 5;
+    let hc = parse_health_check(&args.common).unwrap();
+    assert_eq!(hc.cmd, vec!["sh", "-c", "curl localhost"]);
+    assert_eq!(hc.interval_secs, 10);
+    assert_eq!(hc.retries, 5);
+}
+
+#[test]
+fn test_validate_run_mode_rejects_detached_tty_before_boot() {
+    let mut args = default_run_args();
+    args.detach = true;
+    args.tty = true;
+
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("Cannot use -t"));
+}
+
+#[test]
+fn test_validate_run_mode_rejects_tty_without_terminal_before_boot() {
+    let mut args = default_run_args();
+    args.tty = true;
+
+    let err = validate_run_mode(&args, false).unwrap_err();
+    assert!(err.contains("requires a terminal"));
+}
+
+#[test]
+fn test_validate_run_mode_allows_detached_without_tty() {
+    let mut args = default_run_args();
+    args.detach = true;
+
+    assert!(validate_run_mode(&args, false).is_ok());
+}
+
+#[test]
+fn test_validate_run_mode_rejects_no_stdin_with_interactive() {
+    let mut args = default_run_args();
+    args.interactive = true;
+    args.no_stdin = true;
+
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("--interactive"));
+}
+
+#[test]
+fn test_validate_run_mode_rejects_invalid_timeout_modes() {
+    let mut args = default_run_args();
+    args.timeout = Some(0);
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("greater than zero"));
+
+    let mut args = default_run_args();
+    args.timeout = Some(30);
+    args.detach = true;
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("--timeout"));
+    assert!(err.contains("detach"));
+
+    let mut args = default_run_args();
+    args.timeout = Some(30);
+    args.tty = true;
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("--timeout"));
+    assert!(err.contains("tty"));
+}
+
+#[test]
+fn test_validate_pool_run_mode_requires_auto_remove_and_command() {
+    let mut args = default_pool_run_args();
+    args.rm = false;
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("requires --rm"));
+
+    let mut args = default_pool_run_args();
+    args.cmd = vec![];
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("explicit command"));
+}
+
+#[test]
+fn test_validate_pool_run_mode_rejects_unsupported_modes() {
+    let mut args = default_pool_run_args();
+    args.detach = true;
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("--pool"));
+    assert!(err.contains("detach"));
+
+    let mut args = default_pool_run_args();
+    args.interactive = true;
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("--interactive"));
+
+    let mut args = default_pool_run_args();
+    args.common.publish = vec!["8080:80".to_string()];
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("currently supports only"));
+
+    let mut args = default_pool_run_args();
+    args.common.name = Some("named-pool-run".to_string());
+    let err = validate_run_mode(&args, true).unwrap_err();
+    assert!(err.contains("currently supports only"));
+}
+
+#[test]
+fn test_validate_pool_run_mode_allows_timeout() {
+    let mut args = default_pool_run_args();
+    args.timeout = Some(30);
+
+    assert!(validate_run_mode(&args, true).is_ok());
+}
+
+#[test]
+fn test_selected_pool_socket_prefers_explicit_pool_socket() {
+    let mut args = default_pool_run_args();
+    args.pool_socket = "/tmp/explicit.sock".to_string();
+
+    assert_eq!(
+        selected_pool_socket(&args, Some("/tmp/env.sock")).as_deref(),
+        Some("/tmp/explicit.sock")
+    );
+}
+
+#[test]
+fn test_selected_pool_socket_uses_env_for_compatible_foreground_run() {
+    let mut args = default_run_args();
+    args.rm = true;
+    args.cmd = vec!["bash".to_string(), "-lc".to_string(), "echo ok".to_string()];
+    args.package_cache = vec![PackageCache::Pnpm];
+    args.common.volumes = vec!["/host/work:/workspace:rw".to_string()];
+    args.common.workdir = Some("/workspace".to_string());
+
+    assert_eq!(
+        selected_pool_socket(&args, Some(" /tmp/runtime.sock ")).as_deref(),
+        Some("/tmp/runtime.sock")
+    );
+}
+
+#[test]
+fn test_selected_pool_socket_ignores_env_for_incompatible_run() {
+    let mut args = default_run_args();
+    args.rm = true;
+    args.detach = true;
+    args.cmd = vec!["echo".to_string(), "ok".to_string()];
+
+    assert!(selected_pool_socket(&args, Some("/tmp/runtime.sock")).is_none());
+
+    let mut named = default_run_args();
+    named.rm = true;
+    named.common.name = Some("named-run".to_string());
+    named.cmd = vec!["echo".to_string(), "ok".to_string()];
+    assert!(selected_pool_socket(&named, Some("/tmp/runtime.sock")).is_none());
+    assert!(selected_pool_socket(&args, Some("")).is_none());
+}
+
+#[test]
+fn test_selected_pool_socket_uses_autostart_flag() {
+    let mut args = default_pool_run_args();
+    args.pool = false;
+    args.pool_autostart = true;
+    args.pool_socket = "/tmp/autostart.sock".to_string();
+
+    assert_eq!(
+        selected_pool_socket(&args, None).as_deref(),
+        Some("/tmp/autostart.sock")
+    );
+}
+
+#[test]
+fn test_pool_autostart_config_prewarms_simple_run() {
+    let args = default_pool_run_args();
+    let config = pool_autostart_config_for_run(&args, "/tmp/pool.sock").unwrap();
+
+    assert_eq!(config.socket, "/tmp/pool.sock");
+    assert_eq!(config.image.as_deref(), Some("test"));
+}
+
+#[test]
+fn test_pool_autostart_config_skips_prewarm_for_volume_shape() {
+    let mut args = default_pool_run_args();
+    args.common.volumes = vec!["/host:/work:ro".to_string()];
+    let config = pool_autostart_config_for_run(&args, "/tmp/pool.sock").unwrap();
+
+    assert!(config.image.is_none());
+}
+
+#[test]
+fn test_build_pool_client_run_plumbs_supported_options() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env_file = tmp.path().join("env.list");
+    std::fs::write(&env_file, "B=file\nC=file\n").unwrap();
+    let bind = format!("{}:/workspace:ro", tmp.path().display());
+
+    let mut args = default_pool_run_args();
+    args.common.image = "node:24-bookworm".to_string();
+    args.common.cpus = 4;
+    args.common.memory = "2g".to_string();
+    args.common.volumes = vec![bind.clone()];
+    args.common.env = vec!["A=cli".to_string(), "B=cli".to_string()];
+    args.common.env_file = vec![env_file.display().to_string()];
+    args.common.user = Some("root".to_string());
+    args.common.workdir = Some("/workspace".to_string());
+    args.pool_socket = "/tmp/a3s-box-test-pool.sock".to_string();
+    args.pool_exec = true;
+    args.timeout = Some(45);
+
+    let req = build_pool_client_run(&args, &args.pool_socket).unwrap();
+
+    assert_eq!(req.socket, "/tmp/a3s-box-test-pool.sock");
+    assert_eq!(req.image.as_deref(), Some("node:24-bookworm"));
+    assert_eq!(req.user.as_deref(), Some("0"));
+    assert_eq!(req.workdir.as_deref(), Some("/workspace"));
+    assert_eq!(req.volumes, vec![bind]);
+    assert_eq!(req.vcpus, 4);
+    assert_eq!(req.memory_mb, 2048);
+    assert!(req.exec);
+    assert_eq!(req.timeout_ns, Some(45_000_000_000));
+    assert_eq!(req.cmd, vec!["echo", "hello"]);
+    assert_eq!(req.env, vec!["A=cli", "B=cli", "C=file"]);
+}
+
+#[test]
+fn test_apply_package_caches_adds_pnpm_volume_and_env() {
+    let mut volumes = Vec::new();
+    let mut env = std::collections::HashMap::new();
+
+    apply_package_caches(&[PackageCache::Pnpm], &mut volumes, &mut env);
+
+    assert_eq!(volumes, vec![PNPM_CACHE_VOLUME_SPEC.to_string()]);
+    assert_eq!(
+        env.get(PNPM_CONFIG_STORE_ENV).map(String::as_str),
+        Some(PNPM_STORE_DIR)
+    );
+    assert_eq!(
+        env.get(PNPM_STORE_ENV).map(String::as_str),
+        Some(PNPM_STORE_DIR)
+    );
+    assert_eq!(
+        env.get(PNPM_COREPACK_HOME_ENV).map(String::as_str),
+        Some(PNPM_COREPACK_HOME_DIR)
+    );
+    assert_eq!(
+        env.get(PNPM_HOME_ENV).map(String::as_str),
+        Some(PNPM_HOME_DIR)
+    );
+    assert_eq!(
+        env.get(PNPM_NPM_CACHE_ENV).map(String::as_str),
+        Some(PNPM_NPM_CACHE_DIR)
+    );
+    assert_eq!(
+        env.get(PNPM_CONFIG_PREFER_OFFLINE_ENV).map(String::as_str),
+        Some(PNPM_PREFER_OFFLINE_VALUE)
+    );
+    assert_eq!(
+        env.get(PNPM_PREFER_OFFLINE_ENV).map(String::as_str),
+        Some(PNPM_PREFER_OFFLINE_VALUE)
+    );
+    assert_eq!(
+        env.get(COREPACK_DOWNLOAD_PROMPT_ENV).map(String::as_str),
+        Some(COREPACK_DOWNLOAD_PROMPT_VALUE)
+    );
+}
+
+#[test]
+fn test_apply_package_caches_preserves_user_pnpm_env() {
+    let mut volumes = Vec::new();
+    let mut env = std::collections::HashMap::from([
+        (
+            PNPM_CONFIG_STORE_ENV.to_string(),
+            "/custom/pnpm-config-store".to_string(),
+        ),
+        (PNPM_STORE_ENV.to_string(), "/custom/pnpm-store".to_string()),
+        (
+            PNPM_COREPACK_HOME_ENV.to_string(),
+            "/custom/corepack".to_string(),
+        ),
+        (PNPM_HOME_ENV.to_string(), "/custom/pnpm-home".to_string()),
+        (
+            PNPM_NPM_CACHE_ENV.to_string(),
+            "/custom/npm-cache".to_string(),
+        ),
+        (
+            PNPM_CONFIG_PREFER_OFFLINE_ENV.to_string(),
+            "false".to_string(),
+        ),
+        (PNPM_PREFER_OFFLINE_ENV.to_string(), "false".to_string()),
+        (COREPACK_DOWNLOAD_PROMPT_ENV.to_string(), "1".to_string()),
+    ]);
+
+    apply_package_caches(&[PackageCache::Pnpm], &mut volumes, &mut env);
+
+    assert_eq!(
+        env.get(PNPM_CONFIG_STORE_ENV).map(String::as_str),
+        Some("/custom/pnpm-config-store")
+    );
+    assert_eq!(
+        env.get(PNPM_STORE_ENV).map(String::as_str),
+        Some("/custom/pnpm-store")
+    );
+    assert_eq!(
+        env.get(PNPM_COREPACK_HOME_ENV).map(String::as_str),
+        Some("/custom/corepack")
+    );
+    assert_eq!(
+        env.get(PNPM_HOME_ENV).map(String::as_str),
+        Some("/custom/pnpm-home")
+    );
+    assert_eq!(
+        env.get(PNPM_NPM_CACHE_ENV).map(String::as_str),
+        Some("/custom/npm-cache")
+    );
+    assert_eq!(
+        env.get(PNPM_CONFIG_PREFER_OFFLINE_ENV).map(String::as_str),
+        Some("false")
+    );
+    assert_eq!(
+        env.get(PNPM_PREFER_OFFLINE_ENV).map(String::as_str),
+        Some("false")
+    );
+    assert_eq!(
+        env.get(COREPACK_DOWNLOAD_PROMPT_ENV).map(String::as_str),
+        Some("1")
+    );
+}
+
+#[test]
+fn test_apply_package_caches_deduplicates_pnpm_volume() {
+    let mut volumes = vec![PNPM_CACHE_VOLUME_SPEC.to_string()];
+    let mut env = std::collections::HashMap::new();
+
+    apply_package_caches(
+        &[PackageCache::Pnpm, PackageCache::Pnpm],
+        &mut volumes,
+        &mut env,
+    );
+
+    assert_eq!(volumes, vec![PNPM_CACHE_VOLUME_SPEC.to_string()]);
+}
+
+#[test]
+fn test_apply_package_caches_adds_npm_volume_and_env() {
+    let mut volumes = Vec::new();
+    let mut env = std::collections::HashMap::new();
+
+    apply_package_caches(&[PackageCache::Npm], &mut volumes, &mut env);
+
+    assert_eq!(volumes, vec![NPM_CACHE_VOLUME_SPEC.to_string()]);
+    assert_eq!(
+        env.get(NPM_CACHE_ENV).map(String::as_str),
+        Some(NPM_CACHE_DIR)
+    );
+    assert_eq!(
+        env.get(NPM_PREFER_OFFLINE_ENV).map(String::as_str),
+        Some(NPM_PREFER_OFFLINE_VALUE)
+    );
+    assert!(!env.contains_key(PNPM_STORE_ENV));
+    assert!(!env.contains_key(PNPM_COREPACK_HOME_ENV));
+    assert!(!env.contains_key(PNPM_HOME_ENV));
+}
+
+#[test]
+fn test_apply_package_caches_preserves_user_npm_env() {
+    let mut volumes = Vec::new();
+    let mut env = std::collections::HashMap::from([
+        (NPM_CACHE_ENV.to_string(), "/custom/npm-cache".to_string()),
+        (NPM_PREFER_OFFLINE_ENV.to_string(), "false".to_string()),
+    ]);
+
+    apply_package_caches(&[PackageCache::Npm], &mut volumes, &mut env);
+
+    assert_eq!(
+        env.get(NPM_CACHE_ENV).map(String::as_str),
+        Some("/custom/npm-cache")
+    );
+    assert_eq!(
+        env.get(NPM_PREFER_OFFLINE_ENV).map(String::as_str),
+        Some("false")
+    );
+}
+
+#[test]
+fn test_apply_package_caches_deduplicates_npm_volume() {
+    let mut volumes = vec![NPM_CACHE_VOLUME_SPEC.to_string()];
+    let mut env = std::collections::HashMap::new();
+
+    apply_package_caches(
+        &[PackageCache::Npm, PackageCache::Npm],
+        &mut volumes,
+        &mut env,
+    );
+
+    assert_eq!(volumes, vec![NPM_CACHE_VOLUME_SPEC.to_string()]);
+}
+
+#[test]
+fn test_build_box_config_uses_keepalive_for_interactive_tty_boot() {
+    let mut args = default_run_args();
+    args.tty = true;
+    args.cmd = vec!["/bin/echo".to_string(), "hello".to_string()];
+
+    let config = build_box_config(
+        &args,
+        512,
+        Default::default(),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+
+    assert_eq!(config.cmd, vec!["a3s-box-pty-keepalive"]);
+    assert_eq!(
+        config.entrypoint_override,
+        Some(interactive_keepalive_entrypoint())
+    );
+}
+
+#[test]
+fn test_build_box_config_plumbs_virtiofs_cache_mode() {
+    let mut args = default_run_args();
+    args.common.virtiofs_cache = Some(common::VirtiofsCacheMode::Always);
+
+    let config = build_box_config(
+        &args,
+        512,
+        Default::default(),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+
+    assert_eq!(config.virtiofs_cache.as_deref(), Some("always"));
+}
+
+#[test]
+fn test_build_box_config_preserves_non_tty_command() {
+    let mut args = default_run_args();
+    args.cmd = vec!["/bin/echo".to_string(), "hello".to_string()];
+    let entrypoint = Some(vec!["/custom-entrypoint".to_string()]);
+
+    let config = build_box_config(
+        &args,
+        512,
+        Default::default(),
+        entrypoint.clone(),
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+
+    assert_eq!(config.cmd, args.cmd);
+    assert_eq!(config.entrypoint_override, entrypoint);
+}
+
+#[test]
+fn test_build_box_config_controls_stdin_open() {
+    let args = default_run_args();
+    let config = build_box_config(
+        &args,
+        512,
+        Default::default(),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+    assert!(!config.stdin_open);
+
+    let mut args = default_run_args();
+    args.interactive = true;
+    let config = build_box_config(
+        &args,
+        512,
+        Default::default(),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+    assert!(config.stdin_open);
+
+    let mut args = default_run_args();
+    args.no_stdin = true;
+    let config = build_box_config(
+        &args,
+        512,
+        Default::default(),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+    assert!(!config.stdin_open);
+}
+
+#[test]
+fn test_mark_record_stopped_persists_exit_context() {
+    let record = crate::test_helpers::fixtures::make_record(
+        "550e8400-e29b-41d4-a716-446655440000",
+        "run-exit",
+        "running",
+        Some(1234),
+    );
+    let (_tmp, mut state) = crate::test_helpers::fixtures::setup_state(vec![record]);
+
+    mark_record_stopped(
+        &mut state,
+        "550e8400-e29b-41d4-a716-446655440000",
+        Some(42),
+        true,
+    );
+
+    let record = state
+        .find_by_id("550e8400-e29b-41d4-a716-446655440000")
+        .unwrap();
+    assert_eq!(record.status, "stopped");
+    assert_eq!(record.pid, None);
+    assert_eq!(record.exit_code, Some(42));
+    assert!(record.stopped_by_user);
+}
+
+#[tokio::test]
+async fn test_cleanup_failure_is_reported_and_preserves_recovery_state() {
+    let temporary = tempfile::tempdir().unwrap();
+    let id = "550e8400-e29b-41d4-a716-446655440000";
+    let mut record =
+        crate::test_helpers::fixtures::make_record(id, "run-cleanup", "running", Some(1234));
+    record.box_dir = temporary.path().join("boxes").join(id);
+    record.exec_socket_path = record.box_dir.join("sockets/exec.sock");
+    std::fs::create_dir_all(&record.box_dir).unwrap();
+
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let manager = LocalExecutionManager::new(
+        temporary.path().join("empty-state.json"),
+        temporary.path(),
+        std::sync::Arc::new(backend),
+    );
+    let mut context = RunContext {
+        manager,
+        execution_id: ExecutionId::new(id).unwrap(),
+        generation: ExecutionGeneration::new(1).unwrap(),
+        box_id: id.to_string(),
+        box_dir: record.box_dir.clone(),
+        name: record.name.clone(),
+        record,
+        exec_socket_path: temporary.path().join("exec.sock"),
+        pty_socket_path: temporary.path().join("pty.sock"),
+        anonymous_volumes: Vec::new(),
+        health_checker: None,
+    };
+
+    let error = cleanup_managed_execution(&mut context, true, Some(1), false, false)
+        .await
+        .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("state was preserved for recovery"));
+    assert!(context.box_dir.exists());
+}
+
+#[test]
+fn test_foreground_exit_code_preserves_vm_code() {
+    assert_eq!(
+        foreground_exit_code(
+            ForegroundStopReason::UserInterrupted(FOREGROUND_SIGTERM),
+            Some(143)
+        ),
+        Some(143)
+    );
+    assert_eq!(
+        foreground_exit_code(ForegroundStopReason::VmUnhealthy, Some(2)),
+        Some(2)
+    );
+    assert_eq!(
+        foreground_exit_code(ForegroundStopReason::TimedOut, Some(0)),
+        Some(124)
+    );
+}
+
+#[test]
+fn test_foreground_exit_code_has_deterministic_fallbacks() {
+    assert_eq!(
+        foreground_exit_code(ForegroundStopReason::ProcessExited, None),
+        None
+    );
+    assert_eq!(
+        foreground_exit_code(
+            ForegroundStopReason::UserInterrupted(FOREGROUND_SIGINT),
+            None
+        ),
+        Some(130)
+    );
+    assert_eq!(
+        foreground_exit_code(
+            ForegroundStopReason::UserInterrupted(FOREGROUND_SIGTERM),
+            None
+        ),
+        Some(143)
+    );
+    assert_eq!(
+        foreground_exit_code(ForegroundStopReason::VmUnhealthy, None),
+        Some(1)
+    );
+    assert_eq!(
+        foreground_exit_code(ForegroundStopReason::TimedOut, None),
+        Some(124)
+    );
+}
+
+#[test]
+fn test_foreground_stop_reason_user_flag() {
+    assert!(ForegroundStopReason::UserInterrupted(FOREGROUND_SIGINT).stopped_by_user());
+    assert!(!ForegroundStopReason::ProcessExited.stopped_by_user());
+    assert!(!ForegroundStopReason::VmUnhealthy.stopped_by_user());
+    assert!(!ForegroundStopReason::TimedOut.stopped_by_user());
+}
+
+#[test]
+fn test_foreground_poll_cadence_avoids_fixed_startup_delay() {
+    assert!(FOREGROUND_EXIT_POLL <= std::time::Duration::from_millis(20));
+    assert!(FOREGROUND_EXIT_POLL < FOREGROUND_HEALTH_POLL);
+    assert!(FOREGROUND_LOG_DRAIN_QUIET <= std::time::Duration::from_millis(50));
+    assert!(FOREGROUND_LOG_DRAIN_POLL < FOREGROUND_LOG_DRAIN_QUIET);
+}
+
+#[test]
+fn test_retained_log_hint_only_for_non_user_failures() {
+    assert!(should_print_retained_log_hint(Some(1), false));
+    assert!(!should_print_retained_log_hint(Some(0), false));
+    assert!(!should_print_retained_log_hint(None, false));
+    assert!(!should_print_retained_log_hint(Some(130), true));
+}
+
+#[test]
+fn test_foreground_completion_messages() {
+    assert_eq!(
+        foreground_completion_message(ForegroundStopReason::ProcessExited, true, "box"),
+        "Box box exited and was removed."
+    );
+    assert_eq!(
+        foreground_completion_message(
+            ForegroundStopReason::UserInterrupted(FOREGROUND_SIGINT),
+            false,
+            "box"
+        ),
+        "Box box stopped."
+    );
+    assert_eq!(
+        foreground_completion_message(ForegroundStopReason::VmUnhealthy, true, "box"),
+        "Box box stopped after VM health check failed and was removed."
+    );
+    assert_eq!(
+        foreground_completion_message(ForegroundStopReason::TimedOut, false, "box"),
+        "Box box stopped after --timeout expired."
+    );
+}
+
+#[test]
+fn test_build_box_config_passes_security_options() {
+    let mut args = default_run_args();
+    args.common.cap_add = vec!["NET_ADMIN".to_string()];
+    args.common.cap_drop = vec!["NET_RAW".to_string()];
+    args.common.security_opt = vec!["seccomp=unconfined".to_string()];
+    args.common.privileged = true;
+
+    let config = build_box_config(
+        &args,
+        512,
+        a3s_box_core::config::ResourceLimits::default(),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+
+    assert_eq!(config.cap_add, vec!["NET_ADMIN"]);
+    assert_eq!(config.cap_drop, vec!["NET_RAW"]);
+    assert_eq!(config.security_opt, vec!["seccomp=unconfined"]);
+    assert!(config.privileged);
+}
+
+#[test]
+fn test_build_box_config_passes_user_and_workdir() {
+    let mut args = default_run_args();
+    args.common.user = Some("root:root".to_string());
+    args.common.workdir = Some("/app".to_string());
+
+    let config = build_box_config(
+        &args,
+        512,
+        a3s_box_core::config::ResourceLimits::default(),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+
+    assert_eq!(config.user.as_deref(), Some("0:0"));
+    assert_eq!(config.workdir.as_deref(), Some("/app"));
+}
+
+#[test]
+fn test_build_box_config_passes_hostname_and_add_hosts() {
+    let mut args = default_run_args();
+    args.common.hostname = Some("web".to_string());
+    args.common.add_host = vec!["db.local:10.88.0.10".to_string()];
+
+    let config = build_box_config(
+        &args,
+        512,
+        a3s_box_core::config::ResourceLimits::default(),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        a3s_box_core::NetworkMode::Tsi,
+        vec![],
+        TeeConfig::None,
+    )
+    .unwrap();
+
+    assert_eq!(config.hostname.as_deref(), Some("web"));
+    assert_eq!(config.add_hosts, vec!["db.local:10.88.0.10"]);
+}
+
+#[path = "request_tests.rs"]
+mod request_tests;
+
+#[test]
+fn test_resolve_volumes_empty() {
+    let (resolved, names) = resolve_volumes(&[]).unwrap();
+    assert!(resolved.is_empty());
+    assert!(names.is_empty());
+}

--- a/src/cli/src/state/file.rs
+++ b/src/cli/src/state/file.rs
@@ -121,16 +121,6 @@ impl StateFile {
         Self::modify(|sf| Ok::<bool, std::io::Error>(sf.store.remove_by_id(id)))
     }
 
-    /// Remove a record by id atomically under the state lock and return it.
-    pub(crate) fn take_record(id: &str) -> Result<Option<BoxRecord>, std::io::Error> {
-        Self::modify(|sf| {
-            let Some(index) = sf.store.records().iter().position(|record| record.id == id) else {
-                return Ok(None);
-            };
-            Ok::<Option<BoxRecord>, std::io::Error>(Some(sf.store.records_mut().remove(index)))
-        })
-    }
-
     /// Add a record and persist.
     pub fn add(&mut self, record: BoxRecord) -> Result<(), std::io::Error> {
         self.store.records_mut().push(record);

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -114,7 +114,7 @@ pub use tee::{AttestationReport, AttestationRequest, PlatformInfo};
 
 // VM
 #[cfg(feature = "vm")]
-pub use vm::{BoxState, VmManager};
+pub use vm::{BoxState, PullProgressFn, VmManager};
 #[cfg(feature = "vm")]
 pub use vmm::{
     Entrypoint, FsMount, InstanceSpec, NetworkInstanceConfig, ShimHandler, TeeInstanceConfig,

--- a/src/runtime/src/local_execution/resources.rs
+++ b/src/runtime/src/local_execution/resources.rs
@@ -383,4 +383,44 @@ mod tests {
             1
         );
     }
+
+    #[test]
+    fn concurrent_preparation_allocates_distinct_network_endpoints() {
+        use std::collections::HashSet;
+        use std::sync::{Arc, Barrier};
+
+        let temporary = tempfile::tempdir().unwrap();
+        let home_dir = temporary.path().to_path_buf();
+        let (_volumes, networks) = stores(&home_dir);
+        let barrier = Arc::new(Barrier::new(16));
+        let handles = (0..16)
+            .map(|index| {
+                let home_dir = home_dir.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let mut record = record(&home_dir);
+                    record.id = format!("00000000-0000-4000-8000-{index:012}");
+                    record.name = format!("worker-{index}");
+                    record.volume_names.clear();
+                    barrier.wait();
+                    ExecutionResourceGuard::prepare(&home_dir, &record)
+                        .unwrap()
+                        .disarm();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let network = networks.get("dev").unwrap().unwrap();
+        let addresses = network
+            .endpoints
+            .values()
+            .map(|endpoint| endpoint.ip_address)
+            .collect::<HashSet<_>>();
+        assert_eq!(network.endpoints.len(), 16);
+        assert_eq!(addresses.len(), 16);
+    }
 }

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use a3s_box_core::{
     EventEmitter, ExecutionBackend, ExecutionId, ExecutionManagerError, ExecutionManagerResult,
-    ExecutionState, KillOutcome,
+    ExecutionState, KillOutcome, DEFAULT_SHUTDOWN_TIMEOUT_MS,
 };
 use async_trait::async_trait;
 use dashmap::mapref::entry::Entry;
@@ -33,6 +33,7 @@ type SharedVm = Arc<Mutex<VmManager>>;
 pub struct VmLocalExecutionBackend {
     home_dir: PathBuf,
     managers: Arc<DashMap<String, SharedVm>>,
+    pull_progress_fn: Option<crate::PullProgressFn>,
 }
 
 impl VmLocalExecutionBackend {
@@ -40,7 +41,13 @@ impl VmLocalExecutionBackend {
         Self {
             home_dir: home_dir.into(),
             managers: Arc::new(DashMap::new()),
+            pull_progress_fn: None,
         }
+    }
+
+    pub fn with_pull_progress_fn(mut self, pull_progress_fn: crate::PullProgressFn) -> Self {
+        self.pull_progress_fn = Some(pull_progress_fn);
+        self
     }
 
     pub fn home_dir(&self) -> &Path {
@@ -97,6 +104,9 @@ impl VmLocalExecutionBackend {
         }
         let mut manager = VmManager::with_box_id(config, EventEmitter::new(256), record.id.clone());
         manager.home_dir = self.home_dir.clone();
+        if let Some(pull_progress_fn) = self.pull_progress_fn.clone() {
+            manager.set_pull_progress_fn(pull_progress_fn);
+        }
         manager.anonymous_volumes = record.anonymous_volumes.clone();
         manager.set_log_config(record.log_config.clone());
         manager.resolved_execution_plan = Some(metadata.plan.clone());
@@ -337,21 +347,9 @@ impl VmLocalExecutionBackend {
         } else {
             manager.anonymous_volumes().to_vec()
         };
-        let result = if let Some(timeout_secs) = timeout_secs {
-            let timeout_ms = timeout_secs.checked_mul(1_000).ok_or_else(|| {
-                ExecutionManagerError::InvalidRequest(format!(
-                    "restart timeout is too large for execution {}",
-                    record.id
-                ))
-            })?;
-            let signal = record
-                .stop_signal
-                .as_deref()
-                .map(a3s_box_core::vmm::parse_signal_name)
-                .unwrap_or(libc::SIGTERM);
-            manager.destroy_with_options(signal, timeout_ms).await
-        } else {
-            manager.destroy().await
+        let result = match graceful_stop_options(record, timeout_secs)? {
+            Some((signal, timeout_ms)) => manager.destroy_with_options(signal, timeout_ms).await,
+            None => manager.destroy().await,
         };
         drop(manager);
         self.remove_manager(&record.id, &shared);
@@ -554,14 +552,22 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
 
     async fn kill(&self, record: &BoxRecord) -> ExecutionManagerResult<KillOutcome> {
         let metadata = self.metadata(record)?;
+        let remove_anonymous_volumes = record.auto_remove;
+        let timeout_secs = record.stop_timeout;
         if let Some(manager) = self.manager(&record.id) {
-            return self.destroy_registered(record, manager, true, None).await;
+            return self
+                .destroy_registered(record, manager, remove_anonymous_volumes, timeout_secs)
+                .await;
         }
         match metadata.plan.backend {
-            ExecutionBackend::Crun => self.destroy_detached_sandbox(record, true, None).await,
+            ExecutionBackend::Crun => {
+                self.destroy_detached_sandbox(record, remove_anonymous_volumes, timeout_secs)
+                    .await
+            }
             ExecutionBackend::Krun => {
                 let manager = self.recover_microvm(record).await?;
-                self.destroy_registered(record, manager, true, None).await
+                self.destroy_registered(record, manager, remove_anonymous_volumes, timeout_secs)
+                    .await
             }
         }
     }
@@ -590,6 +596,30 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
             }
         }
     }
+}
+
+fn graceful_stop_options(
+    record: &BoxRecord,
+    timeout_secs: Option<u64>,
+) -> ExecutionManagerResult<Option<(i32, u64)>> {
+    if timeout_secs.is_none() && record.stop_signal.is_none() {
+        return Ok(None);
+    }
+    let timeout_ms = timeout_secs
+        .unwrap_or(DEFAULT_SHUTDOWN_TIMEOUT_MS / 1_000)
+        .checked_mul(1_000)
+        .ok_or_else(|| {
+            ExecutionManagerError::InvalidRequest(format!(
+                "stop timeout is too large for execution {}",
+                record.id
+            ))
+        })?;
+    let signal = record
+        .stop_signal
+        .as_deref()
+        .map(a3s_box_core::vmm::parse_signal_name)
+        .unwrap_or(libc::SIGTERM);
+    Ok(Some((signal, timeout_ms)))
 }
 
 async fn require_recorded_pid(

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -54,6 +54,19 @@ fn manager_uses_the_full_persisted_request_config() {
 }
 
 #[test]
+fn manager_uses_the_backend_pull_progress_callback() {
+    let temporary = tempfile::tempdir().unwrap();
+    let callback: crate::PullProgressFn = Arc::new(|_, _, _, _| {});
+    let backend =
+        VmLocalExecutionBackend::new(temporary.path()).with_pull_progress_fn(Arc::clone(&callback));
+    let record = record(temporary.path(), ExecutionIsolation::Microvm);
+
+    let manager = backend.new_manager(&record).unwrap();
+
+    assert!(manager.pull_progress_fn.is_some());
+}
+
+#[test]
 fn manager_applies_persisted_shared_memory_policy_to_runtime_config() {
     let temporary = tempfile::tempdir().unwrap();
     let backend = VmLocalExecutionBackend::new(temporary.path());
@@ -156,7 +169,7 @@ async fn unsupported_pause_modes_fail_before_starting_a_runtime() {
 }
 
 #[tokio::test]
-async fn restart_stop_preserves_anonymous_volumes_but_terminal_kill_removes_them() {
+async fn retained_stops_preserve_anonymous_volumes_but_auto_remove_kill_removes_them() {
     let temporary = tempfile::tempdir().unwrap();
     let backend = VmLocalExecutionBackend::new(temporary.path());
     let mut record = record(temporary.path(), ExecutionIsolation::Microvm);
@@ -176,7 +189,54 @@ async fn restart_stop_preserves_anonymous_volumes_but_terminal_kill_removes_them
     let manager = Arc::new(Mutex::new(backend.new_manager(&record).unwrap()));
     backend.managers.insert(record.id.clone(), manager);
     backend.kill(&record).await.unwrap();
+    assert!(volumes.get(volume_name).unwrap().is_some());
+
+    record.auto_remove = true;
+    record
+        .managed_execution
+        .as_mut()
+        .unwrap()
+        .request
+        .policy
+        .auto_remove = true;
+    let manager = Arc::new(Mutex::new(backend.new_manager(&record).unwrap()));
+    backend.managers.insert(record.id.clone(), manager);
+    backend.kill(&record).await.unwrap();
     assert!(volumes.get(volume_name).unwrap().is_none());
+}
+
+#[test]
+fn managed_kill_uses_persisted_stop_signal_and_timeout() {
+    let temporary = tempfile::tempdir().unwrap();
+    let mut record = record(temporary.path(), ExecutionIsolation::Microvm);
+
+    assert_eq!(graceful_stop_options(&record, None).unwrap(), None);
+
+    record.stop_signal = Some("SIGINT".to_string());
+    assert_eq!(
+        graceful_stop_options(&record, None).unwrap(),
+        Some((libc::SIGINT, a3s_box_core::DEFAULT_SHUTDOWN_TIMEOUT_MS))
+    );
+
+    record.stop_timeout = Some(7);
+    assert_eq!(
+        graceful_stop_options(&record, record.stop_timeout).unwrap(),
+        Some((libc::SIGINT, 7_000))
+    );
+    assert_eq!(
+        graceful_stop_options(&record, Some(3)).unwrap(),
+        Some((libc::SIGINT, 3_000))
+    );
+}
+
+#[test]
+fn managed_kill_rejects_stop_timeout_overflow() {
+    let temporary = tempfile::tempdir().unwrap();
+    let record = record(temporary.path(), ExecutionIsolation::Microvm);
+
+    let error = graceful_stop_options(&record, Some(u64::MAX)).unwrap_err();
+
+    assert!(error.to_string().contains("stop timeout is too large"));
 }
 
 #[test]

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// Callback type for image pull progress: `(current, total, digest, size_bytes)`.
-type PullProgressFn = Arc<dyn Fn(usize, usize, &str, i64) + Send + Sync>;
+pub type PullProgressFn = Arc<dyn Fn(usize, usize, &str, i64) + Send + Sync>;
 
 use a3s_box_core::config::BoxConfig;
 #[cfg(unix)]


### PR DESCRIPTION
Summary:
- route CLI run reservations, starts, foreground teardown, and detached state through LocalExecutionManager
- preserve image health and stop defaults, caller policy, rootfs, network, and volume semantics
- propagate cleanup failures and add complete run request and lifecycle coverage
- update E2B implementation status without claiming full compatibility

Validation:
- cargo fmt --all -- --check
- cargo test -p a3s-box-runtime -p a3s-box-cli
- cargo clippy -p a3s-box-runtime -p a3s-box-cli --all-targets --no-deps
- git diff --check