### PR TITLE
perf(sandbox): make hot lifecycle competitive with Docker

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -19,6 +19,7 @@ is the environment used by the original foreground-latency regression report.
 bench/bench.sh            # default Linux/KVM suite, including foreground latency
 bench/bench.sh cold       # cold-boot latency only
 bench/bench.sh foreground # cached foreground no-op, optionally versus Docker
+bench/bench.sh sandbox    # phased hot Sandbox lifecycle, optionally versus Docker
 bench/bench.sh warm       # warm-pool acquire latency
 bench/bench.sh fork       # snapshot-fork pool fill (cold-fill vs CoW restore)
 bench/bench.sh leak       # churn + leak assertion (exit != 0 on leak)
@@ -38,6 +39,11 @@ Tunables (env):
 | `FOREGROUND_DOCKER` | `1` | compare Docker when its CLI and daemon are available |
 | `FOREGROUND_MAX_P50_MS` | `0` | optional absolute a3s-box p50 gate; `0` reports without gating |
 | `FOREGROUND_MAX_DOCKER_RATIO` | `0` | optional p50 ratio gate; `0` reports without gating |
+| `SANDBOX_RUNS` | `RUNS` | recorded hot Sandbox lifecycle samples |
+| `SANDBOX_WARMUPS` | `1` | unmeasured warm-up runs before Sandbox sampling |
+| `SANDBOX_DOCKER` | `1` | alternate matching Docker samples when its daemon is available |
+| `SANDBOX_RESULTS` | `/tmp/a3s-box-sandbox-lifecycle-<pid>.csv` | machine-readable per-sample output |
+| `SANDBOX_LOG_DIR` | `/tmp/a3s-box-sandbox-lifecycle-<pid>` | raw opt-in JSONL profile logs |
 | `POOL_SIZE` | `16` | warm-pool / fork fill size |
 | `CHURN` | `30` | create/run/remove cycles for the leak test |
 | `PNPM_PROJECT` | unset | project directory with `package.json` and `pnpm-lock.yaml` for `pnpm` mode |
@@ -61,6 +67,15 @@ Tunables (env):
   and minimum. When Docker is available, the harness runs the matching cached
   Docker no-op and reports the p50 ratio. Set `FOREGROUND_MAX_DOCKER_RATIO` only
   on a stable dedicated runner when the comparison should be a hard gate.
+- **sandbox** — explicitly selects `--isolation sandbox`, completes image pull
+  and unpack before warm-up, then records the hot one-shot lifecycle as four
+  non-cold measurements: create/start, command execution, reconciliation, and
+  removal. The CSV also retains the create/start internals (capability probe,
+  layout, instance preparation, managed mount preparation, rootfs ownership,
+  OCI bundle, `crun` launch, and readiness) for regression diagnosis. When
+  Docker is available, samples alternate runtime order and the matching hot
+  `docker run --rm IMAGE true` totals are written to the same CSV. Profiling is
+  opt-in and emits no workload arguments, paths, or credentials.
 - **warm** — `pool start` then `pool run` acquire latency (p50 / p90 / min).
 - **fork** — `pool start --size N` fill time **without** vs **with**
   `--snapshot-fork`, as total + amortized-per-VM, so the CoW speedup is a

--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -8,7 +8,7 @@
 # foreground comparison also runs on macOS with HVF.
 #
 # Usage:
-#   bench/bench.sh [all|cold|foreground|warm|fork|leak|race|pnpm]   (default: all)
+#   bench/bench.sh [all|cold|foreground|sandbox|warm|fork|leak|race|pnpm]   (default: all)
 # Env:
 #   A3S_BOX   path to the a3s-box binary           (default: a3s-box on PATH)
 #   IMAGE     OCI image to benchmark                (default: alpine:latest)
@@ -21,6 +21,11 @@
 #   FOREGROUND_DOCKER 1 compares Docker when available, 0 skips it (default: 1)
 #   FOREGROUND_MAX_P50_MS optional a3s-box p50 gate; 0 only reports (default: 0)
 #   FOREGROUND_MAX_DOCKER_RATIO optional p50 ratio gate; 0 only reports (default: 0)
+#   SANDBOX_RUNS hot Sandbox lifecycle samples       (default: RUNS)
+#   SANDBOX_WARMUPS unmeasured Sandbox warm-ups      (default: 1)
+#   SANDBOX_DOCKER 1 alternates matching Docker samples, 0 skips (default: 1)
+#   SANDBOX_RESULTS machine-readable CSV output path (default: /tmp/...csv)
+#   SANDBOX_LOG_DIR per-sample profile logs           (default: /tmp/...)
 #   PNPM_PROJECT project dir with package.json + pnpm-lock.yaml (required for pnpm mode)
 #   PNPM_IMAGE   Node image for pnpm mode             (default: node:22-alpine)
 #   PNPM_VERSION pnpm version for corepack prepare    (default: 10.30.3)
@@ -46,6 +51,11 @@ FOREGROUND_WARMUPS="${FOREGROUND_WARMUPS:-1}"
 FOREGROUND_DOCKER="${FOREGROUND_DOCKER:-1}"
 FOREGROUND_MAX_P50_MS="${FOREGROUND_MAX_P50_MS:-0}"
 FOREGROUND_MAX_DOCKER_RATIO="${FOREGROUND_MAX_DOCKER_RATIO:-0}"
+SANDBOX_RUNS="${SANDBOX_RUNS:-$RUNS}"
+SANDBOX_WARMUPS="${SANDBOX_WARMUPS:-1}"
+SANDBOX_DOCKER="${SANDBOX_DOCKER:-1}"
+SANDBOX_RESULTS="${SANDBOX_RESULTS:-/tmp/a3s-box-sandbox-lifecycle-$$.csv}"
+SANDBOX_LOG_DIR="${SANDBOX_LOG_DIR:-/tmp/a3s-box-sandbox-lifecycle-$$}"
 PNPM_PROJECT="${PNPM_PROJECT:-}"
 PNPM_IMAGE="${PNPM_IMAGE:-node:22-alpine}"
 PNPM_VERSION="${PNPM_VERSION:-10.30.3}"
