### PR TITLE
feat(e2b): add generation-fenced route leases

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,11 @@ pause, resume, restart, kill, and reconciliation calls through that same
 manager. Production credential providers now store account keys as salted
 PBKDF2-SHA256 hashes and protect scope-separated sandbox tokens with
 AES-256-GCM, independent HMAC validation, and versioned key rotation. Wiring
-those providers into the production ACL service, generation-fenced route
-leases, the wildcard TLS gateway, the envd data plane, and the real
-official-client Sandbox suite remain open gates.
+those providers into the production ACL service and the wildcard TLS gateway
+remains open. Route policy is now persisted with each lifecycle record, and
+strict wildcard/shared parsing projects generation-, expiry-, port-, and
+token-scope-fenced leases without a second mutable routing state. The envd data
+plane and the real official-client Sandbox suite also remain open gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,7 +1,7 @@
 # E2B Protocol Compatibility and SDK Design
 
 Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 4 complete;
-slice 5 credential providers complete)**
+slice 5 credential and routing foundations complete)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -22,7 +22,7 @@ unversioned claim.
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, reaping, and startup reconciliation | Wire the repository and supervisor into the production service process and exercise restart and host-reboot recovery end to end |
 | Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI and Rust SDK create/start/run paths use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery; A3S OS smoke tests prove managed CLI and SDK execution through certified `crun`, explicit Sandbox pause rejection, kill, and cleanup without MicroVM fallback | Compose the runtime manager into the production compatibility service and exercise service restart recovery end to end |
-| Credentials and routing | Injected interfaces isolate protocol logic; production account credentials use salted PBKDF2-SHA256 hashes; sandbox tokens use scope-bound AES-256-GCM ciphertext, independent HMAC validation, and versioned key rotation | Wire the providers through ACL, then add generation-fenced route leases, validated wildcard/direct routing, and the TLS data-plane gateway |
+| Credentials and routing | Production account credentials use salted PBKDF2-SHA256 hashes; sandbox tokens use scope-bound AES-256-GCM ciphertext, independent HMAC validation, and versioned key rotation; strict direct/shared route parsing and durable-record-projected leases fence sandbox and execution generations, expiry, port policy, and token scope | Wire these components through ACL and add the TLS data-plane gateway |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
 The lifecycle fixture and the managed Sandbox smoke validate opposite sides of
@@ -687,8 +687,9 @@ src/compat/src/
     error.rs          # exact upstream error mapping
     lifecycle.rs      # lifecycle route handlers and DTO conversion
     router.rs         # route assembly and request limits
-  routing/            # planned production data-plane boundary
-    lease.rs          # generation-fenced sandbox route leases
+  routing/            # production data-plane authorization boundary
+    policy.rs         # persisted exact-port and token-scope policy
+    lease.rs          # generation-fenced sandbox route projection
     parser.rs         # wildcard host and explicit-header validation
   bin/
     a3s-box-e2b-fixture-server.rs # deterministic protocol fixture
@@ -777,6 +778,17 @@ host parser is a pure validated component. It accepts neither arbitrary
 hostnames nor a sandbox ID recovered by string splitting after routing has
 begun.
 
+Route policy is persisted inside the canonical lifecycle record. A lease is an
+immutable projection of a currently running record rather than a second mutable
+database row, so timeout replacement, pause, kill, or recreation advances the
+record generation and immediately fences every prior lease. Resolution also
+checks the execution generation, expiry, exact routed port, and the separately
+scoped envd or traffic HMAC. Both `<port>-<sandbox-id>.<domain>` and the shared
+host plus `E2b-Sandbox-Id`/`E2b-Sandbox-Port` form use the same parser; duplicate
+or conflicting headers and domain-suffix confusion fail closed. SQLite restart
+coverage proves that the policy and generation remain authoritative after the
+service process is recreated.
+
 ### Incremental merge gates
 
 Phase 2 is delivered as small, immediately merged changes:
@@ -796,11 +808,11 @@ Phase 2 is delivered as small, immediately merged changes:
    lifecycle; switch CLI create to the same reservation path; switch CLI
    start/restart/run and the Rust SDK to the same implementation with behavior
    parity tests.
-5. **In progress:** production account credential and sandbox token providers
-   are complete. Add the ACL-configured service binary, generation-fenced route
-   leases, and TLS data-plane gateway. Pull each merge commit on an A3S OS
-   server and run the unmodified official clients against real
-   `--isolation sandbox` executions.
+5. **In progress:** production account credentials, sandbox token providers,
+   generation-fenced route leases, and validated wildcard/shared parsing are
+   complete. Add the ACL-configured service binary and TLS data-plane gateway.
+   Pull each merge commit on an A3S OS server and run the unmodified official
+   clients against real `--isolation sandbox` executions.
 
 The runtime foundation of slice 4 is complete. The persisted execution record
 is the canonical schema shared by the CLI and Rust SDK, preventing either

--- a/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
+++ b/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
@@ -151,6 +151,16 @@ impl TemplateProvider for FixtureTemplates {
                 ..BoxConfig::default()
             },
             envd_version: "0.1.3".to_string(),
+            routing: if template_id == "code-interpreter-v1" {
+                a3s_box_compat::routing::SandboxRoutePolicy::default()
+                    .with_port(
+                        a3s_box_compat::routing::CODE_INTERPRETER_PORT,
+                        TokenScope::Traffic,
+                    )
+                    .map_err(|error| TemplateProviderError::Invalid(error.to_string()))?
+            } else {
+                a3s_box_compat::routing::SandboxRoutePolicy::default()
+            },
         })
     }
 }

