### PR TITLE
fix(runtime): deduplicate reused anonymous volumes

### DIFF
--- a/src/runtime/src/vm/spec.rs
+++ b/src/runtime/src/vm/spec.rs
@@ -51,6 +51,9 @@ impl VmManager {
             .filter_map(|v| v.split(':').nth(1).map(String::from))
             .collect();
         let mut anon_vol_offset = self.config.volumes.len();
+        let mut seen_anonymous_volumes = std::collections::HashSet::new();
+        self.anonymous_volumes
+            .retain(|name| seen_anonymous_volumes.insert(name.clone()));
 
         if let Some(ref oci_config) = layout.oci_config {
             for vol_path in &oci_config.volumes {
@@ -77,7 +80,9 @@ impl VmManager {
                             host_path: PathBuf::from(&host_path),
                             read_only: false,
                         });
-                        self.anonymous_volumes.push(anon_name.clone());
+                        if seen_anonymous_volumes.insert(anon_name.clone()) {
+                            self.anonymous_volumes.push(anon_name.clone());
+                        }
                         if created {
                             self.created_anonymous_volumes.push(anon_name);
                         }
@@ -1572,10 +1577,20 @@ mod tests {
 
         let mut second_vm = test_vm_manager(BoxConfig::default());
         second_vm.home_dir = home.path().to_path_buf();
+        second_vm.anonymous_volumes = vec![volume_name.clone(), volume_name.clone()];
+        second_vm.build_instance_spec(&layout).unwrap();
         second_vm.build_instance_spec(&layout).unwrap();
 
         assert_eq!(second_vm.anonymous_volumes, vec![volume_name]);
         assert!(second_vm.created_anonymous_volumes.is_empty());
+        assert_eq!(
+            store
+                .get(&second_vm.anonymous_volumes[0])
+                .unwrap()
+                .unwrap()
+                .in_use_by,
+            vec!["test-box".to_string()]
+        );
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary

- preserve first-seen anonymous-volume order while removing duplicate recovered entries
- avoid appending a deterministic OCI VOLUME name already carried by the manager
- extend the existing reuse test across duplicate recovery and repeated spec builds
- assert VolumeStore ownership remains exactly once

Fixes #82.

## Validation

- TDD: the focused test reproduced `left: [name, name]` before the fix
- `cargo test -p a3s-box-runtime` (1264 passed, 1 ignored)
- `cargo clippy -p a3s-box-runtime --all-targets -- -A clippy::needless_return -D warnings`
- A3S OS MariaDB Sandbox: one retained anonymous volume across initial run, stop, restart from stopped, and restart while running (generations 1 through 3)
- VolumeStore kept one owner, `/var/lib/mysql/probe` survived both restarts, and final removal cleaned record/runtime/socket/volume