@@ -208,6 +218,217 @@ bench_foreground() {
   fi
 
   rm -f "$a3s_log" "$docker_log"
+}
+
+# Parse the opt-in JSONL events produced by one profiled `a3s-box run`.
+# Output order matches the machine-readable CSV columns in
+# bench_sandbox_lifecycle. Reconciliation is the sum of the raw/structured log
+# drains, log archival, and managed runtime reconciliation. Removal is the
+# final durable-state and residual-path deletion phase.
+sandbox_profile_fields() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+prefix = "A3S_BOX_LIFECYCLE "
+durations = {}
+with open(sys.argv[1], encoding="utf-8", errors="replace") as stream:
+    for line in stream:
+        marker = line.find(prefix)
+        if marker < 0:
+            continue
+        try:
+            event = json.loads(line[marker + len(prefix):])
+        except json.JSONDecodeError:
+            continue
+        if event.get("schema") != "a3s.box.lifecycle-profile.v1":
+            continue
+        phase = event.get("phase")
+        duration = event.get("duration_ns")
+        if isinstance(phase, str) and isinstance(duration, int):
+            durations[phase] = durations.get(phase, 0) + duration
+
+required = [
+    "cli.create_start",
+    "foreground.command_execution",
+    "foreground.raw_log_drain",
+    "foreground.structured_log_drain",
+    "foreground.archive",
+    "foreground.manager_reconcile",
+    "foreground.removal",
+    "sandbox.capability",
+    "sandbox.layout",
+    "sandbox.instance_prepare",
+    "sandbox.mount_sources",
+    "sandbox.rootfs_ownership",
+    "sandbox.bundle",
+    "sandbox.launch",
+    "sandbox.readiness",
+]
+missing = [phase for phase in required if phase not in durations]
+if missing:
+    raise SystemExit("missing lifecycle profile phases: " + ", ".join(missing))
+
+def milliseconds(phase):
+    return durations[phase] / 1_000_000
+
+reconciliation = sum(milliseconds(phase) for phase in [
+    "foreground.raw_log_drain",
+    "foreground.structured_log_drain",
+    "foreground.archive",
+    "foreground.manager_reconcile",
+])
+fields = [
+    milliseconds("cli.create_start"),
+    milliseconds("foreground.command_execution"),
+    reconciliation,
+    milliseconds("foreground.removal"),
+    milliseconds("sandbox.capability"),
+    milliseconds("sandbox.layout"),
+    milliseconds("sandbox.instance_prepare"),
+    milliseconds("sandbox.mount_sources"),
+    milliseconds("sandbox.rootfs_ownership"),
+    milliseconds("sandbox.bundle"),
+    milliseconds("sandbox.launch"),
+    milliseconds("sandbox.readiness"),
+]
+print(",".join(f"{value:.3f}" for value in fields))
+PY
+}
+
+bench_sandbox_lifecycle() {
+  echo "## Hot Sandbox lifecycle ($SANDBOX_RUNS runs, $SANDBOX_WARMUPS warm-up, $IMAGE)"
+  echo "  cold image import/unpack: excluded (pull completes before warm-up)"
+  mkdir -p "$SANDBOX_LOG_DIR" "$(dirname "$SANDBOX_RESULTS")"
+  printf '%s\n' "runtime,iteration,wall_ms,create_start_ms,command_execution_ms,reconciliation_ms,removal_ms,capability_ms,layout_ms,instance_prepare_ms,mount_sources_ms,rootfs_ownership_ms,bundle_ms,launch_ms,readiness_ms,exit_code" >"$SANDBOX_RESULTS"
+
+  local a3s_log="$SANDBOX_LOG_DIR/a3s-warmup.log"
+  local docker_log="$SANDBOX_LOG_DIR/docker-warmup.log"
+  local i status
+  "$A3S_BOX" pull "$IMAGE" >"$SANDBOX_LOG_DIR/a3s-pull.log" 2>&1 || {
+    echo "  FAIL: a3s-box image preparation failed" >&2
+    tail -80 "$SANDBOX_LOG_DIR/a3s-pull.log" >&2
+    return 1
+  }
+  for i in $(seq 1 "$SANDBOX_WARMUPS"); do
+    if ! "$A3S_BOX" run --rm --isolation sandbox --no-stdin --timeout 180 "$IMAGE" -- true >"$a3s_log" 2>&1; then
+      echo "  FAIL: Sandbox warm-up $i failed" >&2
+      tail -80 "$a3s_log" >&2
+      return 1
+    fi
+  done
+
+  local compare_docker="$SANDBOX_DOCKER"
+  if [ "$compare_docker" = "1" ]; then
+    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+      docker pull "$IMAGE" >"$SANDBOX_LOG_DIR/docker-pull.log" 2>&1 || {
+        echo "  FAIL: Docker image preparation failed" >&2
+        tail -80 "$SANDBOX_LOG_DIR/docker-pull.log" >&2
+        return 1
+      }
+      for i in $(seq 1 "$SANDBOX_WARMUPS"); do
+        if ! docker run --rm "$IMAGE" true >"$docker_log" 2>&1; then
+          echo "  FAIL: Docker warm-up $i failed" >&2
+          tail -80 "$docker_log" >&2
+          return 1
+        fi
+      done
+    else
+      compare_docker=0
+      echo "  Docker comparison: skipped (docker CLI or daemon unavailable)"
+    fi
+  fi
+
+  local a3s_samples="" docker_samples=""
+  local create_samples="" command_samples="" reconciliation_samples="" removal_samples=""
+  local capability_samples="" layout_samples="" instance_samples="" mount_samples=""
+  local ownership_samples="" bundle_samples="" launch_samples="" readiness_samples=""
+
+  measure_a3s_sandbox_sample() {
+    local iteration="$1"
+    local log_file="$SANDBOX_LOG_DIR/a3s-$iteration.log"
+    local s e wall fields
+    s=$(now_ms)
+    A3S_BOX_LIFECYCLE_PROFILE=1 "$A3S_BOX" run --rm --isolation sandbox --no-stdin --timeout 180 "$IMAGE" -- true >"$log_file" 2>&1
+    status=$?
+    e=$(now_ms)
+    wall=$(( e - s ))
+    if [ "$status" -ne 0 ]; then
+      printf 'a3s,%s,%s,,,,,,,,,,,,,%s\n' "$iteration" "$wall" "$status" >>"$SANDBOX_RESULTS"
+      echo "  FAIL: Sandbox sample $iteration failed" >&2
+      tail -100 "$log_file" >&2
+      return "$status"
+    fi
+    if ! fields=$(sandbox_profile_fields "$log_file"); then
+      echo "  FAIL: incomplete lifecycle profile for Sandbox sample $iteration" >&2
+      tail -120 "$log_file" >&2
+      return 1
+    fi
+    local create command reconciliation removal capability layout instance mount ownership bundle launch readiness
+    IFS=, read -r create command reconciliation removal capability layout instance mount ownership bundle launch readiness <<EOF
+$fields
+EOF
+    printf 'a3s,%s,%s,%s,%s\n' "$iteration" "$wall" "$fields" "$status" >>"$SANDBOX_RESULTS"
+    a3s_samples="$a3s_samples $wall"
+    create_samples="$create_samples $create"
+    command_samples="$command_samples $command"
+    reconciliation_samples="$reconciliation_samples $reconciliation"
+    removal_samples="$removal_samples $removal"
+    capability_samples="$capability_samples $capability"
+    layout_samples="$layout_samples $layout"
+    instance_samples="$instance_samples $instance"
+    mount_samples="$mount_samples $mount"
+    ownership_samples="$ownership_samples $ownership"
+    bundle_samples="$bundle_samples $bundle"
+    launch_samples="$launch_samples $launch"
+    readiness_samples="$readiness_samples $readiness"
+  }
+
+  measure_docker_sandbox_sample() {
+    local iteration="$1"
+    local log_file="$SANDBOX_LOG_DIR/docker-$iteration.log"
+    local s e wall
+    s=$(now_ms)
+    docker run --rm "$IMAGE" true >"$log_file" 2>&1
+    status=$?
+    e=$(now_ms)
+    wall=$(( e - s ))
+    printf 'docker,%s,%s,,,,,,,,,,,,,%s\n' "$iteration" "$wall" "$status" >>"$SANDBOX_RESULTS"
+    if [ "$status" -ne 0 ]; then
+      echo "  FAIL: Docker sample $iteration failed" >&2
+      tail -100 "$log_file" >&2
+      return "$status"
+    fi
+    docker_samples="$docker_samples $wall"
+  }
+
+  for i in $(seq 1 "$SANDBOX_RUNS"); do
+    if [ "$compare_docker" = "1" ] && [ $(( i % 2 )) -eq 0 ]; then
+      measure_docker_sandbox_sample "$i" || return $?
+      measure_a3s_sandbox_sample "$i" || return $?
+    else
+      measure_a3s_sandbox_sample "$i" || return $?
+      if [ "$compare_docker" = "1" ]; then
+        measure_docker_sandbox_sample "$i" || return $?
+      fi
+    fi
+  done
+
+  echo "  a3s-box total:       mean=$(mean_ms "$a3s_samples")ms p50=$(pct "$a3s_samples" 50)ms p95=$(pct "$a3s_samples" 95)ms"
+  echo "  create/start:        p50=$(pct "$create_samples" 50)ms"
+  echo "  command execution:   p50=$(pct "$command_samples" 50)ms"
+  echo "  reconciliation:      p50=$(pct "$reconciliation_samples" 50)ms"
+  echo "  removal:             p50=$(pct "$removal_samples" 50)ms"
+  echo "  start internals p50: capability=$(pct "$capability_samples" 50)ms layout=$(pct "$layout_samples" 50)ms instance=$(pct "$instance_samples" 50)ms mounts=$(pct "$mount_samples" 50)ms ownership=$(pct "$ownership_samples" 50)ms bundle=$(pct "$bundle_samples" 50)ms launch=$(pct "$launch_samples" 50)ms readiness=$(pct "$readiness_samples" 50)ms"
+  if [ "$compare_docker" = "1" ]; then
+    local a3s_p50 docker_p50
+    a3s_p50=$(pct "$a3s_samples" 50)
+    docker_p50=$(pct "$docker_samples" 50)
+    echo "  Docker total:        mean=$(mean_ms "$docker_samples")ms p50=${docker_p50}ms p95=$(pct "$docker_samples" 95)ms"
+    echo "  a3s-box/Docker p50:  $(ratio "$a3s_p50" "$docker_p50")"
+  fi
+  echo "  CSV: $SANDBOX_RESULTS"
+  echo "  profile logs: $SANDBOX_LOG_DIR"
 }
 
 bench_warm() {
@@ -511,6 +732,7 @@ rc=0
 case "$MODE" in
   cold) bench_cold ;;
   foreground) bench_foreground || rc=$? ;;
