### PR TITLE
feat(e2b): add production credential providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,9 +361,12 @@ manager, freezes image-defined health and stop defaults into the durable
 request, and leaves network, volume, rootfs, stop, and auto-remove ownership to
 the managed backend. The Rust SDK now exposes typed create, start, run, inspect,
 pause, resume, restart, kill, and reconciliation calls through that same
-manager. The production HCL service, encrypted credentials, generation-fenced
-route leases, wildcard TLS gateway, envd data plane, and real official-client
-Sandbox suite remain open gates.
+manager. Production credential providers now store account keys as salted
+PBKDF2-SHA256 hashes and protect scope-separated sandbox tokens with
+AES-256-GCM, independent HMAC validation, and versioned key rotation. Wiring
+those providers into the production ACL service, generation-fenced route
+leases, the wildcard TLS gateway, the envd data plane, and the real
+official-client Sandbox suite remain open gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,6 +1,7 @@
 # E2B Protocol Compatibility and SDK Design
 
-Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 4 complete)**
+Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 4 complete;
+slice 5 credential providers complete)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -21,7 +22,7 @@ unversioned claim.
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, reaping, and startup reconciliation | Wire the repository and supervisor into the production service process and exercise restart and host-reboot recovery end to end |
 | Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI and Rust SDK create/start/run paths use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery; A3S OS smoke tests prove managed CLI and SDK execution through certified `crun`, explicit Sandbox pause rejection, kill, and cleanup without MicroVM fallback | Compose the runtime manager into the production compatibility service and exercise service restart recovery end to end |
-| Credentials and routing | Injected verifier, token, cursor, and template interfaces isolate protocol logic from infrastructure | Add production credential hashing, token encryption and rotation, generation-fenced route leases, validated wildcard/direct routing, and the TLS data-plane gateway |
+| Credentials and routing | Injected interfaces isolate protocol logic; production account credentials use salted PBKDF2-SHA256 hashes; sandbox tokens use scope-bound AES-256-GCM ciphertext, independent HMAC validation, and versioned key rotation | Wire the providers through ACL, then add generation-fenced route leases, validated wildcard/direct routing, and the TLS data-plane gateway |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
 The lifecycle fixture and the managed Sandbox smoke validate opposite sides of
@@ -545,9 +546,10 @@ modified with required A3S fields.
 
 ## Configuration
 
-Product configuration uses HCL. A production service configuration resembles:
+Product configuration uses A3S Agent Configuration Language (ACL), parsed by
+`a3s-acl`. A production service configuration resembles:
 
