### PR TITLE
fix(oci): retry Basic-auth registry pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,16 @@ a3s-box push --plain-http localhost:5000/org/image:v1
 
 Docker Hub aliases share cache resolution, so `alpine`, `alpine:latest`, and `docker.io/library/alpine:latest` can resolve to the same local image when unambiguous. Digest-only references resolve locally when the digest matches exactly or by unique prefix.
 
+Authenticated pulls use credentials from `a3s-box login`, Docker configuration,
+or `REGISTRY_USERNAME` / `REGISTRY_PASSWORD`. If a registry advertises Basic
+authentication only after a protected manifest or blob request, Box retries an
+unauthorized request with preemptive Basic authentication when both credential
+fields are non-empty. Manifest, config, and layer digests are verified; layers
+remain streamed to disk. Same-origin redirects retain authentication, while
+cross-origin redirects never receive the registry Authorization header. The
+same pull path is used by explicit `pull` and an implicit image pull during
+`run`.
+
 Use `a3s-box push --plain-http` for an explicit HTTP registry. `--insecure` is accepted as an alias, and `--tls-verify=false` maps to the same behavior for Docker-compatible scripts.
 
 Build support is intentionally explicit:

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "a3s-box-netproxy",
  "a3s-common",
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bzip2",
  "chrono",

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -116,5 +116,6 @@ bzip2 = "0.5"
 xz2 = "0.1"
 
 [dev-dependencies]
+axum = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }

--- a/src/runtime/src/oci/pull.rs
+++ b/src/runtime/src/oci/pull.rs
@@ -54,6 +54,16 @@ impl ImagePuller {
         Self::with_platform(store, auth, None)
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_registry_puller(store: Arc<ImageStore>, puller: RegistryPuller) -> Self {
+        Self {
+            store,
+            puller,
+            metrics: None,
+            mirrors: std::collections::HashMap::new(),
+        }
+    }
+
     /// Create an image puller that resolves multi-arch images to an explicit
     /// platform (e.g. "linux/arm64") instead of the host architecture. `None`
     /// keeps the host-architecture default.

--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -18,8 +18,16 @@ use super::credentials::CredentialStore;
 use super::reference::ImageReference;
 use super::signing::{verify_image_signature, SignaturePolicy, VerifyResult};
 
+mod basic_pull;
+mod blob_pull;
+
+use basic_pull::{BasicImageManifest, BasicPullClient};
+#[cfg(test)]
+use blob_pull::HashingFileWriter;
+use blob_pull::{stream_and_verify_blob, BlobPullTransport};
+
 const REGISTRY_PROTOCOL_ENV: &str = "A3S_REGISTRY_PROTOCOL";
-const MANIFEST_ACCEPT: &str = "application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json";
+const MANIFEST_ACCEPT: &str = "application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json";
 
 /// Transport protocol used for registry operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,135 +85,15 @@ pub(crate) fn validated_digest_hex(digest: &str) -> Result<&str> {
         })
 }
 
-/// An `AsyncWrite` that streams bytes straight to a file while computing their
-/// SHA-256, so a pulled blob is hashed and written in bounded chunks instead of
-/// being fully buffered in memory.
-struct HashingFileWriter {
-    file: tokio::fs::File,
-    hasher: sha2::Sha256,
-}
-
-impl HashingFileWriter {
-    fn new(file: tokio::fs::File) -> Self {
-        use sha2::Digest;
-        Self {
-            file,
-            hasher: sha2::Sha256::new(),
-        }
-    }
-
-    fn finalize_hex(self) -> String {
-        use sha2::Digest;
-        format!("{:x}", self.hasher.finalize())
-    }
-}
-
-impl tokio::io::AsyncWrite for HashingFileWriter {
-    fn poll_write(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &[u8],
-    ) -> std::task::Poll<std::io::Result<usize>> {
-        use sha2::Digest;
-        let this = self.get_mut();
-        match std::pin::Pin::new(&mut this.file).poll_write(cx, buf) {
-            std::task::Poll::Ready(Ok(n)) => {
-                this.hasher.update(&buf[..n]);
-                std::task::Poll::Ready(Ok(n))
-            }
-            other => other,
-        }
-    }
-
-    fn poll_flush(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
-        std::pin::Pin::new(&mut self.get_mut().file).poll_flush(cx)
-    }
-
-    fn poll_shutdown(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
-        std::pin::Pin::new(&mut self.get_mut().file).poll_shutdown(cx)
-    }
-}
-
-/// Stream a blob to `dest`, verifying its SHA-256 against `descriptor.digest`
-/// as it downloads. The blob is written to a `.partial` temp file and only
-/// renamed into place once the digest checks out, so a failed/corrupted pull
-/// never leaves a bad blob under its content-addressed name. A blob whose digest
-/// uses an unsupported algorithm (anything but sha256) is rejected rather than
-/// stored unverified.
-async fn stream_and_verify_blob(
-    client: &Client,
-    oci_ref: &Reference,
-    descriptor: &oci_distribution::manifest::OciDescriptor,
-    dest: &Path,
-    what: &str,
-    registry: &str,
-) -> Result<()> {
-    use tokio::io::AsyncWriteExt;
-
-    let tmp = dest.with_extension("partial");
-    let file = tokio::fs::File::create(&tmp)
-        .await
-        .map_err(|e| BoxError::RegistryError {
-            registry: registry.to_string(),
-            message: format!("Failed to create {what} file: {e}"),
-        })?;
-    let mut writer = HashingFileWriter::new(file);
-
-    if let Err(e) = client.pull_blob(oci_ref, descriptor, &mut writer).await {
-        let _ = tokio::fs::remove_file(&tmp).await;
-        return Err(BoxError::RegistryError {
-            registry: registry.to_string(),
-            message: format!("Failed to pull {what}: {e}"),
-        });
-    }
-    let _ = writer.flush().await;
-    let _ = writer.shutdown().await;
-    let actual_hex = writer.finalize_hex();
-
-    match descriptor.digest.strip_prefix("sha256:") {
-        Some(expected_hex) if actual_hex.eq_ignore_ascii_case(expected_hex) => {}
-        Some(expected_hex) => {
-            let _ = tokio::fs::remove_file(&tmp).await;
-            return Err(BoxError::RegistryError {
-                registry: registry.to_string(),
-                message: format!(
-                    "{what} digest mismatch: expected sha256:{expected_hex}, computed sha256:{actual_hex}"
-                ),
-            });
-        }
-        None => {
-            // We can only verify sha256. Refuse to store a blob whose digest
-            // algorithm we cannot check rather than silently trust the registry's
-            // bytes — otherwise a malicious/MITM registry could serve arbitrary
-            // content under a sha512:/unknown digest and have it reach the rootfs.
-            let _ = tokio::fs::remove_file(&tmp).await;
-            return Err(BoxError::RegistryError {
-                registry: registry.to_string(),
-                message: format!(
-                    "{what} uses an unsupported digest algorithm ({}); refusing to store \
-                     unverifiable content (only sha256 is supported)",
-                    descriptor.digest
-                ),
-            });
-        }
-    }
-
-    tokio::fs::rename(&tmp, dest)
-        .await
-        .map_err(|e| BoxError::RegistryError {
-            registry: registry.to_string(),
-            message: format!("Failed to store {what} blob: {e}"),
-        })
-}
-
 /// Callback type for layer pull progress: `(current, total, digest, size_bytes)`.
 type PullProgressFn = Arc<dyn Fn(usize, usize, &str, i64) + Send + Sync>;
+
+struct PulledImageManifest {
+    manifest: OciImageManifest,
+    digest: String,
+    bytes: Option<Vec<u8>>,
+    used_basic: bool,
+}
 
 /// Authentication credentials for a container registry.
 #[derive(Debug, Clone)]