+  sandbox) bench_sandbox_lifecycle || rc=$? ;;
   warm) bench_warm ;;
   fork) bench_fork ;;
   leak) bench_leak || rc=$? ;;
@@ -524,6 +746,6 @@ case "$MODE" in
     bench_leak || rc=$?
     bench_race || rc=$?
     ;;
-  *) echo "unknown mode: $MODE (use all|cold|foreground|warm|fork|leak|race|pnpm)"; exit 2 ;;
+  *) echo "unknown mode: $MODE (use all|cold|foreground|sandbox|warm|fork|leak|race|pnpm)"; exit 2 ;;
 esac
 exit "$rc"

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -604,16 +604,34 @@ async fn run_foreground(
         foreground_start.elapsed(),
     );
 
+    let sandbox_natural_exit =
+        stop_reason == ForegroundStopReason::ProcessExited && ctx.record.isolation.is_sandbox();
+    if sandbox_natural_exit {
+        // The generation-owned worker exits only after crun has closed both
+        // raw console streams and projected their final records. Once it is
+        // gone, the terminal tailers can catch up to immutable file lengths
+        // without an additional writer-quiet grace period.
+        let structured_log_drain_start = std::time::Instant::now();
+        wait_for_sandbox_structured_log_drain(&ctx).await?;
+        a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+            "foreground.structured_log_drain",
+            structured_log_drain_start.elapsed(),
+        );
+    }
+
     let raw_log_drain_start = std::time::Instant::now();
-    wait_for_foreground_log_drain(&[(&console_log, &stdout_pos), (&console_err, &stderr_pos)])
-        .await;
+    wait_for_foreground_log_drain(
+        &[(&console_log, &stdout_pos), (&console_err, &stderr_pos)],
+        sandbox_natural_exit,
+    )
+    .await;
     a3s_box_core::lifecycle_profile::record_lifecycle_phase(
         "foreground.raw_log_drain",
         raw_log_drain_start.elapsed(),
     );
     log_handle.abort();
 
-    if stop_reason == ForegroundStopReason::ProcessExited {
+    if stop_reason == ForegroundStopReason::ProcessExited && !sandbox_natural_exit {
         let structured_log_drain_start = std::time::Instant::now();
         wait_for_sandbox_structured_log_drain(&ctx).await?;
         a3s_box_core::lifecycle_profile::record_lifecycle_phase(
@@ -687,7 +705,10 @@ async fn recv_foreground_timeout(deadline: Option<tokio::time::Instant>) {
     }
 }
 
-async fn wait_for_foreground_log_drain(paths: &[(&std::path::Path, &AtomicU64)]) {
+async fn wait_for_foreground_log_drain(
+    paths: &[(&std::path::Path, &AtomicU64)],
+    writers_finished: bool,
+) {
     let start = std::time::Instant::now();
     let mut last_lens = foreground_log_lengths(paths);
     let mut quiet_since = None;
@@ -699,6 +720,10 @@ async fn wait_for_foreground_log_drain(paths: &[(&std::path::Path, &AtomicU64)])
             .iter()
             .zip(lens.iter())
             .all(|((_, pos), len)| pos.load(Ordering::Relaxed) >= *len);
+
+        if writers_finished && tails_caught_up {
+            break;
+        }
 
         if lengths_stable && tails_caught_up {
             let now = std::time::Instant::now();

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -533,6 +533,7 @@ async fn run_foreground(
     mut ctx: RunContext,
     args: &RunArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let foreground_start = std::time::Instant::now();
     println!(
         "Box {} ({}) started. Press Ctrl-C to stop.",
         ctx.name,
@@ -598,18 +599,37 @@ async fn run_foreground(
             }
         }
     };
+    a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+        "foreground.command_execution",
+        foreground_start.elapsed(),
+    );
 
+    let raw_log_drain_start = std::time::Instant::now();
     wait_for_foreground_log_drain(&[(&console_log, &stdout_pos), (&console_err, &stderr_pos)])
         .await;
+    a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+        "foreground.raw_log_drain",
+        raw_log_drain_start.elapsed(),
+    );
     log_handle.abort();
 
     if stop_reason == ForegroundStopReason::ProcessExited {
+        let structured_log_drain_start = std::time::Instant::now();
         wait_for_sandbox_structured_log_drain(&ctx).await?;
+        a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+            "foreground.structured_log_drain",
+            structured_log_drain_start.elapsed(),
+        );
     }
 
     let persisted_exit_code = a3s_box_runtime::rootfs::read_persisted_exit_code(&ctx.box_dir);
     let exit_code = foreground_exit_code(stop_reason, persisted_exit_code);
+    let archive_start = std::time::Instant::now();
     archive_auto_removed_logs(&ctx, args.rm, exit_code, stop_reason.stopped_by_user());
+    a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+        "foreground.archive",
+        archive_start.elapsed(),
+    );
     cleanup_managed_execution(
         &mut ctx,
         args.rm,
@@ -863,6 +883,7 @@ async fn cleanup_managed_execution(
         handle.abort();
     }
 
+    let manager_reconcile_start = std::time::Instant::now();
     let cleanup_result = if natural_exit {
         match ctx.manager.inspect(&ctx.execution_id).await {
             Ok(status)
@@ -897,7 +918,12 @@ async fn cleanup_managed_execution(
             ctx.box_id
         )
     })?;
+    a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+        "foreground.manager_reconcile",
+        manager_reconcile_start.elapsed(),
+    );
 
+    let removal_start = std::time::Instant::now();
     if auto_remove {
         StateFile::remove_record(&ctx.box_id)
             .map_err(|error| format!("failed to remove box {} state: {error}", ctx.box_id))?;
@@ -923,6 +949,10 @@ async fn cleanup_managed_execution(
         })
         .map_err(|error| format!("failed to mark box {} stopped: {error}", ctx.box_id))?;
     }
