### PR TITLE
feat(sdk): expose managed execution lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,10 +359,11 @@ kill/start responses from backend evidence, and rebinds local resources without
 duplicating ownership. CLI `run` now reserves and starts through the same
 manager, freezes image-defined health and stop defaults into the durable
 request, and leaves network, volume, rootfs, stop, and auto-remove ownership to
-the managed backend. The Rust SDK still needs migration. The production
-HCL service, encrypted credentials, generation-fenced route leases, wildcard
-TLS gateway, envd data plane, and real official-client Sandbox suite also
-remain open gates.
+the managed backend. The Rust SDK now exposes typed create, start, run, inspect,
+pause, resume, restart, kill, and reconciliation calls through that same
+manager. The production HCL service, encrypted credentials, generation-fenced
+route leases, wildcard TLS gateway, envd data plane, and real official-client
+Sandbox suite remain open gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,8 +1,6 @@
 # E2B Protocol Compatibility and SDK Design
 
-Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 3 complete;
-slice 4 runtime path and CLI create/start/restart/run complete, Rust SDK
-pending)**
+Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 4 complete)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -22,7 +20,7 @@ unversioned claim.
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, reaping, and startup reconciliation | Wire the repository and supervisor into the production service process and exercise restart and host-reboot recovery end to end |
-| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI `create`, first `start`, `run`, and explicit two-phase `restart` use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery tests; A3S OS smoke tests prove reservation-only create, creation reconciliation, real `crun` start, managed restart, explicit pause rejection, kill, and cleanup without MicroVM fallback | Validate managed CLI `run` on A3S OS, migrate the Rust SDK, and add its caller parity tests |
+| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI and Rust SDK create/start/run paths use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery; A3S OS smoke tests prove managed CLI and SDK execution through certified `crun`, explicit Sandbox pause rejection, kill, and cleanup without MicroVM fallback | Compose the runtime manager into the production compatibility service and exercise service restart recovery end to end |
 | Credentials and routing | Injected verifier, token, cursor, and template interfaces isolate protocol logic from infrastructure | Add production credential hashing, token encryption and rotation, generation-fenced route leases, validated wildcard/direct routing, and the TLS data-plane gateway |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
@@ -780,12 +778,11 @@ Phase 2 is delivered as small, immediately merged changes:
 3. **Complete:** add SQLite WAL migrations, strict compare-and-swap repository
    operations, atomic generation-fenced expiry claims, restart recovery,
    startup reconciliation, and corruption/crash/concurrency tests.
-4. **Partially complete:** extract canonical A3S state and the runtime
+4. **Complete:** extract canonical A3S state and the runtime
    `ExecutionManager`; add the production backend and prove its real Sandbox
    lifecycle; switch CLI create to the same reservation path; switch CLI
    start/restart/run and the Rust SDK to the same implementation with behavior
-   parity tests. CLI create, start, restart, and run are complete; the SDK
-   remains.
+   parity tests.
 5. Add the production HCL-configured service binary, credential and token
    providers, generation-fenced route leases, and TLS data-plane gateway. Pull
    each merge commit on an A3S OS server and run the unmodified official clients
@@ -855,10 +852,13 @@ volume, rootfs, stop, and auto-remove ownership to the managed backend. Caller
 parity tests cover isolation, DNS, environment, security, limits, TEE/sidecar,
 logs, health, stop policy, shared memory, persistence, and resource metadata.
 
-Slice 4 remains incomplete until the Rust SDK calls the same manager with
-behavior parity tests. The existing Rust SDK uses the canonical record store
-for management operations but still has a separate local lifecycle model and
-does not expose create/start/run.
+The Rust SDK now injects the same backend-neutral manager used by the CLI and
+exposes typed create, start, create-and-start, inspect, pause, resume, restart,
+kill, and reconciliation operations. Caller-parity coverage compares the full
+serialized `CreateExecutionRequest`, including `BoxConfig` and
+`ExecutionRecordPolicy`, at the injected manager boundary. An opt-in A3S OS
+smoke test proves staged create, start, create-and-start, inspect, kill, and
+runtime cleanup through the real Sandbox backend without invoking the CLI.
 
 Each slice must pass its focused tests and repository CI before merge. The
 Phase 2 gate remains closed until slice 5 composes the durable repository,

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -219,6 +219,7 @@ version = "3.0.9"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
+ "async-trait",
  "chrono",
  "libc",
  "serde",