-```hcl
+```acl
 e2b_compat {
   api_listen          = "0.0.0.0:443"
   api_public_url      = "https://api.box.example.com"
@@ -606,10 +608,10 @@ must not assume that the single-host limit is part of the upstream contract.
 
 The runtime now owns a canonical managed-execution store, a backend-neutral
 `LocalExecutionManager`, and a production VM/Sandbox backend. CLI
-`create`/`start`/`restart`/`run` use that manager, while the Rust SDK
-intentionally omits those lifecycle operations. The compatibility service must
-not work around the remaining SDK gap by spawning `a3s-box`, importing CLI
-modules, or editing `boxes.json`. Phase 2 completes this dependency direction:
+`create`/`start`/`restart`/`run` and the Rust SDK lifecycle API use that
+manager. The compatibility service must use the same manager directly rather
+than spawning `a3s-box`, importing CLI modules, or editing `boxes.json`. Phase
+2 completes this dependency direction:
 
 ```text
 a3s-box-core
@@ -704,7 +706,7 @@ unless protocol translation eventually requires one.
 ### Durable lifecycle transaction
 
 The initial durable repository is SQLite in WAL mode through an asynchronous
-driver. Its location is explicit in HCL and it owns versioned migrations. A
+driver. Its location is explicit in ACL and it owns versioned migrations. A
 database transaction is never held across an image pull, sandbox boot, or shim
 call.
 
@@ -758,6 +760,17 @@ logs raw headers. The first server fixture uses an injected verifier; the
 production binary refuses to start without a configured credential and token
 encryption provider.
 
+The production credential provider stores account credentials as encoded
+PBKDF2-SHA256 records with a per-credential random salt and a minimum work
+factor. Compatibility API keys retain the pinned `e2b_[0-9a-f]+` lexical form;
+Bearer and Supabase credentials use the same hashed-record boundary without
+sharing plaintext material. Sandbox envd and traffic tokens are encrypted with
+AES-256-GCM and authenticated separately with a scope- and version-bound HMAC.
+The active key version issues new tokens while retained older versions remain
+decryptable during rotation. Removing an old version makes its records fail
+closed, and swapping an envd token into the traffic scope fails both decryption
+and constant-time digest validation.
+
 Each published route lease contains the external sandbox ID, internal
 execution ID, generation, port scope, expiry, and token scope. The wildcard
 host parser is a pure validated component. It accepts neither arbitrary
@@ -783,10 +796,11 @@ Phase 2 is delivered as small, immediately merged changes:
    lifecycle; switch CLI create to the same reservation path; switch CLI
    start/restart/run and the Rust SDK to the same implementation with behavior
    parity tests.
-5. Add the production HCL-configured service binary, credential and token
-   providers, generation-fenced route leases, and TLS data-plane gateway. Pull
-   each merge commit on an A3S OS server and run the unmodified official clients
-   against real `--isolation sandbox` executions.
+5. **In progress:** production account credential and sandbox token providers
+   are complete. Add the ACL-configured service binary, generation-fenced route
+   leases, and TLS data-plane gateway. Pull each merge commit on an A3S OS
+   server and run the unmodified official clients against real
+   `--isolation sandbox` executions.
 
 The runtime foundation of slice 4 is complete. The persisted execution record
 is the canonical schema shared by the CLI and Rust SDK, preventing either

--- a/docs/host-sandbox-backend-design.md
+++ b/docs/host-sandbox-backend-design.md
@@ -135,9 +135,9 @@ but it is an internal and persisted value rather than a new CLI spelling. The
 public value `sandbox` stays concise, while state and audit output always
 expose `isolation_class=shared-kernel`.
 
-The equivalent HCL setting is explicit only for the sandbox backend:
+The equivalent ACL setting is explicit only for the sandbox backend:
 
-```hcl
+```acl
 runtime {
   isolation = "sandbox"
 }

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "hyper 0.14.32",
  "prost",
  "prost-types",
+ "ring",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src/compat/Cargo.toml
+++ b/src/compat/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { workspace = true }
 hex = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
+ring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
+++ b/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
@@ -173,7 +173,11 @@ impl TokenIssuer for FixtureTokens {
 
 #[async_trait]
 impl TokenResolver for FixtureTokens {
-    async fn resolve(&self, stored: &StoredToken) -> TokenIssuerResult<SecretToken> {
+    async fn resolve(
+        &self,
+        _scope: TokenScope,
+        stored: &StoredToken,
+    ) -> TokenIssuerResult<SecretToken> {
         let digest = Sha256::digest(stored.ciphertext());
         if &digest[..] != stored.digest() {
             return Err(TokenIssuerError::InvalidMaterial);

--- a/src/compat/src/control/credential.rs
+++ b/src/compat/src/control/credential.rs
@@ -133,6 +133,8 @@ pub enum TokenScope {
 pub enum TokenIssuerError {
     #[error("token material is invalid")]
     InvalidMaterial,
+    #[error("token key version {0} is not configured")]
+    UnknownKeyVersion(u32),
     #[error("token provider is unavailable: {0}")]
     Unavailable(String),
 }
@@ -146,5 +148,19 @@ pub trait TokenIssuer: Send + Sync {
 
 #[async_trait]
 pub trait TokenResolver: Send + Sync {
-    async fn resolve(&self, stored: &StoredToken) -> TokenIssuerResult<SecretToken>;
+    async fn resolve(
+        &self,
+        scope: TokenScope,
+        stored: &StoredToken,
+    ) -> TokenIssuerResult<SecretToken>;
+}
+
+#[async_trait]
+pub trait TokenVerifier: Send + Sync {
+    async fn verify(
+        &self,
+        scope: TokenScope,
+        presented: &SecretToken,
+        stored: &StoredToken,
+    ) -> TokenIssuerResult<bool>;
 }

--- a/src/compat/src/control/mod.rs
+++ b/src/compat/src/control/mod.rs
@@ -6,11 +6,12 @@ mod repository;
 mod service;
 mod sqlite;
 mod supervisor;
+mod token_keyring;
 mod validation;
 
 pub use credential::{
     IssuedToken, SandboxCredentials, SecretToken, StoredToken, TokenIssuer, TokenIssuerError,
-    TokenIssuerResult, TokenResolver, TokenScope,
+    TokenIssuerResult, TokenResolver, TokenScope, TokenVerifier,
 };
 pub use memory::MemorySandboxRepository;
 pub use model::{
@@ -35,6 +36,7 @@ pub use supervisor::{
     LifecycleMaintenanceFailure, LifecycleMaintenanceReport, LifecycleSupervisor,
     LifecycleSupervisorDependencies, LifecycleSupervisorError, LifecycleSupervisorResult,
 };
+pub use token_keyring::{RotatingTokenProvider, TokenKeyMaterial};
 
 #[cfg(test)]
 mod tests;

--- a/src/compat/src/control/service.rs
+++ b/src/compat/src/control/service.rs
@@ -320,11 +320,11 @@ impl ControlService {
     ) -> ControlServiceResult<SandboxConnection> {
         let envd_access_token = self
             .token_resolver
-            .resolve(&record.credentials().envd)
+            .resolve(TokenScope::Envd, &record.credentials().envd)
             .await?;
         let traffic_access_token = self
             .token_resolver
-            .resolve(&record.credentials().traffic)
+            .resolve(TokenScope::Traffic, &record.credentials().traffic)
             .await?;
         Ok(SandboxConnection {
             record,

--- a/src/compat/src/control/test_support.rs
+++ b/src/compat/src/control/test_support.rs
@@ -134,7 +134,11 @@ impl TokenIssuer for TestTokens {
 
 #[async_trait]
 impl TokenResolver for TestTokens {
-    async fn resolve(&self, stored: &StoredToken) -> TokenIssuerResult<SecretToken> {
+    async fn resolve(
+        &self,
+        _scope: TokenScope,
+        stored: &StoredToken,
+    ) -> TokenIssuerResult<SecretToken> {
         SecretToken::new(
             std::str::from_utf8(stored.ciphertext())
                 .map_err(|_| TokenIssuerError::InvalidMaterial)?,

--- a/src/compat/src/control/token_keyring.rs
+++ b/src/compat/src/control/token_keyring.rs
@@ -1,0 +1,368 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use async_trait::async_trait;
+use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
+use ring::hmac;
+use ring::rand::{SecureRandom, SystemRandom};
+
+use super::{
+    IssuedToken, SecretToken, StoredToken, TokenIssuer, TokenIssuerError, TokenIssuerResult,
+    TokenResolver, TokenScope, TokenVerifier,
+};
+
+const KEY_BYTES: usize = 32;
+const NONCE_BYTES: usize = 12;
+const TOKEN_BYTES: usize = 32;
+const TOKEN_AAD_DOMAIN: &[u8] = b"a3s-box-e2b-token-v1";
+const TOKEN_DIGEST_DOMAIN: &[u8] = b"a3s-box-e2b-token-digest-v1";
+
+#[derive(Clone)]
+pub struct TokenKeyMaterial {
+    version: u32,
+    encryption_key: [u8; KEY_BYTES],
+    digest_key: [u8; KEY_BYTES],
+}
+
+impl TokenKeyMaterial {
+    pub fn new(version: u32, encryption_key: &[u8], digest_key: &[u8]) -> TokenIssuerResult<Self> {
+        if version == 0 {
+            return Err(TokenIssuerError::InvalidMaterial);
+        }
+        let encryption_key = encryption_key
+            .try_into()
+            .map_err(|_| TokenIssuerError::InvalidMaterial)?;
+        let digest_key = digest_key
+            .try_into()
+            .map_err(|_| TokenIssuerError::InvalidMaterial)?;
+        Ok(Self {
+            version,
+            encryption_key,
+            digest_key,
+        })
+    }
+
+    pub const fn version(&self) -> u32 {
+        self.version
+    }
+}
+
+impl fmt::Debug for TokenKeyMaterial {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TokenKeyMaterial")
+            .field("version", &self.version)
+            .field("encryption_key", &"[REDACTED]")
+            .field("digest_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+pub struct RotatingTokenProvider {
+    active_version: u32,
+    keys: BTreeMap<u32, TokenKeyMaterial>,
+    random: SystemRandom,
+}
+
+impl RotatingTokenProvider {
+    pub fn new(
+        active_version: u32,
+        keys: impl IntoIterator<Item = TokenKeyMaterial>,
+    ) -> TokenIssuerResult<Self> {
+        let mut by_version = BTreeMap::new();
+        for key in keys {
+            let version = key.version();
+            if by_version.insert(version, key).is_some() {
+                return Err(TokenIssuerError::InvalidMaterial);
+            }
+        }
+        if active_version == 0 || !by_version.contains_key(&active_version) {
+            return Err(TokenIssuerError::UnknownKeyVersion(active_version));
+        }
+        Ok(Self {
+            active_version,
+            keys: by_version,
+            random: SystemRandom::new(),
+        })
+    }
+
+    pub const fn active_version(&self) -> u32 {
+        self.active_version
+    }
+
+    fn key(&self, version: u32) -> TokenIssuerResult<&TokenKeyMaterial> {
+        self.keys
+            .get(&version)
+            .ok_or(TokenIssuerError::UnknownKeyVersion(version))
+    }
+
+    fn store(&self, scope: TokenScope, secret: &SecretToken) -> TokenIssuerResult<StoredToken> {
+        let key = self.key(self.active_version)?;
+        let mut nonce_bytes = [0_u8; NONCE_BYTES];
+        self.random
+            .fill(&mut nonce_bytes)
+            .map_err(|_| TokenIssuerError::Unavailable("secure random generation failed".into()))?;
+
+        let mut sealed = secret.expose_secret().as_bytes().to_vec();
+        encryption_key(key)?
+            .seal_in_place_append_tag(
+                Nonce::assume_unique_for_key(nonce_bytes),
+                Aad::from(aad(key.version(), scope)),
+                &mut sealed,
+            )
+            .map_err(|_| TokenIssuerError::Unavailable("token encryption failed".into()))?;
+
+        let mut ciphertext = Vec::with_capacity(NONCE_BYTES + sealed.len());
+        ciphertext.extend_from_slice(&nonce_bytes);
+        ciphertext.extend_from_slice(&sealed);
+        let digest = token_digest(key, scope, secret.expose_secret());
+        StoredToken::new(key.version(), ciphertext, digest)
+            .map_err(|_| TokenIssuerError::InvalidMaterial)
+    }
+
+    fn open(&self, scope: TokenScope, stored: &StoredToken) -> TokenIssuerResult<SecretToken> {
+        let key = self.key(stored.key_version())?;
+        let (nonce, sealed) = stored
+            .ciphertext()
+            .split_at_checked(NONCE_BYTES)
+            .ok_or(TokenIssuerError::InvalidMaterial)?;
+        let nonce: [u8; NONCE_BYTES] = nonce
+            .try_into()
+            .map_err(|_| TokenIssuerError::InvalidMaterial)?;
+        let mut sealed = sealed.to_vec();
+        let plaintext = encryption_key(key)?
+            .open_in_place(
+                Nonce::assume_unique_for_key(nonce),
+                Aad::from(aad(key.version(), scope)),
+                &mut sealed,
+            )
+            .map_err(|_| TokenIssuerError::InvalidMaterial)?;
+        let secret =
+            std::str::from_utf8(plaintext).map_err(|_| TokenIssuerError::InvalidMaterial)?;
+        let secret = SecretToken::new(secret)?;
+        if !verify_token_digest(key, scope, &secret, stored.digest()) {
+            return Err(TokenIssuerError::InvalidMaterial);
+        }
+        Ok(secret)
+    }
+}
+
+impl fmt::Debug for RotatingTokenProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RotatingTokenProvider")
+            .field("active_version", &self.active_version)
+            .field("configured_versions", &self.keys.keys())
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl TokenIssuer for RotatingTokenProvider {
+    async fn issue(&self, scope: TokenScope) -> TokenIssuerResult<IssuedToken> {
+        let mut random = [0_u8; TOKEN_BYTES];
+        self.random
+            .fill(&mut random)
+            .map_err(|_| TokenIssuerError::Unavailable("secure random generation failed".into()))?;
+        let secret = SecretToken::new(hex::encode(random))?;
+        let stored = self.store(scope, &secret)?;
+        Ok(IssuedToken { secret, stored })
+    }
+}
+
+#[async_trait]
+impl TokenResolver for RotatingTokenProvider {
+    async fn resolve(
+        &self,
+        scope: TokenScope,
+        stored: &StoredToken,
+    ) -> TokenIssuerResult<SecretToken> {
+        self.open(scope, stored)
+    }
+}
+
+#[async_trait]
+impl TokenVerifier for RotatingTokenProvider {
+    async fn verify(
+        &self,
+        scope: TokenScope,
+        presented: &SecretToken,
+        stored: &StoredToken,
+    ) -> TokenIssuerResult<bool> {
+        let key = self.key(stored.key_version())?;
+        Ok(verify_token_digest(key, scope, presented, stored.digest()))
+    }
+}
+
+fn encryption_key(key: &TokenKeyMaterial) -> TokenIssuerResult<LessSafeKey> {
+    UnboundKey::new(&aead::AES_256_GCM, &key.encryption_key)
+        .map(LessSafeKey::new)
+        .map_err(|_| TokenIssuerError::InvalidMaterial)
+}
+
+fn aad(version: u32, scope: TokenScope) -> Vec<u8> {
+    let mut value = Vec::with_capacity(TOKEN_AAD_DOMAIN.len() + 5);
+    value.extend_from_slice(TOKEN_AAD_DOMAIN);
+    value.extend_from_slice(&version.to_be_bytes());
+    value.push(scope_marker(scope));
+    value
+}
+
+fn token_digest(key: &TokenKeyMaterial, scope: TokenScope, secret: &str) -> Vec<u8> {
+    let digest_key = hmac::Key::new(hmac::HMAC_SHA256, &key.digest_key);
+    hmac::sign(&digest_key, &digest_input(key.version(), scope, secret))
+        .as_ref()
+        .to_vec()
+}
+
+fn verify_token_digest(
+    key: &TokenKeyMaterial,
+    scope: TokenScope,
+    secret: &SecretToken,
+    expected: &[u8],
+) -> bool {
+    let digest_key = hmac::Key::new(hmac::HMAC_SHA256, &key.digest_key);
+    hmac::verify(
+        &digest_key,
+        &digest_input(key.version(), scope, secret.expose_secret()),
+        expected,
+    )
+    .is_ok()
+}
+
+fn digest_input(version: u32, scope: TokenScope, secret: &str) -> Vec<u8> {
+    let mut value = Vec::with_capacity(TOKEN_DIGEST_DOMAIN.len() + secret.len() + 5);
+    value.extend_from_slice(TOKEN_DIGEST_DOMAIN);
+    value.extend_from_slice(&version.to_be_bytes());
+    value.push(scope_marker(scope));
+    value.extend_from_slice(secret.as_bytes());
+    value
+}
+
+const fn scope_marker(scope: TokenScope) -> u8 {
+    match scope {
+        TokenScope::Envd => 1,
+        TokenScope::Traffic => 2,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(version: u32, marker: u8) -> TokenKeyMaterial {
+        TokenKeyMaterial::new(version, &[marker; KEY_BYTES], &[marker + 1; KEY_BYTES]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn issued_tokens_are_encrypted_hashed_and_scope_bound() {
+        let provider = RotatingTokenProvider::new(1, [key(1, 7)]).unwrap();
+        let issued = provider.issue(TokenScope::Envd).await.unwrap();
+
+        assert_eq!(issued.stored.key_version(), 1);
+        assert_ne!(
+            issued.stored.ciphertext(),
+            issued.secret.expose_secret().as_bytes()
+        );
+        assert!(!issued
+            .stored
+            .ciphertext()
+            .windows(issued.secret.expose_secret().len())
+            .any(|window| window == issued.secret.expose_secret().as_bytes()));
+        assert_eq!(issued.stored.digest().len(), 32);
+        assert_eq!(
+            provider
+                .resolve(TokenScope::Envd, &issued.stored)
+                .await
+                .unwrap()
+                .expose_secret(),
+            issued.secret.expose_secret()
+        );
+        assert!(provider
+            .verify(TokenScope::Envd, &issued.secret, &issued.stored)
+            .await
+            .unwrap());
+        assert!(!provider
+            .verify(TokenScope::Traffic, &issued.secret, &issued.stored)
+            .await
+            .unwrap());
+        assert!(matches!(
+            provider.resolve(TokenScope::Traffic, &issued.stored).await,
+            Err(TokenIssuerError::InvalidMaterial)
+        ));
+    }
+
+    #[tokio::test]
+    async fn key_rotation_issues_with_active_key_and_resolves_retained_versions() {
+        let first = RotatingTokenProvider::new(1, [key(1, 11)]).unwrap();
+        let old = first.issue(TokenScope::Traffic).await.unwrap();
+
+        let rotated = RotatingTokenProvider::new(2, [key(1, 11), key(2, 21)]).unwrap();
+        let current = rotated.issue(TokenScope::Traffic).await.unwrap();
+
+        assert_eq!(current.stored.key_version(), 2);
+        assert_eq!(
+            rotated
+                .resolve(TokenScope::Traffic, &old.stored)
+                .await
+                .unwrap()
+                .expose_secret(),
+            old.secret.expose_secret()
+        );
+        assert_eq!(
+            rotated
+                .resolve(TokenScope::Traffic, &current.stored)
+                .await
+                .unwrap()
+                .expose_secret(),
+            current.secret.expose_secret()
+        );
+
+        let retired = RotatingTokenProvider::new(2, [key(2, 21)]).unwrap();
+        assert!(matches!(
+            retired.resolve(TokenScope::Traffic, &old.stored).await,
+            Err(TokenIssuerError::UnknownKeyVersion(1))
+        ));
+    }
+
+    #[tokio::test]
+    async fn tampered_ciphertext_and_digest_are_rejected() {
+        let provider = RotatingTokenProvider::new(3, [key(3, 31)]).unwrap();
+        let issued = provider.issue(TokenScope::Envd).await.unwrap();
+
+        let mut ciphertext = issued.stored.ciphertext().to_vec();
+        ciphertext[NONCE_BYTES] ^= 1;
+        let tampered_ciphertext =
+            StoredToken::new(3, ciphertext, issued.stored.digest().to_vec()).unwrap();
+        assert!(matches!(
+            provider
+                .resolve(TokenScope::Envd, &tampered_ciphertext)
+                .await,
+            Err(TokenIssuerError::InvalidMaterial)
+        ));
+
+        let mut digest = issued.stored.digest().to_vec();
+        digest[0] ^= 1;
+        let tampered_digest =
+            StoredToken::new(3, issued.stored.ciphertext().to_vec(), digest).unwrap();
+        assert!(!provider
+            .verify(TokenScope::Envd, &issued.secret, &tampered_digest)
+            .await
+            .unwrap());
+        assert!(matches!(
+            provider.resolve(TokenScope::Envd, &tampered_digest).await,
+            Err(TokenIssuerError::InvalidMaterial)
+        ));
+    }
+
+    #[test]
+    fn keyring_debug_output_redacts_key_material() {
+        let material = key(4, 41);
+        let provider = RotatingTokenProvider::new(4, [material.clone()]).unwrap();
+
+        assert!(!format!("{material:?}").contains(&hex::encode([41_u8; KEY_BYTES])));
+        let debug = format!("{provider:?}");
+        assert!(debug.contains("configured_versions"));
+        assert!(!debug.contains(&hex::encode([41_u8; KEY_BYTES])));
+    }
+}

--- a/src/compat/src/http/account.rs
+++ b/src/compat/src/http/account.rs
@@ -1,0 +1,471 @@
+use std::fmt;
+use std::num::NonZeroU32;
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use ring::pbkdf2;
+use ring::rand::{SecureRandom, SystemRandom};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::{
+    AuthenticatedAccount, AuthenticationError, AuthenticationResult, CredentialScheme,
+    CredentialVerifier, PresentedCredential,
+};
+
+const HASH_ALGORITHM: &str = "pbkdf2-sha256";
+const DEFAULT_ITERATIONS: u32 = 210_000;
+const MINIMUM_ITERATIONS: u32 = 100_000;
+const SALT_BYTES: usize = 16;
+const DIGEST_BYTES: usize = 32;
+const MAX_CREDENTIAL_BYTES: usize = 4096;
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct CredentialHash {
+    iterations: NonZeroU32,
+    salt: [u8; SALT_BYTES],
+    digest: [u8; DIGEST_BYTES],
+}
+
+impl CredentialHash {
+    pub fn generate(secret: &str) -> CredentialHashResult<Self> {
+        validate_secret_length(secret)?;
+        let mut salt = [0_u8; SALT_BYTES];
+        SystemRandom::new()
+            .fill(&mut salt)
+            .map_err(|_| CredentialHashError::RandomUnavailable)?;
+        Self::derive(secret, DEFAULT_ITERATIONS, &salt)
+    }
+
+    pub fn derive(secret: &str, iterations: u32, salt: &[u8]) -> CredentialHashResult<Self> {
+        validate_secret_length(secret)?;
+        if iterations < MINIMUM_ITERATIONS {
+            return Err(CredentialHashError::InvalidIterations);
+        }
+        let iterations =
+            NonZeroU32::new(iterations).ok_or(CredentialHashError::InvalidIterations)?;
+        let salt: [u8; SALT_BYTES] = salt
+            .try_into()
+            .map_err(|_| CredentialHashError::InvalidSalt)?;
+        let mut digest = [0_u8; DIGEST_BYTES];
+        pbkdf2::derive(
+            pbkdf2::PBKDF2_HMAC_SHA256,
+            iterations,
+            &salt,
+            secret.as_bytes(),
+            &mut digest,
+        );
+        Ok(Self {
+            iterations,
+            salt,
+            digest,
+        })
+    }
+
+    pub fn verify(&self, secret: &str) -> bool {
+        if validate_secret_length(secret).is_err() {
+            return false;
+        }
+        pbkdf2::verify(
+            pbkdf2::PBKDF2_HMAC_SHA256,
+            self.iterations,
+            &self.salt,
+            secret.as_bytes(),
+            &self.digest,
+        )
+        .is_ok()
+    }
+}
+
+impl fmt::Display for CredentialHash {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{HASH_ALGORITHM}${}${}${}",
+            self.iterations,
+            hex::encode(self.salt),
+            hex::encode(self.digest)
+        )
+    }
+}
+
+impl fmt::Debug for CredentialHash {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CredentialHash")
+            .field("algorithm", &HASH_ALGORITHM)
+            .field("iterations", &self.iterations)
+            .field("salt", &"[REDACTED]")
+            .field("digest", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl FromStr for CredentialHash {
+    type Err = CredentialHashError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut fields = value.split('$');
+        if fields.next() != Some(HASH_ALGORITHM) {
+            return Err(CredentialHashError::InvalidEncoding);
+        }
+        let iterations = fields
+            .next()
+            .ok_or(CredentialHashError::InvalidEncoding)?
+            .parse::<u32>()
+            .map_err(|_| CredentialHashError::InvalidEncoding)?;
+        if iterations < MINIMUM_ITERATIONS {
+            return Err(CredentialHashError::InvalidIterations);
+        }
+        let iterations =
+            NonZeroU32::new(iterations).ok_or(CredentialHashError::InvalidIterations)?;
+        let salt = hex::decode(fields.next().ok_or(CredentialHashError::InvalidEncoding)?)
+            .map_err(|_| CredentialHashError::InvalidEncoding)?;
+        let digest = hex::decode(fields.next().ok_or(CredentialHashError::InvalidEncoding)?)
+            .map_err(|_| CredentialHashError::InvalidEncoding)?;
+        if fields.next().is_some() {
+            return Err(CredentialHashError::InvalidEncoding);
+        }
+        Ok(Self {
+            iterations,
+            salt: salt
+                .try_into()
+                .map_err(|_| CredentialHashError::InvalidSalt)?,
+            digest: digest
+                .try_into()
+                .map_err(|_| CredentialHashError::InvalidDigest)?,
+        })
+    }
+}
+
+impl TryFrom<String> for CredentialHash {
+    type Error = CredentialHashError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl From<CredentialHash> for String {
+    fn from(value: CredentialHash) -> Self {
+        value.to_string()
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CredentialHashError {
+    #[error("credential is empty or too large")]
+    InvalidSecret,
+    #[error("credential hash iteration count is below the production minimum")]
+    InvalidIterations,
+    #[error("credential hash salt is invalid")]
+    InvalidSalt,
+    #[error("credential hash digest is invalid")]
+    InvalidDigest,
+    #[error("credential hash encoding is invalid")]
+    InvalidEncoding,
+    #[error("secure random generation is unavailable")]
+    RandomUnavailable,
+    #[error("account identity is invalid")]
+    InvalidAccount,
+    #[error("compatibility API key must match e2b_[0-9a-f]+")]
+    InvalidApiKey,
+    #[error("at least one hashed account credential is required")]
+    MissingCredentials,
+}
+
+pub type CredentialHashResult<T> = std::result::Result<T, CredentialHashError>;
+
+#[derive(Clone)]
+pub struct HashedAccountCredential {
+    scheme: CredentialScheme,
+    owner_id: String,
+    client_id: String,
+    hash: CredentialHash,
+}
+
+impl HashedAccountCredential {
+    pub fn new(
+        scheme: CredentialScheme,
+        owner_id: impl Into<String>,
+        client_id: impl Into<String>,
+        hash: CredentialHash,
+    ) -> CredentialHashResult<Self> {
+        let owner_id = owner_id.into();
+        let client_id = client_id.into();
+        if owner_id.trim().is_empty() || client_id.trim().is_empty() {
+            return Err(CredentialHashError::InvalidAccount);
+        }
+        Ok(Self {
+            scheme,
+            owner_id,
+            client_id,
+            hash,
+        })
+    }
+
+    pub fn from_secret(
+        scheme: CredentialScheme,
+        owner_id: impl Into<String>,
+        client_id: impl Into<String>,
+        secret: &str,
+    ) -> CredentialHashResult<Self> {
+        if scheme == CredentialScheme::ApiKey && !is_compatibility_api_key(secret) {
+            return Err(CredentialHashError::InvalidApiKey);
+        }
+        Self::new(
+            scheme,
+            owner_id,
+            client_id,
+            CredentialHash::generate(secret)?,
+        )
+    }
+
+    pub const fn scheme(&self) -> CredentialScheme {
+        self.scheme
+    }
+
+    pub fn owner_id(&self) -> &str {
+        &self.owner_id
+    }
+
+    pub fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    pub fn hash(&self) -> &CredentialHash {
+        &self.hash
+    }
+}
+
+impl fmt::Debug for HashedAccountCredential {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HashedAccountCredential")
+            .field("scheme", &self.scheme)
+            .field("owner_id", &self.owner_id)
+            .field("client_id", &self.client_id)
+            .field("hash", &self.hash)
+            .finish()
+    }
+}
+
+pub struct HashedCredentialVerifier {
+    credentials: Vec<HashedAccountCredential>,
+}
+
+impl HashedCredentialVerifier {
+    pub fn new(
+        credentials: impl IntoIterator<Item = HashedAccountCredential>,
+    ) -> CredentialHashResult<Self> {
+        let credentials: Vec<_> = credentials.into_iter().collect();
+        if credentials.is_empty() {
+            return Err(CredentialHashError::MissingCredentials);
+        }
+        Ok(Self { credentials })
+    }
+}
+
+impl fmt::Debug for HashedCredentialVerifier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HashedCredentialVerifier")
+            .field("credential_count", &self.credentials.len())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl CredentialVerifier for HashedCredentialVerifier {
+    async fn verify(
+        &self,
+        credential: &PresentedCredential,
+    ) -> AuthenticationResult<AuthenticatedAccount> {
+        if credential.scheme() == CredentialScheme::ApiKey
+            && !is_compatibility_api_key(credential.expose_secret())
+        {
+            return Err(AuthenticationError::Invalid);
+        }
+
+        let mut account = None;
+        for stored in &self.credentials {
+            if stored.scheme() != credential.scheme()
+                || credential
+                    .owner_hint()
+                    .is_some_and(|hint| hint != stored.owner_id())
+                || !stored.hash().verify(credential.expose_secret())
+            {
+                continue;
+            }
+            if account.is_some() {
+                return Err(AuthenticationError::Invalid);
+            }
+            account = Some(AuthenticatedAccount {
+                owner_id: stored.owner_id().to_string(),
+                client_id: stored.client_id().to_string(),
+            });
+        }
+        account.ok_or(AuthenticationError::Invalid)
+    }
+}
+
+fn validate_secret_length(secret: &str) -> CredentialHashResult<()> {
+    if secret.is_empty() || secret.len() > MAX_CREDENTIAL_BYTES {
+        Err(CredentialHashError::InvalidSecret)
+    } else {
+        Ok(())
+    }
+}
+
+fn is_compatibility_api_key(value: &str) -> bool {
+    value.strip_prefix("e2b_").is_some_and(|suffix| {
+        !suffix.is_empty()
+            && suffix
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{header, HeaderMap, HeaderValue};
+
+    use super::*;
+
+    fn deterministic_hash(secret: &str, marker: u8) -> CredentialHash {
+        CredentialHash::derive(secret, MINIMUM_ITERATIONS, &[marker; SALT_BYTES]).unwrap()
+    }
+
+    fn credential(headers: HeaderMap) -> PresentedCredential {
+        PresentedCredential::from_headers(&headers).unwrap()
+    }
+
+    #[test]
+    fn encoded_hash_round_trips_without_exposing_the_secret() {
+        let hash = deterministic_hash("e2b_a1b2c3", 7);
+        let encoded = hash.to_string();
+
+        assert!(!encoded.contains("e2b_a1b2c3"));
+        let parsed: CredentialHash = encoded.parse().unwrap();
+        assert!(parsed.verify("e2b_a1b2c3"));
+        assert!(!parsed.verify("e2b_deadbeef"));
+        assert_eq!(
+            serde_json::from_str::<CredentialHash>(&serde_json::to_string(&hash).unwrap()).unwrap(),
+            hash
+        );
+    }
+
+    #[test]
+    fn hashes_use_salts_and_enforce_production_cost() {
+        let first = deterministic_hash("e2b_a1b2c3", 1);
+        let second = deterministic_hash("e2b_a1b2c3", 2);
+
+        assert_ne!(first, second);
+        assert_eq!(
+            CredentialHash::derive("e2b_a1b2c3", MINIMUM_ITERATIONS - 1, &[0; SALT_BYTES])
+                .unwrap_err(),
+            CredentialHashError::InvalidIterations
+        );
+        assert!("pbkdf2-sha256$99999$00000000000000000000000000000000$0000000000000000000000000000000000000000000000000000000000000000"
+            .parse::<CredentialHash>()
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn verifier_authenticates_api_keys_and_bearer_tokens_by_hash() {
+        let verifier = HashedCredentialVerifier::new([
+            HashedAccountCredential::new(
+                CredentialScheme::ApiKey,
+                "owner-api",
+                "client-api",
+                deterministic_hash("e2b_a1b2c3", 3),
+            )
+            .unwrap(),
+            HashedAccountCredential::new(
+                CredentialScheme::Bearer,
+                "owner-bearer",
+                "client-bearer",
+                deterministic_hash("bearer-secret", 4),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+
+        let api_key = credential(HeaderMap::from_iter([(
+            "x-api-key".parse().unwrap(),
+            HeaderValue::from_static("e2b_a1b2c3"),
+        )]));
+        let api_account = verifier.verify(&api_key).await.unwrap();
+        assert_eq!(api_account.owner_id, "owner-api");
+        assert_eq!(api_account.client_id, "client-api");
+
+        let bearer = credential(HeaderMap::from_iter([(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer bearer-secret"),
+        )]));
+        let bearer_account = verifier.verify(&bearer).await.unwrap();
+        assert_eq!(bearer_account.owner_id, "owner-bearer");
+    }
+
+    #[tokio::test]
+    async fn verifier_rejects_invalid_lexical_form_hints_and_ambiguous_keys() {
+        assert_eq!(
+            HashedAccountCredential::from_secret(
+                CredentialScheme::ApiKey,
+                "owner",
+                "client",
+                "e2b_UPPER",
+            )
+            .unwrap_err(),
+            CredentialHashError::InvalidApiKey
+        );
+
+        let shared = "shared-bearer";
+        let verifier = HashedCredentialVerifier::new([
+            HashedAccountCredential::new(
+                CredentialScheme::Bearer,
+                "owner-a",
+                "client-a",
+                deterministic_hash(shared, 5),
+            )
+            .unwrap(),
+            HashedAccountCredential::new(
+                CredentialScheme::Bearer,
+                "owner-b",
+                "client-b",
+                deterministic_hash(shared, 6),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+        let ambiguous = credential(HeaderMap::from_iter([(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer shared-bearer"),
+        )]));
+        assert!(matches!(
+            verifier.verify(&ambiguous).await,
+            Err(AuthenticationError::Invalid)
+        ));
+
+        let hinted = credential(HeaderMap::from_iter([
+            (
+                header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer shared-bearer"),
+            ),
+            (
+                "x-team-id".parse().unwrap(),
+                HeaderValue::from_static("owner-a"),
+            ),
+        ]));
+        assert_eq!(verifier.verify(&hinted).await.unwrap().owner_id, "owner-a");
+    }
+
+    #[test]
+    fn debug_output_redacts_hash_material() {
+        let hash = deterministic_hash("e2b_a1b2c3", 9);
+        let debug = format!("{hash:?}");
+        assert!(debug.contains("REDACTED"));
+        assert!(!debug.contains(&hex::encode([9_u8; SALT_BYTES])));
+    }
+}

--- a/src/compat/src/http/auth.rs
+++ b/src/compat/src/http/auth.rs
@@ -2,9 +2,11 @@ use std::fmt;
 
 use async_trait::async_trait;
 use axum::http::{header, HeaderMap};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CredentialScheme {
     ApiKey,
     Bearer,

--- a/src/compat/src/http/mod.rs
+++ b/src/compat/src/http/mod.rs
@@ -1,3 +1,4 @@
+mod account;
 mod auth;
 mod cursor;
 mod dto;
@@ -5,6 +6,10 @@ mod error;
 mod lifecycle;
 mod router;
 
+pub use account::{
+    CredentialHash, CredentialHashError, CredentialHashResult, HashedAccountCredential,
+    HashedCredentialVerifier,
+};
 pub use auth::{
     AuthenticatedAccount, AuthenticationError, AuthenticationResult, CredentialScheme,
     CredentialVerifier, PresentedCredential,


### PR DESCRIPTION
## Summary

- add salted PBKDF2-SHA256 account credential records and constant-time API key, Bearer, and Supabase verification
- enforce the pinned compatibility API-key lexical form
- encrypt sandbox envd and traffic tokens with AES-256-GCM
- validate tokens with independent scope- and version-bound HMAC digests
- retain old key versions for controlled rotation while issuing with the active version
- standardize Box product configuration documentation on ACL parsed by `a3s-acl`

No plaintext credentials or production key material are committed.

## Validation

Run on the A3S OS production server from a Git-fetched worktree:

- `cargo test --locked -p a3s-box-compat` (56 passed)
- `cargo clippy --locked -p a3s-box-compat --all-targets -- -D warnings`
- `cargo run --locked -p a3s-box-compat --bin a3s-box-e2b-contract -- verify`
- `cargo fmt --all --check`

The pinned official Python and TypeScript client matrix runs in CI with its fixed `uv` toolchain.