--- a/src/compat/src/control/credential.rs
+++ b/src/compat/src/control/credential.rs
@@ -123,7 +123,8 @@ impl fmt::Debug for IssuedToken {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TokenScope {
     Envd,
     Traffic,

--- a/src/compat/src/control/model.rs
+++ b/src/compat/src/control/model.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::credential::SandboxCredentials;
+use crate::routing::SandboxRoutePolicy;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
@@ -18,9 +19,17 @@ pub struct SandboxId(String);
 impl SandboxId {
     pub fn new(value: impl Into<String>) -> Result<Self, LifecycleError> {
         let value = value.into();
-        if value.trim().is_empty() {
+        let bytes = value.as_bytes();
+        if bytes.is_empty()
+            || bytes.len() > 48
+            || !is_sandbox_id_alphanumeric(bytes[0])
+            || !is_sandbox_id_alphanumeric(bytes[bytes.len() - 1])
+            || !bytes
+                .iter()
+                .all(|byte| is_sandbox_id_alphanumeric(*byte) || *byte == b'-')
+        {
             return Err(LifecycleError::InvalidIdentity(
-                "sandbox ID cannot be empty".to_string(),
+                "sandbox ID must be 1-48 lowercase DNS-label characters".to_string(),
             ));
         }
         Ok(Self(value))
@@ -29,6 +38,10 @@ impl SandboxId {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+}
+
+const fn is_sandbox_id_alphanumeric(byte: u8) -> bool {
+    byte.is_ascii_lowercase() || byte.is_ascii_digit()
 }
 
 impl fmt::Display for SandboxId {
@@ -151,6 +164,7 @@ pub struct NewSandboxRecord {
     pub secure: bool,
     pub allow_internet_access: Option<bool>,
     pub credentials: SandboxCredentials,
+    pub routing: SandboxRoutePolicy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -174,6 +188,8 @@ pub struct SandboxRecord {
     secure: bool,
     allow_internet_access: Option<bool>,
     credentials: SandboxCredentials,
+    #[serde(default)]
+    routing: SandboxRoutePolicy,
     failure: Option<LifecycleFailure>,
 }
 
@@ -210,6 +226,7 @@ impl SandboxRecord {
             secure: new.secure,
             allow_internet_access: new.allow_internet_access,
             credentials: new.credentials,
+            routing: new.routing,
             failure: None,
         })
     }
@@ -288,6 +305,10 @@ impl SandboxRecord {
 
     pub fn credentials(&self) -> &SandboxCredentials {
         &self.credentials
+    }
+
+    pub fn routing(&self) -> &SandboxRoutePolicy {
+        &self.routing
     }
 
     pub const fn failure(&self) -> Option<LifecycleFailure> {

--- a/src/compat/src/control/ports.rs
+++ b/src/compat/src/control/ports.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use thiserror::Error;
 
 use super::SandboxId;
+use crate::routing::SandboxRoutePolicy;
 
 pub trait Clock: Send + Sync {
     fn now(&self) -> DateTime<Utc>;
@@ -40,6 +41,7 @@ pub trait SandboxIdentityProvider: Send + Sync {
 pub struct ResolvedTemplate {
     pub config: BoxConfig,
     pub envd_version: String,
+    pub routing: SandboxRoutePolicy,
 }
 
 #[derive(Debug, Error)]

--- a/src/compat/src/control/service.rs
+++ b/src/compat/src/control/service.rs
@@ -156,6 +156,7 @@ impl ControlService {
                 envd: envd.stored,
                 traffic: traffic.stored,
             },
+            routing: template.routing,
         })?;
         self.repository.insert(record.clone()).await?;
 

--- a/src/compat/src/control/sqlite/tests.rs
+++ b/src/compat/src/control/sqlite/tests.rs
@@ -82,6 +82,7 @@ fn running_record_at(
             envd: stored_token(10),
             traffic: stored_token(20),
         },
+        routing: crate::routing::SandboxRoutePolicy::default(),
     })
     .unwrap();
     record
@@ -229,6 +230,7 @@ async fn records_survive_restart_and_cas_rejects_stale_writers() {
     assert_eq!(loaded.owner_id(), "owner-1");
     assert_eq!(loaded.execution_id(), record.execution_id());
     assert_eq!(loaded.credentials(), record.credentials());
+    assert_eq!(loaded.routing(), record.routing());
 
     let expected = loaded.generation();
     let mut replacement = loaded.clone();

--- a/src/compat/src/control/supervisor_tests.rs
+++ b/src/compat/src/control/supervisor_tests.rs
@@ -58,6 +58,7 @@ fn creating_record(sandbox_id: &str, action: OnTimeoutAction) -> (SandboxRecord,
             envd: stored_token(10),
             traffic: stored_token(20),
         },
+        routing: crate::routing::SandboxRoutePolicy::default(),
     })
     .unwrap();
     (record, config)

--- a/src/compat/src/control/test_support.rs
+++ b/src/compat/src/control/test_support.rs
@@ -112,6 +112,13 @@ impl TemplateProvider for TestTemplates {
                 ..BoxConfig::default()
             },
             envd_version: "0.1.3".to_string(),
+            routing: if template_id == "code-interpreter-v1" {
+                crate::routing::SandboxRoutePolicy::default()
+                    .with_port(crate::routing::CODE_INTERPRETER_PORT, TokenScope::Traffic)
+                    .unwrap()
+            } else {
+                crate::routing::SandboxRoutePolicy::default()
+            },
         })
     }
 }

--- a/src/compat/src/control/tests.rs
+++ b/src/compat/src/control/tests.rs
@@ -53,6 +53,7 @@ fn creating_record_with_timeout_action(id: &str, on_timeout: OnTimeoutAction) ->
             envd: stored_token(10),
             traffic: stored_token(20),
         },
+        routing: crate::routing::SandboxRoutePolicy::default(),
     })
     .unwrap()
 }
