### PR TITLE
fix(runtime): load registry credentials for managed pulls

### DIFF
--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -137,16 +137,39 @@ impl RegistryAuth {
     /// Create authentication from the credential store, falling back to env vars,
     /// then anonymous.
     pub fn from_credential_store(registry: &str) -> Self {
-        // Try credential store first
         if let Ok(store) = CredentialStore::default_path() {
-            if let Ok(Some((username, password))) = store.get(registry) {
-                return Self::basic(username, password);
+            if let Some(auth) = Self::from_store(&store, registry) {
+                return auth;
             }
         }
+        Self::from_external_sources(registry)
+    }
+
+    /// Create authentication from an explicit A3S home credential store.
+    ///
+    /// Runtime services can own a home directory without mutating the process
+    /// `A3S_HOME`. Registry-specific A3S credentials still take precedence over
+    /// supported Docker credentials and environment fallback.
+    pub fn from_credential_store_at(home_dir: &Path, registry: &str) -> Self {
+        let store = CredentialStore::new(home_dir.join("auth").join("credentials.json"));
+        if let Some(auth) = Self::from_store(&store, registry) {
+            return auth;
+        }
+        Self::from_external_sources(registry)
+    }
+
+    fn from_store(store: &CredentialStore, registry: &str) -> Option<Self> {
+        store
+            .get(registry)
+            .ok()
+            .flatten()
+            .map(|(username, password)| Self::basic(username, password))
+    }
+
+    fn from_external_sources(registry: &str) -> Self {
         if let Some((username, password)) = super::credentials::docker_credentials(registry) {
             return Self::basic(username, password);
         }
-        // Fall back to env vars, then anonymous
         Self::from_env()
     }
 
@@ -1423,6 +1446,56 @@ mod tests {
         let auth = RegistryAuth::basic("user", "pass");
         assert_eq!(auth.username, Some("user".to_string()));
         assert_eq!(auth.password, Some("pass".to_string()));
+    }
+
+    #[test]
+    fn explicit_home_registry_credentials_are_loaded() {
+        let home = tempfile::tempdir().unwrap();
+        let store = CredentialStore::new(home.path().join("auth/credentials.json"));
+        store
+            .store(
+                "manager-auth.invalid:5443",
+                "manager-user",
+                "manager-secret",
+            )
+            .unwrap();
+
+        let auth = RegistryAuth::from_credential_store_at(home.path(), "manager-auth.invalid:5443");
+
+        assert_eq!(
+            auth.basic_credentials(),
+            Some(("manager-user".to_string(), "manager-secret".to_string()))
+        );
+    }
+
+    #[test]
+    fn malformed_explicit_home_store_falls_back_to_environment() {
+        let _guard = env_lock();
+        let previous_username = std::env::var_os("REGISTRY_USERNAME");
+        let previous_password = std::env::var_os("REGISTRY_PASSWORD");
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join("auth")).unwrap();
+        std::fs::write(home.path().join("auth/credentials.json"), b"not-json").unwrap();
+        std::env::set_var("REGISTRY_USERNAME", "fallback-user");
+        std::env::set_var("REGISTRY_PASSWORD", "fallback-secret");
+
+        let auth = RegistryAuth::from_credential_store_at(
+            home.path(),
+            "malformed-manager-auth.invalid:5443",
+        );
+
+        assert_eq!(
+            auth.basic_credentials(),
+            Some(("fallback-user".to_string(), "fallback-secret".to_string()))
+        );
+        match previous_username {
+            Some(value) => std::env::set_var("REGISTRY_USERNAME", value),
+            None => std::env::remove_var("REGISTRY_USERNAME"),
+        }
+        match previous_password {
+            Some(value) => std::env::set_var("REGISTRY_PASSWORD", value),
+            None => std::env::remove_var("REGISTRY_PASSWORD"),
+        }
     }
 
     #[test]

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -31,6 +31,14 @@ pub(crate) fn runtime_socket_dir(home_dir: &Path, box_id: &str) -> PathBuf {
     }
 }
 
+fn registry_auth_for_image(home_dir: &Path, reference: &str) -> Result<crate::oci::RegistryAuth> {
+    let parsed = crate::oci::ImageReference::parse(reference)?;
+    Ok(crate::oci::RegistryAuth::from_credential_store_at(
+        home_dir,
+        &parsed.registry,
+    ))
+}
+
 impl VmManager {
     pub(crate) async fn prepare_layout(&self) -> Result<BoxLayout> {
         // Create box-specific directories
@@ -197,10 +205,8 @@ impl VmManager {
 
         let images_dir = self.home_dir.join("images");
         let store = crate::oci::ImageStore::new(&images_dir, crate::DEFAULT_IMAGE_CACHE_SIZE)?;
-        let mut puller = crate::oci::ImagePuller::new(
-            std::sync::Arc::new(store),
-            crate::oci::RegistryAuth::from_env(),
-        );
+        let auth = registry_auth_for_image(&self.home_dir, reference)?;
+        let mut puller = crate::oci::ImagePuller::new(std::sync::Arc::new(store), auth);
         if let Some(ref m) = self.prom {
             puller = puller.set_metrics(m.clone());
         }
@@ -913,6 +919,30 @@ mod tests {
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
         }
+    }
+
+    #[test]
+    fn vm_image_auth_uses_the_managers_explicit_home() {
+        let home = TempDir::new().unwrap();
+        let store = crate::oci::CredentialStore::new(home.path().join("auth/credentials.json"));
+        store
+            .store(
+                "manager-layout.invalid:5443",
+                "layout-user",
+                "layout-secret",
+            )
+            .unwrap();
+
+        let auth = registry_auth_for_image(
+            home.path(),
+            "manager-layout.invalid:5443/a3s/private:latest",
+        )
+        .unwrap();
+
+        assert_eq!(
+            auth.basic_credentials(),
+            Some(("layout-user".to_string(), "layout-secret".to_string()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- resolve managed image authentication from the `LocalExecutionManager`'s explicit home
- preserve the shared precedence of A3S credentials, Docker credentials/helpers, environment variables, then anonymous access
- keep malformed/missing A3S credential storage non-fatal and covered by fallback tests
- parse the image reference once before constructing the production `VmManager` puller

Fixes #87.

## Validation

- regression test first failed because the explicit-home resolver and manager wiring did not exist
- `cargo fmt --all -- --check`
- `cargo test -p a3s-box-runtime --lib` (`1276 passed, 1 ignored` on macOS)
- A3S OS Linux credential/wiring tests: `3 passed`
- A3S OS release managed-Sandbox example build
- direct `LocalExecutionManager` private-registry cache-miss smoke from a home with no `images/` directory
- direct manager downloaded and cached the 62.1 MB image, then passed create, restart reconstruction, real crun start, explicit pause rejection, kill, and cleanup
- zero residual crun states, box paths, sockets, mounts, processes, or cgroups
- credential file remained mode `0600`; no credential values were logged