+    a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+        "foreground.removal",
+        removal_start.elapsed(),
+    );
 
     Ok(())
 }

--- a/src/cli/src/commands/run/setup.rs
+++ b/src/cli/src/commands/run/setup.rs
@@ -18,6 +18,7 @@ pub(super) struct RunRecordPolicy {
 pub(super) async fn setup_and_boot(
     args: &RunArgs,
 ) -> Result<RunContext, Box<dyn std::error::Error>> {
+    let create_start = std::time::Instant::now();
     common::validate_runtime_options(&args.common)
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
     let (restart_policy, max_restart_count) =
@@ -110,7 +111,12 @@ pub(super) async fn setup_and_boot(
     // compatibility check above, so an invalid Sandbox request has no registry
     // or runtime side effects.
     let pull_progress_fn = pull_progress_callback(args.common.image.clone());
+    let image_config_start = std::time::Instant::now();
     let image_config = pull_image_config(args, std::sync::Arc::clone(&pull_progress_fn)).await?;
+    a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+        "cli.image_config",
+        image_config_start.elapsed(),
+    );
     let health_check =
         common::effective_health_check(&args.common, image_config.health_check.as_ref());
     let effective_stop_signal = common::effective_stop_signal(
@@ -139,7 +145,9 @@ pub(super) async fn setup_and_boot(
     let backend = VmLocalExecutionBackend::new(&home).with_pull_progress_fn(pull_progress_fn);
     let manager =
         LocalExecutionManager::new(home.join("boxes.json"), &home, std::sync::Arc::new(backend));
+    let reserve_start = std::time::Instant::now();
     let reservation = manager.create(request, &operation_id).await?;
+    a3s_box_core::lifecycle_profile::record_lifecycle_phase("cli.reserve", reserve_start.elapsed());
     let execution_id = reservation.execution_id.clone();
     let box_id = execution_id.to_string();
     println!(
@@ -147,6 +155,7 @@ pub(super) async fn setup_and_boot(
         name,
         BoxRecord::make_short_id(&box_id)
     );
+    let runtime_start = std::time::Instant::now();
     let lease = match manager.start(&execution_id, reservation.generation).await {
         Ok(lease) => lease,
         Err(error) => {
@@ -154,6 +163,10 @@ pub(super) async fn setup_and_boot(
             return Err(error.into());
         }
     };
+    a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+        "cli.runtime_start",
+        runtime_start.elapsed(),
+    );
     // A short-lived command can exit between `start` and this reload. Use the
     // side-effect-free snapshot so legacy PID reconciliation cannot auto-remove
     // the just-created managed record before foreground cleanup observes it.
@@ -184,7 +197,7 @@ pub(super) async fn setup_and_boot(
         );
     }
 
-    Ok(RunContext {
+    let context = RunContext {
         manager,
         execution_id,
         generation: lease.generation,
@@ -196,7 +209,12 @@ pub(super) async fn setup_and_boot(
         pty_socket_path,
         anonymous_volumes,
         health_checker: None,
-    })
+    };
+    a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+        "cli.create_start",
+        create_start.elapsed(),
+    );
+    Ok(context)
 }
 
 fn pull_progress_callback(image_name: String) -> a3s_box_runtime::PullProgressFn {

--- a/src/cli/src/commands/run/tests.rs
+++ b/src/cli/src/commands/run/tests.rs
@@ -820,6 +820,36 @@ fn test_foreground_poll_cadence_avoids_fixed_startup_delay() {
     assert!(FOREGROUND_LOG_DRAIN_POLL < FOREGROUND_LOG_DRAIN_QUIET);
 }
 
+#[tokio::test]
+async fn finished_sandbox_writers_need_no_additional_quiet_period() {
+    let directory = tempfile::tempdir().unwrap();
+    let log = directory.path().join("console.log");
+    std::fs::write(&log, b"complete").unwrap();
+    let position = AtomicU64::new(8);
+
+    tokio::time::timeout(
+        std::time::Duration::from_millis(5),
+        wait_for_foreground_log_drain(&[(&log, &position)], true),
+    )
+    .await
+    .expect("a caught-up tail must return immediately after every writer exited");
+}
+
+#[tokio::test]
+async fn finished_sandbox_writer_wait_still_requires_tail_catch_up() {
+    let directory = tempfile::tempdir().unwrap();
+    let log = directory.path().join("console.log");
+    std::fs::write(&log, b"pending").unwrap();
+    let position = AtomicU64::new(0);
+
+    assert!(tokio::time::timeout(
+        std::time::Duration::from_millis(5),
+        wait_for_foreground_log_drain(&[(&log, &position)], true),
+    )
+    .await
+    .is_err());
+}
+
 #[test]
 fn test_retained_log_hint_only_for_non_user_failures() {
     assert!(should_print_retained_log_hint(Some(1), false));

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod event;
 pub mod exec;
 pub mod execution;
 pub mod fs_atomic;
+pub mod lifecycle_profile;
 pub mod log;
 pub mod network;
 pub mod operator;

--- a/src/core/src/lifecycle_profile.rs
+++ b/src/core/src/lifecycle_profile.rs
@@ -1,0 +1,82 @@
+//! Opt-in machine-readable lifecycle profiling.
+//!
+//! The benchmark harness enables this through
+//! `A3S_BOX_LIFECYCLE_PROFILE=1`. Normal CLI output and production behavior are
+//! unchanged when the variable is absent. Events deliberately contain only a
+//! stable phase name, elapsed time, and process identity; workload arguments,
+//! paths, credentials, and other caller data are never emitted.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+/// Environment variable that enables lifecycle JSONL events on stderr.
+pub const LIFECYCLE_PROFILE_ENV: &str = "A3S_BOX_LIFECYCLE_PROFILE";
+
+/// Prefix that makes profile events unambiguous in mixed CLI stderr.
+pub const LIFECYCLE_PROFILE_PREFIX: &str = "A3S_BOX_LIFECYCLE ";
+
+const LIFECYCLE_PROFILE_SCHEMA: &str = "a3s.box.lifecycle-profile.v1";
+
+#[derive(Serialize)]
+struct LifecycleProfileEvent<'a> {
+    schema: &'static str,
+    phase: &'a str,
+    duration_ns: u64,
+    pid: u32,
+}
+
+/// Emit one best-effort JSONL phase event when lifecycle profiling is enabled.
+///
+/// Profiling must never change lifecycle success or failure. Serialization and
+/// stderr write failures are therefore intentionally ignored.
+pub fn record_lifecycle_phase(phase: &str, duration: Duration) {
+    if !lifecycle_profile_enabled(std::env::var_os(LIFECYCLE_PROFILE_ENV).as_deref()) {
+        return;
+    }
+    if let Some(line) = lifecycle_profile_line(phase, duration, std::process::id()) {
+        eprintln!("{LIFECYCLE_PROFILE_PREFIX}{line}");
+    }
+}
+
+fn lifecycle_profile_enabled(value: Option<&std::ffi::OsStr>) -> bool {
+    value.is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+}
+
+fn lifecycle_profile_line(phase: &str, duration: Duration, pid: u32) -> Option<String> {
+    let duration_ns = u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX);
+    serde_json::to_string(&LifecycleProfileEvent {
+        schema: LIFECYCLE_PROFILE_SCHEMA,
+        phase,
+        duration_ns,
+        pid,
+    })
+    .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_gate_accepts_only_explicit_true_values() {
+        assert!(!lifecycle_profile_enabled(None));
+        assert!(!lifecycle_profile_enabled(Some(std::ffi::OsStr::new("0"))));
+        assert!(lifecycle_profile_enabled(Some(std::ffi::OsStr::new("1"))));
+        assert!(lifecycle_profile_enabled(Some(std::ffi::OsStr::new(
+            "TRUE"
+        ))));
+    }
+
+    #[test]
+    fn profile_event_is_stable_json_without_caller_data() {
+        let line = lifecycle_profile_line("sandbox.layout", Duration::from_micros(1250), 42)
+            .expect("profile event should serialize");
+        let event: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(event["schema"], LIFECYCLE_PROFILE_SCHEMA);
+        assert_eq!(event["phase"], "sandbox.layout");
+        assert_eq!(event["duration_ns"], 1_250_000);
+        assert_eq!(event["pid"], 42);
+        assert_eq!(event.as_object().unwrap().len(), 4);
+    }
+}

--- a/src/guest/init/src/main.rs
+++ b/src/guest/init/src/main.rs
@@ -921,7 +921,7 @@ fn run_init() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Step 9: Wait for agent process (reap zombies, handle SIGTERM)
-    wait_for_children(container_pid)?;
+    wait_for_children(container_pid, bootstrap_mode)?;
 
     persist_terminal_rootfs_metadata();
 
@@ -1609,7 +1609,10 @@ fn remount_rootfs_readonly() -> Result<(), Box<dyn std::error::Error>> {
 /// children for their handler. This propagates the container exit code AND fixes
 /// the zombie leak (orphans were previously never reaped until shutdown).
 #[cfg(target_os = "linux")]
-fn wait_for_children(container_pid: nix::unistd::Pid) -> Result<(), Box<dyn std::error::Error>> {
+fn wait_for_children(
+    container_pid: nix::unistd::Pid,
+    bootstrap_mode: BootstrapMode,
+) -> Result<(), Box<dyn std::error::Error>> {
     use a3s_box_guest_init::reaper;
     use nix::sys::wait::{waitid, waitpid, Id, WaitPidFlag, WaitStatus};
 
@@ -1672,12 +1675,15 @@ fn wait_for_children(container_pid: nix::unistd::Pid) -> Result<(), Box<dyn std:
                 // Flush the stdout/stderr relays so the container's last output
                 // reaches the console before this process::exit halts the VM.
                 flush_stdio_relays();
-                // The relay write has reached virtio-console, but libkrun exits
-                // the host shim as soon as PID 1 exits. Give the already-ready
-                // host tail threads one bounded poll interval to consume those
-                // bytes; without this handoff, short detached commands could
-                // leave a complete console.log and an empty container.json.
-                std::thread::sleep(std::time::Duration::from_millis(250));
+                // MicroVM logging still needs a bounded handoff before PID 1
+                // halts the VMM. Host Sandbox logging has a generation-owned
+                // worker that waits for crun to close both writers and drains
+                // through EOF, so retaining this legacy delay there only adds
+                // fixed latency to every short command.
+                let handoff = console_handoff_delay(bootstrap_mode);
+                if !handoff.is_zero() {
+                    std::thread::sleep(handoff);
+                }
                 process::exit(code);
             } else if reaper::is_managed(pid.as_raw()) {
                 // Owned by an exec/PTY handler, which reaps it for the real status.
@@ -1691,6 +1697,15 @@ fn wait_for_children(container_pid: nix::unistd::Pid) -> Result<(), Box<dyn std:
         }
 
         std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn console_handoff_delay(bootstrap_mode: BootstrapMode) -> std::time::Duration {
+    if bootstrap_mode.is_host_sandbox() {
+        std::time::Duration::ZERO
+    } else {
+        std::time::Duration::from_millis(250)
     }
 }
 
@@ -1711,7 +1726,10 @@ fn persist_terminal_rootfs_metadata() {}
 
 /// Non-Linux development stub: just wait for the container process to exit.
 #[cfg(not(target_os = "linux"))]
-fn wait_for_children(container_pid: nix::unistd::Pid) -> Result<(), Box<dyn std::error::Error>> {
+fn wait_for_children(
+    container_pid: nix::unistd::Pid,
+    _bootstrap_mode: BootstrapMode,
+) -> Result<(), Box<dyn std::error::Error>> {
     use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
 
     loop {
@@ -1839,6 +1857,18 @@ mod tests {
             BootstrapMode::HostSandbox
         );
         assert!(BootstrapMode::from_value(Some("sandbox-ish")).is_err());
+    }
+
+    #[test]
+    fn host_sandbox_uses_owned_log_drain_instead_of_legacy_handoff() {
+        assert_eq!(
+            console_handoff_delay(BootstrapMode::HostSandbox),
+            std::time::Duration::ZERO
+        );
+        assert_eq!(
+            console_handoff_delay(BootstrapMode::Microvm),
+            std::time::Duration::from_millis(250)
+        );
     }
 
     fn set_sidecar_env(image: &str, vsock_port: u32, env: &[(&str, &str)]) {

--- a/src/runtime/src/cache/rootfs_cache.rs
+++ b/src/runtime/src/cache/rootfs_cache.rs
@@ -64,7 +64,10 @@ impl RootfsCache {
         env: &[(String, String)],
     ) -> String {
         let mut hasher = Sha256::new();
-        hasher.update(b"rootfs-cache-v1\n");
+        // v2 excludes OCI-provided overlayfs private xattrs before a cached
+        // directory may become a metacopy lower. Do not reuse v1 entries that
+        // predate that ingestion invariant.
+        hasher.update(b"rootfs-cache-v2\n");
         hasher.update(image_ref.as_bytes());
         hasher.update(b"\n");
 

--- a/src/runtime/src/oci/layers.rs
+++ b/src/runtime/src/oci/layers.rs
@@ -239,6 +239,7 @@ fn extract_layer_with_cap(
         } else if entry.header().entry_type().is_hard_link() {
             prepare_hardlink_destination(target_dir, &path)?;
         }
+        reject_overlay_private_xattrs(&mut entry, &path)?;
 
         let desired = if track_metadata {
             Some(metadata_from_header(&entry, &normalized)?)
@@ -277,6 +278,50 @@ fn extract_layer_with_cap(
         "Extracted OCI layer"
     );
 
+    Ok(())
+}
+
+#[cfg(unix)]
+fn reject_overlay_private_xattrs<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    path: &Path,
+) -> Result<()> {
+    const PAX_XATTR_PREFIX: &[u8] = b"SCHILY.xattr.";
+    let Some(extensions) = entry.pax_extensions().map_err(|error| {
+        BoxError::OciImageError(format!(
+            "Failed to inspect extended attributes for {}: {error}",
+            path.display()
+        ))
+    })?
+    else {
+        return Ok(());
+    };
+
+    for extension in extensions {
+        let extension = extension.map_err(|error| {
+            BoxError::OciImageError(format!(
+                "Invalid PAX extended attribute for {}: {error}",
+                path.display()
+            ))
+        })?;
+        let Some(name) = extension.key_bytes().strip_prefix(PAX_XATTR_PREFIX) else {
+            continue;
+        };
+        if name.starts_with(b"trusted.overlay.") || name.starts_with(b"user.overlay.") {
+            return Err(BoxError::OciImageError(format!(
+                "OCI layer entry {} contains reserved overlayfs metadata",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn reject_overlay_private_xattrs<R: Read>(
+    _entry: &mut tar::Entry<'_, R>,
+    _path: &Path,
+) -> Result<()> {
     Ok(())
 }
 
@@ -928,6 +973,28 @@ mod tests {
         assert!(error.to_string().contains("reserved internal path"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn extraction_rejects_overlayfs_private_xattrs() {
+        let temp_dir = TempDir::new().unwrap();
+        for (index, xattr) in ["trusted.overlay.metacopy", "user.overlay.redirect"]
+            .into_iter()
+            .enumerate()
+        {
+            let layer = temp_dir
+                .path()
+                .join(format!("overlay-xattr-{index}.tar.gz"));
+            let target = temp_dir.path().join(format!("rootfs-{index}"));
+            create_overlay_xattr_test_layer(&layer, xattr);
+
+            let error = extract_layer_with_metadata(&layer, &target).unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("contains reserved overlayfs metadata"));
+            assert!(!target.join("payload").exists());
+        }
+    }
+
     #[test]
     fn extract_layer_rejects_decompression_bomb_past_cap() {
         let temp_dir = TempDir::new().unwrap();
@@ -1015,6 +1082,31 @@ mod tests {
         header.set_gid(gid);
         header.set_cksum();
         builder.append_data(&mut header, name, content).unwrap();
+        builder.finish().unwrap();
+    }
+
+    #[cfg(unix)]
+    fn create_overlay_xattr_test_layer(path: &Path, xattr: &str) {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use tar::Builder;
+
+        let file = File::create(path).unwrap();
+        let encoder = GzEncoder::new(file, Compression::default());
+        let mut builder = Builder::new(encoder);
+        let key = format!("SCHILY.xattr.{xattr}");
+        builder
+            .append_pax_extensions([(key.as_str(), b"".as_slice())])
+            .unwrap();
+        let mut header = tar::Header::new_gnu();
+        header.set_size(7);
+        header.set_mode(0o644);
+        header.set_uid(0);
+        header.set_gid(0);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "payload", b"payload".as_slice())
+            .unwrap();
         builder.finish().unwrap();
     }
 

--- a/src/runtime/src/rootfs/overlay.rs
+++ b/src/runtime/src/rootfs/overlay.rs
@@ -27,81 +27,114 @@ pub fn overlay_mount(lower: &Path, upper: &Path, work: &Path, merged: &Path) -> 
         }
     }
 
-    let opts = format!(
-        "lowerdir={},upperdir={},workdir={}",
-        lower.display(),
-        upper.display(),
-        work.display()
-    );
+    let base_options = overlay_options(lower, upper, work, false);
 
     // Try mount(2) syscall first
     #[cfg(target_os = "linux")]
     {
         use std::ffi::CString;
 
+        // Metadata-only copy-up avoids copying every executable's contents
+        // when Sandbox ownership is shifted for its user namespace. Restrict
+        // it to the initial root namespace: rootless overlay uses user.*
+        // private xattrs that an untrusted workload could forge. OCI ingestion
+        // separately rejects both trusted.overlay.* and user.overlay.* xattrs.
+        let metadata_options = overlay_options(lower, upper, work, true);
+        let options = if unsafe { libc::geteuid() } == 0 {
+            vec![(&metadata_options, true), (&base_options, false)]
+        } else {
+            vec![(&base_options, false)]
+        };
         let source = CString::new("overlay").unwrap();
         let target = CString::new(merged.to_string_lossy().as_ref())
             .map_err(|e| BoxError::BuildError(format!("Invalid merged path for mount: {}", e)))?;
         let fstype = CString::new("overlay").unwrap();
-        let data = CString::new(opts.as_str())
-            .map_err(|e| BoxError::BuildError(format!("Invalid overlay mount options: {}", e)))?;
+        let mut failures = Vec::new();
 
-        let ret = unsafe {
-            libc::mount(
-                source.as_ptr(),
-                target.as_ptr(),
-                fstype.as_ptr(),
-                0,
-                data.as_ptr() as *const libc::c_void,
-            )
-        };
-
-        if ret == 0 {
-            tracing::debug!(
-                lower = %lower.display(),
-                merged = %merged.display(),
-                "Overlay mounted via mount(2)"
-            );
-            return Ok(());
+        for &(options, metadata_copy) in &options {
+            let data = CString::new(options.as_str()).map_err(|error| {
+                BoxError::BuildError(format!("Invalid overlay mount options: {error}"))
+            })?;
+            let ret = unsafe {
+                libc::mount(
+                    source.as_ptr(),
+                    target.as_ptr(),
+                    fstype.as_ptr(),
+                    0,
+                    data.as_ptr() as *const libc::c_void,
+                )
+            };
+            if ret == 0 {
+                tracing::debug!(
+                    lower = %lower.display(),
+                    merged = %merged.display(),
+                    metadata_copy,
+                    "Overlay mounted via mount(2)"
+                );
+                return Ok(());
+            }
+            failures.push(format!(
+                "mount(2), metacopy={metadata_copy}: {}",
+                std::io::Error::last_os_error()
+            ));
         }
 
-        let errno = std::io::Error::last_os_error();
         tracing::debug!(
-            error = %errno,
+            errors = ?failures,
             "mount(2) failed, trying mount command"
         );
 
-        // Fallback: try `mount` command
-        let status = std::process::Command::new("mount")
-            .args(["-t", "overlay", "overlay", "-o", &opts])
-            .arg(merged)
-            .status()
-            .map_err(|e| BoxError::BuildError(format!("Failed to run mount command: {}", e)))?;
-
-        if status.success() {
-            tracing::debug!(
-                lower = %lower.display(),
-                merged = %merged.display(),
-                "Overlay mounted via mount command"
-            );
-            return Ok(());
+        for &(options, metadata_copy) in &options {
+            match std::process::Command::new("mount")
+                .args(["-t", "overlay", "overlay", "-o", options])
+                .arg(merged)
+                .status()
+            {
+                Ok(status) if status.success() => {
+                    tracing::debug!(
+                        lower = %lower.display(),
+                        merged = %merged.display(),
+                        metadata_copy,
+                        "Overlay mounted via mount command"
+                    );
+                    return Ok(());
+                }
+                Ok(status) => {
+                    failures.push(format!("mount command, metacopy={metadata_copy}: {status}"))
+                }
+                Err(error) => {
+                    failures.push(format!("mount command, metacopy={metadata_copy}: {error}"))
+                }
+            }
         }
 
         Err(BoxError::BuildError(format!(
-            "Failed to mount overlayfs at {}: mount(2) returned {} and mount command exited with {}",
+            "Failed to mount overlayfs at {}: {}",
             merged.display(),
-            errno,
-            status
+            failures.join("; ")
         )))
     }
 
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (lower, upper, work, merged, opts);
+        let _ = (lower, upper, work, merged, base_options);
         Err(BoxError::BuildError(
             "Overlayfs is only supported on Linux".to_string(),
         ))
     }
+}
+
+fn overlay_options(lower: &Path, upper: &Path, work: &Path, metadata_copy: bool) -> String {
+    let mut options = format!(
+        "lowerdir={},upperdir={},workdir={}",
+        lower.display(),
+        upper.display(),
+        work.display()
+    );
+    if metadata_copy {
+        options.push_str(",metacopy=on");
+    }
+    options
 }
 
 /// Unmount an overlayfs at `merged`.
@@ -238,6 +271,22 @@ mod tests {
 
         assert!(err.to_string().contains("contains a comma"));
         assert!(err.to_string().contains("lower,with-comma"));
+    }
+
+    #[test]
+    fn metadata_copy_option_is_explicit() {
+        let lower = Path::new("/cache/lower");
+        let upper = Path::new("/box/upper");
+        let work = Path::new("/box/work");
+
+        assert_eq!(
+            overlay_options(lower, upper, work, false),
+            "lowerdir=/cache/lower,upperdir=/box/upper,workdir=/box/work"
+        );
+        assert_eq!(
+            overlay_options(lower, upper, work, true),
+            "lowerdir=/cache/lower,upperdir=/box/upper,workdir=/box/work,metacopy=on"
+        );
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -39,7 +39,20 @@ pub fn wait_for_recorded_sandbox_log_drain(
     timeout: std::time::Duration,
 ) -> a3s_box_core::Result<bool> {
     let home_dir = a3s_box_core::dirs_home();
-    let Some(record) = load_recorded_sandbox_runtime(&home_dir, box_dir, box_id)? else {
+    wait_for_recorded_sandbox_log_drain_in(&home_dir, box_dir, box_id, timeout)
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_recorded_sandbox_log_drain_in(
+    home_dir: &Path,
+    box_dir: &Path,
+    box_id: &str,
+    timeout: std::time::Duration,
+) -> a3s_box_core::Result<bool> {
+    // Waiting is read-only: it neither executes the recorded runtime nor
+    // signals a process. Validate fixed paths and the PID/start-time pair, but
+    // leave runtime artifact certification to paths that query or execute crun.
+    let Some(record) = load_recorded_sandbox_runtime_identity(home_dir, box_dir, box_id)? else {
         return Ok(true);
     };
     Ok(wait_for_log_worker_identity(&record, timeout))
@@ -154,6 +167,27 @@ pub(crate) fn load_recorded_sandbox_runtime(
     box_dir: &Path,
     box_id: &str,
 ) -> a3s_box_core::Result<Option<RecordedSandboxRuntime>> {
+    let Some(mut record) = load_recorded_sandbox_runtime_identity(home_dir, box_dir, box_id)?
+    else {
+        return Ok(None);
+    };
+    let capabilities = crate::sandbox::probe_sandbox_capabilities(Some(&record.runtime_path));
+    let runtime = capabilities.runtime.ok_or_else(|| {
+        a3s_box_core::BoxError::StateError(format!(
+            "Cannot verify the recorded Sandbox runtime for {box_id}: {:?}",
+            capabilities.failures
+        ))
+    })?;
+    record.runtime_path = runtime.path;
+    Ok(Some(record))
+}
+
+#[cfg(target_os = "linux")]
+fn load_recorded_sandbox_runtime_identity(
+    home_dir: &Path,
+    box_dir: &Path,
+    box_id: &str,
+) -> a3s_box_core::Result<Option<RecordedSandboxRuntime>> {
     let expected_box_dir = home_dir.join("boxes").join(box_id);
     if box_dir != expected_box_dir {
         return Err(a3s_box_core::BoxError::StateError(format!(
@@ -192,15 +226,8 @@ pub(crate) fn load_recorded_sandbox_runtime(
         )));
     }
 
-    let capabilities = crate::sandbox::probe_sandbox_capabilities(Some(&record.runtime_path));
-    let runtime = capabilities.runtime.ok_or_else(|| {
-        a3s_box_core::BoxError::StateError(format!(
-            "Cannot verify the recorded Sandbox runtime for {box_id}: {:?}",
-            capabilities.failures
-        ))
-    })?;
     Ok(Some(RecordedSandboxRuntime {
-        runtime_path: runtime.path,
+        runtime_path: record.runtime_path,
         runtime_root: record.runtime_root,
         bundle_dir: record.bundle_dir,
         init_pid: record.init_pid,
@@ -524,5 +551,26 @@ mod tests {
 
         assert!(message.contains("path or identity validation"));
         assert!(!message.contains("Cannot verify the recorded Sandbox runtime"));
+    }
+
+    #[test]
+    fn log_drain_wait_validates_identity_without_recertifying_crun() {
+        let home = tempfile::tempdir().unwrap();
+        let box_id = "recorded-sandbox-log-drain";
+        let box_dir = home.path().join("boxes").join(box_id);
+        write_runtime_record(home.path(), &box_dir, box_id, |_| {});
+
+        assert!(wait_for_recorded_sandbox_log_drain_in(
+            home.path(),
+            &box_dir,
+            box_id,
+            std::time::Duration::ZERO,
+        )
+        .unwrap());
+
+        let error = load_recorded_sandbox_runtime(home.path(), &box_dir, box_id).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Cannot verify the recorded Sandbox runtime"));
     }
 }

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -224,7 +224,11 @@ impl VmManager {
 
         let readiness_start = std::time::Instant::now();
         if let Err(error) = async {
-            self.wait_for_vm_running().await?;
+            // CrunController::start only returns after the certified runtime
+            // reports this exact generation as running. The generic VM grace
+            // period would merely recheck process liveness for a fixed 250 ms;
+            // the heartbeat path below already checks liveness on every
+            // attempt and returns immediately for a naturally exited one-shot.
             #[cfg(unix)]
             self.wait_for_exec_ready(&layout.exec_socket_path).await?;
             Ok(())

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -27,6 +27,7 @@ impl VmManager {
     ) -> Result<()> {
         // This probe is deliberately before image pulls, rootfs mounts, volume
         // creation, or bundle writes. Every mandatory control is fail-closed.
+        let capability_start = std::time::Instant::now();
         let capabilities = probe_sandbox_capabilities(None);
         capabilities.require_ready()?;
         let runtime = capabilities
@@ -50,6 +51,10 @@ impl VmManager {
                         .to_string(),
                     hint: None,
                 })?;
+        a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+            "sandbox.capability",
+            capability_start.elapsed(),
+        );
 
         let box_dir = self.home_dir.join("boxes").join(&self.box_id);
         let sandbox_dir = box_dir.join("sandbox");
@@ -67,6 +72,7 @@ impl VmManager {
             "Booting Sandbox"
         );
 
+        let layout_start = std::time::Instant::now();
         let layout = match self.prepare_layout().await {
             Ok(layout) => layout,
             Err(error) => {
@@ -74,9 +80,14 @@ impl VmManager {
                 return Err(error);
             }
         };
+        a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+            "sandbox.layout",
+            layout_start.elapsed(),
+        );
         self.image_config = layout.oci_config.clone();
 
         let prepare = (|| -> Result<_> {
+            let instance_prepare_start = std::time::Instant::now();
             let resolv_content = a3s_box_core::dns::generate_resolv_conf(&self.config.dns);
             std::fs::write(layout.rootfs_path.join("etc/resolv.conf"), resolv_content)
                 .map_err(BoxError::IoError)?;
@@ -109,15 +120,30 @@ impl VmManager {
             let maximum_uid = rootfs_ids.maximum_uid.max(account_uid).max(process_uid);
             let maximum_gid = rootfs_ids.maximum_gid.max(account_gid).max(process_gid);
             let id_mappings = plan_id_mappings(user_namespace, maximum_uid, maximum_gid)?;
+            a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+                "sandbox.instance_prepare",
+                instance_prepare_start.elapsed(),
+            );
 
+            let mount_sources_start = std::time::Instant::now();
             self.prepare_sandbox_mount_sources(&layout, &mounts, &id_mappings)?;
+            a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+                "sandbox.mount_sources",
+                mount_sources_start.elapsed(),
+            );
+            let rootfs_ownership_start = std::time::Instant::now();
             prepare_rootfs_ownership(
                 &layout.rootfs_path,
                 &id_mappings,
                 user_namespace.effective_uid,
                 self.config.read_only,
             )?;
+            a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+                "sandbox.rootfs_ownership",
+                rootfs_ownership_start.elapsed(),
+            );
 
+            let bundle_start = std::time::Instant::now();
             let resources = SandboxResources::from_box_config(&self.config)?;
             let execution_plan_digest = digest_json(&execution_plan)?;
             let bundle_spec = SandboxBundleSpec {
@@ -147,6 +173,10 @@ impl VmManager {
                 &layout.rootfs_path,
                 &bundle_spec.id_mappings,
             )?;
+            a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+                "sandbox.bundle",
+                bundle_start.elapsed(),
+            );
 
             Ok((instance_spec, bundle_spec))
         })();
@@ -178,6 +208,7 @@ impl VmManager {
             log_worker_log_path: box_dir.join("logs").join("sandbox-log-worker.log"),
             log_worker_ready_path: sandbox_dir.join("bundle").join("log-worker.ready"),
         };
+        let launch_start = std::time::Instant::now();
         let handler = match controller.start(launch).await {
             Ok(handler) => handler,
             Err(error) => {
@@ -185,8 +216,13 @@ impl VmManager {
                 return Err(error);
             }
         };
+        a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+            "sandbox.launch",
+            launch_start.elapsed(),
+        );
         *self.handler.write().await = Some(Box::new(handler));
 
+        let readiness_start = std::time::Instant::now();
         if let Err(error) = async {
             self.wait_for_vm_running().await?;
             #[cfg(unix)]
@@ -198,6 +234,10 @@ impl VmManager {
             self.cleanup_boot_failure().await;
             return Err(error);
         }
+        a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+            "sandbox.readiness",
+            readiness_start.elapsed(),
+        );
 
         self.exec_socket_path = Some(layout.exec_socket_path);
         self.pty_socket_path = Some(layout.pty_socket_path);
@@ -217,6 +257,10 @@ impl VmManager {
             parent: boot_span,
             box_id = %self.box_id,
             "Sandbox ready"
+        );
+        a3s_box_core::lifecycle_profile::record_lifecycle_phase(
+            "sandbox.start_total",
+            boot_start.elapsed(),
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

- add an opt-in phased hot Sandbox lifecycle benchmark with alternating Docker samples
- remove redundant readiness and host-Sandbox console handoff waits while retaining the MicroVM handoff
- enable root-owned overlayfs `metacopy=on` with a compatible fallback, reject OCI-provided overlay private xattrs, and invalidate pre-hardening rootfs cache entries

## A3S OS validation

Validated at `218a033` on the production validation server (Ubuntu 24.04.1, Linux 6.8, x86_64) using the same cached Alpine image and certified crun runtime.

- Linux focused guest-init/runtime tests passed
- CLI, shim, and musl-static guest-init release builds passed
- Clippy for CLI, shim, runtime, and guest-init with `-D warnings` passed
- debug evidence confirms the current musl guest-init and `metadata_copy=true`
- 10 alternating hot samples: A3S p50 **558 ms**, Docker p50 **1032 ms**, ratio **0.54x**
- A3S phase p50: create/start 383.130 ms, command 60.419 ms, reconciliation 88.984 ms, removal 7.747 ms
- rootfs ownership p50 fell from about 695 ms to **20.837 ms**
- managed create/recovery/start, split stdout/stderr, pause rejection, kill, and cleanup passed
- foreground and detached natural exit, TERM, SIGKILL, final log drain, archive, and cleanup passed
- 30 Sandbox churn cycles completed with zero growth in shims, overlay mounts, box directories, crun state, or socket directories

No Docker, OrbStack, or runtime was started locally. Server source was updated through Git fetch.

Fixes #48