@@ -223,11 +224,35 @@ fn invalid_transition_does_not_mutate_record() {
 #[test]
 fn persisted_control_identifiers_preserve_invariants() {
     assert!(serde_json::from_str::<SandboxId>("\"\"").is_err());
+    for invalid in [
+        "Uppercase",
+        "-leading",
+        "trailing-",
+        "contains.dot",
+        "contains/slash",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ] {
+        assert!(SandboxId::new(invalid).is_err(), "accepted {invalid}");
+    }
     assert!(serde_json::from_str::<SandboxGeneration>("0").is_err());
     assert!(serde_json::from_str::<StoredToken>(
         r#"{"key_version":0,"ciphertext":[],"digest":[]}"#
     )
     .is_err());
+}
+
+#[test]
+fn records_written_before_route_policies_default_to_envd_only() {
+    let record = creating_record("legacy-route-record");
+    let mut value = serde_json::to_value(record).unwrap();
+    value.as_object_mut().unwrap().remove("routing");
+
+    let restored: SandboxRecord = serde_json::from_value(value).unwrap();
+    assert_eq!(
+        restored.routing().token_scope(crate::routing::ENVD_PORT),
+        Some(TokenScope::Envd)
+    );
+    assert_eq!(restored.routing().ports().count(), 1);
 }
 
 #[test]

--- a/src/compat/src/control/validation.rs
+++ b/src/compat/src/control/validation.rs
@@ -12,6 +12,9 @@ pub(crate) fn validate_persisted_record(record: &SandboxRecord) -> Result<(), Li
     if record.expires_at() < record.created_at() {
         return Err(LifecycleError::InvalidExpiry);
     }
+    record.routing().validate().map_err(|error| {
+        LifecycleError::InvalidPersistedState(format!("invalid route policy: {error}"))
+    })?;
     if record.execution_id().is_some() != record.execution_generation().is_some() {
         return Err(LifecycleError::InvalidPersistedState(
             "execution ID and generation must be present together".to_string(),

--- a/src/compat/src/lib.rs
+++ b/src/compat/src/lib.rs
@@ -9,5 +9,6 @@ mod proto;
 
 pub mod control;
 pub mod http;
+pub mod routing;
 
 pub use fixture::{generate_fixture, verify_fixture, FixturePaths};

--- a/src/compat/src/routing/lease.rs
+++ b/src/compat/src/routing/lease.rs
@@ -191,7 +191,8 @@ mod tests {
 
     use crate::control::{
         LifecyclePolicy, MemorySandboxRepository, NewSandboxRecord, OnTimeoutAction,
-        RotatingTokenProvider, SandboxCredentials, SandboxRecord, TokenIssuer, TokenKeyMaterial,
+        RotatingTokenProvider, SandboxCredentials, SandboxRecord, SqliteSandboxRepository,
+        TokenIssuer, TokenKeyMaterial,
     };
     use crate::routing::{SandboxRoutePolicy, CODE_INTERPRETER_PORT, ENVD_PORT};
 
@@ -411,5 +412,39 @@ mod tests {
                 .await,
             Err(RouteLeaseError::Inactive)
         ));
+    }
+
+    #[tokio::test]
+    async fn resolves_a_generation_fenced_lease_after_sqlite_restart() {
+        let harness = Harness::new().await;
+        let record = harness
+            .repository
+            .get(&harness.sandbox_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("routes.db");
+        let repository = SqliteSandboxRepository::open(&path).await.unwrap();
+        repository.insert(record).await.unwrap();
+        drop(repository);
+
+        let repository = Arc::new(SqliteSandboxRepository::open(&path).await.unwrap());
+        let tokens = Arc::new(
+            RotatingTokenProvider::new(1, [TokenKeyMaterial::new(1, &[7; 32], &[8; 32]).unwrap()])
+                .unwrap(),
+        );
+        let service = RouteLeaseService::new(repository, tokens, Arc::new(FixedClock(harness.now)));
+        let lease = service
+            .resolve(
+                &harness.route(ENVD_PORT),
+                &token_headers(ENVD_ACCESS_TOKEN_HEADER, &harness.envd_secret),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(lease.sandbox_id(), &harness.sandbox_id);
+        assert_eq!(lease.token_scope(), TokenScope::Envd);
+        assert_eq!(lease.expires_at(), harness.now + Duration::minutes(5));
     }
 }

--- a/src/compat/src/routing/lease.rs
+++ b/src/compat/src/routing/lease.rs
@@ -1,0 +1,415 @@
+use std::num::NonZeroU16;
+use std::sync::Arc;
+
+use a3s_box_core::{ExecutionGeneration, ExecutionId};
+use axum::http::{HeaderMap, HeaderName};
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+
+use crate::control::{
+    Clock, LifecycleState, RepositoryError, SandboxGeneration, SandboxId, SandboxRecord,
+    SandboxRepository, SecretToken, TokenIssuerError, TokenScope, TokenVerifier,
+};
+
+use super::ParsedSandboxRoute;
+
+pub const ENVD_ACCESS_TOKEN_HEADER: &str = "x-access-token";
+pub const TRAFFIC_ACCESS_TOKEN_HEADER: &str = "e2b-traffic-access-token";
+const MAX_TOKEN_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteLease {
+    sandbox_id: SandboxId,
+    execution_id: ExecutionId,
+    sandbox_generation: SandboxGeneration,
+    execution_generation: ExecutionGeneration,
+    port: NonZeroU16,
+    token_scope: TokenScope,
+    expires_at: DateTime<Utc>,
+}
+
+impl RouteLease {
+    pub fn sandbox_id(&self) -> &SandboxId {
+        &self.sandbox_id
+    }
+
+    pub fn execution_id(&self) -> &ExecutionId {
+        &self.execution_id
+    }
+
+    pub const fn sandbox_generation(&self) -> SandboxGeneration {
+        self.sandbox_generation
+    }
+
+    pub const fn execution_generation(&self) -> ExecutionGeneration {
+        self.execution_generation
+    }
+
+    pub const fn port(&self) -> NonZeroU16 {
+        self.port
+    }
+
+    pub const fn token_scope(&self) -> TokenScope {
+        self.token_scope
+    }
+
+    pub const fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+
+    pub fn is_current(&self, record: &SandboxRecord, now: DateTime<Utc>) -> bool {
+        record.state() == LifecycleState::Running
+            && record.sandbox_id() == &self.sandbox_id
+            && record.generation() == self.sandbox_generation
+            && record.execution_id() == Some(&self.execution_id)
+            && record.execution_generation() == Some(self.execution_generation)
+            && record.expires_at() > now
+            && record.routing().token_scope(self.port.get()) == Some(self.token_scope)
+    }
+}
+
+#[derive(Clone)]
+pub struct RouteLeaseService {
+    repository: Arc<dyn SandboxRepository>,
+    tokens: Arc<dyn TokenVerifier>,
+    clock: Arc<dyn Clock>,
+}
+
+impl RouteLeaseService {
+    pub fn new(
+        repository: Arc<dyn SandboxRepository>,
+        tokens: Arc<dyn TokenVerifier>,
+        clock: Arc<dyn Clock>,
+    ) -> Self {
+        Self {
+            repository,
+            tokens,
+            clock,
+        }
+    }
+
+    pub async fn resolve(
+        &self,
+        route: &ParsedSandboxRoute,
+        headers: &HeaderMap,
+    ) -> RouteLeaseResult<RouteLease> {
+        let record = self
+            .repository
+            .get(&route.sandbox_id)
+            .await?
+            .ok_or(RouteLeaseError::NotFound)?;
+        if record.state() != LifecycleState::Running {
+            return Err(RouteLeaseError::Inactive);
+        }
+        let now = self.clock.now();
+        if record.expires_at() <= now {
+            return Err(RouteLeaseError::Expired);
+        }
+        let token_scope = record
+            .routing()
+            .token_scope(route.port.get())
+            .ok_or(RouteLeaseError::PortDenied)?;
+        let execution_id = record
+            .execution_id()
+            .cloned()
+            .ok_or(RouteLeaseError::InvalidRecord)?;
+        let execution_generation = record
+            .execution_generation()
+            .ok_or(RouteLeaseError::InvalidRecord)?;
+        let presented = presented_token(headers, token_scope)?;
+        let stored = match token_scope {
+            TokenScope::Envd => &record.credentials().envd,
+            TokenScope::Traffic => &record.credentials().traffic,
+        };
+        if !self.tokens.verify(token_scope, &presented, stored).await? {
+            return Err(RouteLeaseError::Unauthorized);
+        }
+        Ok(RouteLease {
+            sandbox_id: record.sandbox_id().clone(),
+            execution_id,
+            sandbox_generation: record.generation(),
+            execution_generation,
+            port: route.port,
+            token_scope,
+            expires_at: record.expires_at(),
+        })
+    }
+}
+
+fn presented_token(headers: &HeaderMap, scope: TokenScope) -> RouteLeaseResult<SecretToken> {
+    let name = HeaderName::from_static(match scope {
+        TokenScope::Envd => ENVD_ACCESS_TOKEN_HEADER,
+        TokenScope::Traffic => TRAFFIC_ACCESS_TOKEN_HEADER,
+    });
+    let mut values = headers.get_all(name).iter();
+    let value = values.next().ok_or(RouteLeaseError::MissingToken)?;
+    if values.next().is_some() {
+        return Err(RouteLeaseError::InvalidToken);
+    }
+    let value = value.to_str().map_err(|_| RouteLeaseError::InvalidToken)?;
+    if value.is_empty() || value.len() > MAX_TOKEN_BYTES {
+        return Err(RouteLeaseError::InvalidToken);
+    }
+    SecretToken::new(value).map_err(|_| RouteLeaseError::InvalidToken)
+}
+
+#[derive(Debug, Error)]
+pub enum RouteLeaseError {
+    #[error("sandbox route was not found")]
+    NotFound,
+    #[error("sandbox route is not active")]
+    Inactive,
+    #[error("sandbox route has expired")]
+    Expired,
+    #[error("sandbox port is not routed")]
+    PortDenied,
+    #[error("sandbox route token is missing")]
+    MissingToken,
+    #[error("sandbox route token is invalid")]
+    InvalidToken,
+    #[error("sandbox route is unauthorized")]
+    Unauthorized,
+    #[error("sandbox route record is invalid")]
+    InvalidRecord,
+    #[error(transparent)]
+    Repository(#[from] RepositoryError),
+    #[error(transparent)]
+    Token(#[from] TokenIssuerError),
+}
+
+pub type RouteLeaseResult<T> = std::result::Result<T, RouteLeaseError>;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use a3s_box_core::{
+        resolve_execution, BoxConfig, ExecutionIsolation, ExecutionLease, OperationId,
+    };
+    use axum::http::HeaderValue;
+    use chrono::{Duration, TimeZone};
+
+    use crate::control::{
+        LifecyclePolicy, MemorySandboxRepository, NewSandboxRecord, OnTimeoutAction,
+        RotatingTokenProvider, SandboxCredentials, SandboxRecord, TokenIssuer, TokenKeyMaterial,
+    };
+    use crate::routing::{SandboxRoutePolicy, CODE_INTERPRETER_PORT, ENVD_PORT};
+
+    use super::*;
+
+    struct FixedClock(DateTime<Utc>);
+
+    impl Clock for FixedClock {
+        fn now(&self) -> DateTime<Utc> {
+            self.0
+        }
+    }
+
+    struct Harness {
+        repository: Arc<MemorySandboxRepository>,
+        service: RouteLeaseService,
+        envd_secret: SecretToken,
+        traffic_secret: SecretToken,
+        now: DateTime<Utc>,
+        sandbox_id: SandboxId,
+    }
+
+    impl Harness {
+        async fn new() -> Self {
+            let now = Utc
+                .with_ymd_and_hms(2026, 7, 15, 10, 0, 0)
+                .single()
+                .unwrap();
+            let tokens = Arc::new(
+                RotatingTokenProvider::new(
+                    1,
+                    [TokenKeyMaterial::new(1, &[7; 32], &[8; 32]).unwrap()],
+                )
+                .unwrap(),
+            );
+            let envd = tokens.issue(TokenScope::Envd).await.unwrap();
+            let traffic = tokens.issue(TokenScope::Traffic).await.unwrap();
+            let sandbox_id = SandboxId::new("sandbox-route-1").unwrap();
+            let config = BoxConfig {
+                isolation: ExecutionIsolation::Sandbox,
+                ..BoxConfig::default()
+            };
+            let plan = resolve_execution(&config).unwrap();
+            let routing = SandboxRoutePolicy::default()
+                .with_port(CODE_INTERPRETER_PORT, TokenScope::Traffic)
+                .unwrap();
+            let mut record = SandboxRecord::creating(NewSandboxRecord {
+                sandbox_id: sandbox_id.clone(),
+                operation_id: OperationId::new("operation-route-1").unwrap(),
+                owner_id: "owner-route".to_string(),
+                template_id: "code-interpreter-v1".to_string(),
+                plan: plan.clone(),
+                resources: config.resources.clone(),
+                lifecycle: LifecyclePolicy {
+                    on_timeout: OnTimeoutAction::Kill,
+                    auto_resume: false,
+                    keep_memory_on_pause: false,
+                },
+                created_at: now,
+                expires_at: now + Duration::minutes(5),
+                metadata: BTreeMap::new(),
+                envd_version: "0.1.3".to_string(),
+                secure: true,
+                allow_internet_access: Some(false),
+                credentials: SandboxCredentials {
+                    envd: envd.stored,
+                    traffic: traffic.stored,
+                },
+                routing,
+            })
+            .unwrap();
+            record
+                .mark_running(ExecutionLease {
+                    execution_id: ExecutionId::new("execution-route-1").unwrap(),
+                    generation: ExecutionGeneration::INITIAL,
+                    plan,
+                    resources: config.resources,
+                    started_at: now,
+                })
+                .unwrap();
+            let repository = Arc::new(MemorySandboxRepository::default());
+            repository.insert(record).await.unwrap();
+            let service =
+                RouteLeaseService::new(repository.clone(), tokens, Arc::new(FixedClock(now)));
+            Self {
+                repository,
+                service,
+                envd_secret: envd.secret,
+                traffic_secret: traffic.secret,
+                now,
+                sandbox_id,
+            }
+        }
+
+        fn route(&self, port: u16) -> ParsedSandboxRoute {
+            ParsedSandboxRoute {
+                sandbox_id: self.sandbox_id.clone(),
+                port: NonZeroU16::new(port).unwrap(),
+                form: super::super::RouteForm::Direct,
+            }
+        }
+    }
+
+    fn token_headers(name: &'static str, token: &SecretToken) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(name, HeaderValue::from_str(token.expose_secret()).unwrap());
+        headers
+    }
+
+    #[tokio::test]
+    async fn resolves_scope_bound_generation_fenced_leases() {
+        let harness = Harness::new().await;
+        let envd = harness
+            .service
+            .resolve(
+                &harness.route(ENVD_PORT),
+                &token_headers(ENVD_ACCESS_TOKEN_HEADER, &harness.envd_secret),
+            )
+            .await
+            .unwrap();
+        assert_eq!(envd.token_scope(), TokenScope::Envd);
+        assert_eq!(envd.execution_id().as_str(), "execution-route-1");
+
+        let traffic = harness
+            .service
+            .resolve(
+                &harness.route(CODE_INTERPRETER_PORT),
+                &token_headers(TRAFFIC_ACCESS_TOKEN_HEADER, &harness.traffic_secret),
+            )
+            .await
+            .unwrap();
+        assert_eq!(traffic.token_scope(), TokenScope::Traffic);
+        assert!(traffic.is_current(
+            &harness
+                .repository
+                .get(&harness.sandbox_id)
+                .await
+                .unwrap()
+                .unwrap(),
+            harness.now
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_swapped_tokens_unrouted_ports_and_stale_generations() {
+        let harness = Harness::new().await;
+        assert!(matches!(
+            harness
+                .service
+                .resolve(
+                    &harness.route(ENVD_PORT),
+                    &token_headers(ENVD_ACCESS_TOKEN_HEADER, &harness.traffic_secret),
+                )
+                .await,
+            Err(RouteLeaseError::Unauthorized)
+        ));
+        assert!(matches!(
+            harness
+                .service
+                .resolve(
+                    &harness.route(8080),
+                    &token_headers(TRAFFIC_ACCESS_TOKEN_HEADER, &harness.traffic_secret),
+                )
+                .await,
+            Err(RouteLeaseError::PortDenied)
+        ));
+
+        let old = harness
+            .service
+            .resolve(
+                &harness.route(ENVD_PORT),
+                &token_headers(ENVD_ACCESS_TOKEN_HEADER, &harness.envd_secret),
+            )
+            .await
+            .unwrap();
+        let mut record = harness
+            .repository
+            .get(&harness.sandbox_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let expected = record.generation();
+        record
+            .replace_expiry(harness.now + Duration::minutes(10))
+            .unwrap();
+        harness
+            .repository
+            .compare_and_swap(&harness.sandbox_id, expected, record.clone())
+            .await
+            .unwrap();
+        assert!(!old.is_current(&record, harness.now));
+
+        let renewed = harness
+            .service
+            .resolve(
+                &harness.route(ENVD_PORT),
+                &token_headers(ENVD_ACCESS_TOKEN_HEADER, &harness.envd_secret),
+            )
+            .await
+            .unwrap();
+        assert!(renewed.sandbox_generation() > old.sandbox_generation());
+
+        let expected = record.generation();
+        record.begin_kill().unwrap();
+        harness
+            .repository
+            .compare_and_swap(&harness.sandbox_id, expected, record)
+            .await
+            .unwrap();
+        assert!(matches!(
+            harness
+                .service
+                .resolve(
+                    &harness.route(ENVD_PORT),
+                    &token_headers(ENVD_ACCESS_TOKEN_HEADER, &harness.envd_secret),
+                )
+                .await,
+            Err(RouteLeaseError::Inactive)
+        ));
+    }
+}

--- a/src/compat/src/routing/mod.rs
+++ b/src/compat/src/routing/mod.rs
@@ -1,0 +1,16 @@
+mod lease;
+mod parser;
+mod policy;
+
+pub use lease::{
+    RouteLease, RouteLeaseError, RouteLeaseResult, RouteLeaseService, ENVD_ACCESS_TOKEN_HEADER,
+    TRAFFIC_ACCESS_TOKEN_HEADER,
+};
+pub use parser::{
+    ParsedSandboxRoute, RouteForm, RouteParseError, RouteParseResult, SandboxDomain,
+    SandboxRouteParser, SANDBOX_ID_HEADER, SANDBOX_PORT_HEADER,
+};
+pub use policy::{
+    RoutePolicyError, RoutePolicyResult, SandboxRoutePolicy, CODE_INTERPRETER_PORT, ENVD_PORT,
+    MCP_PORT,
+};

--- a/src/compat/src/routing/parser.rs
+++ b/src/compat/src/routing/parser.rs
@@ -1,0 +1,300 @@
+use std::fmt;
+use std::num::NonZeroU16;
+use std::str::FromStr;
+
+use axum::http::header::HOST;
+use axum::http::uri::Authority;
+use axum::http::{HeaderMap, HeaderName};
+use thiserror::Error;
+
+use crate::control::SandboxId;
+
+pub const SANDBOX_ID_HEADER: &str = "e2b-sandbox-id";
+pub const SANDBOX_PORT_HEADER: &str = "e2b-sandbox-port";
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SandboxDomain(String);
+
+impl SandboxDomain {
+    pub fn new(value: impl Into<String>) -> RouteParseResult<Self> {
+        let value = value.into();
+        if value.is_empty()
+            || value.len() > 253
+            || value.ends_with('.')
+            || value.bytes().any(|byte| byte.is_ascii_uppercase())
+            || !value.split('.').all(valid_dns_label)
+        {
+            return Err(RouteParseError::InvalidDomain);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn shared_hostname(&self) -> String {
+        format!("sandbox.{}", self.0)
+    }
+}
+
+impl fmt::Debug for SandboxDomain {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("SandboxDomain")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteForm {
+    Direct,
+    SharedHeaders,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedSandboxRoute {
+    pub sandbox_id: SandboxId,
+    pub port: NonZeroU16,
+    pub form: RouteForm,
+}
+
+#[derive(Debug, Clone)]
+pub struct SandboxRouteParser {
+    domain: SandboxDomain,
+}
+
+impl SandboxRouteParser {
+    pub fn new(domain: SandboxDomain) -> Self {
+        Self { domain }
+    }
+
+    pub fn parse(&self, headers: &HeaderMap) -> RouteParseResult<ParsedSandboxRoute> {
+        let host = single_header(headers, &HOST)?.ok_or(RouteParseError::MissingHost)?;
+        self.parse_host(host, headers)
+    }
+
+    pub fn parse_host(
+        &self,
+        authority: &str,
+        headers: &HeaderMap,
+    ) -> RouteParseResult<ParsedSandboxRoute> {
+        let authority = Authority::from_str(authority).map_err(|_| RouteParseError::InvalidHost)?;
+        let host = authority.host().to_ascii_lowercase();
+        let header_route = route_headers(headers)?;
+
+        if host == self.domain.shared_hostname() {
+            let (sandbox_id, port) = header_route.ok_or(RouteParseError::MissingRouteHeaders)?;
+            return Ok(ParsedSandboxRoute {
+                sandbox_id,
+                port,
+                form: RouteForm::SharedHeaders,
+            });
+        }
+
+        let suffix = format!(".{}", self.domain.as_str());
+        let label = host
+            .strip_suffix(&suffix)
+            .filter(|label| !label.is_empty() && !label.contains('.'))
+            .ok_or(RouteParseError::UnsupportedHost)?;
+        let (port, sandbox_id) = parse_direct_label(label)?;
+        if let Some((header_id, header_port)) = header_route {
+            if header_id != sandbox_id || header_port != port {
+                return Err(RouteParseError::ConflictingRouteHeaders);
+            }
+        }
+        Ok(ParsedSandboxRoute {
+            sandbox_id,
+            port,
+            form: RouteForm::Direct,
+        })
+    }
+}
+
+fn route_headers(headers: &HeaderMap) -> RouteParseResult<Option<(SandboxId, NonZeroU16)>> {
+    let sandbox_id = single_named_header(headers, SANDBOX_ID_HEADER)?;
+    let port = single_named_header(headers, SANDBOX_PORT_HEADER)?;
+    match (sandbox_id, port) {
+        (None, None) => Ok(None),
+        (Some(sandbox_id), Some(port)) => Ok(Some((
+            SandboxId::new(sandbox_id).map_err(|_| RouteParseError::InvalidRouteHeaders)?,
+            parse_port(port).map_err(|_| RouteParseError::InvalidRouteHeaders)?,
+        ))),
+        _ => Err(RouteParseError::MissingRouteHeaders),
+    }
+}
+
+fn parse_direct_label(label: &str) -> RouteParseResult<(NonZeroU16, SandboxId)> {
+    let (port, sandbox_id) = label.split_once('-').ok_or(RouteParseError::InvalidHost)?;
+    Ok((
+        parse_port(port).map_err(|_| RouteParseError::InvalidHost)?,
+        SandboxId::new(sandbox_id).map_err(|_| RouteParseError::InvalidHost)?,
+    ))
+}
+
+fn parse_port(value: &str) -> Result<NonZeroU16, ()> {
+    if value.starts_with('0') {
+        return Err(());
+    }
+    let port = value.parse::<u16>().map_err(|_| ())?;
+    NonZeroU16::new(port).ok_or(())
+}
+
+fn single_named_header<'a>(
+    headers: &'a HeaderMap,
+    name: &'static str,
+) -> RouteParseResult<Option<&'a str>> {
+    single_header(headers, &HeaderName::from_static(name))
+}
+
+fn single_header<'a>(
+    headers: &'a HeaderMap,
+    name: &HeaderName,
+) -> RouteParseResult<Option<&'a str>> {
+    let mut values = headers.get_all(name).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(RouteParseError::DuplicateHeader);
+    }
+    let value = value
+        .to_str()
+        .map_err(|_| RouteParseError::InvalidRouteHeaders)?;
+    if value.is_empty() {
+        return Err(RouteParseError::InvalidRouteHeaders);
+    }
+    Ok(Some(value))
+}
+
+fn valid_dns_label(label: &str) -> bool {
+    let bytes = label.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 63
+        && (bytes[0].is_ascii_lowercase() || bytes[0].is_ascii_digit())
+        && (bytes[bytes.len() - 1].is_ascii_lowercase() || bytes[bytes.len() - 1].is_ascii_digit())
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'-')
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RouteParseError {
+    #[error("sandbox domain is invalid")]
+    InvalidDomain,
+    #[error("Host header is missing")]
+    MissingHost,
+    #[error("Host header is invalid")]
+    InvalidHost,
+    #[error("host is outside the configured sandbox domain")]
+    UnsupportedHost,
+    #[error("sandbox route headers are incomplete")]
+    MissingRouteHeaders,
+    #[error("sandbox route headers are invalid")]
+    InvalidRouteHeaders,
+    #[error("sandbox route headers conflict with the direct hostname")]
+    ConflictingRouteHeaders,
+    #[error("routing header is duplicated")]
+    DuplicateHeader,
+}
+
+pub type RouteParseResult<T> = std::result::Result<T, RouteParseError>;
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderValue, Request};
+
+    use super::*;
+
+    fn parser() -> SandboxRouteParser {
+        SandboxRouteParser::new(SandboxDomain::new("box.example.com").unwrap())
+    }
+
+    fn headers(host: &str) -> HeaderMap {
+        Request::builder()
+            .header(HOST, host)
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0
+            .headers
+    }
+
+    #[test]
+    fn parses_direct_and_shared_routes_without_string_split_ambiguity() {
+        let direct = parser()
+            .parse(&headers("49983-sandbox-abc.box.example.com:443"))
+            .unwrap();
+        assert_eq!(direct.sandbox_id.as_str(), "sandbox-abc");
+        assert_eq!(direct.port.get(), 49_983);
+        assert_eq!(direct.form, RouteForm::Direct);
+
+        let mut shared = headers("sandbox.box.example.com");
+        shared.insert(SANDBOX_ID_HEADER, HeaderValue::from_static("sandbox-abc"));
+        shared.insert(SANDBOX_PORT_HEADER, HeaderValue::from_static("49999"));
+        let shared = parser().parse(&shared).unwrap();
+        assert_eq!(shared.sandbox_id.as_str(), "sandbox-abc");
+        assert_eq!(shared.port.get(), 49_999);
+        assert_eq!(shared.form, RouteForm::SharedHeaders);
+    }
+
+    #[test]
+    fn direct_route_headers_must_match_the_hostname() {
+        let mut matching = headers("49983-sandbox-abc.box.example.com");
+        matching.insert(SANDBOX_ID_HEADER, HeaderValue::from_static("sandbox-abc"));
+        matching.insert(SANDBOX_PORT_HEADER, HeaderValue::from_static("49983"));
+        assert!(parser().parse(&matching).is_ok());
+
+        matching.insert(SANDBOX_PORT_HEADER, HeaderValue::from_static("49999"));
+        assert_eq!(
+            parser().parse(&matching).unwrap_err(),
+            RouteParseError::ConflictingRouteHeaders
+        );
+    }
+
+    #[test]
+    fn rejects_domain_confusion_invalid_ports_and_hostile_identities() {
+        for host in [
+            "49983-sandbox-abc.box.example.com.evil.invalid",
+            "49983-sandbox-abc.evil.box.example.com",
+            "0-sandbox-abc.box.example.com",
+            "65536-sandbox-abc.box.example.com",
+            "049983-sandbox-abc.box.example.com",
+            "49983-../box.example.com",
+            "49983--leading.box.example.com",
+        ] {
+            assert!(parser().parse(&headers(host)).is_err(), "accepted {host}");
+        }
+    }
+
+    #[test]
+    fn shared_routes_require_one_complete_header_pair() {
+        let mut missing = headers("sandbox.box.example.com");
+        missing.insert(SANDBOX_ID_HEADER, HeaderValue::from_static("sandbox-abc"));
+        assert_eq!(
+            parser().parse(&missing).unwrap_err(),
+            RouteParseError::MissingRouteHeaders
+        );
+
+        let mut duplicated = headers("sandbox.box.example.com");
+        duplicated.append(SANDBOX_ID_HEADER, HeaderValue::from_static("sandbox-abc"));
+        duplicated.append(SANDBOX_ID_HEADER, HeaderValue::from_static("sandbox-other"));
+        duplicated.insert(SANDBOX_PORT_HEADER, HeaderValue::from_static("49983"));
+        assert_eq!(
+            parser().parse(&duplicated).unwrap_err(),
+            RouteParseError::DuplicateHeader
+        );
+    }
+
+    #[test]
+    fn validates_canonical_acl_domains() {
+        assert_eq!(
+            SandboxDomain::new("Box.Example.com").unwrap_err(),
+            RouteParseError::InvalidDomain
+        );
+        for valid in ["localhost", "box.example", "sandbox-1.box.example"] {
+            assert!(SandboxDomain::new(valid).is_ok(), "rejected {valid}");
+        }
+    }
+}

--- a/src/compat/src/routing/policy.rs
+++ b/src/compat/src/routing/policy.rs
@@ -1,0 +1,159 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::control::TokenScope;
+
+pub const ENVD_PORT: u16 = 49_983;
+pub const CODE_INTERPRETER_PORT: u16 = 49_999;
+pub const MCP_PORT: u16 = 50_005;
+const MAX_ROUTED_PORTS: usize = 64;
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    try_from = "BTreeMap<u16, TokenScope>",
+    into = "BTreeMap<u16, TokenScope>"
+)]
+pub struct SandboxRoutePolicy {
+    ports: BTreeMap<u16, TokenScope>,
+}
+
+impl SandboxRoutePolicy {
+    pub fn new(ports: impl IntoIterator<Item = (u16, TokenScope)>) -> RoutePolicyResult<Self> {
+        let mut routed = BTreeMap::new();
+        for (port, scope) in ports {
+            if port == 0 || routed.insert(port, scope).is_some() {
+                return Err(RoutePolicyError::InvalidPort(port));
+            }
+        }
+        let policy = Self { ports: routed };
+        policy.validate()?;
+        Ok(policy)
+    }
+
+    pub fn with_port(mut self, port: u16, scope: TokenScope) -> RoutePolicyResult<Self> {
+        if port == 0 || self.ports.insert(port, scope).is_some() {
+            return Err(RoutePolicyError::InvalidPort(port));
+        }
+        self.validate()?;
+        Ok(self)
+    }
+
+    pub fn token_scope(&self, port: u16) -> Option<TokenScope> {
+        self.ports.get(&port).copied()
+    }
+
+    pub fn ports(&self) -> impl Iterator<Item = (u16, TokenScope)> + '_ {
+        self.ports.iter().map(|(port, scope)| (*port, *scope))
+    }
+
+    pub fn validate(&self) -> RoutePolicyResult<()> {
+        if self.ports.len() > MAX_ROUTED_PORTS {
+            return Err(RoutePolicyError::TooManyPorts);
+        }
+        if self.ports.get(&ENVD_PORT) != Some(&TokenScope::Envd) {
+            return Err(RoutePolicyError::MissingEnvd);
+        }
+        if self
+            .ports
+            .iter()
+            .any(|(port, scope)| *port == 0 || (*scope == TokenScope::Envd && *port != ENVD_PORT))
+        {
+            return Err(RoutePolicyError::InvalidScope);
+        }
+        Ok(())
+    }
+}
+
+impl Default for SandboxRoutePolicy {
+    fn default() -> Self {
+        Self {
+            ports: BTreeMap::from([(ENVD_PORT, TokenScope::Envd)]),
+        }
+    }
+}
+
+impl fmt::Debug for SandboxRoutePolicy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SandboxRoutePolicy")
+            .field("ports", &self.ports)
+            .finish()
+    }
+}
+
+impl TryFrom<BTreeMap<u16, TokenScope>> for SandboxRoutePolicy {
+    type Error = RoutePolicyError;
+
+    fn try_from(ports: BTreeMap<u16, TokenScope>) -> Result<Self, Self::Error> {
+        let policy = Self { ports };
+        policy.validate()?;
+        Ok(policy)
+    }
+}
+
+impl From<SandboxRoutePolicy> for BTreeMap<u16, TokenScope> {
+    fn from(policy: SandboxRoutePolicy) -> Self {
+        policy.ports
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RoutePolicyError {
+    #[error("routed port {0} is invalid or duplicated")]
+    InvalidPort(u16),
+    #[error("the envd compatibility port is required")]
+    MissingEnvd,
+    #[error("envd token scope is valid only for the envd compatibility port")]
+    InvalidScope,
+    #[error("too many routed ports")]
+    TooManyPorts,
+}
+
+pub type RoutePolicyResult<T> = std::result::Result<T, RoutePolicyError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_requires_scope_separated_envd_and_traffic_ports() {
+        let policy = SandboxRoutePolicy::default()
+            .with_port(CODE_INTERPRETER_PORT, TokenScope::Traffic)
+            .unwrap()
+            .with_port(MCP_PORT, TokenScope::Traffic)
+            .unwrap();
+
+        assert_eq!(policy.token_scope(ENVD_PORT), Some(TokenScope::Envd));
+        assert_eq!(
+            policy.token_scope(CODE_INTERPRETER_PORT),
+            Some(TokenScope::Traffic)
+        );
+        assert_eq!(policy.ports().count(), 3);
+        assert_eq!(
+            SandboxRoutePolicy::new([(CODE_INTERPRETER_PORT, TokenScope::Traffic)]).unwrap_err(),
+            RoutePolicyError::MissingEnvd
+        );
+        assert_eq!(
+            SandboxRoutePolicy::default()
+                .with_port(MCP_PORT, TokenScope::Envd)
+                .unwrap_err(),
+            RoutePolicyError::InvalidScope
+        );
+    }
+
+    #[test]
+    fn persisted_policy_revalidates_scope_invariants() {
+        let invalid = format!(r#"{{"{ENVD_PORT}":"traffic"}}"#);
+        assert!(serde_json::from_str::<SandboxRoutePolicy>(&invalid).is_err());
+
+        let policy = SandboxRoutePolicy::default();
+        assert_eq!(
+            serde_json::from_str::<SandboxRoutePolicy>(&serde_json::to_string(&policy).unwrap())
+                .unwrap(),
+            policy
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- persist exact routed-port and token-scope policy in the canonical sandbox lifecycle record
- parse direct wildcard hosts and shared route headers with strict domain, port, sandbox-ID, duplicate-header, and conflict validation
- project immutable leases only from current running records
- fence leases by sandbox generation, execution generation, expiry, port policy, and envd/traffic token scope
- validate route tokens through the versioned production HMAC provider
- preserve envd-only routing when older SQLite records lack the new policy field

The lease is deliberately derived from the durable lifecycle record rather than stored as a second mutable routing row, so pause, timeout replacement, kill, and recreation invalidate stale leases immediately.

## Validation

Run on the A3S OS production server from a Git-fetched worktree:

- `cargo test --locked -p a3s-box-compat` (67 passed)
- `cargo clippy --locked -p a3s-box-compat --all-targets -- -D warnings`
- SQLite close/reopen route-lease recovery test
- `cargo run --locked -p a3s-box-compat --bin a3s-box-e2b-contract -- verify`
- `cargo fmt --all --check`