--- a/src/sdk/Cargo.toml
+++ b/src/sdk/Cargo.toml
@@ -46,4 +46,5 @@ path = "tests/soak_kvm.rs"
 required-features = ["pipeline-cli"]
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tempfile = { workspace = true }

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -63,10 +63,59 @@ println!(
 Use `A3sBoxClient::from_home(path)` for tests or tools that should operate on a
 non-default a3s-box state directory.
 
+## Managed Lifecycle
+
+The SDK submits lifecycle requests directly to the same generation-fenced
+`ExecutionManager` used by the CLI and compatibility service. It does not spawn
+the CLI or construct a parallel box record.
+
+```rust
+use std::collections::BTreeMap;
+
+use a3s_box_sdk::{
+    A3sBoxClient, BoxConfig, CreateExecutionRequest, ExecutionIsolation,
+    ExecutionRecordPolicy, OperationId,
+};
+
+# async fn lifecycle() -> Result<(), a3s_box_sdk::ClientError> {
+let client = A3sBoxClient::new();
+let operation = OperationId::new("example-create")?;
+let request = CreateExecutionRequest {
+    external_sandbox_id: "example-sandbox".to_string(),
+    config: BoxConfig {
+        image: "alpine:latest".to_string(),
+        isolation: ExecutionIsolation::Sandbox,
+        cmd: vec!["sleep".to_string(), "60".to_string()],
+        ..BoxConfig::default()
+    },
+    labels: BTreeMap::new(),
+    policy: ExecutionRecordPolicy {
+        name: Some("sdk-example".to_string()),
+        ..ExecutionRecordPolicy::default()
+    },
+};
+
+let reservation = client.create_box(request, &operation).await?;
+let lease = client
+    .start_box(&reservation.execution_id, reservation.generation)
+    .await?;
+let status = client.inspect_execution(&lease.execution_id).await?;
+client
+    .kill_execution(&status.execution_id, status.generation)
+    .await?;
+# Ok(()) }
+```
+
+`run_box` provides the idempotent create-and-start composition. Typed methods
+also expose inspect, pause, resume, restart, kill, and operation reconciliation.
+`A3sBoxClient::with_execution_manager` accepts an explicit typed manager for
+embedding or tests without changing request semantics.
+
 ## API Coverage
 
-- Boxes: list, get, pause, unpause, stop on Unix, remove, prune inactive boxes,
-  log snapshots, and host-side stats snapshots.
+- Boxes: generation-fenced create, start, run, inspect, pause, resume, restart,
+  kill, and reconciliation; plus list, get, legacy pause/unpause, Unix stop,
+  remove, prune inactive boxes, log snapshots, and host-side stats snapshots.
 - Images: list, get, inspect local OCI metadata, read OCI history, pull, build,
   tag, push, remove, and evict.
 - Volumes: list, get, create, remove, and prune.
@@ -84,13 +133,11 @@ The client reads the shared `boxes.json` state format through an SDK-local model
 so it does not depend on the CLI crate. Image, volume, network, snapshot, build,
 registry, exec, PTY, and attestation operations use `a3s-box-runtime` directly.
 
-The runtime now provides generation-fenced `create`, `start`, and
-`create_and_start` operations over the canonical managed-execution store.
-Container lifecycle orchestration is not exposed by this SDK yet: the SDK
-adapter and the CLI-specific record-policy mapping still need behavior-parity
-coverage before becoming default APIs. Pause, unpause, Unix stop, and box
-removal remain available through the existing direct management surface. The
-default SDK does not shell out for lifecycle commands.
+Managed lifecycle methods preserve the complete typed `BoxConfig` and
+`ExecutionRecordPolicy` request and call the canonical runtime facade. Pause,
+unpause, Unix stop, and box removal remain available through the existing
+query-based management surface for backwards compatibility. The default SDK
+does not shell out for lifecycle commands.
 
 ## Maintenance Calls
 

--- a/src/sdk/src/client/core.rs
+++ b/src/sdk/src/client/core.rs
@@ -1,8 +1,19 @@
 /// Runtime-backed SDK client for local a3s-box state.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct A3sBoxClient {
     paths: A3sBoxPaths,
     image_cache_size: u64,
+    execution_manager: Arc<dyn ExecutionManager>,
+}
+
+impl std::fmt::Debug for A3sBoxClient {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("A3sBoxClient")
+            .field("paths", &self.paths)
+            .field("image_cache_size", &self.image_cache_size)
+            .finish_non_exhaustive()
+    }
 }
 
 impl A3sBoxClient {
@@ -18,9 +29,26 @@ impl A3sBoxClient {
 
     /// Create a client using explicit state paths.
     pub fn with_paths(paths: A3sBoxPaths) -> Self {
+        let execution_manager = Arc::new(a3s_box_runtime::LocalExecutionManager::with_vm_backend(
+            paths.boxes_file.clone(),
+            paths.home.clone(),
+        ));
+        Self::with_execution_manager(paths, execution_manager)
+    }
+
+    /// Create a client with an explicit backend-neutral execution manager.
+    ///
+    /// This keeps lifecycle calls on the same canonical facade used by the CLI
+    /// and remote compatibility service while allowing an embedding application
+    /// to inject its own manager implementation.
+    pub fn with_execution_manager(
+        paths: A3sBoxPaths,
+        execution_manager: Arc<dyn ExecutionManager>,
+    ) -> Self {
         Self {
             paths,
             image_cache_size: a3s_box_runtime::DEFAULT_IMAGE_CACHE_SIZE,
+            execution_manager,
         }
     }
 

--- a/src/sdk/src/client/lifecycle.rs
+++ b/src/sdk/src/client/lifecycle.rs
@@ -1,0 +1,98 @@
+impl A3sBoxClient {
+    /// Persist an unstarted execution through the canonical lifecycle facade.
+    pub async fn create_box(
+        &self,
+        request: CreateExecutionRequest,
+        operation_id: &OperationId,
+    ) -> Result<ExecutionReservation> {
+        Ok(self.execution_manager.create(request, operation_id).await?)
+    }
+
+    /// Start a previously created execution with generation fencing.
+    pub async fn start_box(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> Result<ExecutionLease> {
+        Ok(self
+            .execution_manager
+            .start(execution_id, generation)
+            .await?)
+    }
+
+    /// Atomically create or recover and then start an execution.
+    pub async fn run_box(
+        &self,
+        request: CreateExecutionRequest,
+        operation_id: &OperationId,
+    ) -> Result<ExecutionLease> {
+        Ok(self
+            .execution_manager
+            .create_and_start(request, operation_id)
+            .await?)
+    }
+
+    /// Inspect the generation-fenced state of a managed execution.
+    pub async fn inspect_execution(&self, execution_id: &ExecutionId) -> Result<ExecutionStatus> {
+        Ok(self.execution_manager.inspect(execution_id).await?)
+    }
+
+    /// Pause a managed execution through its resolved backend.
+    pub async fn pause_execution(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+        keep_memory: bool,
+    ) -> Result<ExecutionLease> {
+        Ok(self
+            .execution_manager
+            .pause(execution_id, generation, keep_memory)
+            .await?)
+    }
+
+    /// Resume a managed execution through its resolved backend.
+    pub async fn resume_execution(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> Result<ExecutionLease> {
+        Ok(self
+            .execution_manager
+            .resume(execution_id, generation)
+            .await?)
+    }
+
+    /// Restart a managed execution under an idempotent operation identity.
+    pub async fn restart_execution(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+        operation_id: &OperationId,
+        options: RestartExecutionOptions,
+    ) -> Result<ExecutionLease> {
+        Ok(self
+            .execution_manager
+            .restart_with_options(execution_id, generation, operation_id, options)
+            .await?)
+    }
+
+    /// Kill a managed execution and release runtime-owned resources.
+    pub async fn kill_execution(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> Result<KillOutcome> {
+        Ok(self
+            .execution_manager
+            .kill(execution_id, generation)
+            .await?)
+    }
+
+    /// Reconcile one idempotent create operation after caller or service restart.
+    pub async fn reconcile_operation(
+        &self,
+        operation_id: &OperationId,
+    ) -> Result<ReconcileOutcome> {
+        Ok(self.execution_manager.reconcile(operation_id).await?)
+    }
+}

--- a/src/sdk/src/client/mod.rs
+++ b/src/sdk/src/client/mod.rs
@@ -17,7 +17,11 @@ use a3s_box_core::platform::Platform;
 use a3s_box_core::snapshot::SnapshotMetadata;
 use a3s_box_core::vmm::parse_signal_name;
 use a3s_box_core::volume::VolumeConfig;
-use a3s_box_core::{ExecOutput, ExecRequest, FileRequest, FileResponse, StoredImage};
+use a3s_box_core::{
+    CreateExecutionRequest, ExecOutput, ExecRequest, ExecutionGeneration, ExecutionId,
+    ExecutionLease, ExecutionManager, ExecutionReservation, ExecutionStatus, FileRequest,
+    FileResponse, KillOutcome, OperationId, ReconcileOutcome, RestartExecutionOptions, StoredImage,
+};
 use a3s_box_runtime::oci::BuildResult as RuntimeBuildResult;
 use a3s_box_runtime::{
     is_process_alive, is_process_alive_with_identity, BuildConfig as RuntimeBuildConfig,
@@ -37,6 +41,7 @@ use crate::box_state::{BoxRecord, StateFile};
 include!("types.rs");
 include!("summaries.rs");
 include!("core.rs");
+include!("lifecycle.rs");
 include!("support.rs");
 
 #[cfg(test)]

--- a/src/sdk/src/client/tests/lifecycle.rs
+++ b/src/sdk/src/client/tests/lifecycle.rs
@@ -114,7 +114,7 @@ async fn lifecycle_calls_preserve_complete_request_and_fencing_identity() {
     use a3s_box_core::{
         resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionGeneration,
         ExecutionHealthCheck, ExecutionId, ExecutionLease, ExecutionRecordPolicy,
-        ExecutionReservation, ExecutionRestartPolicy, OperationId,
+        ExecutionReservation, ExecutionRestartPolicy, OperationId, ResourceLimits,
     };
     use chrono::Utc;
 
@@ -125,7 +125,10 @@ async fn lifecycle_calls_preserve_complete_request_and_fencing_identity() {
         extra_env: vec![("SDK_CALLER".to_string(), "preserved".to_string())],
         dns: vec!["1.1.1.1".to_string()],
         read_only: true,
-        pids_limit: Some(64),
+        resource_limits: ResourceLimits {
+            pids_limit: Some(64),
+            ..ResourceLimits::default()
+        },
         ..BoxConfig::default()
     };
     let request = CreateExecutionRequest {

--- a/src/sdk/src/client/tests/lifecycle.rs
+++ b/src/sdk/src/client/tests/lifecycle.rs
@@ -1,0 +1,222 @@
+#[derive(Debug)]
+enum LifecycleCall {
+    Create {
+        request: serde_json::Value,
+        operation_id: String,
+    },
+    Start {
+        execution_id: String,
+        generation: u64,
+    },
+    Run {
+        request: serde_json::Value,
+        operation_id: String,
+    },
+}
+
+struct RecordingExecutionManager {
+    calls: std::sync::Mutex<Vec<LifecycleCall>>,
+    reservation: a3s_box_core::ExecutionReservation,
+    lease: a3s_box_core::ExecutionLease,
+}
+
+#[async_trait::async_trait]
+impl a3s_box_core::ExecutionManager for RecordingExecutionManager {
+    async fn create(
+        &self,
+        request: a3s_box_core::CreateExecutionRequest,
+        operation_id: &a3s_box_core::OperationId,
+    ) -> a3s_box_core::ExecutionManagerResult<a3s_box_core::ExecutionReservation> {
+        self.calls.lock().unwrap().push(LifecycleCall::Create {
+            request: serde_json::to_value(request).unwrap(),
+            operation_id: operation_id.to_string(),
+        });
+        Ok(self.reservation.clone())
+    }
+
+    async fn start(
+        &self,
+        execution_id: &a3s_box_core::ExecutionId,
+        generation: a3s_box_core::ExecutionGeneration,
+    ) -> a3s_box_core::ExecutionManagerResult<a3s_box_core::ExecutionLease> {
+        self.calls.lock().unwrap().push(LifecycleCall::Start {
+            execution_id: execution_id.to_string(),
+            generation: generation.get(),
+        });
+        Ok(self.lease.clone())
+    }
+
+    async fn create_and_start(
+        &self,
+        request: a3s_box_core::CreateExecutionRequest,
+        operation_id: &a3s_box_core::OperationId,
+    ) -> a3s_box_core::ExecutionManagerResult<a3s_box_core::ExecutionLease> {
+        self.calls.lock().unwrap().push(LifecycleCall::Run {
+            request: serde_json::to_value(request).unwrap(),
+            operation_id: operation_id.to_string(),
+        });
+        Ok(self.lease.clone())
+    }
+
+    async fn inspect(
+        &self,
+        execution_id: &a3s_box_core::ExecutionId,
+    ) -> a3s_box_core::ExecutionManagerResult<a3s_box_core::ExecutionStatus> {
+        Err(a3s_box_core::ExecutionManagerError::NotFound(
+            execution_id.clone(),
+        ))
+    }
+
+    async fn pause(
+        &self,
+        execution_id: &a3s_box_core::ExecutionId,
+        _generation: a3s_box_core::ExecutionGeneration,
+        _keep_memory: bool,
+    ) -> a3s_box_core::ExecutionManagerResult<a3s_box_core::ExecutionLease> {
+        Err(a3s_box_core::ExecutionManagerError::NotFound(
+            execution_id.clone(),
+        ))
+    }
+
+    async fn resume(
+        &self,
+        execution_id: &a3s_box_core::ExecutionId,
+        _generation: a3s_box_core::ExecutionGeneration,
+    ) -> a3s_box_core::ExecutionManagerResult<a3s_box_core::ExecutionLease> {
+        Err(a3s_box_core::ExecutionManagerError::NotFound(
+            execution_id.clone(),
+        ))
+    }
+
+    async fn kill(
+        &self,
+        execution_id: &a3s_box_core::ExecutionId,
+        _generation: a3s_box_core::ExecutionGeneration,
+    ) -> a3s_box_core::ExecutionManagerResult<a3s_box_core::KillOutcome> {
+        Err(a3s_box_core::ExecutionManagerError::NotFound(
+            execution_id.clone(),
+        ))
+    }
+
+    async fn reconcile(
+        &self,
+        _operation_id: &a3s_box_core::OperationId,
+    ) -> a3s_box_core::ExecutionManagerResult<a3s_box_core::ReconcileOutcome> {
+        Ok(a3s_box_core::ReconcileOutcome::Absent)
+    }
+}
+
+#[tokio::test]
+async fn lifecycle_calls_preserve_complete_request_and_fencing_identity() {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use a3s_box_core::{
+        resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionGeneration,
+        ExecutionHealthCheck, ExecutionId, ExecutionLease, ExecutionRecordPolicy,
+        ExecutionReservation, ExecutionRestartPolicy, OperationId,
+    };
+    use chrono::Utc;
+
+    let temp = tempfile::tempdir().unwrap();
+    let config = BoxConfig {
+        image: "registry.example/sdk:latest".to_string(),
+        isolation: a3s_box_core::ExecutionIsolation::Sandbox,
+        extra_env: vec![("SDK_CALLER".to_string(), "preserved".to_string())],
+        dns: vec!["1.1.1.1".to_string()],
+        read_only: true,
+        pids_limit: Some(64),
+        ..BoxConfig::default()
+    };
+    let request = CreateExecutionRequest {
+        external_sandbox_id: "sdk-external-id".to_string(),
+        config: config.clone(),
+        labels: BTreeMap::from([("caller".to_string(), "rust-sdk".to_string())]),
+        policy: ExecutionRecordPolicy {
+            name: Some("sdk-box".to_string()),
+            auto_remove: true,
+            restart_policy: ExecutionRestartPolicy::OnFailure,
+            max_restart_count: 4,
+            health_check: Some(ExecutionHealthCheck {
+                cmd: vec!["true".to_string()],
+                interval_secs: 7,
+                timeout_secs: 3,
+                retries: 2,
+                start_period_secs: 1,
+            }),
+            healthcheck_disabled: false,
+            log_config: a3s_box_core::log::LogConfig::default(),
+            volume_names: vec!["sdk-data".to_string()],
+            platform: Some("linux/amd64".to_string()),
+            init: true,
+            devices: vec!["/dev/null".to_string()],
+            gpus: Some("none".to_string()),
+            shm_size: Some(16 * 1024 * 1024),
+            stop_signal: Some("SIGTERM".to_string()),
+            stop_timeout: Some(9),
+            oom_kill_disable: true,
+            oom_score_adj: Some(100),
+        },
+    };
+    let request_json = serde_json::to_value(&request).unwrap();
+    let execution_id = ExecutionId::new("sdk-execution-id").unwrap();
+    let operation_id = OperationId::new("sdk-operation-id").unwrap();
+    let plan = resolve_execution(&config).unwrap();
+    let reservation = ExecutionReservation {
+        execution_id: execution_id.clone(),
+        generation: ExecutionGeneration::INITIAL,
+        plan: plan.clone(),
+        resources: config.resources.clone(),
+        created_at: Utc::now(),
+    };
+    let lease = ExecutionLease {
+        execution_id: execution_id.clone(),
+        generation: ExecutionGeneration::INITIAL,
+        plan,
+        resources: config.resources,
+        started_at: Utc::now(),
+    };
+    let manager = Arc::new(RecordingExecutionManager {
+        calls: std::sync::Mutex::new(Vec::new()),
+        reservation,
+        lease,
+    });
+    let client =
+        A3sBoxClient::with_execution_manager(A3sBoxPaths::from_home(temp.path()), manager.clone());
+
+    let created = client
+        .create_box(request.clone(), &operation_id)
+        .await
+        .unwrap();
+    assert_eq!(created.execution_id, execution_id);
+    let started = client
+        .start_box(&created.execution_id, created.generation)
+        .await
+        .unwrap();
+    assert_eq!(started.execution_id, execution_id);
+    let running = client.run_box(request, &operation_id).await.unwrap();
+    assert_eq!(running.execution_id, execution_id);
+
+    let calls = manager.calls.lock().unwrap();
+    assert!(matches!(
+        &calls[0],
+        LifecycleCall::Create {
+            request,
+            operation_id
+        } if request == &request_json && operation_id == "sdk-operation-id"
+    ));
+    assert!(matches!(
+        &calls[1],
+        LifecycleCall::Start {
+            execution_id,
+            generation: 1
+        } if execution_id == "sdk-execution-id"
+    ));
+    assert!(matches!(
+        &calls[2],
+        LifecycleCall::Run {
+            request,
+            operation_id
+        } if request == &request_json && operation_id == "sdk-operation-id"
+    ));
+}

--- a/src/sdk/src/client/tests/mod.rs
+++ b/src/sdk/src/client/tests/mod.rs
@@ -5,4 +5,5 @@ use std::path::Path;
 include!("common.rs");
 include!("state.rs");
 include!("images.rs");
+include!("lifecycle.rs");
 include!("resources.rs");

--- a/src/sdk/src/client/types.rs
+++ b/src/sdk/src/client/types.rs
@@ -8,6 +8,8 @@ pub enum ClientError {
     State(#[from] std::io::Error),
     #[error("runtime error: {0}")]
     Runtime(#[from] a3s_box_core::error::BoxError),
+    #[error("execution lifecycle error: {0}")]
+    Execution(#[from] a3s_box_core::ExecutionManagerError),
     #[error("validation error: {0}")]
     Validation(String),
     #[error("box not found: {0}")]

--- a/src/sdk/src/lib.rs
+++ b/src/sdk/src/lib.rs
@@ -22,7 +22,13 @@ pub use client::{
     SnapshotSummary, StopBox, StopBoxSummary, StopOutcome, TagImage, VolumeSummary,
 };
 
-pub use a3s_box_core::{ExecOutput, ExecRequest, FileOp, FileRequest, FileResponse, Platform};
+pub use a3s_box_core::{
+    BoxConfig, CreateExecutionRequest, ExecOutput, ExecRequest, ExecutionGeneration,
+    ExecutionHealthCheck, ExecutionId, ExecutionIsolation, ExecutionLease, ExecutionManager,
+    ExecutionManagerError, ExecutionRecordPolicy, ExecutionReservation, ExecutionRestartPolicy,
+    ExecutionState, ExecutionStatus, FileOp, FileRequest, FileResponse, KillOutcome, OperationId,
+    Platform, ReconcileOutcome, RestartExecutionOptions,
+};
 pub use a3s_box_runtime::{RegistryAuth, RegistryProtocol, SignaturePolicy};
 
 #[cfg(unix)]

--- a/src/sdk/tests/managed_lifecycle.rs
+++ b/src/sdk/tests/managed_lifecycle.rs
@@ -1,0 +1,133 @@
+//! Opt-in real-runtime proof for the SDK managed lifecycle facade.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use a3s_box_sdk::{
+    A3sBoxClient, BoxConfig, CreateExecutionRequest, ExecutionIsolation, ExecutionRecordPolicy,
+    ExecutionState, KillOutcome, OperationId,
+};
+
+#[tokio::test]
+#[ignore = "requires a dedicated A3S OS home and certified Sandbox runtime"]
+async fn sdk_create_start_run_and_kill_use_the_canonical_manager() {
+    let home = validated_home();
+    let client = A3sBoxClient::from_home(&home);
+    let image =
+        std::env::var("A3S_BOX_SDK_SMOKE_IMAGE").unwrap_or_else(|_| "alpine:3.20".to_string());
+
+    let create_operation = operation("create");
+    let reservation = client
+        .create_box(request(&image, "created"), &create_operation)
+        .await
+        .unwrap();
+    assert!(!home
+        .join("boxes")
+        .join(reservation.execution_id.as_str())
+        .exists());
+    let lease = client
+        .start_box(&reservation.execution_id, reservation.generation)
+        .await
+        .unwrap();
+    assert_eq!(lease.execution_id, reservation.execution_id);
+    assert_eq!(
+        client
+            .inspect_execution(&lease.execution_id)
+            .await
+            .unwrap()
+            .state,
+        ExecutionState::Running
+    );
+    assert_eq!(
+        client
+            .kill_execution(&lease.execution_id, lease.generation)
+            .await
+            .unwrap(),
+        KillOutcome::Killed
+    );
+    assert_runtime_removed(&home, lease.execution_id.as_str());
+
+    let run_operation = operation("run");
+    let running = client
+        .run_box(request(&image, "running"), &run_operation)
+        .await
+        .unwrap();
+    assert_eq!(
+        client
+            .inspect_execution(&running.execution_id)
+            .await
+            .unwrap()
+            .state,
+        ExecutionState::Running
+    );
+    assert_eq!(
+        client
+            .kill_execution(&running.execution_id, running.generation)
+            .await
+            .unwrap(),
+        KillOutcome::Killed
+    );
+    assert_runtime_removed(&home, running.execution_id.as_str());
+}
+
+fn validated_home() -> PathBuf {
+    assert_eq!(
+        std::env::var("A3S_BOX_SDK_MANAGED_SMOKE").as_deref(),
+        Ok("1"),
+        "set A3S_BOX_SDK_MANAGED_SMOKE=1 to acknowledge the destructive smoke test"
+    );
+    let home = PathBuf::from(std::env::var_os("A3S_HOME").expect("A3S_HOME is required"));
+    assert!(home.is_absolute());
+    assert!(home
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.contains("sdk-managed-smoke")));
+    let configured_crun = PathBuf::from(
+        std::env::var_os("A3S_BOX_CRUN_PATH").expect("A3S_BOX_CRUN_PATH is required"),
+    );
+    assert_eq!(
+        configured_crun.canonicalize().unwrap(),
+        home.join("bin/crun").canonicalize().unwrap()
+    );
+    for binary in ["crun", "a3s-box-shim", "a3s-box-guest-init"] {
+        assert!(home.join("bin").join(binary).is_file());
+    }
+    home
+}
+
+fn request(image: &str, suffix: &str) -> CreateExecutionRequest {
+    CreateExecutionRequest {
+        external_sandbox_id: format!("sdk-smoke-{suffix}"),
+        config: BoxConfig {
+            image: image.to_string(),
+            isolation: ExecutionIsolation::Sandbox,
+            cmd: vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "while :; do sleep 60; done".to_string(),
+            ],
+            ..BoxConfig::default()
+        },
+        labels: BTreeMap::from([("purpose".to_string(), "sdk-managed-smoke".to_string())]),
+        policy: ExecutionRecordPolicy {
+            name: Some(format!("sdk-managed-smoke-{suffix}")),
+            ..ExecutionRecordPolicy::default()
+        },
+    }
+}
+
+fn operation(suffix: &str) -> OperationId {
+    OperationId::new(format!(
+        "sdk-managed-smoke-{suffix}-{}",
+        uuid::Uuid::new_v4()
+    ))
+    .unwrap()
+}
+
+fn assert_runtime_removed(home: &Path, execution_id: &str) {
+    assert!(!home.join("boxes").join(execution_id).exists());
+    assert!(!home.join("run/crun").join(execution_id).exists());
+    assert!(!Path::new("/tmp/a3s-box-sockets")
+        .join(execution_id)
+        .exists());
+}


### PR DESCRIPTION
## Summary

- inject the canonical `ExecutionManager` into `A3sBoxClient`
- expose typed create, start, run, inspect, pause, resume, restart, kill, and reconcile operations
- preserve complete serialized caller intent and generation fencing in tests
- add an opt-in real A3S OS Sandbox lifecycle smoke test
- update SDK and E2B migration documentation

## Validation

- `cargo fmt --all --check`
- `cargo test --locked -p a3s-box-sdk` (31 passed)
- `cargo clippy --locked -p a3s-box-sdk --all-targets -- -D warnings`
- real A3S OS Sandbox SDK lifecycle smoke (1 passed, create/start/inspect/kill and run/inspect/kill)

All runtime validation was performed on the A3S OS production server using a dedicated disposable home.