@@ -285,6 +173,8 @@ impl RegistryAuth {
 pub(crate) struct RegistryPuller {
     client: Client,
     auth: RegistryAuth,
+    protocol: RegistryProtocol,
+    target_arch: String,
     /// Signature verification policy (default: Skip).
     signature_policy: SignaturePolicy,
     /// Optional layer progress callback: (current, total, digest, size_bytes).
@@ -305,19 +195,11 @@ impl RegistryPuller {
 
     /// Create a new registry puller with the given authentication.
     pub fn with_auth(auth: RegistryAuth) -> Self {
-        let config = ClientConfig {
-            protocol: RegistryProtocol::from_env().client_protocol(),
-            platform_resolver: Some(Box::new(linux_platform_resolver)),
-            ..Default::default()
-        };
-        let client = Client::new(config);
-
-        Self {
-            client,
+        Self::with_auth_arch_and_protocol(
             auth,
-            signature_policy: SignaturePolicy::default(),
-            progress_fn: None,
-        }
+            resolve_target_arch(None),
+            RegistryProtocol::from_env(),
+        )
     }
 
     /// Like [`with_auth`](Self::with_auth) but resolves multi-arch image indexes
@@ -328,9 +210,17 @@ impl RegistryPuller {
             return Self::with_auth(auth);
         };
         let arch = resolve_target_arch(Some(&platform));
+        Self::with_auth_arch_and_protocol(auth, arch, RegistryProtocol::from_env())
+    }
+
+    fn with_auth_arch_and_protocol(
+        auth: RegistryAuth,
+        target_arch: String,
+        protocol: RegistryProtocol,
+    ) -> Self {
         let config = ClientConfig {
-            protocol: RegistryProtocol::from_env().client_protocol(),
-            platform_resolver: Some(Box::new(platform_resolver_for(arch))),
+            protocol: protocol.client_protocol(),
+            platform_resolver: Some(Box::new(platform_resolver_for(target_arch.clone()))),
             ..Default::default()
         };
         let client = Client::new(config);
@@ -338,6 +228,8 @@ impl RegistryPuller {
         Self {
             client,
             auth,
+            protocol,
+            target_arch,
             signature_policy: SignaturePolicy::default(),
             progress_fn: None,
         }
@@ -378,15 +270,11 @@ impl RegistryPuller {
         })?;
 
         // Pull manifest (resolves multi-arch image indexes to current platform)
-        let auth = self.auth.to_oci_auth();
-        let (image_manifest, manifest_digest) = self
-            .client
-            .pull_image_manifest(&oci_ref, &auth)
-            .await
-            .map_err(|e| BoxError::RegistryError {
-                registry: reference.registry.clone(),
-                message: format!("Failed to pull manifest: {}", e),
-            })?;
+        let pulled_manifest = self
+            .pull_image_manifest_with_auth_fallback(reference, &oci_ref)
+            .await?;
+        let image_manifest = pulled_manifest.manifest;
+        let manifest_digest = pulled_manifest.digest;
 
         // Verify image signature before downloading layers
         let verify_result = verify_image_signature(
@@ -421,7 +309,9 @@ impl RegistryPuller {
         // the Docker-Content-Digest header verbatim, and feeding `sha256:../../x`
         // into blobs_dir.join() would write the (attacker-shaped) manifest JSON to
         // an arbitrary host path outside the store.
-        let manifest_json = serde_json::to_vec(&image_manifest)?;
+        let manifest_json = pulled_manifest
+            .bytes
+            .unwrap_or(serde_json::to_vec(&image_manifest)?);
         let manifest_digest_hex = validated_digest_hex(&manifest_digest)?;
         std::fs::write(blobs_dir.join(manifest_digest_hex), &manifest_json).map_err(|e| {
             BoxError::RegistryError {
@@ -431,8 +321,14 @@ impl RegistryPuller {
         })?;
 
         // Pull image config and layers
-        self.pull_image_content(&oci_ref, &image_manifest, &blobs_dir, &reference.registry)
-            .await?;
+        self.pull_image_content(
+            reference,
+            &oci_ref,
+            &image_manifest,
+            &blobs_dir,
+            pulled_manifest.used_basic,
+        )
+        .await?;
 
         // Write oci-layout file
         std::fs::write(
@@ -476,43 +372,165 @@ impl RegistryPuller {
         let oci_ref = self.to_oci_reference(reference)?;
         let auth = self.auth.to_oci_auth();
 
-        let (_manifest, digest) =
-            self.client
-                .pull_manifest(&oci_ref, &auth)
-                .await
-                .map_err(|e| BoxError::RegistryError {
-                    registry: reference.registry.clone(),
-                    message: format!("Failed to pull manifest: {}", e),
-                })?;
+        match self.client.pull_manifest(&oci_ref, &auth).await {
+            Ok((_manifest, digest)) => {
+                validated_digest_hex(&digest)?;
+                Ok(digest)
+            }
+            Err(first_error)
+                if is_unauthorized_registry_error(&first_error)
+                    && self.auth.basic_credentials().is_some() =>
+            {
+                tracing::warn!(
+                    reference = %reference,
+                    error = %registry_error_summary(&first_error, &self.auth),
+                    "Registry rejected the default OCI manifest auth flow; retrying with preemptive Basic auth"
+                );
+                let basic_client = self
+                    .basic_pull_client(reference)
+                    .map_err(|fallback_error| {
+                        self.combined_pull_error(reference, &first_error, &fallback_error)
+                    })?;
+                basic_client
+                    .pull_manifest_digest(reference)
+                    .await
+                    .map_err(|fallback_error| {
+                        self.combined_pull_error(reference, &first_error, &fallback_error)
+                    })
+            }
+            Err(error) => Err(self.pull_error(reference, &error)),
+        }
+    }
 
-        Ok(digest)
+    async fn pull_image_manifest_with_auth_fallback(
+        &self,
+        reference: &ImageReference,
+        oci_ref: &Reference,
+    ) -> Result<PulledImageManifest> {
+        let auth = self.auth.to_oci_auth();
+        match self.client.pull_image_manifest(oci_ref, &auth).await {
+            Ok((manifest, digest)) => Ok(PulledImageManifest {
+                manifest,
+                digest,
+                bytes: None,
+                used_basic: false,
+            }),
+            Err(first_error)
+                if is_unauthorized_registry_error(&first_error)
+                    && self.auth.basic_credentials().is_some() =>
+            {
+                tracing::warn!(
+                    reference = %reference,
+                    error = %registry_error_summary(&first_error, &self.auth),
+                    "Registry rejected the default OCI manifest auth flow; retrying with preemptive Basic auth"
+                );
+                let basic_client = self
+                    .basic_pull_client(reference)
+                    .map_err(|fallback_error| {
+                        self.combined_pull_error(reference, &first_error, &fallback_error)
+                    })?;
+                let BasicImageManifest {
+                    manifest,
+                    digest,
+                    bytes,
+                } = basic_client.pull_image_manifest(reference).await.map_err(
+                    |fallback_error| {
+                        self.combined_pull_error(reference, &first_error, &fallback_error)
+                    },
+                )?;
+                Ok(PulledImageManifest {
+                    manifest,
+                    digest,
+                    bytes: Some(bytes),
+                    used_basic: true,
+                })
+            }
+            Err(error) => Err(self.pull_error(reference, &error)),
+        }
+    }
+
+    fn basic_pull_client(
+        &self,
+        reference: &ImageReference,
+    ) -> std::result::Result<BasicPullClient, OciDistributionError> {
+        BasicPullClient::new(
+            self.protocol,
+            reference,
+            &self.auth,
+            self.target_arch.clone(),
+        )
+    }
+
+    fn pull_error(&self, reference: &ImageReference, error: &OciDistributionError) -> BoxError {
+        BoxError::RegistryError {
+            registry: reference.registry.clone(),
+            message: format!(
+                "Failed to pull manifest: {}",
+                registry_error_summary(error, &self.auth)
+            ),
+        }
+    }
+
+    fn combined_pull_error(
+        &self,
+        reference: &ImageReference,
+        first_error: &OciDistributionError,
+        fallback_error: &OciDistributionError,
+    ) -> BoxError {
+        BoxError::RegistryError {
+            registry: reference.registry.clone(),
+            message: format!(
+                "Failed to pull manifest: default auth failed: {}; preemptive Basic retry failed: {}",
+                registry_error_summary(first_error, &self.auth),
+                registry_error_summary(fallback_error, &self.auth)
+            ),
+        }
     }
 
     /// Pull config and layers for an image manifest, writing blobs to disk.
     async fn pull_image_content(
         &self,
+        reference: &ImageReference,
         oci_ref: &Reference,
         manifest: &OciImageManifest,
         blobs_dir: &Path,
-        registry: &str,
+        force_basic: bool,
     ) -> Result<()> {
+        let basic_client = if self.auth.basic_credentials().is_some() {
+            Some(
+                self.basic_pull_client(reference)
+                    .map_err(|error| BoxError::RegistryError {
+                        registry: reference.registry.clone(),
+                        message: format!(
+                            "Failed to prepare authenticated blob pull: {}",
+                            registry_error_summary(&error, &self.auth)
+                        ),
+                    })?,
+            )
+        } else {
+            None
+        };
+        let transport = BlobPullTransport {
+            client: &self.client,
+            oci_ref,
+            basic_client: basic_client.as_ref(),
+            force_basic,
+            auth: &self.auth,
+            registry: &reference.registry,
+        };
+
         // Stream the config blob to disk, verifying its digest on the fly.
         // pull_blob delivers raw bytes without validation, so the streaming
         // hasher both bounds memory and guards against a buggy/malicious
         // registry or a corrupted transfer being stored content-addressed and
         // later extracted into the guest.
         let config_descriptor = &manifest.config;
-        let config_digest_hex = config_descriptor
-            .digest
-            .strip_prefix("sha256:")
-            .unwrap_or(&config_descriptor.digest);
+        let config_digest_hex = validated_digest_hex(&config_descriptor.digest)?;
         stream_and_verify_blob(
-            &self.client,
-            oci_ref,
+            &transport,
             config_descriptor,
             &blobs_dir.join(config_digest_hex),
             "config blob",
-            registry,
         )
         .await?;
 
@@ -529,17 +547,12 @@ impl RegistryPuller {
                 f(idx + 1, total, &layer.digest, layer.size);
             }
 
-            let layer_digest_hex = layer
-                .digest
-                .strip_prefix("sha256:")
-                .unwrap_or(&layer.digest);
+            let layer_digest_hex = validated_digest_hex(&layer.digest)?;
             stream_and_verify_blob(
-                &self.client,
-                oci_ref,
+                &transport,
                 layer,
                 &blobs_dir.join(layer_digest_hex),
                 "layer",
-                registry,
             )
             .await?;
 
@@ -809,7 +822,7 @@ impl RegistryPusher {
             .await
         {
             Err(first_error)
-                if is_unauthorized_push_error(&first_error)
+                if is_unauthorized_registry_error(&first_error)
                     && self.auth.basic_credentials().is_some() =>
             {
                 tracing::warn!(
@@ -923,7 +936,7 @@ impl RegistryPusher {
                 verify_remote_manifest_digest(reference, expected_digest, &remote_digest)
             }
             Err(error)
-                if is_unauthorized_push_error(&error)
+                if is_unauthorized_registry_error(&error)
                     && self.auth.basic_credentials().is_some() =>
             {
                 let remote_digest = self
@@ -1018,6 +1031,18 @@ fn registry_manifest_url(
 ) -> std::result::Result<oci_reqwest::Url, OciDistributionError> {
     oci_reqwest::Url::parse(&format!(
         "{}/v2/{repository}/manifests/{reference}",
+        base.as_str().trim_end_matches('/')
+    ))
+    .map_err(|e| OciDistributionError::UrlParseError(e.to_string()))
+}
+
+fn registry_blob_url(
+    base: &oci_reqwest::Url,
+    repository: &str,
+    digest: &str,
+) -> std::result::Result<oci_reqwest::Url, OciDistributionError> {
+    oci_reqwest::Url::parse(&format!(
+        "{}/v2/{repository}/blobs/{digest}",
         base.as_str().trim_end_matches('/')
     ))
     .map_err(|e| OciDistributionError::UrlParseError(e.to_string()))
@@ -1175,17 +1200,32 @@ async fn push_blob_with_basic_auth(
     response_location_or_url(&response, &complete_url)
 }
 
-fn is_unauthorized_push_error(error: &OciDistributionError) -> bool {
+fn is_unauthorized_registry_error(error: &OciDistributionError) -> bool {
     match error {
         OciDistributionError::UnauthorizedError { .. }
         | OciDistributionError::AuthenticationFailure(_)
         | OciDistributionError::ServerError { code: 401, .. } => true,
+        OciDistributionError::RequestError(error) => error
+            .status()
+            .is_some_and(|status| status == oci_reqwest::StatusCode::UNAUTHORIZED),
         OciDistributionError::RegistryError { envelope, .. } => envelope
             .errors
             .iter()
             .any(|err| matches!(err.code, OciErrorCode::Unauthorized)),
         _ => false,
     }
+}
+
+fn registry_error_summary(error: &OciDistributionError, auth: &RegistryAuth) -> String {
+    let mut message = error.to_string();
+    if let Some((username, password)) = auth.basic_credentials() {
+        for secret in [username, password] {
+            if !secret.is_empty() {
+                message = message.replace(&secret, "[redacted]");
+            }
+        }
+    }
+    message
 }
 
 fn is_repository_already_exists_push_error(error: &OciDistributionError) -> bool {
@@ -1274,11 +1314,6 @@ fn platform_resolver_for(arch: String) -> impl Fn(&[ImageIndexEntry]) -> Option<
             })
             .map(|entry| entry.digest.clone())
     }
-}
-
-/// Platform resolver selecting the linux manifest matching the host architecture.
-fn linux_platform_resolver(manifests: &[ImageIndexEntry]) -> Option<String> {
-    platform_resolver_for(resolve_target_arch(None))(manifests)
 }
 
 #[cfg(test)]
@@ -1707,3 +1742,6 @@ mod tests {
         assert!(err.to_string().contains(&layer_digest));
     }
 }
+
+#[cfg(test)]
+mod basic_pull_tests;

--- a/src/runtime/src/oci/registry/basic_pull.rs
+++ b/src/runtime/src/oci/registry/basic_pull.rs
@@ -1,0 +1,293 @@
+use oci_distribution::errors::OciDistributionError;
+use oci_distribution::manifest::{
+    OciDescriptor, OciImageManifest, OciManifest, IMAGE_MANIFEST_LIST_MEDIA_TYPE,
+    IMAGE_MANIFEST_MEDIA_TYPE, OCI_IMAGE_INDEX_MEDIA_TYPE, OCI_IMAGE_MEDIA_TYPE,
+};
+use oci_reqwest::header::ACCEPT;
+use sha2::Digest as _;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+use super::{
+    registry_base_url, registry_blob_url, registry_manifest_url, ImageReference, RegistryAuth,
+    RegistryProtocol, MANIFEST_ACCEPT,
+};
+
+pub(super) struct BasicImageManifest {
+    pub(super) manifest: OciImageManifest,
+    pub(super) digest: String,
+    pub(super) bytes: Vec<u8>,
+}
+
+struct RawManifest {
+    manifest: OciManifest,
+    digest: String,
+    bytes: Vec<u8>,
+}
+
+/// Minimal OCI pull transport for registries that require preemptive HTTP
+/// Basic authentication on protected endpoints but do not advertise that
+/// challenge from `/v2/`.
+pub(super) struct BasicPullClient {
+    http: oci_reqwest::Client,
+    base: oci_reqwest::Url,
+    repository: String,
+    username: String,
+    password: String,
+    target_arch: String,
+}
+
+impl BasicPullClient {
+    pub(super) fn new(
+        protocol: RegistryProtocol,
+        reference: &ImageReference,
+        auth: &RegistryAuth,
+        target_arch: String,
+    ) -> std::result::Result<Self, OciDistributionError> {
+        let (username, password) = auth.basic_credentials().ok_or_else(|| {
+            OciDistributionError::GenericError(Some(
+                "preemptive Basic pull requires non-empty credentials".to_string(),
+            ))
+        })?;
+
+        Ok(Self {
+            http: oci_reqwest::Client::builder().build()?,
+            base: registry_base_url(protocol, reference)?,
+            repository: reference.repository.clone(),
+            username,
+            password,
+            target_arch,
+        })
+    }
+
+    pub(super) async fn pull_manifest_digest(
+        &self,
+        reference: &ImageReference,
+    ) -> std::result::Result<String, OciDistributionError> {
+        let manifest_ref = manifest_reference(reference);
+        let response = self
+            .fetch_manifest(manifest_ref, reference.digest.as_deref(), None)
+            .await?;
+        Ok(response.digest)
+    }
+
+    pub(super) async fn pull_image_manifest(
+        &self,
+        reference: &ImageReference,
+    ) -> std::result::Result<BasicImageManifest, OciDistributionError> {
+        let manifest_ref = manifest_reference(reference);
+        let root = self
+            .fetch_manifest(manifest_ref, reference.digest.as_deref(), None)
+            .await?;
+
+        match root.manifest {
+            OciManifest::Image(manifest) => Ok(BasicImageManifest {
+                manifest,
+                digest: root.digest,
+                bytes: root.bytes,
+            }),
+            OciManifest::ImageIndex(index) => {
+                let entry = index
+                    .manifests
+                    .iter()
+                    .find(|entry| {
+                        entry.platform.as_ref().is_some_and(|platform| {
+                            platform.os == "linux" && platform.architecture == self.target_arch
+                        })
+                    })
+                    .cloned()
+                    .ok_or_else(|| {
+                        OciDistributionError::ImageManifestNotFoundError(format!(
+                            "no linux/{} entry found in image index",
+                            self.target_arch
+                        ))
+                    })?;
+                let selected = self
+                    .fetch_manifest(&entry.digest, Some(&entry.digest), Some(entry.size))
+                    .await?;
+                match selected.manifest {
+                    OciManifest::Image(manifest) => Ok(BasicImageManifest {
+                        manifest,
+                        digest: selected.digest,
+                        bytes: selected.bytes,
+                    }),
+                    OciManifest::ImageIndex(_) => {
+                        Err(OciDistributionError::ImageManifestNotFoundError(
+                            "selected image-index entry resolved to another image index"
+                                .to_string(),
+                        ))
+                    }
+                }
+            }
+        }
+    }
+
+    pub(super) async fn pull_blob<W>(
+        &self,
+        descriptor: &OciDescriptor,
+        writer: &mut W,
+    ) -> std::result::Result<(), OciDistributionError>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        validate_sha256_digest(&descriptor.digest)?;
+        let url = registry_blob_url(&self.base, &self.repository, &descriptor.digest)?;
+        let response = self
+            .http
+            .get(url.clone())
+            .basic_auth(&self.username, Some(&self.password))
+            .send()
+            .await?;
+        let mut response = ensure_pull_status(response, url.as_str())?;
+
+        while let Some(chunk) = response.chunk().await? {
+            writer.write_all(&chunk).await?;
+        }
+        Ok(())
+    }
+
+    async fn fetch_manifest(
+        &self,
+        reference: &str,
+        expected_digest: Option<&str>,
+        expected_size: Option<i64>,
+    ) -> std::result::Result<RawManifest, OciDistributionError> {
+        let url = registry_manifest_url(&self.base, &self.repository, reference)?;
+        let response = self
+            .http
+            .get(url.clone())
+            .basic_auth(&self.username, Some(&self.password))
+            .header(ACCEPT, MANIFEST_ACCEPT)
+            .send()
+            .await?;
+        let response = ensure_pull_status(response, url.as_str())?;
+        let header_digest = response
+            .headers()
+            .get("docker-content-digest")
+            .map(|value| value.to_str().map(str::to_string))
+            .transpose()?;
+        let bytes = response.bytes().await?.to_vec();
+
+        if let Some(expected_size) = expected_size {
+            if expected_size < 0 || bytes.len() as i64 != expected_size {
+                return Err(OciDistributionError::SpecViolationError(format!(
+                    "manifest size mismatch: expected {expected_size} bytes, received {}",
+                    bytes.len()
+                )));
+            }
+        }
+
+        let computed_digest = format!("sha256:{:x}", sha2::Sha256::digest(&bytes));
+        if let Some(expected_digest) = expected_digest {
+            validate_sha256_digest(expected_digest)?;
+            ensure_digest_matches("manifest descriptor", expected_digest, &computed_digest)?;
+        }
+        if let Some(header_digest) = header_digest.as_deref() {
+            validate_sha256_digest(header_digest)?;
+            ensure_digest_matches(
+                "Docker-Content-Digest header",
+                header_digest,
+                &computed_digest,
+            )?;
+        }
+        let digest = header_digest.unwrap_or(computed_digest);
+
+        let manifest: OciManifest = serde_json::from_slice(&bytes)
+            .map_err(|error| OciDistributionError::ManifestParsingError(error.to_string()))?;
+        validate_manifest(&manifest)?;
+
+        Ok(RawManifest {
+            manifest,
+            digest,
+            bytes,
+        })
+    }
+}
+
+fn manifest_reference(reference: &ImageReference) -> &str {
+    reference
+        .tag
+        .as_deref()
+        .or(reference.digest.as_deref())
+        .unwrap_or("latest")
+}
+
+fn validate_manifest(manifest: &OciManifest) -> std::result::Result<(), OciDistributionError> {
+    let (schema_version, media_type) = match manifest {
+        OciManifest::Image(manifest) => (manifest.schema_version, manifest.media_type.as_deref()),
+        OciManifest::ImageIndex(index) => (index.schema_version, index.media_type.as_deref()),
+    };
+    if schema_version != 2 {
+        return Err(OciDistributionError::UnsupportedSchemaVersionError(
+            i32::from(schema_version),
+        ));
+    }
+    if let Some(media_type) = media_type {
+        if ![
+            IMAGE_MANIFEST_MEDIA_TYPE,
+            OCI_IMAGE_MEDIA_TYPE,
+            IMAGE_MANIFEST_LIST_MEDIA_TYPE,
+            OCI_IMAGE_INDEX_MEDIA_TYPE,
+        ]
+        .contains(&media_type)
+        {
+            return Err(OciDistributionError::UnsupportedMediaTypeError(
+                media_type.to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_sha256_digest(digest: &str) -> std::result::Result<(), OciDistributionError> {
+    let valid = digest.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    });
+    if valid {
+        Ok(())
+    } else {
+        Err(OciDistributionError::SpecViolationError(
+            "registry returned a malformed content digest (expected sha256:<64 lowercase hex>)"
+                .to_string(),
+        ))
+    }
+}
+
+fn ensure_digest_matches(
+    source: &str,
+    expected: &str,
+    computed: &str,
+) -> std::result::Result<(), OciDistributionError> {
+    if expected.eq_ignore_ascii_case(computed) {
+        Ok(())
+    } else {
+        Err(OciDistributionError::SpecViolationError(format!(
+            "{source} digest mismatch: expected {expected}, computed {computed}"
+        )))
+    }
+}
+
+fn ensure_pull_status(
+    response: oci_reqwest::Response,
+    url: &str,
+) -> std::result::Result<oci_reqwest::Response, OciDistributionError> {
+    let status = response.status();
+    if status == oci_reqwest::StatusCode::OK {
+        return Ok(response);
+    }
+    if status == oci_reqwest::StatusCode::UNAUTHORIZED {
+        return Err(OciDistributionError::UnauthorizedError {
+            url: url.to_string(),
+        });
+    }
+
+    // Do not include a registry-controlled response body. A hostile endpoint
+    // could echo the Authorization header or submitted credentials into it.
+    Err(OciDistributionError::ServerError {
+        code: status.as_u16(),
+        url: url.to_string(),
+        message: "registry request failed".to_string(),
+    })
+}

--- a/src/runtime/src/oci/registry/basic_pull_tests.rs
+++ b/src/runtime/src/oci/registry/basic_pull_tests.rs
@@ -1,0 +1,705 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Method, Request, Response, StatusCode};
+use axum::routing::any;
+use axum::Router;
+use base64::Engine as _;
+use serde_json::json;
+use sha2::Digest as _;
+
+use super::super::pull::ImagePuller;
+use super::super::store::ImageStore;
+use super::{ImageReference, RegistryAuth, RegistryProtocol, RegistryPuller};
+
+const USERNAME: &str = "fixture-user";
+const PASSWORD: &str = "fixture-secret-password";
+const REPOSITORY: &str = "a3s/app";
+
+#[derive(Clone, Debug)]
+struct RecordedRequest {
+    path: String,
+    authorization: Option<String>,
+}
+
+#[derive(Clone)]
+struct RegistryFixtureState {
+    expected_authorization: String,
+    manifests: Arc<HashMap<String, FixtureContent>>,
+    blobs: Arc<HashMap<String, FixtureContent>>,
+    redirected_layer_digest: String,
+    public_manifests: Arc<AtomicBool>,
+    external_layer_redirect: Arc<Mutex<Option<String>>>,
+    corrupt_manifest: Arc<Mutex<Option<String>>>,
+    corrupt_blob: Arc<Mutex<Option<String>>>,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+}
+
+#[derive(Clone)]
+struct FixtureContent {
+    bytes: Vec<u8>,
+    media_type: &'static str,
+    digest: String,
+}
+
+struct RegistryFixture {
+    reference: ImageReference,
+    index_digest: String,
+    manifest_digest: String,
+    config_digest: String,
+    layer_digest: String,
+    manifest_bytes: Vec<u8>,
+    config_bytes: Vec<u8>,
+    layer_bytes: Vec<u8>,
+    public_manifests: Arc<AtomicBool>,
+    external_layer_redirect: Arc<Mutex<Option<String>>>,
+    corrupt_manifest: Arc<Mutex<Option<String>>>,
+    corrupt_blob: Arc<Mutex<Option<String>>>,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl RegistryFixture {
+    async fn start() -> Self {
+        let config_bytes = serde_json::to_vec(&json!({
+            "architecture": "amd64",
+            "os": "linux",
+            "config": {"Cmd": ["sh", "-c", "echo fixture-ok"]},
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "history": []
+        }))
+        .unwrap();
+        let layer_bytes = b"streamed-layer-payload".repeat(256);
+        let config_digest = digest(&config_bytes);
+        let layer_digest = digest(&layer_bytes);
+
+        let manifest_bytes = serde_json::to_vec(&json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": config_digest,
+                "size": config_bytes.len()
+            },
+            "layers": [{
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "digest": layer_digest,
+                "size": layer_bytes.len()
+            }]
+        }))
+        .unwrap();
+        let manifest_digest = digest(&manifest_bytes);
+
+        let wrong_manifest = serde_json::to_vec(&json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": config_digest,
+                "size": config_bytes.len()
+            },
+            "layers": []
+        }))
+        .unwrap();
+        let wrong_manifest_digest = digest(&wrong_manifest);
+
+        let index_bytes = serde_json::to_vec(&json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": wrong_manifest_digest,
+                    "size": wrong_manifest.len(),
+                    "platform": {"architecture": "arm64", "os": "linux"}
+                },
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": manifest_digest,
+                    "size": manifest_bytes.len(),
+                    "platform": {"architecture": "amd64", "os": "linux"}
+                }
+            ]
+        }))
+        .unwrap();
+        let index_digest = digest(&index_bytes);
+
+        let manifests = HashMap::from([
+            (
+                "latest".to_string(),
+                FixtureContent {
+                    bytes: index_bytes,
+                    media_type: "application/vnd.oci.image.index.v1+json",
+                    digest: index_digest.clone(),
+                },
+            ),
+            (
+                manifest_digest.clone(),
+                FixtureContent {
+                    bytes: manifest_bytes.clone(),
+                    media_type: "application/vnd.oci.image.manifest.v1+json",
+                    digest: manifest_digest.clone(),
+                },
+            ),
+            (
+                wrong_manifest_digest.clone(),
+                FixtureContent {
+                    bytes: wrong_manifest,
+                    media_type: "application/vnd.oci.image.manifest.v1+json",
+                    digest: wrong_manifest_digest,
+                },
+            ),
+        ]);
+        let blobs = HashMap::from([
+            (
+                config_digest.clone(),
+                FixtureContent {
+                    bytes: config_bytes.clone(),
+                    media_type: "application/octet-stream",
+                    digest: config_digest.clone(),
+                },
+            ),
+            (
+                layer_digest.clone(),
+                FixtureContent {
+                    bytes: layer_bytes.clone(),
+                    media_type: "application/octet-stream",
+                    digest: layer_digest.clone(),
+                },
+            ),
+        ]);
+
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let public_manifests = Arc::new(AtomicBool::new(false));
+        let external_layer_redirect = Arc::new(Mutex::new(None));
+        let corrupt_manifest = Arc::new(Mutex::new(None));
+        let corrupt_blob = Arc::new(Mutex::new(None));
+        let state = RegistryFixtureState {
+            expected_authorization: format!(
+                "Basic {}",
+                base64::engine::general_purpose::STANDARD.encode(format!("{USERNAME}:{PASSWORD}"))
+            ),
+            manifests: Arc::new(manifests),
+            blobs: Arc::new(blobs),
+            redirected_layer_digest: layer_digest.clone(),
+            public_manifests: Arc::clone(&public_manifests),
+            external_layer_redirect: Arc::clone(&external_layer_redirect),
+            corrupt_manifest: Arc::clone(&corrupt_manifest),
+            corrupt_blob: Arc::clone(&corrupt_blob),
+            requests: Arc::clone(&requests),
+        };
+        let app = Router::new()
+            .route("/*path", any(registry_handler))
+            .with_state(state);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .unwrap()
+                .serve(app.into_make_service())
+                .await
+                .unwrap();
+        });
+
+        Self {
+            reference: ImageReference {
+                registry: addr.to_string(),
+                repository: REPOSITORY.to_string(),
+                tag: Some("latest".to_string()),
+                digest: None,
+            },
+            index_digest,
+            manifest_digest,
+            config_digest,
+            layer_digest,
+            manifest_bytes,
+            config_bytes,
+            layer_bytes,
+            public_manifests,
+            external_layer_redirect,
+            corrupt_manifest,
+            corrupt_blob,
+            requests,
+            task,
+        }
+    }
+
+    fn request_snapshot(&self) -> Vec<RecordedRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    fn corrupt_manifest(&self, reference: &str) {
+        *self.corrupt_manifest.lock().unwrap() = Some(reference.to_string());
+    }
+
+    fn corrupt_blob(&self, digest: &str) {
+        *self.corrupt_blob.lock().unwrap() = Some(digest.to_string());
+    }
+
+    fn redirect_layer_to(&self, location: String) {
+        *self.external_layer_redirect.lock().unwrap() = Some(location);
+    }
+
+    fn allow_anonymous_manifests(&self) {
+        self.public_manifests.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for RegistryFixture {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[derive(Clone)]
+struct RedirectTargetState {
+    content: FixtureContent,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+}
+
+struct RedirectTarget {
+    url: String,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl RedirectTarget {
+    async fn start(bytes: Vec<u8>, digest: String) -> Self {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let state = RedirectTargetState {
+            content: FixtureContent {
+                bytes,
+                media_type: "application/octet-stream",
+                digest,
+            },
+            requests: Arc::clone(&requests),
+        };
+        let app = Router::new()
+            .route("/external-layer", any(redirect_target_handler))
+            .with_state(state);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .unwrap()
+                .serve(app.into_make_service())
+                .await
+                .unwrap();
+        });
+        Self {
+            url: format!("http://{addr}/external-layer"),
+            requests,
+            task,
+        }
+    }
+}
+
+impl Drop for RedirectTarget {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn redirect_target_handler(
+    State(state): State<RedirectTargetState>,
+    request: Request<Body>,
+) -> Response<Body> {
+    state.requests.lock().unwrap().push(RecordedRequest {
+        path: request.uri().path().to_string(),
+        authorization: request
+            .headers()
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string),
+    });
+    response(
+        StatusCode::OK,
+        Some(state.content.media_type),
+        Some(&state.content.digest),
+        state.content.bytes,
+    )
+}
+
+async fn registry_handler(
+    State(state): State<RegistryFixtureState>,
+    request: Request<Body>,
+) -> Response<Body> {
+    let path = request.uri().path().to_string();
+    let authorization = request
+        .headers()
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    state.requests.lock().unwrap().push(RecordedRequest {
+        path: path.clone(),
+        authorization: authorization.clone(),
+    });
+
+    if request.method() != Method::GET {
+        return response(StatusCode::METHOD_NOT_ALLOWED, None, None, Vec::new());
+    }
+    if path == "/v2/" {
+        // This registry advertises Basic only on protected resources. That is
+        // the production behavior that oci-distribution does not negotiate.
+        return response(StatusCode::OK, None, None, Vec::new());
+    }
+    let manifest_prefix = format!("/v2/{REPOSITORY}/manifests/");
+    let anonymous_manifest_allowed =
+        state.public_manifests.load(Ordering::Relaxed) && path.starts_with(&manifest_prefix);
+    if authorization.as_deref() != Some(&state.expected_authorization)
+        && !anonymous_manifest_allowed
+    {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header("www-authenticate", "Basic realm=\"A3S OCI Registry\"")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":{}}]}"#,
+            ))
+            .unwrap();
+    }
+
+    if let Some(reference) = path.strip_prefix(&manifest_prefix) {
+        return match state.manifests.get(reference) {
+            Some(content) => {
+                let mut bytes = content.bytes.clone();
+                if state.corrupt_manifest.lock().unwrap().as_deref() == Some(reference) {
+                    bytes[0] ^= 0x01;
+                }
+                response(
+                    StatusCode::OK,
+                    Some(content.media_type),
+                    Some(&content.digest),
+                    bytes,
+                )
+            }
+            None => response(StatusCode::NOT_FOUND, None, None, Vec::new()),
+        };
+    }
+
+    let blob_prefix = format!("/v2/{REPOSITORY}/blobs/");
+    if let Some(blob_digest) = path.strip_prefix(&blob_prefix) {
+        if blob_digest == state.redirected_layer_digest {
+            let location = state
+                .external_layer_redirect
+                .lock()
+                .unwrap()
+                .clone()
+                .unwrap_or_else(|| format!("/redirected/{blob_digest}"));
+            return Response::builder()
+                .status(StatusCode::TEMPORARY_REDIRECT)
+                .header("location", location)
+                .body(Body::empty())
+                .unwrap();
+        }
+        return match state.blobs.get(blob_digest) {
+            Some(content) => blob_response(&state, blob_digest, content),
+            None => response(StatusCode::NOT_FOUND, None, None, Vec::new()),
+        };
+    }
+
+    if let Some(blob_digest) = path.strip_prefix("/redirected/") {
+        return match state.blobs.get(blob_digest) {
+            Some(content) => blob_response(&state, blob_digest, content),
+            None => response(StatusCode::NOT_FOUND, None, None, Vec::new()),
+        };
+    }
+
+    response(StatusCode::NOT_FOUND, None, None, Vec::new())
+}
+
+fn blob_response(
+    state: &RegistryFixtureState,
+    digest: &str,
+    content: &FixtureContent,
+) -> Response<Body> {
+    let mut bytes = content.bytes.clone();
+    if state.corrupt_blob.lock().unwrap().as_deref() == Some(digest) {
+        bytes[0] ^= 0x01;
+    }
+    response(
+        StatusCode::OK,
+        Some(content.media_type),
+        Some(&content.digest),
+        bytes,
+    )
+}
+
+fn response(
+    status: StatusCode,
+    media_type: Option<&str>,
+    digest: Option<&str>,
+    body: Vec<u8>,
+) -> Response<Body> {
+    let mut builder = Response::builder().status(status);
+    if let Some(media_type) = media_type {
+        builder = builder.header("content-type", media_type);
+    }
+    if let Some(digest) = digest {
+        builder = builder.header("docker-content-digest", digest);
+    }
+    builder.body(Body::from(body)).unwrap()
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", sha2::Sha256::digest(bytes))
+}
+
+fn assert_blob(path: &Path, digest: &str, expected: &[u8]) {
+    let hex = digest.strip_prefix("sha256:").unwrap();
+    assert_eq!(
+        std::fs::read(path.join("blobs/sha256").join(hex)).unwrap(),
+        expected
+    );
+}
+
+#[tokio::test]
+async fn basic_challenge_pull_resolves_index_streams_blobs_and_follows_redirect() {
+    let fixture = RegistryFixture::start().await;
+    let puller = RegistryPuller::with_auth_arch_and_protocol(
+        RegistryAuth::basic(USERNAME, PASSWORD),
+        "amd64".to_string(),
+        RegistryProtocol::Http,
+    );
+    let target = tempfile::tempdir().unwrap();
+
+    assert_eq!(
+        puller
+            .pull_manifest_digest(&fixture.reference)
+            .await
+            .unwrap(),
+        fixture.index_digest
+    );
+    puller
+        .pull(&fixture.reference, target.path())
+        .await
+        .unwrap();
+
+    assert_blob(
+        target.path(),
+        &fixture.manifest_digest,
+        &fixture.manifest_bytes,
+    );
+    assert_blob(target.path(), &fixture.config_digest, &fixture.config_bytes);
+    assert_blob(target.path(), &fixture.layer_digest, &fixture.layer_bytes);
+    let index: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(target.path().join("index.json")).unwrap()).unwrap();
+    assert_eq!(index["manifests"][0]["digest"], fixture.manifest_digest);
+
+    let requests = fixture.request_snapshot();
+    assert!(requests.iter().any(|request| {
+        request.path.ends_with("/manifests/latest") && request.authorization.is_none()
+    }));
+    for suffix in [
+        "/manifests/latest",
+        &format!("/manifests/{}", fixture.manifest_digest),
+        &format!("/blobs/{}", fixture.config_digest),
+        &format!("/blobs/{}", fixture.layer_digest),
+        &format!("/redirected/{}", fixture.layer_digest),
+    ] {
+        assert!(
+            requests.iter().any(|request| {
+                request.path.ends_with(suffix)
+                    && request.authorization.as_deref()
+                        == Some(&format!(
+                            "Basic {}",
+                            base64::engine::general_purpose::STANDARD
+                                .encode(format!("{USERNAME}:{PASSWORD}"))
+                        ))
+            }),
+            "missing authenticated request ending in {suffix}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn image_puller_common_to_explicit_pull_and_run_uses_basic_fallback() {
+    let fixture = RegistryFixture::start().await;
+    let root = tempfile::tempdir().unwrap();
+    let store = Arc::new(ImageStore::new(root.path(), 10 * 1024 * 1024).unwrap());
+    let registry_puller = RegistryPuller::with_auth_arch_and_protocol(
+        RegistryAuth::basic(USERNAME, PASSWORD),
+        "amd64".to_string(),
+        RegistryProtocol::Http,
+    );
+    // Both `a3s-box pull` and run's implicit image preparation call this same
+    // cache-first ImagePuller path.
+    let puller = ImagePuller::with_registry_puller(Arc::clone(&store), registry_puller);
+    let full_reference = fixture.reference.full_reference();
+
+    let image = puller.pull(&full_reference).await.unwrap();
+
+    assert_eq!(image.manifest_digest(), fixture.manifest_digest);
+    let stored = store.get(&full_reference).await.unwrap();
+    assert_eq!(stored.digest, fixture.index_digest);
+    assert_blob(&stored.path, &fixture.config_digest, &fixture.config_bytes);
+    assert_blob(&stored.path, &fixture.layer_digest, &fixture.layer_bytes);
+}
+
+#[tokio::test]
+async fn cross_origin_blob_redirect_does_not_forward_basic_credentials() {
+    let fixture = RegistryFixture::start().await;
+    let redirect_target =
+        RedirectTarget::start(fixture.layer_bytes.clone(), fixture.layer_digest.clone()).await;
+    fixture.redirect_layer_to(redirect_target.url.clone());
+    let puller = RegistryPuller::with_auth_arch_and_protocol(
+        RegistryAuth::basic(USERNAME, PASSWORD),
+        "amd64".to_string(),
+        RegistryProtocol::Http,
+    );
+    let target = tempfile::tempdir().unwrap();
+
+    puller
+        .pull(&fixture.reference, target.path())
+        .await
+        .unwrap();
+
+    let requests = redirect_target.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/external-layer");
+    assert!(requests[0].authorization.is_none());
+}
+
+#[tokio::test]
+async fn blob_unauthorized_after_public_manifest_retries_with_basic() {
+    let fixture = RegistryFixture::start().await;
+    fixture.allow_anonymous_manifests();
+    let puller = RegistryPuller::with_auth_arch_and_protocol(
+        RegistryAuth::basic(USERNAME, PASSWORD),
+        "amd64".to_string(),
+        RegistryProtocol::Http,
+    );
+    let target = tempfile::tempdir().unwrap();
+
+    puller
+        .pull(&fixture.reference, target.path())
+        .await
+        .unwrap();
+
+    let config_path = format!("/v2/{REPOSITORY}/blobs/{}", fixture.config_digest);
+    let requests = fixture.request_snapshot();
+    assert!(requests
+        .iter()
+        .any(|request| { request.path == config_path && request.authorization.is_none() }));
+    assert!(requests
+        .iter()
+        .any(|request| { request.path == config_path && request.authorization.is_some() }));
+    assert_blob(target.path(), &fixture.config_digest, &fixture.config_bytes);
+    assert_blob(target.path(), &fixture.layer_digest, &fixture.layer_bytes);
+}
+
+#[tokio::test]
+async fn anonymous_pull_does_not_attempt_preemptive_basic() {
+    let fixture = RegistryFixture::start().await;
+    let puller = RegistryPuller::with_auth_arch_and_protocol(
+        RegistryAuth::anonymous(),
+        "amd64".to_string(),
+        RegistryProtocol::Http,
+    );
+
+    let error = puller
+        .pull_manifest_digest(&fixture.reference)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("Failed to pull manifest"));
+    assert!(fixture
+        .request_snapshot()
+        .iter()
+        .all(|request| request.authorization.is_none()));
+}
+
+#[tokio::test]
+async fn empty_basic_credentials_do_not_enable_preemptive_retry() {
+    for auth in [
+        RegistryAuth::basic("", PASSWORD),
+        RegistryAuth::basic(USERNAME, ""),
+    ] {
+        let fixture = RegistryFixture::start().await;
+        let puller = RegistryPuller::with_auth_arch_and_protocol(
+            auth,
+            "amd64".to_string(),
+            RegistryProtocol::Http,
+        );
+
+        puller
+            .pull_manifest_digest(&fixture.reference)
+            .await
+            .unwrap_err();
+        assert!(fixture
+            .request_snapshot()
+            .iter()
+            .all(|request| request.authorization.is_none()));
+    }
+}
+
+#[tokio::test]
+async fn failed_basic_pull_never_exposes_credentials() {
+    let fixture = RegistryFixture::start().await;
+    let wrong_username = "credential-user-must-not-leak";
+    let wrong_password = "credential-password-must-not-leak";
+    let puller = RegistryPuller::with_auth_arch_and_protocol(
+        RegistryAuth::basic(wrong_username, wrong_password),
+        "amd64".to_string(),
+        RegistryProtocol::Http,
+    );
+
+    let message = puller
+        .pull_manifest_digest(&fixture.reference)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(!message.contains(wrong_username));
+    assert!(!message.contains(wrong_password));
+}
+
+#[tokio::test]
+async fn basic_pull_rejects_corrupted_manifest_bytes() {
+    let fixture = RegistryFixture::start().await;
+    fixture.corrupt_manifest("latest");
+    let puller = RegistryPuller::with_auth_arch_and_protocol(
+        RegistryAuth::basic(USERNAME, PASSWORD),
+        "amd64".to_string(),
+        RegistryProtocol::Http,
+    );
+
+    let message = puller
+        .pull_manifest_digest(&fixture.reference)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(message.contains("Docker-Content-Digest header digest mismatch"));
+    assert!(!message.contains(USERNAME));
+    assert!(!message.contains(PASSWORD));
+}
+
+#[tokio::test]
+async fn basic_pull_rejects_corrupted_layer_and_removes_partial_blob() {
+    let fixture = RegistryFixture::start().await;
+    fixture.corrupt_blob(&fixture.layer_digest);
+    let puller = RegistryPuller::with_auth_arch_and_protocol(
+        RegistryAuth::basic(USERNAME, PASSWORD),
+        "amd64".to_string(),
+        RegistryProtocol::Http,
+    );
+    let target = tempfile::tempdir().unwrap();
+
+    let message = puller
+        .pull(&fixture.reference, target.path())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(message.contains("layer digest mismatch"));
+    assert!(!message.contains(USERNAME));
+    assert!(!message.contains(PASSWORD));
+
+    let layer_hex = fixture.layer_digest.strip_prefix("sha256:").unwrap();
+    let layer_path = target.path().join("blobs/sha256").join(layer_hex);
+    assert!(!layer_path.exists());
+    assert!(!layer_path.with_extension("partial").exists());
+}

--- a/src/runtime/src/oci/registry/blob_pull.rs
+++ b/src/runtime/src/oci/registry/blob_pull.rs
@@ -1,0 +1,235 @@
+use std::path::Path;
+
+use a3s_box_core::error::{BoxError, Result};
+use oci_distribution::errors::OciDistributionError;
+use oci_distribution::manifest::OciDescriptor;
+use oci_distribution::{Client, Reference};
+
+use super::basic_pull::BasicPullClient;
+use super::{is_unauthorized_registry_error, registry_error_summary, RegistryAuth};
+
+/// An `AsyncWrite` that streams bytes straight to a file while computing its
+/// SHA-256 and size, so a pulled blob is never fully buffered in memory.
+pub(super) struct HashingFileWriter {
+    file: tokio::fs::File,
+    hasher: sha2::Sha256,
+    bytes_written: u64,
+}
+
+impl HashingFileWriter {
+    pub(super) fn new(file: tokio::fs::File) -> Self {
+        use sha2::Digest as _;
+
+        Self {
+            file,
+            hasher: sha2::Sha256::new(),
+            bytes_written: 0,
+        }
+    }
+
+    fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+
+    pub(super) fn finalize_hex(self) -> String {
+        use sha2::Digest as _;
+
+        format!("{:x}", self.hasher.finalize())
+    }
+}
+
+impl tokio::io::AsyncWrite for HashingFileWriter {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        use sha2::Digest as _;
+
+        let this = self.get_mut();
+        match std::pin::Pin::new(&mut this.file).poll_write(cx, buf) {
+            std::task::Poll::Ready(Ok(written)) => {
+                this.hasher.update(&buf[..written]);
+                this.bytes_written = this.bytes_written.saturating_add(written as u64);
+                std::task::Poll::Ready(Ok(written))
+            }
+            other => other,
+        }
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.get_mut().file).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.get_mut().file).poll_shutdown(cx)
+    }
+}
+
+pub(super) struct BlobPullTransport<'a> {
+    pub(super) client: &'a Client,
+    pub(super) oci_ref: &'a Reference,
+    pub(super) basic_client: Option<&'a BasicPullClient>,
+    pub(super) force_basic: bool,
+    pub(super) auth: &'a RegistryAuth,
+    pub(super) registry: &'a str,
+}
+
+/// Stream a blob to `dest`, verifying its declared size and SHA-256 before
+/// atomically publishing it under its content-addressed name.
+pub(super) async fn stream_and_verify_blob(
+    transport: &BlobPullTransport<'_>,
+    descriptor: &OciDescriptor,
+    dest: &Path,
+    what: &str,
+) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let tmp = dest.with_extension("partial");
+    let mut writer = create_blob_writer(&tmp, what, transport.registry).await?;
+
+    let first_result = if transport.force_basic {
+        match transport.basic_client {
+            Some(basic_client) => basic_client.pull_blob(descriptor, &mut writer).await,
+            None => Err(OciDistributionError::GenericError(Some(
+                "preemptive Basic blob pull requires non-empty credentials".to_string(),
+            ))),
+        }
+    } else {
+        transport
+            .client
+            .pull_blob(transport.oci_ref, descriptor, &mut writer)
+            .await
+    };
+
+    if let Err(first_error) = first_result {
+        if !transport.force_basic && is_unauthorized_registry_error(&first_error) {
+            if let Some(basic_client) = transport.basic_client {
+                tracing::warn!(
+                    error = %registry_error_summary(&first_error, transport.auth),
+                    "Registry rejected the default OCI blob auth flow; retrying with preemptive Basic auth"
+                );
+                drop(writer);
+                let _ = tokio::fs::remove_file(&tmp).await;
+                writer = create_blob_writer(&tmp, what, transport.registry).await?;
+                if let Err(fallback_error) = basic_client.pull_blob(descriptor, &mut writer).await {
+                    let _ = tokio::fs::remove_file(&tmp).await;
+                    return Err(BoxError::RegistryError {
+                        registry: transport.registry.to_string(),
+                        message: format!(
+                            "Failed to pull {what}: default auth failed: {}; preemptive Basic retry failed: {}",
+                            registry_error_summary(&first_error, transport.auth),
+                            registry_error_summary(&fallback_error, transport.auth)
+                        ),
+                    });
+                }
+            } else {
+                let _ = tokio::fs::remove_file(&tmp).await;
+                return Err(blob_pull_error(
+                    transport.registry,
+                    what,
+                    &first_error,
+                    transport.auth,
+                ));
+            }
+        } else {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(blob_pull_error(
+                transport.registry,
+                what,
+                &first_error,
+                transport.auth,
+            ));
+        }
+    }
+
+    if let Err(error) = writer.flush().await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(blob_io_error(transport.registry, what, "flush", error));
+    }
+    if let Err(error) = writer.shutdown().await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(blob_io_error(transport.registry, what, "close", error));
+    }
+    let actual_size = writer.bytes_written();
+    let actual_hex = writer.finalize_hex();
+
+    if descriptor.size < 0 || actual_size != descriptor.size as u64 {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(BoxError::RegistryError {
+            registry: transport.registry.to_string(),
+            message: format!(
+                "{what} size mismatch: expected {} bytes, received {actual_size}",
+                descriptor.size
+            ),
+        });
+    }
+
+    match descriptor.digest.strip_prefix("sha256:") {
+        Some(expected_hex) if actual_hex.eq_ignore_ascii_case(expected_hex) => {}
+        Some(expected_hex) => {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(BoxError::RegistryError {
+                registry: transport.registry.to_string(),
+                message: format!(
+                    "{what} digest mismatch: expected sha256:{expected_hex}, computed sha256:{actual_hex}"
+                ),
+            });
+        }
+        None => {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(BoxError::RegistryError {
+                registry: transport.registry.to_string(),
+                message: format!(
+                    "{what} uses an unsupported digest algorithm ({}); refusing to store \
+                     unverifiable content (only sha256 is supported)",
+                    descriptor.digest
+                ),
+            });
+        }
+    }
+
+    if let Err(error) = tokio::fs::rename(&tmp, dest).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(BoxError::RegistryError {
+            registry: transport.registry.to_string(),
+            message: format!("Failed to store {what} blob: {error}"),
+        });
+    }
+    Ok(())
+}
+
+fn blob_pull_error(
+    registry: &str,
+    what: &str,
+    error: &OciDistributionError,
+    auth: &RegistryAuth,
+) -> BoxError {
+    BoxError::RegistryError {
+        registry: registry.to_string(),
+        message: format!(
+            "Failed to pull {what}: {}",
+            registry_error_summary(error, auth)
+        ),
+    }
+}
+
+async fn create_blob_writer(tmp: &Path, what: &str, registry: &str) -> Result<HashingFileWriter> {
+    tokio::fs::File::create(tmp)
+        .await
+        .map(HashingFileWriter::new)
+        .map_err(|error| blob_io_error(registry, what, "create", error))
+}
+
+fn blob_io_error(registry: &str, what: &str, operation: &str, error: std::io::Error) -> BoxError {
+    BoxError::RegistryError {
+        registry: registry.to_string(),
+        message: format!("Failed to {operation} {what} file: {error}"),
+    }
+}


### PR DESCRIPTION
Closes #84

## Summary
- retry unauthorized manifest and blob pulls with preemptive Basic auth only when both credentials are non-empty
- resolve multi-architecture indexes and stream config/layer blobs through the fallback while verifying sizes and SHA-256 digests
- preserve Basic auth on same-origin redirects, strip it on cross-origin redirects, and redact credentials from errors and logs
- exercise the shared ImagePuller path used by explicit pull and implicit run pulls against a Basic-challenge HTTP fixture

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p a3s-box-runtime basic_pull_tests`
- `cargo test --workspace --lib`
- `cargo clippy -p a3s-box-runtime --all-targets -- -D warnings` (Linux CI; local macOS has a pre-existing cfg-only needless-return warning)