### PR TITLE
fix(sandbox): preserve split structured logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ As of **v2.4.0**, three adversarial audits — production-operability (24 findin
 | OCI images | Pull, load, save, tag, inspect, history, remove, and local cache resolution are implemented. Push and cosign signing/verification paths exist and require registry access for end-to-end validation. |
 | Dockerfile build | Honest subset. `FROM`, metadata instructions, `COPY`/`ADD`, and shell/exec-form `RUN` are implemented by the host engine on Linux. `--run-pool` can execute `RUN` through a leased warm-pool VM by mounting the mutable build rootfs into the guest. On macOS, auto `RUN` builds still delegate to BuildKit inside an A3S Linux VM (`--builder=buildkit-vm`) unless `--run-pool` is selected; unsafe host execution remains an explicit experiment-only escape hatch. |
 | Lifecycle and exec | `run`, `create`, `start`, `stop`, `restart`, `rm`, `wait`, foreground/detached runs, non-PTY exec, PTY exec, logs, stats, and inspect are implemented. |
+| OCI Sandbox | Linux-only, explicit `--isolation sandbox` shared-kernel execution through certified `crun`. Structured `json-file` logs preserve stdout/stderr identity for foreground, detached, natural-exit, stop, kill, and auto-remove paths. Generation-owned log workers are PID-start-time fenced, drained before archival, and recovered during cleanup. The security-negative matrix and performance gate remain release work; this mode does not claim MicroVM-equivalent isolation. |
 | Warm pool and snapshot-fork | A warm pool serves pre-booted sandboxes over a socket. Native snapshot-fork (Copy-on-Write microVM cloning) snapshots one booted template and restores many forks from it, each mapping the template RAM `MAP_PRIVATE`. Verified on `/dev/kvm`: ~4× faster than a cold boot per fork, 100 forks in under ~1 s (~8 ms amortized each). Requires `/dev/kvm`; opt in with `pool start --snapshot-fork` or the `KRUN_SNAPSHOT_*` / `KRUN_RESTORE_FROM` env. |
 | Networking | Default TSI networking, TCP `host:guest` publishing, user-defined bridge networks, network inspect/connect/disconnect/rm, and `/etc/hosts` peer discovery are implemented with documented platform boundaries. |
 | Compose | A useful local subset is implemented: image, command, entrypoint, env, env_file, ports, volumes, depends_on, networks, DNS, tmpfs, workdir, hostname, extra_hosts, labels, healthcheck, restart, CPU/memory, capabilities, and privileged mode. |
@@ -341,7 +342,10 @@ choices with runtime defaults.
 Separately, an A3S OS smoke harness proves that `--isolation sandbox` create
 persists a recoverable `created` reservation without allocating backend
 resources, then starts through certified `crun`, rejects pause explicitly, and
-owns kill and cleanup without MicroVM fallback.
+owns kill and cleanup without MicroVM fallback. The same host validation proves
+that structured Sandbox logs retain both stdout and stderr, drain final records
+before natural-exit or auto-remove archival, and leave no generation log worker,
+crun state, box directory, or socket behind.
 
 Those protocol and runtime tests are not yet one end-to-end service path. CLI
 `create` now persists its reservation and complete caller policy through the

--- a/docs/host-sandbox-backend-design.md
+++ b/docs/host-sandbox-backend-design.md
@@ -330,6 +330,30 @@ The shim owns the OCI container lifecycle, control listeners, stdio pipes,
 ready handshake, and durable cleanup metadata. The workload must not be able to
 replace the shim or mutate its bundle after validation.
 
+### Structured log lifecycle
+
+Each running Sandbox generation owns a separate packaged log worker alongside
+`crun run`. The runtime opens independent raw console files for container
+stdout and stderr, and the worker tails both into Docker-compatible
+`logs/container.json` records without losing the `stdout` or `stderr` stream
+field. Runtime and init diagnostics use their dedicated log and are never
+projected as workload output.
+
+The worker becomes ready only after both console readers are open. It watches
+the exact `crun run` PID and Linux process start time recorded for that
+generation, so PID reuse cannot end or extend another generation's logging.
+Once that writer is gone or is an unreaped zombie, its output descriptors are
+closed and the worker drains both files through final EOF, including a trailing
+partial line. The runtime record persists the worker PID and start time so an
+explicit stop, kill, detached natural-exit reconciliation, or crash recovery can
+wait for the same generation to finish before deleting its artifacts.
+
+Auto-remove archival happens only after that drain completes. Consequently,
+`a3s-box logs <name-or-id>` reads complete structured output from
+`removed-logs`, even after the box directory and crun state have been removed.
+Failure to prove that the worker finished is a cleanup error: state is retained
+for recovery instead of silently archiving an incomplete log.
+
 ### OCI bundle compiler
 
 The compiler writes a protected, per-box bundle from the resolved plan. It must
@@ -554,7 +578,7 @@ explicitly unsafe execution posture and cannot satisfy production acceptance.
 | run, foreground, detach | Supported | MVP |
 | exec and non-TTY streams | Supported | MVP |
 | PTY, shell, attach | Supported | MVP |
-| logs and exit code | Supported | MVP |
+| logs and exit code | Supported | Split structured stdout/stderr, final drain, detached recovery, and auto-remove archival implemented |
 | stop, kill, wait, restart | Supported | MVP |
 | health checks | Supported | MVP |
 | numeric user/workdir/env | Supported | MVP |

--- a/src/cli/src/cleanup.rs
+++ b/src/cli/src/cleanup.rs
@@ -135,6 +135,11 @@ pub fn cleanup_external_socket_dir(box_dir: &Path, exec_socket_path: &Path) {
 
 /// Remove all host-side resources owned by a box record.
 pub fn cleanup_removed_box(record: &BoxRecord) -> a3s_box_core::error::Result<()> {
+    // A Sandbox log worker exits only after crun closes both output streams.
+    // Reconcile that runtime first so the archive includes final stderr and a
+    // complete structured projection. This does not remove the box log dir.
+    cleanup_sandbox_runtime(record)?;
+
     if record.auto_remove {
         if let Err(err) = crate::log_archive::archive_removed_logs(record) {
             tracing::debug!(
@@ -144,8 +149,6 @@ pub fn cleanup_removed_box(record: &BoxRecord) -> a3s_box_core::error::Result<()
             );
         }
     }
-
-    cleanup_sandbox_runtime(record)?;
 
     cleanup_record_resources(record);
     cleanup_anonymous_volumes(&record.anonymous_volumes);

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -603,6 +603,10 @@ async fn run_foreground(
         .await;
     log_handle.abort();
 
+    if stop_reason == ForegroundStopReason::ProcessExited {
+        wait_for_sandbox_structured_log_drain(&ctx).await?;
+    }
+
     let persisted_exit_code = a3s_box_runtime::rootfs::read_persisted_exit_code(&ctx.box_dir);
     let exit_code = foreground_exit_code(stop_reason, persisted_exit_code);
     archive_auto_removed_logs(&ctx, args.rm, exit_code, stop_reason.stopped_by_user());
@@ -625,6 +629,33 @@ async fn run_foreground(
         }
     }
 
+    Ok(())
+}
+
+async fn wait_for_sandbox_structured_log_drain(
+    ctx: &RunContext,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !ctx.record.isolation.is_sandbox() {
+        return Ok(());
+    }
+    let box_dir = ctx.box_dir.clone();
+    let box_id = ctx.box_id.clone();
+    let drained = tokio::task::spawn_blocking(move || {
+        a3s_box_runtime::vm::reap::wait_for_recorded_sandbox_log_drain(
+            &box_dir,
+            &box_id,
+            std::time::Duration::from_secs(3),
+        )
+    })
+    .await
+    .map_err(|error| format!("Sandbox log drain task failed for {}: {error}", ctx.box_id))??;
+    if !drained {
+        return Err(format!(
+            "Sandbox logs did not finish draining for {}; state was preserved for recovery",
+            ctx.box_id
+        )
+        .into());
+    }
     Ok(())
 }
 

--- a/src/core/src/log.rs
+++ b/src/core/src/log.rs
@@ -118,6 +118,27 @@ pub struct LogEntry {
     pub time: String,
 }
 
+/// Schema used to hand one Sandbox log worker its immutable generation data.
+pub const SANDBOX_LOG_WORKER_SCHEMA: &str = "a3s.box.sandbox-log-worker.v1";
+
+/// Configuration for the host process that projects Sandbox stdout/stderr into
+/// the configured logging driver after the launching client has detached.
+///
+/// The worker watches the exact `crun run` wrapper PID identity. Once that
+/// process exits, both inherited output descriptors are closed and EOF is
+/// authoritative, so the worker can drain the final bytes without a fixed
+/// late-write delay.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxLogWorkerSpec {
+    pub schema: String,
+    pub box_id: String,
+    pub console_log: PathBuf,
+    pub log_config: LogConfig,
+    pub watched_pid: u32,
+    pub watched_pid_start_time: u64,
+    pub ready_file: PathBuf,
+}
+
 /// Parse a human-readable size string (e.g., "10m", "1g", "4096") into bytes.
 fn parse_size(s: &str) -> std::result::Result<u64, String> {
     let s = s.trim().to_lowercase();
@@ -158,6 +179,18 @@ fn parse_size(s: &str) -> std::result::Result<u64, String> {
 use std::io::{BufRead, BufReader, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Whether the producer may still publish bytes after its apparent exit.
+///
+/// libkrun can return before its console backend's final host write becomes
+/// visible, whereas a reaped `crun run` wrapper has already closed stdout and
+/// stderr. Keeping the distinction explicit avoids imposing the MicroVM's
+/// half-second settle window on every short Sandbox execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsoleEofPolicy {
+    MayReceiveLateWrites,
+    WriterClosed,
+}
 
 /// Truncate `path` to empty if it has grown past `cap` bytes; returns whether it
 /// truncated.
@@ -209,20 +242,21 @@ fn tail_next_line(
     buf: &mut String,
     stop: &AtomicBool,
     on_eof: Option<&dyn Fn() -> bool>,
+    eof_policy: ConsoleEofPolicy,
 ) -> Option<String> {
     // `krun_start_enter()` can return a few scheduler ticks before the
     // virtio-console backend's final host write becomes visible. Treat the
     // first stopped EOFs as provisional; otherwise a very short detached
     // command can leave bytes in console.log after the processor has exited.
-    const STOPPED_EOF_SETTLE_POLLS: u8 = 25;
     const STOPPED_EOF_SETTLE_MILLIS: u64 = 20;
+    let stopped_eof_settle_polls = stopped_eof_settle_polls(eof_policy);
     let mut stopped_eof_polls = 0u8;
     loop {
         match reader.read_line(buf) {
             Ok(0) | Err(_) => {
                 if stop.load(Ordering::Relaxed) {
                     stopped_eof_polls = stopped_eof_polls.saturating_add(1);
-                    if stopped_eof_polls < STOPPED_EOF_SETTLE_POLLS {
+                    if stopped_eof_polls < stopped_eof_settle_polls {
                         std::thread::sleep(std::time::Duration::from_millis(
                             STOPPED_EOF_SETTLE_MILLIS,
                         ));
@@ -260,6 +294,14 @@ fn tail_next_line(
     }
 }
 
+fn stopped_eof_settle_polls(eof_policy: ConsoleEofPolicy) -> u8 {
+    const LATE_WRITE_POLLS: u8 = 25;
+    match eof_policy {
+        ConsoleEofPolicy::MayReceiveLateWrites => LATE_WRITE_POLLS,
+        ConsoleEofPolicy::WriterClosed => 1,
+    }
+}
+
 /// Run the log processor for a box, blocking until `stop` is set and the console
 /// is drained. Intended to run on a dedicated thread for the VM's lifetime; set
 /// `stop` after the VM exits, then join, to guarantee the final lines are
@@ -283,6 +325,29 @@ pub fn run_log_processor_with_ready(
     stop: &AtomicBool,
     ready: Option<&std::sync::atomic::AtomicUsize>,
 ) {
+    run_log_processor_with_ready_and_eof_policy(
+        console_log,
+        log_dir,
+        config,
+        stop,
+        ready,
+        ConsoleEofPolicy::MayReceiveLateWrites,
+    );
+}
+
+/// Run the log processor with an explicit final-EOF policy.
+///
+/// Sandbox workers use [`ConsoleEofPolicy::WriterClosed`] only after the exact
+/// `crun run` wrapper has exited. Other callers should retain the conservative
+/// default exposed by [`run_log_processor_with_ready`].
+pub fn run_log_processor_with_ready_and_eof_policy(
+    console_log: &Path,
+    log_dir: &Path,
+    config: &LogConfig,
+    stop: &AtomicBool,
+    ready: Option<&std::sync::atomic::AtomicUsize>,
+    eof_policy: ConsoleEofPolicy,
+) {
     match config.driver {
         // `none` produces no structured output, but libkrun still writes the raw
         // console for the VM's lifetime — drain + bound it so a chatty box with
@@ -293,6 +358,7 @@ pub fn run_log_processor_with_ready(
             Some(console_cap(config.max_size(), config.max_file())),
             stop,
             ready,
+            eof_policy,
         ),
         LogDriver::JsonFile => run_json_file_processor(
             console_log,
@@ -301,6 +367,7 @@ pub fn run_log_processor_with_ready(
             config.max_file(),
             stop,
             ready,
+            eof_policy,
         ),
         LogDriver::Syslog => run_syslog_processor(
             console_log,
@@ -310,6 +377,7 @@ pub fn run_log_processor_with_ready(
             Some(console_cap(config.max_size(), config.max_file())),
             stop,
             ready,
+            eof_policy,
         ),
     }
 }
@@ -347,6 +415,7 @@ fn run_tagged_tail(
     stop: &AtomicBool,
     emit: &(dyn Fn(&str, &str) + Sync),
     ready: Option<&std::sync::atomic::AtomicUsize>,
+    eof_policy: ConsoleEofPolicy,
 ) {
     let f = match open_console(file, stop) {
         Some(f) => f,
@@ -361,7 +430,7 @@ fn run_tagged_tail(
     // console_truncate_if_over). None = unbounded (used by tests).
     let truncate = bound.map(|cap| move || console_truncate_if_over(file, cap));
     let on_eof: Option<&dyn Fn() -> bool> = truncate.as_ref().map(|t| t as &dyn Fn() -> bool);
-    while let Some(line) = tail_next_line(&mut reader, &mut buf, stop, on_eof) {
+    while let Some(line) = tail_next_line(&mut reader, &mut buf, stop, on_eof, eof_policy) {
         if filter_noise && is_runtime_console_noise(&line) {
             continue;
         }
@@ -385,13 +454,29 @@ fn run_discard_processor(
     cap: Option<u64>,
     stop: &AtomicBool,
     ready: Option<&std::sync::atomic::AtomicUsize>,
+    eof_policy: ConsoleEofPolicy,
 ) {
     let err_log = stderr_console_path(console_log);
     let discard = |_line: &str, _stream: &str| {};
     let discard: &(dyn Fn(&str, &str) + Sync) = &discard;
     std::thread::scope(|s| {
-        s.spawn(|| run_tagged_tail(console_log, "stdout", false, cap, stop, discard, ready));
-        s.spawn(|| run_tagged_tail(&err_log, "stderr", false, cap, stop, discard, ready));
+        s.spawn(|| {
+            run_tagged_tail(
+                console_log,
+                "stdout",
+                false,
+                cap,
+                stop,
+                discard,
+                ready,
+                eof_policy,
+            )
+        });
+        s.spawn(|| {
+            run_tagged_tail(
+                &err_log, "stderr", false, cap, stop, discard, ready, eof_policy,
+            )
+        });
     });
 }
 
@@ -402,6 +487,7 @@ fn run_json_file_processor(
     max_file: u32,
     stop: &AtomicBool,
     ready: Option<&std::sync::atomic::AtomicUsize>,
+    eof_policy: ConsoleEofPolicy,
 ) {
     let json_path = json_log_path(log_dir);
     let writer = std::sync::Mutex::new(match RotatingWriter::new(&json_path, max_size, max_file) {
@@ -428,10 +514,21 @@ fn run_json_file_processor(
 
     let cap = Some(console_cap(max_size, max_file));
     std::thread::scope(|s| {
-        s.spawn(|| run_tagged_tail(console_log, "stdout", true, cap, stop, emit, ready));
+        s.spawn(|| {
+            run_tagged_tail(
+                console_log,
+                "stdout",
+                true,
+                cap,
+                stop,
+                emit,
+                ready,
+                eof_policy,
+            )
+        });
         // libkrun's `init.krun:` preamble can land on EITHER stream, so filter
         // the noise on stderr too.
-        s.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready));
+        s.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready, eof_policy));
     });
 }
 
@@ -444,6 +541,7 @@ fn run_syslog_processor(
     cap: Option<u64>,
     stop: &AtomicBool,
     ready: Option<&std::sync::atomic::AtomicUsize>,
+    eof_policy: ConsoleEofPolicy,
 ) {
     use std::net::UdpSocket;
 
@@ -469,8 +567,21 @@ fn run_syslog_processor(
             };
             let emit: &(dyn Fn(&str, &str) + Sync) = &emit;
             std::thread::scope(|s| {
-                s.spawn(|| run_tagged_tail(console_log, "stdout", true, cap, stop, emit, ready));
-                s.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready));
+                s.spawn(|| {
+                    run_tagged_tail(
+                        console_log,
+                        "stdout",
+                        true,
+                        cap,
+                        stop,
+                        emit,
+                        ready,
+                        eof_policy,
+                    )
+                });
+                s.spawn(|| {
+                    run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready, eof_policy)
+                });
             });
         }
         "tcp" => {
@@ -491,8 +602,21 @@ fn run_syslog_processor(
             };
             let emit: &(dyn Fn(&str, &str) + Sync) = &emit;
             std::thread::scope(|sc| {
-                sc.spawn(|| run_tagged_tail(console_log, "stdout", true, cap, stop, emit, ready));
-                sc.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready));
+                sc.spawn(|| {
+                    run_tagged_tail(
+                        console_log,
+                        "stdout",
+                        true,
+                        cap,
+                        stop,
+                        emit,
+                        ready,
+                        eof_policy,
+                    )
+                });
+                sc.spawn(|| {
+                    run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready, eof_policy)
+                });
             });
         }
         _ => {}
@@ -645,6 +769,33 @@ mod tests {
     }
 
     #[test]
+    fn sandbox_log_worker_spec_round_trips_generation_identity() {
+        let spec = SandboxLogWorkerSpec {
+            schema: SANDBOX_LOG_WORKER_SCHEMA.to_string(),
+            box_id: "sandbox-id".to_string(),
+            console_log: PathBuf::from("/tmp/sandbox-id/logs/console.log"),
+            log_config: LogConfig::default(),
+            watched_pid: 123,
+            watched_pid_start_time: 456,
+            ready_file: PathBuf::from("/tmp/sandbox-id/sandbox/log-worker.ready"),
+        };
+
+        let encoded = serde_json::to_vec(&spec).unwrap();
+        let decoded: SandboxLogWorkerSpec = serde_json::from_slice(&encoded).unwrap();
+
+        assert_eq!(decoded, spec);
+    }
+
+    #[test]
+    fn writer_closed_eof_skips_the_late_console_settle_window() {
+        assert_eq!(
+            stopped_eof_settle_polls(ConsoleEofPolicy::MayReceiveLateWrites),
+            25
+        );
+        assert_eq!(stopped_eof_settle_polls(ConsoleEofPolicy::WriterClosed), 1);
+    }
+
+    #[test]
     fn test_syslog_config_defaults() {
         let config = LogConfig {
             driver: LogDriver::Syslog,
@@ -698,14 +849,35 @@ mod tests {
         let mut buf = String::new();
         let stop = AtomicBool::new(true);
         assert_eq!(
-            tail_next_line(&mut reader, &mut buf, &stop, None),
+            tail_next_line(
+                &mut reader,
+                &mut buf,
+                &stop,
+                None,
+                ConsoleEofPolicy::MayReceiveLateWrites,
+            ),
             Some("alpha".to_string())
         );
         assert_eq!(
-            tail_next_line(&mut reader, &mut buf, &stop, None),
+            tail_next_line(
+                &mut reader,
+                &mut buf,
+                &stop,
+                None,
+                ConsoleEofPolicy::MayReceiveLateWrites,
+            ),
             Some("beta".to_string())
         );
-        assert_eq!(tail_next_line(&mut reader, &mut buf, &stop, None), None);
+        assert_eq!(
+            tail_next_line(
+                &mut reader,
+                &mut buf,
+                &stop,
+                None,
+                ConsoleEofPolicy::MayReceiveLateWrites,
+            ),
+            None
+        );
         assert!(buf.is_empty());
     }
 
@@ -718,10 +890,25 @@ mod tests {
         let mut buf = String::new();
         let stop = AtomicBool::new(true);
         assert_eq!(
-            tail_next_line(&mut reader, &mut buf, &stop, None),
+            tail_next_line(
+                &mut reader,
+                &mut buf,
+                &stop,
+                None,
+                ConsoleEofPolicy::MayReceiveLateWrites,
+            ),
             Some("only-partial".to_string())
         );
-        assert_eq!(tail_next_line(&mut reader, &mut buf, &stop, None), None);
+        assert_eq!(
+            tail_next_line(
+                &mut reader,
+                &mut buf,
+                &stop,
+                None,
+                ConsoleEofPolicy::MayReceiveLateWrites,
+            ),
+            None
+        );
     }
 
     #[test]
@@ -757,7 +944,16 @@ mod tests {
         let handle = std::thread::spawn(move || {
             let emit = move |line: &str, _stream: &str| c2.lock().unwrap().push(line.to_string());
             let emit: &(dyn Fn(&str, &str) + Sync) = &emit;
-            run_tagged_tail(&p2, "stdout", false, Some(cap), &s2, emit, None);
+            run_tagged_tail(
+                &p2,
+                "stdout",
+                false,
+                Some(cap),
+                &s2,
+                emit,
+                None,
+                ConsoleEofPolicy::MayReceiveLateWrites,
+            );
         });
 
         // Let the tail drain l1..l3, hit EOF, and truncate (9 bytes > cap 4).
@@ -811,10 +1007,25 @@ mod tests {
         let mut buffer = String::new();
         let stop = AtomicBool::new(true);
         assert_eq!(
-            tail_next_line(&mut reader, &mut buffer, &stop, None),
+            tail_next_line(
+                &mut reader,
+                &mut buffer,
+                &stop,
+                None,
+                ConsoleEofPolicy::MayReceiveLateWrites,
+            ),
             Some("late-final-line".to_string())
         );
-        assert_eq!(tail_next_line(&mut reader, &mut buffer, &stop, None), None);
+        assert_eq!(
+            tail_next_line(
+                &mut reader,
+                &mut buffer,
+                &stop,
+                None,
+                ConsoleEofPolicy::MayReceiveLateWrites,
+            ),
+            None
+        );
         writer.join().unwrap();
     }
 
@@ -870,7 +1081,15 @@ mod tests {
         let console = dir.path().join("console.log");
         std::fs::write(&console, "AAA\ninit.krun: noise\nBBB\n").unwrap();
         let stop = AtomicBool::new(true);
-        run_json_file_processor(&console, dir.path(), 10 * 1024 * 1024, 3, &stop, None);
+        run_json_file_processor(
+            &console,
+            dir.path(),
+            10 * 1024 * 1024,
+            3,
+            &stop,
+            None,
+            ConsoleEofPolicy::MayReceiveLateWrites,
+        );
         let json = std::fs::read_to_string(json_log_path(dir.path())).unwrap();
         assert!(json.contains("\"log\":\"AAA\\n\""), "AAA missing: {json}");
         assert!(

--- a/src/core/src/log.rs
+++ b/src/core/src/log.rs
@@ -369,16 +369,7 @@ pub fn run_log_processor_with_ready_and_eof_policy(
             ready,
             eof_policy,
         ),
-        LogDriver::Syslog => run_syslog_processor(
-            console_log,
-            config.syslog_address(),
-            config.syslog_facility(),
-            config.tag().unwrap_or("a3s-box"),
-            Some(console_cap(config.max_size(), config.max_file())),
-            stop,
-            ready,
-            eof_policy,
-        ),
+        LogDriver::Syslog => run_syslog_processor(console_log, config, stop, ready, eof_policy),
     }
 }
 
@@ -407,34 +398,41 @@ pub fn stderr_console_path(console_log: &Path) -> PathBuf {
 /// Tail one console file, emitting each container line via `emit(line, stream)`.
 /// `filter_noise` drops libkrun's `init.krun:` preamble (only on the stdout
 /// console). Blocks until `stop` is set and the file is drained.
-fn run_tagged_tail(
-    file: &Path,
-    stream: &str,
+#[derive(Clone, Copy)]
+struct TaggedTailOptions<'a> {
+    stream: &'static str,
     filter_noise: bool,
     bound: Option<u64>,
+    ready: Option<&'a std::sync::atomic::AtomicUsize>,
+    eof_policy: ConsoleEofPolicy,
+}
+
+fn run_tagged_tail(
+    file: &Path,
     stop: &AtomicBool,
     emit: &(dyn Fn(&str, &str) + Sync),
-    ready: Option<&std::sync::atomic::AtomicUsize>,
-    eof_policy: ConsoleEofPolicy,
+    options: TaggedTailOptions<'_>,
 ) {
     let f = match open_console(file, stop) {
         Some(f) => f,
         None => return,
     };
-    if let Some(ready) = ready {
+    if let Some(ready) = options.ready {
         ready.fetch_add(1, Ordering::Release);
     }
     let mut reader = BufReader::new(f);
     let mut buf = String::new();
     // Bound the raw console file's growth at clean line boundaries (see
     // console_truncate_if_over). None = unbounded (used by tests).
-    let truncate = bound.map(|cap| move || console_truncate_if_over(file, cap));
+    let truncate = options
+        .bound
+        .map(|cap| move || console_truncate_if_over(file, cap));
     let on_eof: Option<&dyn Fn() -> bool> = truncate.as_ref().map(|t| t as &dyn Fn() -> bool);
-    while let Some(line) = tail_next_line(&mut reader, &mut buf, stop, on_eof, eof_policy) {
-        if filter_noise && is_runtime_console_noise(&line) {
+    while let Some(line) = tail_next_line(&mut reader, &mut buf, stop, on_eof, options.eof_policy) {
+        if options.filter_noise && is_runtime_console_noise(&line) {
             continue;
         }
-        emit(&line, stream);
+        emit(&line, options.stream);
     }
 }
 
@@ -463,18 +461,29 @@ fn run_discard_processor(
         s.spawn(|| {
             run_tagged_tail(
                 console_log,
-                "stdout",
-                false,
-                cap,
                 stop,
                 discard,
-                ready,
-                eof_policy,
+                TaggedTailOptions {
+                    stream: "stdout",
+                    filter_noise: false,
+                    bound: cap,
+                    ready,
+                    eof_policy,
+                },
             )
         });
         s.spawn(|| {
             run_tagged_tail(
-                &err_log, "stderr", false, cap, stop, discard, ready, eof_policy,
+                &err_log,
+                stop,
+                discard,
+                TaggedTailOptions {
+                    stream: "stderr",
+                    filter_noise: false,
+                    bound: cap,
+                    ready,
+                    eof_policy,
+                },
             )
         });
     });
@@ -517,34 +526,50 @@ fn run_json_file_processor(
         s.spawn(|| {
             run_tagged_tail(
                 console_log,
-                "stdout",
-                true,
-                cap,
                 stop,
                 emit,
-                ready,
-                eof_policy,
+                TaggedTailOptions {
+                    stream: "stdout",
+                    filter_noise: true,
+                    bound: cap,
+                    ready,
+                    eof_policy,
+                },
             )
         });
         // libkrun's `init.krun:` preamble can land on EITHER stream, so filter
         // the noise on stderr too.
-        s.spawn(|| run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready, eof_policy));
+        s.spawn(|| {
+            run_tagged_tail(
+                &err_log,
+                stop,
+                emit,
+                TaggedTailOptions {
+                    stream: "stderr",
+                    filter_noise: true,
+                    bound: cap,
+                    ready,
+                    eof_policy,
+                },
+            )
+        });
     });
 }
 
 /// Forward both console streams (stdout + stderr) to a syslog endpoint.
 fn run_syslog_processor(
     console_log: &Path,
-    address: &str,
-    _facility: &str,
-    tag: &str,
-    cap: Option<u64>,
+    config: &LogConfig,
     stop: &AtomicBool,
     ready: Option<&std::sync::atomic::AtomicUsize>,
     eof_policy: ConsoleEofPolicy,
 ) {
     use std::net::UdpSocket;
 
+    let address = config.syslog_address();
+    let _facility = config.syslog_facility();
+    let tag = config.tag().unwrap_or("a3s-box");
+    let cap = Some(console_cap(config.max_size(), config.max_file()));
     let (proto, addr) = if let Some(rest) = address.strip_prefix("udp://") {
         ("udp", rest)
     } else if let Some(rest) = address.strip_prefix("tcp://") {
@@ -570,17 +595,30 @@ fn run_syslog_processor(
                 s.spawn(|| {
                     run_tagged_tail(
                         console_log,
-                        "stdout",
-                        true,
-                        cap,
                         stop,
                         emit,
-                        ready,
-                        eof_policy,
+                        TaggedTailOptions {
+                            stream: "stdout",
+                            filter_noise: true,
+                            bound: cap,
+                            ready,
+                            eof_policy,
+                        },
                     )
                 });
                 s.spawn(|| {
-                    run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready, eof_policy)
+                    run_tagged_tail(
+                        &err_log,
+                        stop,
+                        emit,
+                        TaggedTailOptions {
+                            stream: "stderr",
+                            filter_noise: true,
+                            bound: cap,
+                            ready,
+                            eof_policy,
+                        },
+                    )
                 });
             });
         }
@@ -605,17 +643,30 @@ fn run_syslog_processor(
                 sc.spawn(|| {
                     run_tagged_tail(
                         console_log,
-                        "stdout",
-                        true,
-                        cap,
                         stop,
                         emit,
-                        ready,
-                        eof_policy,
+                        TaggedTailOptions {
+                            stream: "stdout",
+                            filter_noise: true,
+                            bound: cap,
+                            ready,
+                            eof_policy,
+                        },
                     )
                 });
                 sc.spawn(|| {
-                    run_tagged_tail(&err_log, "stderr", true, cap, stop, emit, ready, eof_policy)
+                    run_tagged_tail(
+                        &err_log,
+                        stop,
+                        emit,
+                        TaggedTailOptions {
+                            stream: "stderr",
+                            filter_noise: true,
+                            bound: cap,
+                            ready,
+                            eof_policy,
+                        },
+                    )
                 });
             });
         }
@@ -946,13 +997,15 @@ mod tests {
             let emit: &(dyn Fn(&str, &str) + Sync) = &emit;
             run_tagged_tail(
                 &p2,
-                "stdout",
-                false,
-                Some(cap),
                 &s2,
                 emit,
-                None,
-                ConsoleEofPolicy::MayReceiveLateWrites,
+                TaggedTailOptions {
+                    stream: "stdout",
+                    filter_noise: false,
+                    bound: Some(cap),
+                    ready: None,
+                    eof_policy: ConsoleEofPolicy::MayReceiveLateWrites,
+                },
             );
         });
 

--- a/src/runtime/examples/managed_sandbox_smoke.rs
+++ b/src/runtime/examples/managed_sandbox_smoke.rs
@@ -84,6 +84,10 @@ mod linux {
             home_dir.join("bin/a3s-box-guest-init").is_file(),
             "A3S_HOME/bin/a3s-box-guest-init is missing",
         )?;
+        require(
+            home_dir.join("bin/a3s-box-shim").is_file(),
+            "A3S_HOME/bin/a3s-box-shim is missing",
+        )?;
         Ok(home_dir)
     }
 
@@ -102,7 +106,8 @@ mod linux {
                 cmd: vec![
                     "/bin/sh".to_string(),
                     "-c".to_string(),
-                    "while :; do sleep 60; done".to_string(),
+                    "printf 'sandbox-stdout\\n'; printf 'sandbox-stderr\\n' >&2; while :; do sleep 60; done"
+                        .to_string(),
                 ],
                 network: NetworkMode::None,
                 ..Default::default()
@@ -176,7 +181,8 @@ mod linux {
             running_status.state == ExecutionState::Running,
             "started managed Sandbox is not running",
         )?;
-        validate_runtime_record(home_dir, &box_dir, &execution_id)?;
+        let log_worker_identity = validate_runtime_record(home_dir, &box_dir, &execution_id)?;
+        validate_structured_logs(&box_dir).await?;
         println!("started execution={} state=running", execution_id);
 
         let pause_error = match restarted
@@ -224,6 +230,7 @@ mod linux {
                 .exists(),
             "managed Sandbox socket directory leaked",
         )?;
+        wait_for_process_exit(log_worker_identity).await?;
         println!("killed execution={} state=stopped cleanup=ok", execution_id);
         Ok(())
     }
@@ -262,7 +269,7 @@ mod linux {
         home_dir: &Path,
         box_dir: &Path,
         execution_id: &ExecutionId,
-    ) -> Result<(), AnyError> {
+    ) -> Result<(u32, u64), AnyError> {
         let runtime_record = box_dir.join("sandbox/runtime.json");
         let record: serde_json::Value = serde_json::from_slice(&std::fs::read(&runtime_record)?)?;
         require(
@@ -285,7 +292,65 @@ mod linux {
         require(
             runtime_path.canonicalize()? == home_dir.join("bin/crun").canonicalize()?,
             "Sandbox runtime record does not reference the certified crun artifact",
-        )
+        )?;
+        let log_worker_pid = record
+            .get("log_worker_pid")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| failure("Sandbox runtime record has no log worker PID"))?;
+        let log_worker_pid_start_time = record
+            .get("log_worker_pid_start_time")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| failure("Sandbox runtime record has no log worker PID identity"))?;
+        require(
+            a3s_box_runtime::is_process_alive_with_identity(
+                log_worker_pid,
+                Some(log_worker_pid_start_time),
+            ),
+            "Sandbox log worker is not alive with its recorded identity",
+        )?;
+        Ok((log_worker_pid, log_worker_pid_start_time))
+    }
+
+    async fn validate_structured_logs(box_dir: &Path) -> Result<(), AnyError> {
+        let path = box_dir.join("logs/container.json");
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if let Ok(contents) = tokio::fs::read_to_string(&path).await {
+                let entries: Vec<a3s_box_core::log::LogEntry> = contents
+                    .lines()
+                    .filter_map(|line| serde_json::from_str(line).ok())
+                    .collect();
+                let stdout = entries
+                    .iter()
+                    .any(|entry| entry.stream == "stdout" && entry.log == "sandbox-stdout\n");
+                let stderr = entries
+                    .iter()
+                    .any(|entry| entry.stream == "stderr" && entry.log == "sandbox-stderr\n");
+                if stdout && stderr {
+                    println!("logs stdout=ok stderr=ok format=json-file");
+                    return Ok(());
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(failure(format!(
+                    "Sandbox structured logs did not capture both streams at {}",
+                    path.display()
+                )));
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
+    async fn wait_for_process_exit(identity: (u32, u64)) -> Result<(), AnyError> {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        while a3s_box_runtime::is_process_alive_with_identity(identity.0, Some(identity.1)) {
+            if tokio::time::Instant::now() >= deadline {
+                return Err(failure("Sandbox log worker leaked after terminal cleanup"));
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        Ok(())
     }
 
     async fn cleanup(

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -64,14 +64,16 @@ impl VmLocalExecutionBackend {
         manager.port_forward_socket_path = Some(socket_dir.join("portfwd.sock"));
         *manager.handler.write().await = Some(Box::new(
             crate::sandbox::handler::CrunHandler::from_recorded_runtime(
-                inspection.runtime.runtime_path,
-                inspection.runtime.runtime_root,
-                record.id.clone(),
-                inspection.pid,
+                crate::sandbox::handler::CrunHandlerSpec::new(
+                    inspection.runtime.runtime_path,
+                    inspection.runtime.runtime_root,
+                    record.id.clone(),
+                    inspection.pid,
+                    inspection.runtime.bundle_dir,
+                    record.box_dir.join("sandbox/runtime.json"),
+                ),
                 inspection.runtime.log_worker_pid,
                 inspection.runtime.log_worker_pid_start_time,
-                inspection.runtime.bundle_dir,
-                record.box_dir.join("sandbox/runtime.json"),
             ),
         ));
         if !matches!(

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -68,6 +68,8 @@ impl VmLocalExecutionBackend {
                 inspection.runtime.runtime_root,
                 record.id.clone(),
                 inspection.pid,
+                inspection.runtime.log_worker_pid,
+                inspection.runtime.log_worker_pid_start_time,
                 inspection.runtime.bundle_dir,
                 record.box_dir.join("sandbox/runtime.json"),
             ),

--- a/src/runtime/src/process.rs
+++ b/src/runtime/src/process.rs
@@ -46,7 +46,7 @@ pub fn is_process_alive(_pid: u32) -> bool {
 #[cfg(target_os = "linux")]
 pub fn pid_start_time(pid: u32) -> Option<u64> {
     let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-    linux_pid_start_time_from_stat(&stat)
+    linux_process_identity_from_stat(&stat).map(|(_, start_time)| start_time)
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -69,12 +69,41 @@ pub fn is_process_alive_with_identity(pid: u32, expected_start_time: Option<u64>
     }
 }
 
+/// Check whether a process identity is actively running rather than a zombie.
+///
+/// A completed child remains addressable by `kill(pid, 0)` until its parent
+/// reaps it. Lifecycle ownership still uses [`is_process_alive_with_identity`]
+/// when that distinction matters; completion waiters use this helper so a
+/// fully drained worker zombie is treated as finished immediately.
 #[cfg(target_os = "linux")]
-fn linux_pid_start_time_from_stat(stat: &str) -> Option<u64> {
+pub fn is_process_running_with_identity(pid: u32, expected_start_time: Option<u64>) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    linux_process_identity_from_stat(&stat).is_some_and(|(state, start_time)| {
+        state != 'Z'
+            && expected_start_time
+                .map(|expected| expected == start_time)
+                .unwrap_or(true)
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn is_process_running_with_identity(pid: u32, expected_start_time: Option<u64>) -> bool {
+    is_process_alive_with_identity(pid, expected_start_time)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_identity_from_stat(stat: &str) -> Option<(char, u64)> {
     // `comm` may contain spaces and parentheses, so fields begin after the
     // final `)`. Field 3 is then token zero and field 22 is token 19.
-    let fields = stat.get(stat.rfind(')')? + 1..)?;
-    fields.split_whitespace().nth(19)?.parse().ok()
+    let fields: Vec<&str> = stat
+        .get(stat.rfind(')')? + 1..)?
+        .split_whitespace()
+        .collect();
+    let state = fields.first()?.chars().next()?;
+    let start_time = fields.get(19)?.parse().ok()?;
+    Some((state, start_time))
 }
 
 #[cfg(test)]
@@ -96,9 +125,9 @@ mod tests {
     fn parses_start_time_after_complex_command_name() {
         let stat =
             "123 (command (with) spaces) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 4242";
-        assert_eq!(linux_pid_start_time_from_stat(stat), Some(4242));
-        assert_eq!(linux_pid_start_time_from_stat("malformed"), None);
-        assert_eq!(linux_pid_start_time_from_stat("123 (short) S 1"), None);
+        assert_eq!(linux_process_identity_from_stat(stat), Some(('S', 4242)));
+        assert_eq!(linux_process_identity_from_stat("malformed"), None);
+        assert_eq!(linux_process_identity_from_stat("123 (short) S 1"), None);
     }
 
     #[cfg(target_os = "linux")]
@@ -111,5 +140,31 @@ mod tests {
         assert!(!is_process_alive_with_identity(pid, Some(u64::MAX)));
         assert!(is_process_alive_with_identity(pid, None));
         assert!(!is_process_alive_with_identity(0x7fff_fffe, None));
+        assert!(is_process_running_with_identity(pid, start_time));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parses_zombie_state_for_completion_waiters() {
+        let stat = "123 (completed worker) Z 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 4242";
+        assert_eq!(linux_process_identity_from_stat(stat), Some(('Z', 4242)));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn running_identity_treats_an_unreaped_child_as_finished() {
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id();
+        let start_time = pid_start_time(pid).unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        while is_process_running_with_identity(pid, Some(start_time))
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        assert!(is_process_alive_with_identity(pid, Some(start_time)));
+        assert!(!is_process_running_with_identity(pid, Some(start_time)));
+        child.wait().unwrap();
     }
 }

--- a/src/runtime/src/sandbox/controller.rs
+++ b/src/runtime/src/sandbox/controller.rs
@@ -21,9 +21,9 @@ use oci_spec::runtime::Spec;
 use serde::Serialize;
 
 use super::capability::{CertifiedCrun, SandboxCapabilitySnapshot};
-use super::handler::CrunHandler;
 #[cfg(target_os = "linux")]
 use super::handler::CrunState;
+use super::handler::{CrunHandler, CrunHandlerSpec};
 
 #[cfg(target_os = "linux")]
 const EXEC_LISTENER_FD: i32 = 3;
@@ -324,15 +324,17 @@ impl CrunController {
         }
 
         Ok(CrunHandler::from_child(
-            self.runtime.path.clone(),
-            launch.runtime_root,
-            launch.container_id,
-            init_pid,
+            CrunHandlerSpec::new(
+                self.runtime.path.clone(),
+                launch.runtime_root,
+                launch.container_id,
+                init_pid,
+                launch.bundle_dir,
+                launch.runtime_record,
+            ),
             child,
             log_worker,
             log_worker_pid_start_time,
-            launch.bundle_dir,
-            launch.runtime_record,
         ))
     }
 

--- a/src/runtime/src/sandbox/controller.rs
+++ b/src/runtime/src/sandbox/controller.rs
@@ -21,9 +21,9 @@ use oci_spec::runtime::Spec;
 use serde::Serialize;
 
 use super::capability::{CertifiedCrun, SandboxCapabilitySnapshot};
+use super::handler::CrunHandler;
 #[cfg(target_os = "linux")]
-use super::handler::CrunState;
-use super::handler::{CrunHandler, CrunHandlerSpec};
+use super::handler::{CrunHandlerSpec, CrunState};
 
 #[cfg(target_os = "linux")]
 const EXEC_LISTENER_FD: i32 = 3;

--- a/src/runtime/src/sandbox/controller.rs
+++ b/src/runtime/src/sandbox/controller.rs
@@ -14,6 +14,9 @@ use std::time::{Duration, Instant};
 
 use a3s_box_core::error::{BoxError, Result};
 use a3s_box_core::execution::ResolvedExecutionPlan;
+use a3s_box_core::log::LogConfig;
+#[cfg(target_os = "linux")]
+use a3s_box_core::log::{SandboxLogWorkerSpec, SANDBOX_LOG_WORKER_SCHEMA};
 use oci_spec::runtime::Spec;
 use serde::Serialize;
 
@@ -46,6 +49,10 @@ pub struct SandboxLaunchSpec {
     pub stdout_path: PathBuf,
     pub stderr_path: PathBuf,
     pub init_log_path: PathBuf,
+    pub log_config: LogConfig,
+    pub log_worker_path: PathBuf,
+    pub log_worker_log_path: PathBuf,
+    pub log_worker_ready_path: PathBuf,
 }
 
 #[cfg(target_os = "linux")]
@@ -57,6 +64,8 @@ struct SandboxRuntimeRecord<'a> {
     runtime_root: &'a Path,
     bundle_dir: &'a Path,
     init_pid: u32,
+    log_worker_pid: u32,
+    log_worker_pid_start_time: u64,
 }
 
 /// Controller pinned to one already-verified `crun` artifact.
@@ -258,6 +267,44 @@ impl CrunController {
             tokio::time::sleep(Duration::from_millis(25)).await;
         };
 
+        let watched_pid = child.id();
+        let watched_pid_start_time = match crate::process::pid_start_time(watched_pid) {
+            Some(start_time) => start_time,
+            None => {
+                cleanup_failed_start(&self.runtime.path, &launch);
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(BoxError::BoxBootError {
+                    message: "Failed to capture crun wrapper process identity for Sandbox logs"
+                        .to_string(),
+                    hint: None,
+                });
+            }
+        };
+        let mut log_worker = match start_log_worker(&launch, watched_pid, watched_pid_start_time) {
+            Ok(worker) => worker,
+            Err(error) => {
+                cleanup_failed_start(&self.runtime.path, &launch);
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+        };
+        let log_worker_pid = log_worker.id();
+        let log_worker_pid_start_time = match crate::process::pid_start_time(log_worker_pid) {
+            Some(start_time) => start_time,
+            None => {
+                cleanup_failed_start(&self.runtime.path, &launch);
+                reap_failed_log_worker(&mut log_worker);
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(BoxError::BoxBootError {
+                    message: "Failed to capture Sandbox log worker process identity".to_string(),
+                    hint: None,
+                });
+            }
+        };
+
         let record = SandboxRuntimeRecord {
             schema: "a3s.box.sandbox-runtime.v1",
             container_id: &launch.container_id,
@@ -265,9 +312,12 @@ impl CrunController {
             runtime_root: &launch.runtime_root,
             bundle_dir: &launch.bundle_dir,
             init_pid,
+            log_worker_pid,
+            log_worker_pid_start_time,
         };
         if let Err(error) = write_json_atomic(&launch.runtime_record, &record) {
             cleanup_failed_start(&self.runtime.path, &launch);
+            reap_failed_log_worker(&mut log_worker);
             let _ = child.kill();
             let _ = child.wait();
             return Err(error);
@@ -279,6 +329,8 @@ impl CrunController {
             launch.container_id,
             init_pid,
             child,
+            log_worker,
+            log_worker_pid_start_time,
             launch.bundle_dir,
             launch.runtime_record,
         ))
@@ -363,6 +415,90 @@ fn open_log(path: &Path) -> Result<File> {
 }
 
 #[cfg(target_os = "linux")]
+fn start_log_worker(
+    launch: &SandboxLaunchSpec,
+    watched_pid: u32,
+    watched_pid_start_time: u64,
+) -> Result<std::process::Child> {
+    let _ = std::fs::remove_file(&launch.log_worker_ready_path);
+    let worker_spec = SandboxLogWorkerSpec {
+        schema: SANDBOX_LOG_WORKER_SCHEMA.to_string(),
+        box_id: launch.container_id.clone(),
+        console_log: launch.stdout_path.clone(),
+        log_config: launch.log_config.clone(),
+        watched_pid,
+        watched_pid_start_time,
+        ready_file: launch.log_worker_ready_path.clone(),
+    };
+    let config = serde_json::to_string(&worker_spec).map_err(|error| {
+        BoxError::SerializationError(format!(
+            "Failed to encode Sandbox log worker configuration: {error}"
+        ))
+    })?;
+    let stdout = open_log(&launch.log_worker_log_path)?;
+    let stderr = stdout.try_clone().map_err(BoxError::IoError)?;
+    let mut worker = Command::new(&launch.log_worker_path)
+        .arg("--sandbox-log-worker-config")
+        .arg(config)
+        .env("LC_ALL", "C")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .map_err(|error| BoxError::BoxBootError {
+            message: format!("Failed to start Sandbox log worker: {error}"),
+            hint: None,
+        })?;
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if launch.log_worker_ready_path.is_file() {
+            return Ok(worker);
+        }
+        match worker.try_wait() {
+            Ok(Some(status)) => {
+                let diagnostics =
+                    read_log_tail(&launch.log_worker_log_path, START_FAILURE_LOG_LIMIT_BYTES)
+                        .map(|excerpt| format!(": {excerpt}"))
+                        .unwrap_or_default();
+                return Err(BoxError::BoxBootError {
+                    message: format!(
+                        "Sandbox log worker exited before readiness with {status}{diagnostics}"
+                    ),
+                    hint: None,
+                });
+            }
+            Ok(None) => {}
+            Err(error) => return Err(BoxError::IoError(error)),
+        }
+        if Instant::now() >= deadline {
+            reap_failed_log_worker(&mut worker);
+            return Err(BoxError::BoxBootError {
+                message: "Timed out waiting for Sandbox log worker readiness".to_string(),
+                hint: None,
+            });
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn reap_failed_log_worker(worker: &mut std::process::Child) {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        match worker.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            _ => break,
+        }
+    }
+    let _ = worker.kill();
+    let _ = worker.wait();
+}
+
+#[cfg(target_os = "linux")]
 fn bind_control_listener(path: &Path) -> Result<std::os::unix::net::UnixListener> {
     use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 
@@ -408,6 +544,7 @@ fn start_failure_diagnostics(launch: &SandboxLaunchSpec) -> String {
     let diagnostics = [
         ("crun stderr", &launch.stderr_path),
         ("guest-init log", &launch.init_log_path),
+        ("Sandbox log worker", &launch.log_worker_log_path),
     ]
     .into_iter()
     .filter_map(|(label, path)| {

--- a/src/runtime/src/sandbox/handler.rs
+++ b/src/runtime/src/sandbox/handler.rs
@@ -44,61 +44,80 @@ pub struct CrunHandler {
     cleaned: bool,
 }
 
-impl CrunHandler {
-    #[cfg(target_os = "linux")]
-    pub(crate) fn from_child(
+pub(crate) struct CrunHandlerSpec {
+    runtime_path: PathBuf,
+    runtime_root: PathBuf,
+    container_id: String,
+    init_pid: u32,
+    bundle_dir: PathBuf,
+    runtime_record: PathBuf,
+}
+
+impl CrunHandlerSpec {
+    pub(crate) fn new(
         runtime_path: PathBuf,
         runtime_root: PathBuf,
         container_id: String,
         init_pid: u32,
-        process: Child,
-        log_worker: Child,
-        log_worker_pid_start_time: u64,
         bundle_dir: PathBuf,
         runtime_record: PathBuf,
     ) -> Self {
-        let log_worker_pid = log_worker.id();
         Self {
             runtime_path,
             runtime_root,
             container_id,
             init_pid,
+            bundle_dir,
+            runtime_record,
+        }
+    }
+}
+
+impl CrunHandler {
+    #[cfg(target_os = "linux")]
+    pub(crate) fn from_child(
+        spec: CrunHandlerSpec,
+        process: Child,
+        log_worker: Child,
+        log_worker_pid_start_time: u64,
+    ) -> Self {
+        let log_worker_pid = log_worker.id();
+        Self {
+            runtime_path: spec.runtime_path,
+            runtime_root: spec.runtime_root,
+            container_id: spec.container_id,
+            init_pid: spec.init_pid,
             process: Some(process),
             log_worker: Some(log_worker),
             log_worker_pid: Some(log_worker_pid),
             log_worker_pid_start_time: Some(log_worker_pid_start_time),
             metrics_sys: Mutex::new(System::new()),
             exit_code: None,
-            bundle_dir,
-            runtime_record,
+            bundle_dir: spec.bundle_dir,
+            runtime_record: spec.runtime_record,
             cleaned: false,
         }
     }
 
     #[cfg(all(target_os = "linux", feature = "vm"))]
     pub(crate) fn from_recorded_runtime(
-        runtime_path: PathBuf,
-        runtime_root: PathBuf,
-        container_id: String,
-        init_pid: u32,
+        spec: CrunHandlerSpec,
         log_worker_pid: Option<u32>,
         log_worker_pid_start_time: Option<u64>,
-        bundle_dir: PathBuf,
-        runtime_record: PathBuf,
     ) -> Self {
         Self {
-            runtime_path,
-            runtime_root,
-            container_id,
-            init_pid,
+            runtime_path: spec.runtime_path,
+            runtime_root: spec.runtime_root,
+            container_id: spec.container_id,
+            init_pid: spec.init_pid,
             process: None,
             log_worker: None,
             log_worker_pid,
             log_worker_pid_start_time,
             metrics_sys: Mutex::new(System::new()),
             exit_code: None,
-            bundle_dir,
-            runtime_record,
+            bundle_dir: spec.bundle_dir,
+            runtime_record: spec.runtime_record,
             cleaned: false,
         }
     }
@@ -454,14 +473,16 @@ mod tests {
         let runtime_record = temporary.path().join("runtime.json");
 
         let handler = CrunHandler::from_recorded_runtime(
-            runtime_path.clone(),
-            runtime_root.clone(),
-            "recorded-test".to_string(),
-            42,
+            CrunHandlerSpec::new(
+                runtime_path.clone(),
+                runtime_root.clone(),
+                "recorded-test".to_string(),
+                42,
+                bundle_dir.clone(),
+                runtime_record.clone(),
+            ),
             None,
             None,
-            bundle_dir.clone(),
-            runtime_record.clone(),
         );
 
         assert_eq!(handler.runtime_path, runtime_path);
@@ -485,15 +506,17 @@ mod tests {
         let log_worker_pid = log_worker.id();
         let log_worker_pid_start_time = crate::process::pid_start_time(log_worker_pid).unwrap();
         let handler = CrunHandler::from_child(
-            PathBuf::from("/bin/true"),
-            temporary.path().join("runtime"),
-            "detached-test".to_string(),
-            pid,
+            CrunHandlerSpec::new(
+                PathBuf::from("/bin/true"),
+                temporary.path().join("runtime"),
+                "detached-test".to_string(),
+                pid,
+                temporary.path().join("bundle"),
+                temporary.path().join("runtime.json"),
+            ),
             child,
             log_worker,
             log_worker_pid_start_time,
-            temporary.path().join("bundle"),
-            temporary.path().join("runtime.json"),
         );
 
         drop(handler);

--- a/src/runtime/src/sandbox/handler.rs
+++ b/src/runtime/src/sandbox/handler.rs
@@ -44,6 +44,7 @@ pub struct CrunHandler {
     cleaned: bool,
 }
 
+#[cfg(target_os = "linux")]
 pub(crate) struct CrunHandlerSpec {
     runtime_path: PathBuf,
     runtime_root: PathBuf,
@@ -53,6 +54,7 @@ pub(crate) struct CrunHandlerSpec {
     runtime_record: PathBuf,
 }
 
+#[cfg(target_os = "linux")]
 impl CrunHandlerSpec {
     pub(crate) fn new(
         runtime_path: PathBuf,
@@ -313,6 +315,7 @@ impl CrunHandler {
             );
             // The start-time token was revalidated immediately before the
             // signal, so a reused PID cannot be targeted.
+            #[cfg(target_os = "linux")]
             if let Ok(pid) = i32::try_from(pid) {
                 unsafe {
                     libc::kill(pid, libc::SIGKILL);

--- a/src/runtime/src/sandbox/handler.rs
+++ b/src/runtime/src/sandbox/handler.rs
@@ -34,6 +34,9 @@ pub struct CrunHandler {
     container_id: String,
     init_pid: u32,
     process: Option<Child>,
+    log_worker: Option<Child>,
+    log_worker_pid: Option<u32>,
+    log_worker_pid_start_time: Option<u64>,
     metrics_sys: Mutex<System>,
     exit_code: Option<i32>,
     bundle_dir: PathBuf,
@@ -49,15 +52,21 @@ impl CrunHandler {
         container_id: String,
         init_pid: u32,
         process: Child,
+        log_worker: Child,
+        log_worker_pid_start_time: u64,
         bundle_dir: PathBuf,
         runtime_record: PathBuf,
     ) -> Self {
+        let log_worker_pid = log_worker.id();
         Self {
             runtime_path,
             runtime_root,
             container_id,
             init_pid,
             process: Some(process),
+            log_worker: Some(log_worker),
+            log_worker_pid: Some(log_worker_pid),
+            log_worker_pid_start_time: Some(log_worker_pid_start_time),
             metrics_sys: Mutex::new(System::new()),
             exit_code: None,
             bundle_dir,
@@ -72,6 +81,8 @@ impl CrunHandler {
         runtime_root: PathBuf,
         container_id: String,
         init_pid: u32,
+        log_worker_pid: Option<u32>,
+        log_worker_pid_start_time: Option<u64>,
         bundle_dir: PathBuf,
         runtime_record: PathBuf,
     ) -> Self {
@@ -81,6 +92,9 @@ impl CrunHandler {
             container_id,
             init_pid,
             process: None,
+            log_worker: None,
+            log_worker_pid,
+            log_worker_pid_start_time,
             metrics_sys: Mutex::new(System::new()),
             exit_code: None,
             bundle_dir,
@@ -230,6 +244,64 @@ impl CrunHandler {
         }
     }
 
+    fn reap_log_worker(&mut self) {
+        const LOG_WORKER_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
+        const LOG_WORKER_EXIT_POLL: Duration = Duration::from_millis(10);
+
+        if let Some(mut worker) = self.log_worker.take() {
+            let deadline = Instant::now() + LOG_WORKER_EXIT_TIMEOUT;
+            loop {
+                match worker.try_wait() {
+                    Ok(Some(_)) => return,
+                    Ok(None) if Instant::now() < deadline => {
+                        std::thread::sleep(LOG_WORKER_EXIT_POLL);
+                    }
+                    Ok(None) => break,
+                    Err(error) => {
+                        tracing::warn!(
+                            container_id = %self.container_id,
+                            %error,
+                            "Failed to poll Sandbox log worker before reaping"
+                        );
+                        break;
+                    }
+                }
+            }
+            tracing::warn!(
+                container_id = %self.container_id,
+                "Sandbox log worker did not exit after crun; terminating it"
+            );
+            let _ = worker.kill();
+            let _ = worker.wait();
+            return;
+        }
+
+        let (Some(pid), Some(start_time)) = (self.log_worker_pid, self.log_worker_pid_start_time)
+        else {
+            return;
+        };
+        let deadline = Instant::now() + LOG_WORKER_EXIT_TIMEOUT;
+        while crate::process::is_process_running_with_identity(pid, Some(start_time))
+            && Instant::now() < deadline
+        {
+            std::thread::sleep(LOG_WORKER_EXIT_POLL);
+        }
+        if crate::process::is_process_running_with_identity(pid, Some(start_time)) {
+            tracing::warn!(
+                container_id = %self.container_id,
+                log_worker_pid = pid,
+                "Recovered Sandbox log worker did not exit after crun; terminating it"
+            );
+            // The start-time token was revalidated immediately before the
+            // signal, so a reused PID cannot be targeted.
+            if let Ok(pid) = i32::try_from(pid) {
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                }
+            }
+        }
+    }
+
     fn delete_runtime_state(&mut self) -> Result<()> {
         if self.cleaned {
             return Ok(());
@@ -243,6 +315,11 @@ impl CrunHandler {
         if !output.status.success() && self.query_state()?.is_some() {
             return Err(runtime_failure("crun delete --force", &output));
         }
+        // Reap the wrapper first: its inherited stdout/stderr descriptors must
+        // close before the worker treats EOF as final. Then wait for the worker
+        // to drain both streams before removing durable generation artifacts.
+        self.reap_child();
+        self.reap_log_worker();
         self.cleaned = true;
         remove_file_if_exists(&self.runtime_record);
         remove_dir_if_exists(&self.bundle_dir);
@@ -281,7 +358,6 @@ impl VmHandler for CrunHandler {
         if let Err(error) = self.delete_runtime_state() {
             first_error.get_or_insert(error);
         }
-        self.reap_child();
         match first_error {
             Some(error) => Err(error),
             None => Ok(()),
@@ -382,6 +458,8 @@ mod tests {
             runtime_root.clone(),
             "recorded-test".to_string(),
             42,
+            None,
+            None,
             bundle_dir.clone(),
             runtime_record.clone(),
         );
@@ -391,6 +469,8 @@ mod tests {
         assert_eq!(handler.container_id, "recorded-test");
         assert_eq!(handler.pid(), 42);
         assert!(handler.process.is_none());
+        assert!(handler.log_worker.is_none());
+        assert!(handler.log_worker_pid.is_none());
         assert_eq!(handler.bundle_dir, bundle_dir);
         assert_eq!(handler.runtime_record, runtime_record);
         assert!(!handler.cleaned);
@@ -401,27 +481,39 @@ mod tests {
         let temporary = tempfile::tempdir().unwrap();
         let child = Command::new("sleep").arg("30").spawn().unwrap();
         let pid = child.id();
+        let log_worker = Command::new("sleep").arg("30").spawn().unwrap();
+        let log_worker_pid = log_worker.id();
+        let log_worker_pid_start_time = crate::process::pid_start_time(log_worker_pid).unwrap();
         let handler = CrunHandler::from_child(
             PathBuf::from("/bin/true"),
             temporary.path().join("runtime"),
             "detached-test".to_string(),
             pid,
             child,
+            log_worker,
+            log_worker_pid_start_time,
             temporary.path().join("bundle"),
             temporary.path().join("runtime.json"),
         );
 
         drop(handler);
         let remained_alive = unsafe { libc::kill(pid as i32, 0) == 0 };
+        let log_worker_remained_alive = unsafe { libc::kill(log_worker_pid as i32, 0) == 0 };
 
         unsafe {
             libc::kill(pid as i32, libc::SIGKILL);
             let mut status = 0;
             libc::waitpid(pid as i32, &mut status, 0);
+            libc::kill(log_worker_pid as i32, libc::SIGKILL);
+            libc::waitpid(log_worker_pid as i32, &mut status, 0);
         }
         assert!(
             remained_alive,
             "dropping a runtime handle must not destroy a detached Sandbox"
+        );
+        assert!(
+            log_worker_remained_alive,
+            "dropping a runtime handle must not destroy its detached log worker"
         );
     }
 }

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -30,6 +30,21 @@ pub fn cleanup_recorded_sandbox_runtime(box_dir: &Path, box_id: &str) -> a3s_box
     cleanup_recorded_sandbox_runtime_in(&a3s_box_core::dirs_home(), box_dir, box_id)
 }
 
+/// Wait for a naturally exited Sandbox generation to finish projecting both
+/// console streams before a caller archives or reads its final logs.
+#[cfg(target_os = "linux")]
+pub fn wait_for_recorded_sandbox_log_drain(
+    box_dir: &Path,
+    box_id: &str,
+    timeout: std::time::Duration,
+) -> a3s_box_core::Result<bool> {
+    let home_dir = a3s_box_core::dirs_home();
+    let Some(record) = load_recorded_sandbox_runtime(&home_dir, box_dir, box_id)? else {
+        return Ok(true);
+    };
+    Ok(wait_for_log_worker_identity(&record, timeout))
+}
+
 #[cfg(target_os = "linux")]
 pub(crate) fn cleanup_recorded_sandbox_runtime_in(
     home_dir: &Path,
@@ -111,6 +126,10 @@ struct SandboxRuntimeRecord {
     runtime_root: std::path::PathBuf,
     bundle_dir: std::path::PathBuf,
     init_pid: u32,
+    #[serde(default)]
+    log_worker_pid: Option<u32>,
+    #[serde(default)]
+    log_worker_pid_start_time: Option<u64>,
 }
 
 /// Validated durable evidence for one live or stopped Sandbox generation.
@@ -121,6 +140,8 @@ pub(crate) struct RecordedSandboxRuntime {
     pub(crate) runtime_root: std::path::PathBuf,
     pub(crate) bundle_dir: std::path::PathBuf,
     pub(crate) init_pid: u32,
+    pub(crate) log_worker_pid: Option<u32>,
+    pub(crate) log_worker_pid_start_time: Option<u64>,
 }
 
 /// Load and validate the runtime-owned Sandbox record for one internal box ID.
@@ -153,11 +174,18 @@ pub(crate) fn load_recorded_sandbox_runtime(
     })?;
     let expected_runtime_root = home_dir.join("run/crun").join(box_id);
     let expected_bundle = box_dir.join("sandbox/bundle");
+    let log_worker_identity_valid = match (record.log_worker_pid, record.log_worker_pid_start_time)
+    {
+        (None, None) => true,
+        (Some(pid), Some(start_time)) => pid > 0 && start_time > 0,
+        _ => false,
+    };
     if record.schema != "a3s.box.sandbox-runtime.v1"
         || record.container_id != box_id
         || record.runtime_root != expected_runtime_root
         || record.bundle_dir != expected_bundle
         || record.init_pid == 0
+        || !log_worker_identity_valid
     {
         return Err(a3s_box_core::BoxError::StateError(format!(
             "Sandbox runtime record failed path or identity validation for {box_id}"
@@ -176,6 +204,8 @@ pub(crate) fn load_recorded_sandbox_runtime(
         runtime_root: record.runtime_root,
         bundle_dir: record.bundle_dir,
         init_pid: record.init_pid,
+        log_worker_pid: record.log_worker_pid,
+        log_worker_pid_start_time: record.log_worker_pid_start_time,
     }))
 }
 
@@ -261,11 +291,54 @@ fn reap_orphaned_crun(home_dir: &Path, box_dir: &Path, box_id: &str) -> SandboxR
         }
     }
 
+    drain_recorded_log_worker(&record, box_id);
     let _ = std::fs::remove_dir_all(&record.bundle_dir);
     let _ = std::fs::remove_dir_all(&record.runtime_root);
     let _ = std::fs::remove_file(&record_path);
     tracing::info!(box_id, "Reaped orphaned crun Sandbox after runtime restart");
     SandboxReap::Cleaned
+}
+
+#[cfg(target_os = "linux")]
+fn drain_recorded_log_worker(record: &RecordedSandboxRuntime, box_id: &str) {
+    let (Some(pid), Some(_start_time)) = (record.log_worker_pid, record.log_worker_pid_start_time)
+    else {
+        return;
+    };
+    if wait_for_log_worker_identity(record, std::time::Duration::from_secs(2)) {
+        return;
+    }
+
+    tracing::warn!(
+        box_id,
+        log_worker_pid = pid,
+        "Recovered Sandbox log worker did not drain after crun cleanup; terminating it"
+    );
+    if let Ok(pid) = i32::try_from(pid) {
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_log_worker_identity(
+    record: &RecordedSandboxRuntime,
+    timeout: std::time::Duration,
+) -> bool {
+    let (Some(pid), Some(start_time)) = (record.log_worker_pid, record.log_worker_pid_start_time)
+    else {
+        // Runtime records written before the worker fields have no process to
+        // wait for and retain their legacy raw-console behavior.
+        return true;
+    };
+    let deadline = std::time::Instant::now() + timeout;
+    while crate::process::is_process_running_with_identity(pid, Some(start_time))
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    !crate::process::is_process_running_with_identity(pid, Some(start_time))
 }
 
 /// Poll until every pid in `pids` has exited, or `timeout` elapses.
@@ -298,6 +371,15 @@ pub fn cleanup_recorded_sandbox_runtime(
     _box_id: &str,
 ) -> a3s_box_core::Result<()> {
     Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn wait_for_recorded_sandbox_log_drain(
+    _box_dir: &std::path::Path,
+    _box_id: &str,
+    _timeout: std::time::Duration,
+) -> a3s_box_core::Result<bool> {
+    Ok(true)
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -371,6 +453,8 @@ mod tests {
             runtime_root: home_dir.join("run/crun").join(box_id),
             bundle_dir: box_dir.join("sandbox/bundle"),
             init_pid: 42,
+            log_worker_pid: None,
+            log_worker_pid_start_time: None,
         };
         mutate(&mut record);
         std::fs::create_dir_all(box_dir.join("sandbox")).unwrap();

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -37,6 +37,10 @@ impl VmManager {
                     .to_string(),
                 hint: None,
             })?;
+        // Sandbox logging is hosted by the packaged shim in a dedicated worker
+        // mode so it survives detached CLI clients. Resolve it before image or
+        // rootfs preparation to keep a missing artifact side-effect free.
+        let log_worker_path = crate::vmm::VmController::find_shim()?;
         let user_namespace =
             capabilities
                 .user_namespace
@@ -169,6 +173,10 @@ impl VmManager {
             stdout_path: console_output.clone(),
             stderr_path: a3s_box_core::log::stderr_console_path(&console_output),
             init_log_path: box_dir.join("logs").join("sandbox-init.log"),
+            log_config: self.log_config.clone(),
+            log_worker_path,
+            log_worker_log_path: box_dir.join("logs").join("sandbox-log-worker.log"),
+            log_worker_ready_path: sandbox_dir.join("bundle").join("log-worker.ready"),
         };
         let handler = match controller.start(launch).await {
             Ok(handler) => handler,

--- a/src/shim/src/krun/context.rs
+++ b/src/shim/src/krun/context.rs
@@ -20,9 +20,10 @@ use libkrun_sys::krun_set_port_map;
 use libkrun_sys::{krun_add_net_tcp, krun_add_vsock_port_windows, krun_set_kernel};
 #[cfg(target_os = "linux")]
 use libkrun_sys::{krun_add_net_unixstream, krun_split_irqchip};
+#[cfg(unix)]
+use libkrun_sys::{krun_add_virtio_console_default, krun_disable_implicit_console};
 use libkrun_sys::{
-    krun_add_virtio_console_default, krun_add_virtiofs, krun_create_ctx,
-    krun_disable_implicit_console, krun_free_ctx, krun_init_log, krun_set_console_output,
+    krun_add_virtiofs, krun_create_ctx, krun_free_ctx, krun_init_log, krun_set_console_output,
     krun_set_env, krun_set_exec, krun_set_rlimits, krun_set_root, krun_set_vm_config,
     krun_set_workdir, krun_setgid, krun_setuid, krun_start_enter,
 };
@@ -442,6 +443,7 @@ impl KrunContext {
     /// Replace the implicit console with a virtio-console whose stdout and
     /// stderr go to SEPARATE host fds (so the guest's stderr can be tagged).
     /// `input_fd` may be -1 (no stdin). Caller owns the fds for the VM lifetime.
+    #[cfg(unix)]
     pub unsafe fn add_split_console(
         &self,
         input_fd: i32,

--- a/src/shim/src/main.rs
+++ b/src/shim/src/main.rs
@@ -41,6 +41,12 @@ struct Args {
     #[arg(long)]
     config: Option<String>,
 
+    /// Internal: project one Sandbox generation's split console into its
+    /// configured log driver until the exact crun wrapper exits.
+    #[cfg(target_os = "linux")]
+    #[arg(long, hide = true)]
+    sandbox_log_worker_config: Option<String>,
+
     #[cfg(target_os = "windows")]
     #[arg(long, hide = true)]
     port_fwd_worker: bool,
@@ -113,6 +119,11 @@ fn maybe_enable_ksm_merge() {}
 
 fn run() -> Result<()> {
     let args = Args::parse();
+
+    #[cfg(target_os = "linux")]
+    if let Some(config) = args.sandbox_log_worker_config.as_deref() {
+        return run_sandbox_log_worker(config);
+    }
 
     #[cfg(target_os = "windows")]
     if args.port_fwd_worker {
@@ -202,6 +213,140 @@ fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_sandbox_log_worker(config: &str) -> Result<()> {
+    use a3s_box_core::log::{
+        run_log_processor_with_ready_and_eof_policy, ConsoleEofPolicy, SandboxLogWorkerSpec,
+    };
+    use std::io::Write;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    let spec: SandboxLogWorkerSpec =
+        serde_json::from_str(config).map_err(|error| BoxError::BoxBootError {
+            message: format!("Failed to parse Sandbox log worker config: {error}"),
+            hint: None,
+        })?;
+    validate_sandbox_log_worker_spec(&spec)?;
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let ready = Arc::new(AtomicUsize::new(0));
+    let console_log = spec.console_log.clone();
+    let log_dir = console_log
+        .parent()
+        .ok_or_else(|| BoxError::BoxBootError {
+            message: format!(
+                "Sandbox console path has no parent: {}",
+                console_log.display()
+            ),
+            hint: None,
+        })?
+        .to_path_buf();
+    let log_config = spec.log_config.clone();
+    let processor_stop = Arc::clone(&stop);
+    let processor_ready = Arc::clone(&ready);
+    let processor = std::thread::spawn(move || {
+        run_log_processor_with_ready_and_eof_policy(
+            &console_log,
+            &log_dir,
+            &log_config,
+            &processor_stop,
+            Some(&processor_ready),
+            ConsoleEofPolicy::WriterClosed,
+        );
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while ready.load(Ordering::Acquire) < 2 {
+        if processor.is_finished() {
+            let _ = processor.join();
+            return Err(BoxError::BoxBootError {
+                message: "Sandbox log processor exited before opening both console streams"
+                    .to_string(),
+                hint: None,
+            });
+        }
+        if Instant::now() >= deadline {
+            stop.store(true, Ordering::SeqCst);
+            let _ = processor.join();
+            return Err(BoxError::BoxBootError {
+                message: "Sandbox log processor did not become ready before timeout".to_string(),
+                hint: None,
+            });
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    if let Some(parent) = spec.ready_file.parent() {
+        std::fs::create_dir_all(parent).map_err(BoxError::IoError)?;
+    }
+    let mut ready_file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&spec.ready_file)
+        .map_err(BoxError::IoError)?;
+    ready_file
+        .write_all(format!("{}\n", std::process::id()).as_bytes())
+        .map_err(BoxError::IoError)?;
+    ready_file.sync_all().map_err(BoxError::IoError)?;
+
+    while sandbox_watched_process_is_current(spec.watched_pid, spec.watched_pid_start_time) {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    // The exact wrapper identity is gone (or a zombie), so its stdout/stderr
+    // descriptors are closed. WriterClosed makes the next EOF final and still
+    // flushes a trailing partial line.
+    stop.store(true, Ordering::SeqCst);
+    processor.join().map_err(|_| BoxError::BoxBootError {
+        message: format!("Sandbox log processor panicked for {}", spec.box_id),
+        hint: None,
+    })?;
+    tracing::debug!(box_id = %spec.box_id, "Sandbox logs fully drained");
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn validate_sandbox_log_worker_spec(spec: &a3s_box_core::log::SandboxLogWorkerSpec) -> Result<()> {
+    if spec.schema != a3s_box_core::log::SANDBOX_LOG_WORKER_SCHEMA
+        || spec.box_id.is_empty()
+        || spec.watched_pid == 0
+        || spec.watched_pid_start_time == 0
+        || !spec.console_log.is_absolute()
+        || !spec.ready_file.is_absolute()
+    {
+        return Err(BoxError::BoxBootError {
+            message: "Invalid Sandbox log worker identity or path configuration".to_string(),
+            hint: None,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn sandbox_watched_process_is_current(pid: u32, expected_start_time: u64) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    linux_process_identity_from_stat(&stat)
+        .is_some_and(|(state, start_time)| state != 'Z' && start_time == expected_start_time)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_identity_from_stat(stat: &str) -> Option<(char, u64)> {
+    // `comm` may contain spaces and parentheses. Field 3 (state) begins after
+    // the final `)`, and field 22 (starttime) is token 19 from that point.
+    let fields: Vec<&str> = stat
+        .get(stat.rfind(')')? + 1..)?
+        .split_whitespace()
+        .collect();
+    let state = fields.first()?.chars().next()?;
+    let start_time = fields.get(19)?.parse().ok()?;
+    Some((state, start_time))
 }
 
 /// Parse a Docker-style ulimit string into a krun rlimit string.
@@ -998,6 +1143,33 @@ unsafe fn apply_user_config(ctx: &KrunContext, user: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parses_sandbox_worker_pid_identity_after_complex_comm() {
+        let stat =
+            "123 (crun (sandbox) worker) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 4242";
+        assert_eq!(linux_process_identity_from_stat(stat), Some(('S', 4242)));
+        assert_eq!(linux_process_identity_from_stat("malformed"), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn validates_complete_sandbox_log_worker_identity() {
+        let mut spec = a3s_box_core::log::SandboxLogWorkerSpec {
+            schema: a3s_box_core::log::SANDBOX_LOG_WORKER_SCHEMA.to_string(),
+            box_id: "sandbox-id".to_string(),
+            console_log: std::path::PathBuf::from("/tmp/sandbox-id/console.log"),
+            log_config: a3s_box_core::log::LogConfig::default(),
+            watched_pid: 123,
+            watched_pid_start_time: 456,
+            ready_file: std::path::PathBuf::from("/tmp/sandbox-id/log-worker.ready"),
+        };
+        validate_sandbox_log_worker_spec(&spec).unwrap();
+
+        spec.watched_pid_start_time = 0;
+        assert!(validate_sandbox_log_worker_spec(&spec).is_err());
+    }
 
     #[test]
     fn test_parse_ulimit_nofile() {


### PR DESCRIPTION
## Summary

- run a generation-owned Sandbox log worker that projects separate stdout/stderr console files into Docker-compatible `container.json` records
- fence worker and crun identities by PID start time, drain final bytes after natural exit, and recover cleanup without treating zombies as running
- drain before foreground, detached, explicit stop/kill, reconciliation, and auto-remove archival cleanup
- document the structured log lifecycle and current shared-kernel boundary

## Validation

Final head `7ce056e` on the A3S OS production validation server (Ubuntu 24.04.1, x86_64):

- workspace Clippy with `-D warnings` passed
- core: 431 passed
- runtime: 1293 passed, 1 ignored; doc tests passed
- shim: 23 passed
- managed Sandbox smoke: create/recovery/start, split stdout/stderr, pause rejection, kill, and leak-free cleanup
- foreground `--rm`: final stderr archived with stream identity; box/crun/socket/worker cleanup verified
- detached natural exit, explicit stop, and SIGKILL: final drain, archival, reconciliation, and cleanup verified
- `logs --follow`, `--tail`, `--since`, `--until`, and `--timestamps` verified against a real Sandbox

GitHub CI passed Format, Clippy, Test, E2B Contract, E2B Official Clients, Linux x86_64, Linux arm64, macOS arm64, and Windows WHPX.

No Docker, OrbStack, or local runtime was used. Server source was fetched from Git.

Fixes #47