### PR TITLE
feat(e2b): add ACL production control service

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ that structured Sandbox logs retain both stdout and stderr, drain final records
 before natural-exit or auto-remove archival, and leave no generation log worker,
 crun state, box directory, or socket behind.
 
-Those protocol and runtime tests are not yet one end-to-end service path. CLI
+Those protocol and runtime tests are not yet a complete TLS data-plane path. CLI
 `create` now persists its reservation and complete caller policy through the
 canonical manager, and the first `start` of that reservation consumes its
 persisted generation through the same manager. The production backend prepares
@@ -363,12 +363,15 @@ the managed backend. The Rust SDK now exposes typed create, start, run, inspect,
 pause, resume, restart, kill, and reconciliation calls through that same
 manager. Production credential providers now store account keys as salted
 PBKDF2-SHA256 hashes and protect scope-separated sandbox tokens with
-AES-256-GCM, independent HMAC validation, and versioned key rotation. Wiring
-those providers into the production ACL service and the wildcard TLS gateway
-remains open. Route policy is now persisted with each lifecycle record, and
+AES-256-GCM, independent HMAC validation, and versioned key rotation. The
+`a3s-box-e2b` process reads only `.acl` configuration through `a3s-acl` and
+composes those providers with SQLite lifecycle state, the canonical runtime
+manager, startup reconciliation, periodic expiry reaping, and graceful
+shutdown. Route policy is now persisted with each lifecycle record, and
 strict wildcard/shared parsing projects generation-, expiry-, port-, and
-token-scope-fenced leases without a second mutable routing state. The envd data
-plane and the real official-client Sandbox suite also remain open gates.
+token-scope-fenced leases without a second mutable routing state. The wildcard
+TLS gateway, envd data plane, and the real official-client Sandbox suite remain
+open gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/README.md
+++ b/README.md
@@ -367,11 +367,13 @@ AES-256-GCM, independent HMAC validation, and versioned key rotation. The
 `a3s-box-e2b` process reads only `.acl` configuration through `a3s-acl` and
 composes those providers with SQLite lifecycle state, the canonical runtime
 manager, startup reconciliation, periodic expiry reaping, and graceful
-shutdown. Route policy is now persisted with each lifecycle record, and
-strict wildcard/shared parsing projects generation-, expiry-, port-, and
-token-scope-fenced leases without a second mutable routing state. The wildcard
-TLS gateway, envd data plane, and the real official-client Sandbox suite remain
-open gates.
+shutdown. Its A3S OS smoke creates a real `crun` Sandbox through HTTP, restarts
+the service, reconnects to the preserved execution, updates its timeout, kills
+it, and verifies runtime cleanup. Route policy is now persisted with each
+lifecycle record, and strict wildcard/shared parsing projects generation-,
+expiry-, port-, and token-scope-fenced leases without a second mutable routing
+state. The wildcard TLS gateway, envd data plane, and the real official-client
+Sandbox suite remain open gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/compat/e2b/README.md
+++ b/compat/e2b/README.md
@@ -82,3 +82,8 @@ The validated schema and an operator example are documented in
 This process currently exposes the lifecycle control subset. The wildcard TLS
 gateway and sandbox data-plane protocols remain required before the manifest
 can set `full_compatibility=true`.
+
+The destructive A3S OS integration harness is
+[`scripts/e2b-production-smoke.sh`](../../scripts/e2b-production-smoke.sh). It
+requires a dedicated runtime home and explicit acknowledgement, and verifies a
+real Sandbox lifecycle, service restart recovery, and resource cleanup.

--- a/compat/e2b/README.md
+++ b/compat/e2b/README.md
@@ -61,3 +61,24 @@ vendored sources, inventories, and manifest remain byte-for-byte consistent.
 
 Never edit generated inventories by hand or infer compatibility from matching
 method names alone.
+
+## Production control service
+
+`a3s-box-e2b` composes the lifecycle router with the SQLite repository, the
+canonical A3S runtime manager, production credential providers, startup
+reconciliation, and periodic expiry maintenance. It requires a `.acl` file
+parsed by `a3s-acl`; literal sandbox token keys are rejected in favor of
+`env("VARIABLE")` references.
+
+Run it from the Rust workspace:
+
+```bash
+cargo run --locked -p a3s-box-compat --bin a3s-box-e2b -- \
+  --config /etc/a3s-box/e2b.acl
+```
+
+The validated schema and an operator example are documented in
+[`docs/e2b-compatible-sdk-design.md`](../../docs/e2b-compatible-sdk-design.md#configuration).
+This process currently exposes the lifecycle control subset. The wildcard TLS
+gateway and sandbox data-plane protocols remain required before the manifest
+can set `full_compatibility=true`.

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,7 +1,7 @@
 # E2B Protocol Compatibility and SDK Design
 
 Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 4 complete;
-slice 5 credential and routing foundations complete)**
+slice 5 control-service composition complete, TLS data plane pending)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -20,9 +20,9 @@ unversioned claim.
 | --- | --- | --- |
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
-| Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, reaping, and startup reconciliation | Wire the repository and supervisor into the production service process and exercise restart and host-reboot recovery end to end |
-| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI and Rust SDK create/start/run paths use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery; A3S OS smoke tests prove managed CLI and SDK execution through certified `crun`, explicit Sandbox pause rejection, kill, and cleanup without MicroVM fallback | Compose the runtime manager into the production compatibility service and exercise service restart recovery end to end |
-| Credentials and routing | Production account credentials use salted PBKDF2-SHA256 hashes; sandbox tokens use scope-bound AES-256-GCM ciphertext, independent HMAC validation, and versioned key rotation; strict direct/shared route parsing and durable-record-projected leases fence sandbox and execution generations, expiry, port policy, and token scope | Wire these components through ACL and add the TLS data-plane gateway |
+| Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, startup reconciliation, and periodic reaping are composed into the production service | Exercise service restart and host-reboot recovery end to end |
+| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI and Rust SDK create/start/run paths use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery; the production compatibility process now uses the same manager | Complete the real-service restart and host-reboot matrix |
+| Credentials and routing | ACL config wires salted PBKDF2-SHA256 account hashes, scope-bound AES-256-GCM sandbox tokens, independent HMAC validation, versioned key rotation, strict direct/shared parsing, and durable-record-projected generation-fenced leases | Add the TLS data-plane gateway and exercise routed traffic through it |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
 The lifecycle fixture and the managed Sandbox smoke validate opposite sides of
@@ -547,32 +547,66 @@ modified with required A3S fields.
 ## Configuration
 
 Product configuration uses A3S Agent Configuration Language (ACL), parsed by
-`a3s-acl`. A production service configuration resembles:
+the pinned `a3s-acl` implementation. The service accepts only a `.acl` file.
+Token encryption and digest keys must be independent 32-byte hexadecimal values
+referenced through `env("VARIABLE")`; literal key material is rejected. A
+production control-service configuration resembles:
 
 ```acl
 e2b_compat {
-  api_listen          = "0.0.0.0:443"
-  api_public_url      = "https://api.box.example.com"
-  sandbox_domain     = "box.example.com"
-  shared_sandbox_url = "https://sandbox.box.example.com"
-  default_template   = "code-interpreter-v1"
+  api_listen        = "127.0.0.1:3000"
+  api_public_url    = "https://api.box.example.com"
+  sandbox_domain   = "box.example.com"
+  database_path    = "/var/lib/a3s-box/e2b/lifecycle.sqlite3"
+  runtime_home     = "/var/lib/a3s"
+  runtime_state_path = "/var/lib/a3s-box/e2b/managed-executions.json"
 
-  protocol_manifest = "/etc/a3s-box/e2b-compat-manifest.json"
+  supervisor {
+    interval_seconds          = 5
+    batch_size                = 100
+    reconciliation_page_size = 100
+  }
 
-  routing {
-    wildcard_tls_certificate = "/etc/a3s-box/tls/fullchain.pem"
-    wildcard_tls_key         = "/etc/a3s-box/tls/privkey.pem"
+  account "primary" {
+    scheme    = "api_key"
+    owner_id  = "production-team"
+    client_id = "production-client"
+    hash      = "pbkdf2-sha256$210000$<salt-hex>$<digest-hex>"
+  }
+
+  token_key "2026-07" {
+    version = 1
+    active  = true
+    encryption_key = env("A3S_BOX_E2B_TOKEN_ENCRYPTION_KEY_V1")
+    digest_key     = env("A3S_BOX_E2B_TOKEN_DIGEST_KEY_V1")
   }
 
   template_policy "code-interpreter-v1" {
     isolation = "sandbox"
+    image = "registry.example.com/a3s/code-interpreter:2026-07"
+    envd_version = "0.1.3"
+
+    resources {
+      vcpus     = 2
+      memory_mb = 1024
+      disk_mb   = 4096
+    }
+
+    route {
+      port = 49999
+      token_scope = "traffic"
+    }
   }
 }
 ```
 
-Runtime binaries, credential-store paths, and template-to-isolation mappings
-are validated during startup. No production default accepts an arbitrary host
-runtime binary or disables authentication.
+The envd port and envd token scope are added when omitted. Runtime paths,
+credentials, key versions, template execution policy, resources, and routed
+ports are validated before the listener opens. Startup runs durable lifecycle
+reconciliation; a bounded supervisor then reaps expired records until graceful
+shutdown. The control listener remains behind the deployment TLS edge in this
+slice. Wildcard TLS termination and the sandbox data-plane proxy are the next
+focused slice.
 
 ## Repository boundaries
 
@@ -809,8 +843,8 @@ Phase 2 is delivered as small, immediately merged changes:
    start/restart/run and the Rust SDK to the same implementation with behavior
    parity tests.
 5. **In progress:** production account credentials, sandbox token providers,
-   generation-fenced route leases, and validated wildcard/shared parsing are
-   complete. Add the ACL-configured service binary and TLS data-plane gateway.
+   generation-fenced route leases, validated wildcard/shared parsing, and the
+   ACL-configured service binary are complete. Add the TLS data-plane gateway.
    Pull each merge commit on an A3S OS server and run the unmodified official
    clients against real `--isolation sandbox` executions.
 
@@ -887,11 +921,12 @@ smoke test proves staged create, start, create-and-start, inspect, kill, and
 runtime cleanup through the real Sandbox backend without invoking the CLI.
 
 Each slice must pass its focused tests and repository CI before merge. The
-Phase 2 gate remains closed until slice 5 composes the durable repository,
-production execution manager, credentials, routing, and real
-create/connect/list/timeout/kill behavior. Passing the fake manager in slice 2
-and passing the direct runtime smoke in slice 4 are complementary evidence, not
-the missing end-to-end proof.
+durable repository, production execution manager, credentials, routing, and
+lifecycle HTTP router are now composed in one ACL-configured process. The
+Phase 2 gate remains closed until the real create/connect/list/timeout/kill
+matrix also traverses the production TLS and sandbox data planes. Passing the
+fake manager in slice 2 and passing the direct runtime smoke in slice 4 remain
+complementary evidence, not that missing end-to-end proof.
 
 Slice 2 evidence includes exact recorder drift checks plus live requests from
 the pinned, unmodified clients to the Rust router. The live gate was also run

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -20,17 +20,18 @@ unversioned claim.
 | --- | --- | --- |
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
-| Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, startup reconciliation, and periodic reaping are composed into the production service | Exercise service restart and host-reboot recovery end to end |
-| Runtime lifecycle | Canonical managed-execution store, two-stage backend-neutral `LocalExecutionManager`, and production VM/Sandbox backend; CLI and Rust SDK create/start/run paths use generation fencing with caller-policy parity, idempotent resource preparation, failure rollback, and operation-ID recovery; the production compatibility process now uses the same manager | Complete the real-service restart and host-reboot matrix |
+| Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, startup reconciliation, and periodic reaping are composed into the production service; an A3S OS smoke preserves a running record across process restart | Exercise host-reboot recovery end to end |
+| Runtime lifecycle | The production compatibility process uses the canonical `LocalExecutionManager`; an A3S OS smoke creates through HTTP, starts through certified `crun`, reconnects after service restart, replaces timeout, kills, and verifies box, runtime-state, and socket cleanup | Complete the host-reboot and official-client matrices |
 | Credentials and routing | ACL config wires salted PBKDF2-SHA256 account hashes, scope-bound AES-256-GCM sandbox tokens, independent HMAC validation, versioned key rotation, strict direct/shared parsing, and durable-record-projected generation-fenced leases | Add the TLS data-plane gateway and exercise routed traffic through it |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
-The lifecycle fixture and the managed Sandbox smoke validate opposite sides of
-the architecture. They have not yet been composed into one production path:
-the fixture uses an in-memory repository and fake execution manager, while the
-runtime smoke calls `LocalExecutionManager` directly without the compatibility
-HTTP service or data-plane gateway. Neither result alone is an end-to-end
-compatibility claim, so `full_compatibility=false` remains mandatory.
+The lifecycle control path is now composed and exercised against a real
+Sandbox on A3S OS. That smoke uses HTTP requests rather than the pinned
+official SDKs, and it does not traverse the wildcard TLS or sandbox data-plane
+gateway. The unchanged-client fixture still uses an in-memory repository and
+fake execution manager. These are complementary results rather than the full
+black-box compatibility matrix, so `full_compatibility=false` remains
+mandatory.
 
 ## Executive decision
 

--- a/scripts/e2b-production-smoke.sh
+++ b/scripts/e2b-production-smoke.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Destructive lifecycle smoke for the ACL-configured production service.
+set -euo pipefail
+
+API_KEY="e2b_a1b2c3"
+CREDENTIAL_HASH='pbkdf2-sha256$100000$03030303030303030303030303030303$6ea6a4ae29bedfcdff6890292ff1410b45211268631889c254502776af12ff4d'
+TOKEN_ENCRYPTION="$(printf '07%.0s' {1..32})"
+TOKEN_DIGEST="$(printf '08%.0s' {1..32})"
+PORT="${A3S_BOX_E2B_SMOKE_PORT:-38081}"
+IMAGE="${A3S_BOX_SMOKE_IMAGE:-alpine:3.20}"
+
+fail() {
+  printf 'E2B production smoke failed: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ "${A3S_BOX_E2B_SMOKE:-}" == "1" ]] ||
+  fail 'set A3S_BOX_E2B_SMOKE=1 to acknowledge the destructive smoke test'
+[[ -n "${A3S_HOME:-}" && -d "$A3S_HOME" ]] ||
+  fail 'A3S_HOME must identify a prepared dedicated runtime home'
+[[ "$(basename "$A3S_HOME")" == *e2b-service-smoke* ]] ||
+  fail 'A3S_HOME must have e2b-service-smoke in its final path component'
+[[ -x "${A3S_BOX_E2B_BIN:-}" ]] || fail 'A3S_BOX_E2B_BIN must be executable'
+[[ -x "${A3S_BOX_CRUN_PATH:-}" ]] || fail 'A3S_BOX_CRUN_PATH must be executable'
+[[ "$(realpath "$A3S_BOX_CRUN_PATH")" == "$(realpath "$A3S_HOME/bin/crun")" ]] ||
+  fail 'A3S_BOX_CRUN_PATH must equal A3S_HOME/bin/crun'
+[[ -x "$A3S_HOME/bin/a3s-box-guest-init" ]] || fail 'guest init is missing'
+[[ -x "$A3S_HOME/bin/a3s-box-shim" ]] || fail 'shim is missing'
+[[ "$PORT" =~ ^[0-9]+$ && "$PORT" -gt 0 && "$PORT" -le 65535 ]] ||
+  fail 'A3S_BOX_E2B_SMOKE_PORT must be a valid TCP port'
+
+umask 077
+STATE_DIR="$A3S_HOME/e2b-compat-smoke"
+CONFIG="$STATE_DIR/service.acl"
+LOG="$STATE_DIR/service.log"
+BASE_URL="http://127.0.0.1:$PORT"
+SERVICE_PID=""
+SANDBOX_ID=""
+
+stop_service() {
+  if [[ -n "$SERVICE_PID" ]] && kill -0 "$SERVICE_PID" 2>/dev/null; then
+    kill -TERM "$SERVICE_PID"
+    wait "$SERVICE_PID" || true
+  fi
+  SERVICE_PID=""
+}
+
+wait_ready() {
+  local attempts=0
+  while (( attempts < 100 )); do
+    if curl --silent --show-error --output /dev/null \
+      --header "X-API-Key: $API_KEY" "$BASE_URL/v2/sandboxes"; then
+      return 0
+    fi
+    if [[ -n "$SERVICE_PID" ]] && ! kill -0 "$SERVICE_PID" 2>/dev/null; then
+      printf '%s\n' 'service exited before becoming ready' >&2
+      tail -100 "$LOG" >&2 || true
+      return 1
+    fi
+    attempts=$((attempts + 1))
+    sleep 0.1
+  done
+  printf '%s\n' 'service readiness timed out' >&2
+  tail -100 "$LOG" >&2 || true
+  return 1
+}
+
+start_service() {
+  : >"$LOG"
+  env \
+    A3S_HOME="$A3S_HOME" \
+    A3S_BOX_CRUN_PATH="$A3S_BOX_CRUN_PATH" \
+    TOKEN_ENCRYPTION="$TOKEN_ENCRYPTION" \
+    TOKEN_DIGEST="$TOKEN_DIGEST" \
+    RUST_LOG="a3s_box_compat=info" \
+    "$A3S_BOX_E2B_BIN" --config "$CONFIG" >"$LOG" 2>&1 &
+  SERVICE_PID=$!
+  wait_ready
+}
+
+status_request() {
+  local method="$1"
+  local path="$2"
+  local output="$3"
+  local body="${4:-}"
+  local arguments=(
+    --silent --show-error --output "$output" --write-out '%{http_code}'
+    --request "$method" --header "X-API-Key: $API_KEY"
+  )
+  if [[ -n "$body" ]]; then
+    arguments+=(--header 'Content-Type: application/json' --data "$body")
+  fi
+  curl "${arguments[@]}" "$BASE_URL$path"
+}
+
+json_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    value = json.load(source)
+for component in sys.argv[2].split("."):
+    value = value[component]
+print(value)
+PY
+}
+
+cleanup() {
+  local exit_code=$?
+  trap - EXIT INT TERM
+  set +e
+  if [[ -n "$SANDBOX_ID" ]]; then
+    if [[ -z "$SERVICE_PID" ]] || ! kill -0 "$SERVICE_PID" 2>/dev/null; then
+      start_service >/dev/null 2>&1
+    fi
+    status_request DELETE "/sandboxes/$SANDBOX_ID" /dev/null >/dev/null 2>&1
+  fi
+  stop_service
+  rm -rf "$STATE_DIR"
+  exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+rm -rf "$STATE_DIR"
+mkdir -p "$STATE_DIR"
+cat >"$CONFIG" <<EOF
+e2b_compat {
+  api_listen = "127.0.0.1:$PORT"
+  api_public_url = "$BASE_URL"
+  sandbox_domain = "box.example.com"
+  database_path = "$STATE_DIR/lifecycle.sqlite3"
+  runtime_home = "$A3S_HOME"
+  runtime_state_path = "$STATE_DIR/managed-executions.json"
+
+  supervisor {
+    interval_seconds = 1
+    batch_size = 10
+    reconciliation_page_size = 10
+  }
+
+  account "smoke" {
+    scheme = "api_key"
+    owner_id = "smoke-owner"
+    client_id = "smoke-client"
+    hash = "$CREDENTIAL_HASH"
+  }
+
+  token_key "smoke" {
+    version = 1
+    active = true
+    encryption_key = env("TOKEN_ENCRYPTION")
+    digest_key = env("TOKEN_DIGEST")
+  }
+
+  template_policy "fixture-template" {
+    image = "$IMAGE"
+    envd_version = "0.1.3"
+    isolation = "sandbox"
+    network = "none"
+    command = ["/bin/sh", "-c", "while :; do sleep 60; done"]
+
+    resources {
+      vcpus = 2
+      memory_mb = 512
+      disk_mb = 1024
+    }
+
+    route {
+      port = 49999
+      token_scope = "traffic"
+    }
+  }
+}
+EOF
+
+start_service
+
+CREATE_RESPONSE="$STATE_DIR/create.json"
+CREATE_STATUS="$(status_request POST /sandboxes "$CREATE_RESPONSE" \
+  '{"templateID":"fixture-template","timeout":60,"metadata":{"test":"production-service"},"envVars":{"SMOKE":"true"},"secure":true,"allow_internet_access":false}')"
+[[ "$CREATE_STATUS" == "201" ]] || fail "create returned HTTP $CREATE_STATUS"
+SANDBOX_ID="$(json_field "$CREATE_RESPONSE" sandboxID)"
+[[ "$SANDBOX_ID" == sandbox-* ]] || fail 'create returned an invalid sandbox ID'
+[[ "$(json_field "$CREATE_RESPONSE" domain)" == "box.example.com" ]] ||
+  fail 'create returned the wrong sandbox domain'
+[[ -n "$(json_field "$CREATE_RESPONSE" envdAccessToken)" ]] ||
+  fail 'create omitted the envd access token'
+[[ -n "$(json_field "$CREATE_RESPONSE" trafficAccessToken)" ]] ||
+  fail 'create omitted the traffic access token'
+
+DETAIL_RESPONSE="$STATE_DIR/detail.json"
+[[ "$(status_request GET "/sandboxes/$SANDBOX_ID" "$DETAIL_RESPONSE")" == "200" ]] ||
+  fail 'get did not return HTTP 200'
+[[ "$(json_field "$DETAIL_RESPONSE" state)" == "running" ]] ||
+  fail 'new sandbox is not running'
+
+stop_service
+start_service
+
+[[ "$(status_request GET "/sandboxes/$SANDBOX_ID" "$DETAIL_RESPONSE")" == "200" ]] ||
+  fail 'sandbox was unavailable after service restart'
+[[ "$(json_field "$DETAIL_RESPONSE" state)" == "running" ]] ||
+  fail 'startup reconciliation did not preserve the running sandbox'
+
+CONNECT_RESPONSE="$STATE_DIR/connect.json"
+[[ "$(status_request POST "/sandboxes/$SANDBOX_ID/connect" "$CONNECT_RESPONSE" '{"timeout":45}')" == "200" ]] ||
+  fail 'connect did not return HTTP 200'
+[[ "$(json_field "$CONNECT_RESPONSE" sandboxID)" == "$SANDBOX_ID" ]] ||
+  fail 'connect returned a different sandbox ID'
+
+[[ "$(status_request POST "/sandboxes/$SANDBOX_ID/timeout" /dev/null '{"timeout":30}')" == "204" ]] ||
+  fail 'timeout replacement did not return HTTP 204'
+[[ "$(status_request DELETE "/sandboxes/$SANDBOX_ID" /dev/null)" == "204" ]] ||
+  fail 'kill did not return HTTP 204'
+
+EXECUTION_ID="$(python3 - "$STATE_DIR/managed-executions.json" "$SANDBOX_ID" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    records = json.load(source)
+matches = [
+    record for record in records
+    if record.get("managed_execution", {}).get("request", {}).get("external_sandbox_id") == sys.argv[2]
+]
+if len(matches) != 1:
+    raise SystemExit("managed execution record is missing or ambiguous")
+if matches[0].get("managed_execution", {}).get("state") != "stopped":
+    raise SystemExit("managed execution did not persist stopped state")
+print(matches[0]["id"])
+PY
+)"
+[[ ! -e "$A3S_HOME/boxes/$EXECUTION_ID" ]] || fail 'box directory leaked after kill'
+[[ ! -e "$A3S_HOME/run/crun/$EXECUTION_ID" ]] || fail 'crun state leaked after kill'
+[[ ! -e "/tmp/a3s-box-sockets/$EXECUTION_ID" ]] || fail 'runtime socket directory leaked after kill'
+
+SANDBOX_ID=""
+stop_service
+printf 'E2B production smoke passed: lifecycle, restart recovery, credentials, and cleanup\n'

--- a/scripts/e2b-production-smoke.sh
+++ b/scripts/e2b-production-smoke.sh
@@ -48,7 +48,7 @@ stop_service() {
 wait_ready() {
   local attempts=0
   while (( attempts < 100 )); do
-    if curl --silent --show-error --output /dev/null \
+    if curl --silent --output /dev/null \
       --header "X-API-Key: $API_KEY" "$BASE_URL/v2/sandboxes"; then
       return 0
     fi
@@ -226,7 +226,7 @@ matches = [
 ]
 if len(matches) != 1:
     raise SystemExit("managed execution record is missing or ambiguous")
-if matches[0].get("managed_execution", {}).get("state") != "stopped":
+if matches[0].get("status") != "stopped":
     raise SystemExit("managed execution did not persist stopped state")
 print(matches[0]["id"])
 PY

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3,6 +3,11 @@
 version = 4
 
 [[package]]
+name = "a3s-acl"
+version = "0.2.1"
+source = "git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22#6e2a6469edc0f4c61b1e588d0ace873aaf15ce22"
+
+[[package]]
 name = "a3s-box-cli"
 version = "3.0.9"
 dependencies = [
@@ -38,11 +43,14 @@ dependencies = [
 name = "a3s-box-compat"
 version = "3.0.9"
 dependencies = [
+ "a3s-acl",
  "a3s-box-core",
+ "a3s-box-runtime",
  "anyhow",
  "async-trait",
  "axum",
  "chrono",
+ "clap",
  "hex",
  "hyper 0.14.32",
  "prost",
@@ -57,7 +65,10 @@ dependencies = [
  "tokio",
  "tokio-rusqlite",
  "tower 0.4.13",
+ "tracing",
+ "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/src/compat/Cargo.toml
+++ b/src/compat/Cargo.toml
@@ -8,12 +8,16 @@ repository.workspace = true
 description = "Protocol compatibility service and contract fixtures for A3S Box"
 
 [dependencies]
+a3s-acl = { git = "https://github.com/A3S-Lab/ACL.git", rev = "6e2a6469edc0f4c61b1e588d0ace873aaf15ce22" }
 a3s-box-core = { version = "3.0", path = "../core" }
+a3s-box-runtime = { version = "3.0", path = "../runtime", default-features = false, features = ["vm"] }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }
+clap = { workspace = true }
 hex = { workspace = true }
+hyper = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 ring = { workspace = true }
@@ -25,10 +29,12 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rusqlite = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
-hyper = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 
 [[bin]]
@@ -38,3 +44,7 @@ path = "src/main.rs"
 [[bin]]
 name = "a3s-box-e2b-fixture-server"
 path = "src/bin/a3s-box-e2b-fixture-server.rs"
+
+[[bin]]
+name = "a3s-box-e2b"
+path = "src/bin/a3s-box-e2b.rs"

--- a/src/compat/src/bin/a3s-box-e2b.rs
+++ b/src/compat/src/bin/a3s-box-e2b.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+
+use a3s_box_compat::production::{E2bCompatConfig, E2bCompatService};
+use anyhow::{Context, Result};
+use clap::Parser;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "a3s-box-e2b",
+    version,
+    about = "ACL-configured E2B compatibility service for A3S Box"
+)]
+struct Arguments {
+    /// Production ACL configuration file.
+    #[arg(long, value_name = "PATH")]
+    config: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("a3s-box-e2b failed: {error:#}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<()> {
+    let arguments = Arguments::parse();
+    initialize_tracing()?;
+    let config = E2bCompatConfig::load(&arguments.config)
+        .await
+        .with_context(|| format!("load {}", arguments.config.display()))?;
+    E2bCompatService::build(config)
+        .await
+        .context("compose production service")?
+        .serve()
+        .await
+        .context("run production service")
+}
+
+fn initialize_tracing() -> Result<()> {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("a3s_box_compat=info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .try_init()
+        .context("initialize tracing")
+}

--- a/src/compat/src/bin/a3s-box-e2b.rs
+++ b/src/compat/src/bin/a3s-box-e2b.rs
@@ -45,5 +45,5 @@ fn initialize_tracing() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(filter)
         .try_init()
-        .context("initialize tracing")
+        .map_err(|error| anyhow::anyhow!("initialize tracing: {error}"))
 }

--- a/src/compat/src/lib.rs
+++ b/src/compat/src/lib.rs
@@ -9,6 +9,7 @@ mod proto;
 
 pub mod control;
 pub mod http;
+pub mod production;
 pub mod routing;
 
 pub use fixture::{generate_fixture, verify_fixture, FixturePaths};

--- a/src/compat/src/production/config.rs
+++ b/src/compat/src/production/config.rs
@@ -1,0 +1,842 @@
+use std::collections::BTreeSet;
+use std::fmt;
+use std::net::SocketAddr;
+use std::num::NonZeroU32;
+use std::path::{Component, Path, PathBuf};
+use std::time::Duration;
+
+use a3s_acl::{Block, Document, Value};
+use a3s_box_core::{BoxConfig, ExecutionIsolation, NetworkMode, ResourceConfig};
+use thiserror::Error;
+use url::Url;
+
+use crate::control::{ResolvedTemplate, TokenKeyMaterial, TokenScope};
+use crate::http::{CredentialHash, CredentialScheme, HashedAccountCredential};
+use crate::routing::{SandboxDomain, SandboxRoutePolicy, ENVD_PORT};
+
+use super::StaticTemplateProvider;
+
+const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
+const DEFAULT_MAX_JSON_BYTES: usize = 1024 * 1024;
+const MIN_MAX_JSON_BYTES: usize = 1024;
+const MAX_MAX_JSON_BYTES: usize = 16 * 1024 * 1024;
+const MAX_COMMAND_PARTS: usize = 256;
+const MAX_COMMAND_BYTES: usize = 64 * 1024;
+const TOKEN_KEY_BYTES: usize = 32;
+
+/// Validated service maintenance cadence.
+#[derive(Debug, Clone, Copy)]
+pub struct SupervisorConfig {
+    interval: Duration,
+    batch_size: NonZeroU32,
+    reconciliation_page_size: NonZeroU32,
+}
+
+impl SupervisorConfig {
+    pub const fn interval(self) -> Duration {
+        self.interval
+    }
+
+    pub const fn batch_size(self) -> NonZeroU32 {
+        self.batch_size
+    }
+
+    pub const fn reconciliation_page_size(self) -> NonZeroU32 {
+        self.reconciliation_page_size
+    }
+}
+
+/// Fully resolved ACL configuration. Secret key material is redacted from Debug output.
+pub struct E2bCompatConfig {
+    pub(crate) api_listen: SocketAddr,
+    pub(crate) api_public_url: Url,
+    pub(crate) sandbox_domain: SandboxDomain,
+    pub(crate) database_path: PathBuf,
+    pub(crate) runtime_home: PathBuf,
+    pub(crate) runtime_state_path: PathBuf,
+    pub(crate) max_json_bytes: usize,
+    pub(crate) supervisor: SupervisorConfig,
+    pub(crate) credentials: Vec<HashedAccountCredential>,
+    pub(crate) active_token_version: u32,
+    pub(crate) token_keys: Vec<TokenKeyMaterial>,
+    pub(crate) templates: StaticTemplateProvider,
+}
+
+impl E2bCompatConfig {
+    pub async fn load(path: impl AsRef<Path>) -> E2bConfigResult<Self> {
+        let path = path.as_ref();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("acl") {
+            return Err(E2bConfigError::InvalidExtension(path.to_path_buf()));
+        }
+        let metadata = tokio::fs::metadata(path)
+            .await
+            .map_err(|source| E2bConfigError::Read {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        if metadata.len() > MAX_CONFIG_BYTES {
+            return Err(invalid(format!(
+                "ACL configuration exceeds the {MAX_CONFIG_BYTES}-byte limit"
+            )));
+        }
+        let input =
+            tokio::fs::read_to_string(path)
+                .await
+                .map_err(|source| E2bConfigError::Read {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        if input.len() as u64 > MAX_CONFIG_BYTES {
+            return Err(invalid(format!(
+                "ACL configuration exceeds the {MAX_CONFIG_BYTES}-byte limit"
+            )));
+        }
+        Self::parse_with_environment(&input, |name| std::env::var(name).ok())
+    }
+
+    pub fn parse(input: &str) -> E2bConfigResult<Self> {
+        Self::parse_with_environment(input, |name| std::env::var(name).ok())
+    }
+
+    pub fn api_listen(&self) -> SocketAddr {
+        self.api_listen
+    }
+
+    pub fn api_public_url(&self) -> &Url {
+        &self.api_public_url
+    }
+
+    pub fn sandbox_domain(&self) -> &str {
+        self.sandbox_domain.as_str()
+    }
+
+    pub fn supervisor(&self) -> SupervisorConfig {
+        self.supervisor
+    }
+
+    pub(super) fn parse_with_environment<F>(
+        input: &str,
+        mut environment: F,
+    ) -> E2bConfigResult<Self>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        let document = a3s_acl::parse(input)?;
+        parse_document(document, &mut environment)
+    }
+}
+
+impl fmt::Debug for E2bCompatConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("E2bCompatConfig")
+            .field("api_listen", &self.api_listen)
+            .field("api_public_url", &self.api_public_url)
+            .field("sandbox_domain", &self.sandbox_domain)
+            .field("database_path", &self.database_path)
+            .field("runtime_home", &self.runtime_home)
+            .field("runtime_state_path", &self.runtime_state_path)
+            .field("max_json_bytes", &self.max_json_bytes)
+            .field("supervisor", &self.supervisor)
+            .field("credential_count", &self.credentials.len())
+            .field("active_token_version", &self.active_token_version)
+            .field("token_key_count", &self.token_keys.len())
+            .field("template_count", &self.templates.len())
+            .finish()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum E2bConfigError {
+    #[error("E2B compatibility configuration must use the .acl extension: {0}")]
+    InvalidExtension(PathBuf),
+    #[error("failed to read E2B compatibility ACL configuration {path}: {source}")]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse E2B compatibility ACL configuration: {0}")]
+    Parse(#[from] a3s_acl::ParseError),
+    #[error("invalid E2B compatibility ACL configuration: {0}")]
+    Invalid(String),
+}
+
+pub type E2bConfigResult<T> = std::result::Result<T, E2bConfigError>;
+
+fn parse_document<F>(document: Document, environment: &mut F) -> E2bConfigResult<E2bCompatConfig>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    if document.blocks.len() != 1 || document.blocks[0].name != "e2b_compat" {
+        return Err(invalid(
+            "configuration must contain exactly one e2b_compat block",
+        ));
+    }
+    let root = &document.blocks[0];
+    require_no_labels(root, "e2b_compat")?;
+    ensure_shape(
+        root,
+        &[
+            "api_listen",
+            "api_public_url",
+            "sandbox_domain",
+            "database_path",
+            "runtime_home",
+            "runtime_state_path",
+            "max_json_bytes",
+        ],
+        &["supervisor", "account", "token_key", "template_policy"],
+        "e2b_compat",
+    )?;
+
+    let api_listen = required_string(root, "api_listen", "e2b_compat")?
+        .parse::<SocketAddr>()
+        .map_err(|_| invalid("e2b_compat.api_listen must be an IP socket address"))?;
+    if api_listen.port() == 0 {
+        return Err(invalid("e2b_compat.api_listen port must be non-zero"));
+    }
+    let api_public_url = parse_public_url(required_string(root, "api_public_url", "e2b_compat")?)?;
+    let sandbox_domain = SandboxDomain::new(required_string(root, "sandbox_domain", "e2b_compat")?)
+        .map_err(|error| invalid(format!("e2b_compat.sandbox_domain: {error}")))?;
+    let database_path = required_absolute_path(root, "database_path", "e2b_compat")?;
+    let runtime_home = required_absolute_path(root, "runtime_home", "e2b_compat")?;
+    let runtime_state_path = required_absolute_path(root, "runtime_state_path", "e2b_compat")?;
+    if database_path == runtime_state_path {
+        return Err(invalid(
+            "database_path and runtime_state_path must identify different files",
+        ));
+    }
+    let max_json_bytes =
+        optional_usize(root, "max_json_bytes", "e2b_compat")?.unwrap_or(DEFAULT_MAX_JSON_BYTES);
+    if !(MIN_MAX_JSON_BYTES..=MAX_MAX_JSON_BYTES).contains(&max_json_bytes) {
+        return Err(invalid(format!(
+            "e2b_compat.max_json_bytes must be between {MIN_MAX_JSON_BYTES} and {MAX_MAX_JSON_BYTES}"
+        )));
+    }
+
+    let supervisor = parse_supervisor(single_child(root, "supervisor", "e2b_compat")?)?;
+    let credentials = parse_credentials(children(root, "account"))?;
+    let (active_token_version, token_keys) =
+        parse_token_keys(children(root, "token_key"), environment)?;
+    let templates =
+        StaticTemplateProvider::new(parse_templates(children(root, "template_policy"))?)
+            .map_err(|error| invalid(error.to_string()))?;
+
+    Ok(E2bCompatConfig {
+        api_listen,
+        api_public_url,
+        sandbox_domain,
+        database_path,
+        runtime_home,
+        runtime_state_path,
+        max_json_bytes,
+        supervisor,
+        credentials,
+        active_token_version,
+        token_keys,
+        templates,
+    })
+}
+
+fn parse_public_url(value: String) -> E2bConfigResult<Url> {
+    let url = Url::parse(&value)
+        .map_err(|_| invalid("e2b_compat.api_public_url must be an absolute HTTP(S) URL"))?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(invalid(
+            "e2b_compat.api_public_url must be an HTTP(S) origin without credentials, query, or fragment",
+        ));
+    }
+    Ok(url)
+}
+
+fn parse_supervisor(block: &Block) -> E2bConfigResult<SupervisorConfig> {
+    require_no_labels(block, "e2b_compat.supervisor")?;
+    ensure_shape(
+        block,
+        &["interval_seconds", "batch_size", "reconciliation_page_size"],
+        &[],
+        "e2b_compat.supervisor",
+    )?;
+    let interval_seconds = required_u64(block, "interval_seconds", "e2b_compat.supervisor")?;
+    if !(1..=3600).contains(&interval_seconds) {
+        return Err(invalid(
+            "e2b_compat.supervisor.interval_seconds must be between 1 and 3600",
+        ));
+    }
+    let batch_size = required_nonzero_u32(block, "batch_size", "e2b_compat.supervisor")?;
+    let reconciliation_page_size =
+        required_nonzero_u32(block, "reconciliation_page_size", "e2b_compat.supervisor")?;
+    if batch_size.get() > 10_000 || reconciliation_page_size.get() > 10_000 {
+        return Err(invalid(
+            "supervisor batch sizes cannot exceed 10000 records",
+        ));
+    }
+    Ok(SupervisorConfig {
+        interval: Duration::from_secs(interval_seconds),
+        batch_size,
+        reconciliation_page_size,
+    })
+}
+
+fn parse_credentials(blocks: Vec<&Block>) -> E2bConfigResult<Vec<HashedAccountCredential>> {
+    if blocks.is_empty() {
+        return Err(invalid("at least one account block is required"));
+    }
+    let mut labels = BTreeSet::new();
+    let mut identities = BTreeSet::new();
+    let mut credentials = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        let label = single_label(block, "e2b_compat.account")?;
+        if !labels.insert(label.to_string()) {
+            return Err(invalid(format!(
+                "account label {label:?} is configured more than once"
+            )));
+        }
+        let context = format!("e2b_compat.account[{label}]");
+        ensure_shape(
+            block,
+            &["scheme", "owner_id", "client_id", "hash"],
+            &[],
+            &context,
+        )?;
+        let scheme_name = required_string(block, "scheme", &context)?;
+        let scheme = match scheme_name.as_str() {
+            "api_key" => CredentialScheme::ApiKey,
+            "bearer" => CredentialScheme::Bearer,
+            "supabase" => CredentialScheme::Supabase,
+            _ => {
+                return Err(invalid(format!(
+                    "{context}.scheme must be api_key, bearer, or supabase"
+                )))
+            }
+        };
+        let owner_id = required_nonempty_string(block, "owner_id", &context, 128)?;
+        let client_id = required_nonempty_string(block, "client_id", &context, 128)?;
+        if !identities.insert((scheme_name, client_id.clone())) {
+            return Err(invalid(format!(
+                "credential scheme and client ID are duplicated in {context}"
+            )));
+        }
+        let hash = required_string(block, "hash", &context)?
+            .parse::<CredentialHash>()
+            .map_err(|error| invalid(format!("{context}.hash: {error}")))?;
+        credentials.push(
+            HashedAccountCredential::new(scheme, owner_id, client_id, hash)
+                .map_err(|error| invalid(format!("{context}: {error}")))?,
+        );
+    }
+    Ok(credentials)
+}
+
+fn parse_token_keys<F>(
+    blocks: Vec<&Block>,
+    environment: &mut F,
+) -> E2bConfigResult<(u32, Vec<TokenKeyMaterial>)>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    if blocks.is_empty() {
+        return Err(invalid("at least one token_key block is required"));
+    }
+    let mut labels = BTreeSet::new();
+    let mut versions = BTreeSet::new();
+    let mut active_version = None;
+    let mut materials = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        let label = single_label(block, "e2b_compat.token_key")?;
+        if !labels.insert(label.to_string()) {
+            return Err(invalid(format!(
+                "token key label {label:?} is configured more than once"
+            )));
+        }
+        let context = format!("e2b_compat.token_key[{label}]");
+        ensure_shape(
+            block,
+            &["version", "active", "encryption_key", "digest_key"],
+            &[],
+            &context,
+        )?;
+        let version = required_u32(block, "version", &context)?;
+        if version == 0 || !versions.insert(version) {
+            return Err(invalid(format!(
+                "{context}.version must be unique and greater than zero"
+            )));
+        }
+        if required_bool(block, "active", &context)? {
+            if active_version.replace(version).is_some() {
+                return Err(invalid("exactly one token key can be active"));
+            }
+        }
+        let encryption = required_environment_key(block, "encryption_key", &context, environment)?;
+        let digest = required_environment_key(block, "digest_key", &context, environment)?;
+        if encryption == digest {
+            return Err(invalid(format!(
+                "{context} must use independent encryption and digest keys"
+            )));
+        }
+        materials.push(
+            TokenKeyMaterial::new(version, &encryption, &digest)
+                .map_err(|error| invalid(format!("{context}: {error}")))?,
+        );
+    }
+    let active_version = active_version.ok_or_else(|| invalid("one token key must be active"))?;
+    Ok((active_version, materials))
+}
+
+fn required_environment_key<F>(
+    block: &Block,
+    field: &str,
+    context: &str,
+    environment: &mut F,
+) -> E2bConfigResult<[u8; TOKEN_KEY_BYTES]>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let value = required_value(block, field, context)?;
+    let variable = match value {
+        Value::Call(name, arguments)
+            if name == "env"
+                && arguments.len() == 1
+                && matches!(&arguments[0], Value::String(_)) =>
+        {
+            arguments[0].as_str().unwrap_or_default()
+        }
+        _ => {
+            return Err(invalid(format!(
+                "{context}.{field} must use env(\"VARIABLE\")"
+            )))
+        }
+    };
+    if !valid_environment_name(variable) {
+        return Err(invalid(format!(
+            "{context}.{field} references an invalid environment variable name"
+        )));
+    }
+    let encoded = environment(variable).ok_or_else(|| {
+        invalid(format!(
+            "environment variable {variable} required by {context}.{field} is unavailable"
+        ))
+    })?;
+    let decoded = hex::decode(encoded).map_err(|_| {
+        invalid(format!(
+            "environment variable {variable} must contain a 32-byte hexadecimal key"
+        ))
+    })?;
+    decoded.try_into().map_err(|_| {
+        invalid(format!(
+            "environment variable {variable} must contain a 32-byte hexadecimal key"
+        ))
+    })
+}
+
+fn valid_environment_name(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 128
+        && (bytes[0].is_ascii_uppercase() || bytes[0] == b'_')
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || *byte == b'_')
+}
+
+fn parse_templates(blocks: Vec<&Block>) -> E2bConfigResult<Vec<(String, ResolvedTemplate)>> {
+    if blocks.is_empty() {
+        return Err(invalid("at least one template_policy block is required"));
+    }
+    let mut labels = BTreeSet::new();
+    let mut templates = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        let template_id = single_label(block, "e2b_compat.template_policy")?.to_string();
+        if !labels.insert(template_id.clone()) {
+            return Err(invalid(format!(
+                "template policy {template_id:?} is configured more than once"
+            )));
+        }
+        let context = format!("e2b_compat.template_policy[{template_id}]");
+        ensure_shape(
+            block,
+            &[
+                "image",
+                "envd_version",
+                "isolation",
+                "network",
+                "command",
+                "entrypoint",
+                "user",
+                "workdir",
+                "read_only",
+                "stdin_open",
+            ],
+            &["resources", "route"],
+            &context,
+        )?;
+
+        let image = required_nonempty_string(block, "image", &context, 512)?;
+        if image.chars().any(char::is_whitespace) {
+            return Err(invalid(format!(
+                "{context}.image cannot contain whitespace"
+            )));
+        }
+        let envd_version = required_nonempty_string(block, "envd_version", &context, 128)?;
+        let isolation = match optional_string(block, "isolation", &context)?.as_deref() {
+            None => ExecutionIsolation::Microvm,
+            Some("sandbox") => ExecutionIsolation::Sandbox,
+            Some(_) => {
+                return Err(invalid(format!(
+                "{context}.isolation accepts only the explicit value sandbox; omit it for MicroVM"
+            )))
+            }
+        };
+        let network = match optional_string(block, "network", &context)?.as_deref() {
+            None | Some("tsi") => NetworkMode::Tsi,
+            Some("none") => NetworkMode::None,
+            Some(_) => return Err(invalid(format!("{context}.network must be tsi or none"))),
+        };
+        let resources_block = single_child(block, "resources", &context)?;
+        let resources = parse_resources(resources_block, &context)?;
+        let command = optional_string_list(block, "command", &context)?.unwrap_or_default();
+        let entrypoint_override = optional_string_list(block, "entrypoint", &context)?;
+        if entrypoint_override.as_ref().is_some_and(Vec::is_empty) {
+            return Err(invalid(format!("{context}.entrypoint cannot be empty")));
+        }
+        let user = optional_nonempty_string(block, "user", &context, 128)?;
+        let workdir = optional_nonempty_string(block, "workdir", &context, 4096)?;
+        let read_only = optional_bool(block, "read_only", &context)?.unwrap_or(false);
+        let stdin_open = optional_bool(block, "stdin_open", &context)?.unwrap_or(false);
+        let routing = parse_routes(children(block, "route"), &context)?;
+
+        templates.push((
+            template_id,
+            ResolvedTemplate {
+                config: BoxConfig {
+                    isolation,
+                    image,
+                    resources,
+                    cmd: command,
+                    entrypoint_override,
+                    user,
+                    workdir,
+                    network,
+                    read_only,
+                    stdin_open,
+                    ..BoxConfig::default()
+                },
+                envd_version,
+                routing,
+            },
+        ));
+    }
+    Ok(templates)
+}
+
+fn parse_resources(block: &Block, parent: &str) -> E2bConfigResult<ResourceConfig> {
+    let context = format!("{parent}.resources");
+    require_no_labels(block, &context)?;
+    ensure_shape(block, &["vcpus", "memory_mb", "disk_mb"], &[], &context)?;
+    let vcpus = required_u32(block, "vcpus", &context)?;
+    let memory_mb = required_u32(block, "memory_mb", &context)?;
+    let disk_mb = required_u32(block, "disk_mb", &context)?;
+    if vcpus == 0 || vcpus > 256 {
+        return Err(invalid(format!(
+            "{context}.vcpus must be between 1 and 256"
+        )));
+    }
+    if memory_mb < 16 {
+        return Err(invalid(format!("{context}.memory_mb must be at least 16")));
+    }
+    if disk_mb == 0 {
+        return Err(invalid(format!(
+            "{context}.disk_mb must be greater than zero"
+        )));
+    }
+    Ok(ResourceConfig {
+        vcpus,
+        memory_mb,
+        disk_mb,
+        timeout: ResourceConfig::default().timeout,
+    })
+}
+
+fn parse_routes(blocks: Vec<&Block>, parent: &str) -> E2bConfigResult<SandboxRoutePolicy> {
+    let mut ports = Vec::with_capacity(blocks.len() + 1);
+    for (index, block) in blocks.into_iter().enumerate() {
+        let context = format!("{parent}.route[{index}]");
+        require_no_labels(block, &context)?;
+        ensure_shape(block, &["port", "token_scope"], &[], &context)?;
+        let port = required_u16(block, "port", &context)?;
+        if port == 0 {
+            return Err(invalid(format!("{context}.port must be non-zero")));
+        }
+        let scope = match required_string(block, "token_scope", &context)?.as_str() {
+            "envd" => TokenScope::Envd,
+            "traffic" => TokenScope::Traffic,
+            _ => {
+                return Err(invalid(format!(
+                    "{context}.token_scope must be envd or traffic"
+                )))
+            }
+        };
+        ports.push((port, scope));
+    }
+    if !ports.iter().any(|(port, _)| *port == ENVD_PORT) {
+        ports.push((ENVD_PORT, TokenScope::Envd));
+    }
+    SandboxRoutePolicy::new(ports)
+        .map_err(|error| invalid(format!("{parent} has an invalid route policy: {error}")))
+}
+
+fn ensure_shape(
+    block: &Block,
+    attributes: &[&str],
+    child_blocks: &[&str],
+    context: &str,
+) -> E2bConfigResult<()> {
+    for attribute in block.attributes.keys() {
+        if !attributes.contains(&attribute.as_str()) {
+            return Err(invalid(format!(
+                "{context} contains unknown attribute {attribute}"
+            )));
+        }
+    }
+    for child in &block.blocks {
+        if !child_blocks.contains(&child.name.as_str()) {
+            return Err(invalid(format!(
+                "{context} contains unknown block {}",
+                child.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn children<'a>(block: &'a Block, name: &str) -> Vec<&'a Block> {
+    block
+        .blocks
+        .iter()
+        .filter(|child| child.name == name)
+        .collect()
+}
+
+fn single_child<'a>(block: &'a Block, name: &str, context: &str) -> E2bConfigResult<&'a Block> {
+    let matches = children(block, name);
+    match matches.as_slice() {
+        [child] => Ok(child),
+        [] => Err(invalid(format!("{context}.{name} block is required"))),
+        _ => Err(invalid(format!(
+            "{context} can contain only one {name} block"
+        ))),
+    }
+}
+
+fn require_no_labels(block: &Block, context: &str) -> E2bConfigResult<()> {
+    if block.labels.is_empty() {
+        Ok(())
+    } else {
+        Err(invalid(format!("{context} does not accept block labels")))
+    }
+}
+
+fn single_label<'a>(block: &'a Block, context: &str) -> E2bConfigResult<&'a str> {
+    match block.labels.as_slice() {
+        [label] if !label.trim().is_empty() && label.len() <= 128 => Ok(label),
+        _ => Err(invalid(format!(
+            "{context} requires exactly one non-empty string label"
+        ))),
+    }
+}
+
+fn required_value<'a>(block: &'a Block, field: &str, context: &str) -> E2bConfigResult<&'a Value> {
+    block
+        .attributes
+        .get(field)
+        .ok_or_else(|| invalid(format!("{context}.{field} is required")))
+}
+
+fn required_string(block: &Block, field: &str, context: &str) -> E2bConfigResult<String> {
+    match required_value(block, field, context)? {
+        Value::String(value) => Ok(value.clone()),
+        _ => Err(invalid(format!("{context}.{field} must be a string"))),
+    }
+}
+
+fn optional_string(block: &Block, field: &str, context: &str) -> E2bConfigResult<Option<String>> {
+    block
+        .attributes
+        .get(field)
+        .map(|value| match value {
+            Value::String(value) => Ok(value.clone()),
+            _ => Err(invalid(format!("{context}.{field} must be a string"))),
+        })
+        .transpose()
+}
+
+fn required_nonempty_string(
+    block: &Block,
+    field: &str,
+    context: &str,
+    max_bytes: usize,
+) -> E2bConfigResult<String> {
+    let value = required_string(block, field, context)?;
+    validate_nonempty_string(value, field, context, max_bytes)
+}
+
+fn optional_nonempty_string(
+    block: &Block,
+    field: &str,
+    context: &str,
+    max_bytes: usize,
+) -> E2bConfigResult<Option<String>> {
+    optional_string(block, field, context)?
+        .map(|value| validate_nonempty_string(value, field, context, max_bytes))
+        .transpose()
+}
+
+fn validate_nonempty_string(
+    value: String,
+    field: &str,
+    context: &str,
+    max_bytes: usize,
+) -> E2bConfigResult<String> {
+    if value.trim().is_empty() || value.len() > max_bytes || value.contains('\0') {
+        Err(invalid(format!(
+            "{context}.{field} must be non-empty and no more than {max_bytes} bytes"
+        )))
+    } else {
+        Ok(value)
+    }
+}
+
+fn required_bool(block: &Block, field: &str, context: &str) -> E2bConfigResult<bool> {
+    match required_value(block, field, context)? {
+        Value::Bool(value) => Ok(*value),
+        _ => Err(invalid(format!("{context}.{field} must be a boolean"))),
+    }
+}
+
+fn optional_bool(block: &Block, field: &str, context: &str) -> E2bConfigResult<Option<bool>> {
+    block
+        .attributes
+        .get(field)
+        .map(|value| match value {
+            Value::Bool(value) => Ok(*value),
+            _ => Err(invalid(format!("{context}.{field} must be a boolean"))),
+        })
+        .transpose()
+}
+
+fn required_u64(block: &Block, field: &str, context: &str) -> E2bConfigResult<u64> {
+    number_as_u64(required_value(block, field, context)?, field, context)
+}
+
+fn required_u32(block: &Block, field: &str, context: &str) -> E2bConfigResult<u32> {
+    let value = required_u64(block, field, context)?;
+    u32::try_from(value).map_err(|_| invalid(format!("{context}.{field} exceeds the u32 range")))
+}
+
+fn required_u16(block: &Block, field: &str, context: &str) -> E2bConfigResult<u16> {
+    let value = required_u64(block, field, context)?;
+    u16::try_from(value)
+        .map_err(|_| invalid(format!("{context}.{field} exceeds the TCP port range")))
+}
+
+fn required_nonzero_u32(block: &Block, field: &str, context: &str) -> E2bConfigResult<NonZeroU32> {
+    NonZeroU32::new(required_u32(block, field, context)?)
+        .ok_or_else(|| invalid(format!("{context}.{field} must be greater than zero")))
+}
+
+fn optional_usize(block: &Block, field: &str, context: &str) -> E2bConfigResult<Option<usize>> {
+    block
+        .attributes
+        .get(field)
+        .map(|value| {
+            let value = number_as_u64(value, field, context)?;
+            usize::try_from(value)
+                .map_err(|_| invalid(format!("{context}.{field} exceeds the platform range")))
+        })
+        .transpose()
+}
+
+fn number_as_u64(value: &Value, field: &str, context: &str) -> E2bConfigResult<u64> {
+    match value {
+        Value::Number(value)
+            if value.is_finite()
+                && *value >= 0.0
+                && value.fract() == 0.0
+                && *value <= u64::MAX as f64 =>
+        {
+            Ok(*value as u64)
+        }
+        _ => Err(invalid(format!(
+            "{context}.{field} must be a non-negative integer"
+        ))),
+    }
+}
+
+fn optional_string_list(
+    block: &Block,
+    field: &str,
+    context: &str,
+) -> E2bConfigResult<Option<Vec<String>>> {
+    let Some(value) = block.attributes.get(field) else {
+        return Ok(None);
+    };
+    let Value::List(values) = value else {
+        return Err(invalid(format!(
+            "{context}.{field} must be a list of strings"
+        )));
+    };
+    if values.len() > MAX_COMMAND_PARTS {
+        return Err(invalid(format!(
+            "{context}.{field} cannot contain more than {MAX_COMMAND_PARTS} entries"
+        )));
+    }
+    let mut total_bytes = 0usize;
+    let mut strings = Vec::with_capacity(values.len());
+    for value in values {
+        let Value::String(value) = value else {
+            return Err(invalid(format!(
+                "{context}.{field} must contain only strings"
+            )));
+        };
+        if value.contains('\0') {
+            return Err(invalid(format!(
+                "{context}.{field} cannot contain NUL bytes"
+            )));
+        }
+        total_bytes = total_bytes
+            .checked_add(value.len())
+            .ok_or_else(|| invalid(format!("{context}.{field} is too large")))?;
+        strings.push(value.clone());
+    }
+    if total_bytes > MAX_COMMAND_BYTES {
+        return Err(invalid(format!(
+            "{context}.{field} cannot exceed {MAX_COMMAND_BYTES} bytes"
+        )));
+    }
+    Ok(Some(strings))
+}
+
+fn required_absolute_path(block: &Block, field: &str, context: &str) -> E2bConfigResult<PathBuf> {
+    let path = PathBuf::from(required_nonempty_string(block, field, context, 4096)?);
+    if !path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+    {
+        return Err(invalid(format!(
+            "{context}.{field} must be an absolute normalized path"
+        )));
+    }
+    Ok(path)
+}
+
+fn invalid(message: impl Into<String>) -> E2bConfigError {
+    E2bConfigError::Invalid(message.into())
+}

--- a/src/compat/src/production/config.rs
+++ b/src/compat/src/production/config.rs
@@ -369,10 +369,8 @@ where
                 "{context}.version must be unique and greater than zero"
             )));
         }
-        if required_bool(block, "active", &context)? {
-            if active_version.replace(version).is_some() {
-                return Err(invalid("exactly one token key can be active"));
-            }
+        if required_bool(block, "active", &context)? && active_version.replace(version).is_some() {
+            return Err(invalid("exactly one token key can be active"));
         }
         let encryption = required_environment_key(block, "encryption_key", &context, environment)?;
         let digest = required_environment_key(block, "digest_key", &context, environment)?;

--- a/src/compat/src/production/identity.rs
+++ b/src/compat/src/production/identity.rs
@@ -1,0 +1,30 @@
+use a3s_box_core::OperationId;
+use uuid::Uuid;
+
+use crate::control::{
+    IdentityProviderError, IdentityProviderResult, SandboxId, SandboxIdentity,
+    SandboxIdentityProvider,
+};
+
+/// Generates externally safe sandbox IDs and independent lifecycle operation IDs.
+#[derive(Debug, Default)]
+pub struct UuidSandboxIdentityProvider;
+
+impl SandboxIdentityProvider for UuidSandboxIdentityProvider {
+    fn next_identity(&self) -> IdentityProviderResult<SandboxIdentity> {
+        let sandbox_uuid = Uuid::new_v4();
+        let operation_uuid = Uuid::new_v4();
+        let sandbox_id = SandboxId::new(format!("sandbox-{sandbox_uuid}"))
+            .map_err(|error| unavailable(error.to_string()))?;
+        let operation_id = OperationId::new(format!("e2b-create-{operation_uuid}"))
+            .map_err(|error| unavailable(error.to_string()))?;
+        Ok(SandboxIdentity {
+            sandbox_id,
+            operation_id,
+        })
+    }
+}
+
+fn unavailable(message: String) -> IdentityProviderError {
+    IdentityProviderError::Unavailable(message)
+}

--- a/src/compat/src/production/mod.rs
+++ b/src/compat/src/production/mod.rs
@@ -1,0 +1,14 @@
+//! ACL-configured production composition for the E2B compatibility service.
+
+mod config;
+mod identity;
+mod service;
+mod template;
+
+pub use config::{E2bCompatConfig, E2bConfigError, E2bConfigResult, SupervisorConfig};
+pub use identity::UuidSandboxIdentityProvider;
+pub use service::{E2bCompatService, E2bServiceError, E2bServiceResult};
+pub use template::StaticTemplateProvider;
+
+#[cfg(test)]
+mod tests;

--- a/src/compat/src/production/service.rs
+++ b/src/compat/src/production/service.rs
@@ -321,7 +321,7 @@ pub enum E2bServiceError {
         source: std::io::Error,
     },
     #[error("failed to create E2B compatibility listener: {0}")]
-    Listener(#[source] std::io::Error),
+    Listener(#[source] hyper::Error),
     #[error("E2B compatibility HTTP server failed: {0}")]
     Server(#[source] hyper::Error),
     #[error("failed to install or receive the shutdown signal: {0}")]

--- a/src/compat/src/production/service.rs
+++ b/src/compat/src/production/service.rs
@@ -1,0 +1,341 @@
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use a3s_box_core::ExecutionManager;
+use a3s_box_runtime::LocalExecutionManager;
+use axum::Router;
+use thiserror::Error;
+use tokio::sync::watch;
+use tokio::time::{self, MissedTickBehavior};
+use tracing::{error, info, warn};
+use url::Url;
+
+use crate::control::{
+    ControlService, ControlServiceDependencies, LifecycleMaintenanceReport, LifecycleSupervisor,
+    LifecycleSupervisorDependencies, LifecycleSupervisorError, RepositoryError,
+    RotatingTokenProvider, SandboxRepository, SqliteSandboxRepository, SystemClock,
+    TokenIssuerError,
+};
+use crate::http::{
+    lifecycle_router, CredentialHashError, HashedCredentialVerifier, LifecycleHttpConfig,
+    LifecycleHttpState, RejectingCursorDecoder,
+};
+use crate::routing::{RouteLeaseService, SandboxRouteParser};
+
+use super::{E2bCompatConfig, SupervisorConfig, UuidSandboxIdentityProvider};
+
+/// Production service with one canonical lifecycle store and runtime manager.
+pub struct E2bCompatService {
+    listen: SocketAddr,
+    public_url: Url,
+    sandbox_domain: String,
+    router: Router,
+    supervisor: LifecycleSupervisor,
+    supervisor_config: SupervisorConfig,
+    route_parser: SandboxRouteParser,
+    route_leases: RouteLeaseService,
+}
+
+impl E2bCompatService {
+    pub async fn build(config: E2bCompatConfig) -> E2bServiceResult<Self> {
+        prepare_directory(&config.runtime_home).await?;
+        prepare_parent(&config.database_path).await?;
+        prepare_parent(&config.runtime_state_path).await?;
+
+        let repository = Arc::new(SqliteSandboxRepository::open(&config.database_path).await?);
+        let executions: Arc<dyn ExecutionManager> =
+            Arc::new(LocalExecutionManager::with_vm_backend(
+                &config.runtime_state_path,
+                &config.runtime_home,
+            ));
+        let clock = Arc::new(SystemClock);
+        let tokens = Arc::new(RotatingTokenProvider::new(
+            config.active_token_version,
+            config.token_keys,
+        )?);
+        let verifier = Arc::new(HashedCredentialVerifier::new(config.credentials)?);
+        let templates = Arc::new(config.templates);
+
+        let control = Arc::new(ControlService::new(ControlServiceDependencies {
+            repository: repository.clone(),
+            executions: executions.clone(),
+            clock: clock.clone(),
+            identities: Arc::new(UuidSandboxIdentityProvider),
+            templates,
+            token_issuer: tokens.clone(),
+            token_resolver: tokens.clone(),
+        }));
+        let supervisor = LifecycleSupervisor::new(LifecycleSupervisorDependencies {
+            repository: repository.clone(),
+            executions,
+            clock: clock.clone(),
+        });
+        let route_parser = SandboxRouteParser::new(config.sandbox_domain.clone());
+        let route_leases =
+            RouteLeaseService::new(repository as Arc<dyn SandboxRepository>, tokens, clock);
+        let sandbox_domain = config.sandbox_domain.as_str().to_string();
+        let router = lifecycle_router(LifecycleHttpState::new(
+            control,
+            verifier,
+            Arc::new(RejectingCursorDecoder),
+            LifecycleHttpConfig {
+                domain: Some(sandbox_domain.clone()),
+                max_json_bytes: config.max_json_bytes,
+            },
+        ));
+
+        Ok(Self {
+            listen: config.api_listen,
+            public_url: config.api_public_url,
+            sandbox_domain,
+            router,
+            supervisor,
+            supervisor_config: config.supervisor,
+            route_parser,
+            route_leases,
+        })
+    }
+
+    pub fn listen(&self) -> SocketAddr {
+        self.listen
+    }
+
+    pub fn public_url(&self) -> &Url {
+        &self.public_url
+    }
+
+    pub fn sandbox_domain(&self) -> &str {
+        &self.sandbox_domain
+    }
+
+    pub fn router(&self) -> Router {
+        self.router.clone()
+    }
+
+    pub fn route_parser(&self) -> &SandboxRouteParser {
+        &self.route_parser
+    }
+
+    pub fn route_leases(&self) -> &RouteLeaseService {
+        &self.route_leases
+    }
+
+    pub async fn reconcile_startup(&self) -> E2bServiceResult<LifecycleMaintenanceReport> {
+        Ok(self
+            .supervisor
+            .reconcile_startup(self.supervisor_config.reconciliation_page_size())
+            .await?)
+    }
+
+    pub async fn serve(self) -> E2bServiceResult<()> {
+        let listener = tokio::net::TcpListener::bind(self.listen)
+            .await
+            .map_err(|source| E2bServiceError::Bind {
+                address: self.listen,
+                source,
+            })?;
+        let local_address = listener
+            .local_addr()
+            .map_err(|source| E2bServiceError::Bind {
+                address: self.listen,
+                source,
+            })?;
+        let listener = listener
+            .into_std()
+            .map_err(|source| E2bServiceError::Bind {
+                address: self.listen,
+                source,
+            })?;
+        let (shutdown_sender, shutdown_receiver) = watch::channel(false);
+        let supervisor = self.supervisor.clone();
+        let supervisor_config = self.supervisor_config;
+        let mut maintenance = tokio::spawn(run_maintenance(
+            supervisor,
+            supervisor_config,
+            shutdown_receiver.clone(),
+        ));
+        let mut server = Box::pin(
+            axum::Server::from_tcp(listener)
+                .map_err(E2bServiceError::Listener)?
+                .serve(self.router.into_make_service())
+                .with_graceful_shutdown(wait_for_shutdown(shutdown_receiver)),
+        );
+
+        info!(
+            listen = %local_address,
+            public_url = %self.public_url,
+            sandbox_domain = %self.sandbox_domain,
+            "E2B compatibility service started"
+        );
+
+        tokio::select! {
+            signal = shutdown_signal() => {
+                signal?;
+                info!("shutdown signal received");
+                request_shutdown(&shutdown_sender);
+                server.await.map_err(E2bServiceError::Server)?;
+                join_maintenance(maintenance.await)?
+            }
+            server_result = &mut server => {
+                request_shutdown(&shutdown_sender);
+                let maintenance_result = maintenance.await;
+                server_result.map_err(E2bServiceError::Server)?;
+                join_maintenance(maintenance_result)?
+            }
+            maintenance_result = &mut maintenance => {
+                request_shutdown(&shutdown_sender);
+                server.await.map_err(E2bServiceError::Server)?;
+                join_maintenance(maintenance_result)?
+            }
+        }
+        info!("E2B compatibility service stopped");
+        Ok(())
+    }
+}
+
+async fn run_maintenance(
+    supervisor: LifecycleSupervisor,
+    config: SupervisorConfig,
+    mut shutdown: watch::Receiver<bool>,
+) -> E2bServiceResult<()> {
+    let report = supervisor
+        .reconcile_startup(config.reconciliation_page_size())
+        .await?;
+    log_report("startup reconciliation", &report);
+
+    let start = time::Instant::now() + config.interval();
+    let mut interval = time::interval_at(start, config.interval());
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    return Ok(());
+                }
+            }
+            _ = interval.tick() => {
+                let report = supervisor.reap_expired(config.batch_size()).await?;
+                log_report("expiry maintenance", &report);
+            }
+        }
+    }
+}
+
+fn log_report(operation: &str, report: &LifecycleMaintenanceReport) {
+    if report.failures.is_empty() {
+        info!(
+            operation,
+            examined = report.examined,
+            completed = report.completed,
+            deferred = report.deferred,
+            "lifecycle maintenance completed"
+        );
+        return;
+    }
+    warn!(
+        operation,
+        examined = report.examined,
+        completed = report.completed,
+        deferred = report.deferred,
+        failures = report.failures.len(),
+        "lifecycle maintenance completed with isolated record failures"
+    );
+    for failure in &report.failures {
+        error!(
+            operation,
+            sandbox_id = %failure.sandbox_id,
+            message = %failure.message,
+            "lifecycle record maintenance failed"
+        );
+    }
+}
+
+async fn prepare_parent(path: &Path) -> E2bServiceResult<()> {
+    let parent = path.parent().ok_or_else(|| E2bServiceError::InvalidPath {
+        path: path.to_path_buf(),
+    })?;
+    prepare_directory(parent).await
+}
+
+async fn prepare_directory(path: &Path) -> E2bServiceResult<()> {
+    tokio::fs::create_dir_all(path)
+        .await
+        .map_err(|source| E2bServiceError::CreateDirectory {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+async fn wait_for_shutdown(mut shutdown: watch::Receiver<bool>) {
+    while !*shutdown.borrow() {
+        if shutdown.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+fn request_shutdown(sender: &watch::Sender<bool>) {
+    let _ = sender.send(true);
+}
+
+fn join_maintenance(
+    result: Result<E2bServiceResult<()>, tokio::task::JoinError>,
+) -> E2bServiceResult<()> {
+    result.map_err(E2bServiceError::MaintenanceTask)?
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() -> E2bServiceResult<()> {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut terminate = signal(SignalKind::terminate()).map_err(E2bServiceError::Signal)?;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => result.map_err(E2bServiceError::Signal)?,
+        _ = terminate.recv() => {},
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() -> E2bServiceResult<()> {
+    tokio::signal::ctrl_c()
+        .await
+        .map_err(E2bServiceError::Signal)
+}
+
+#[derive(Debug, Error)]
+pub enum E2bServiceError {
+    #[error("invalid service state path: {path}")]
+    InvalidPath { path: PathBuf },
+    #[error("failed to create service directory {path}: {source}")]
+    CreateDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to bind E2B compatibility listener {address}: {source}")]
+    Bind {
+        address: SocketAddr,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to create E2B compatibility listener: {0}")]
+    Listener(#[source] std::io::Error),
+    #[error("E2B compatibility HTTP server failed: {0}")]
+    Server(#[source] hyper::Error),
+    #[error("failed to install or receive the shutdown signal: {0}")]
+    Signal(#[source] std::io::Error),
+    #[error("lifecycle maintenance task failed: {0}")]
+    MaintenanceTask(#[source] tokio::task::JoinError),
+    #[error(transparent)]
+    Repository(#[from] RepositoryError),
+    #[error(transparent)]
+    Credential(#[from] CredentialHashError),
+    #[error(transparent)]
+    Token(#[from] TokenIssuerError),
+    #[error(transparent)]
+    Supervisor(#[from] LifecycleSupervisorError),
+}
+
+pub type E2bServiceResult<T> = std::result::Result<T, E2bServiceError>;

--- a/src/compat/src/production/template.rs
+++ b/src/compat/src/production/template.rs
@@ -1,0 +1,90 @@
+use std::collections::BTreeMap;
+
+use a3s_box_core::resolve_execution;
+use async_trait::async_trait;
+
+use crate::control::{
+    ResolvedTemplate, TemplateProvider, TemplateProviderError, TemplateProviderResult,
+};
+
+/// Immutable startup-validated template catalog.
+#[derive(Debug, Clone)]
+pub struct StaticTemplateProvider {
+    templates: BTreeMap<String, ResolvedTemplate>,
+}
+
+impl StaticTemplateProvider {
+    pub fn new(
+        templates: impl IntoIterator<Item = (String, ResolvedTemplate)>,
+    ) -> TemplateProviderResult<Self> {
+        let mut catalog = BTreeMap::new();
+        for (template_id, template) in templates {
+            validate_template(&template_id, &template)?;
+            if catalog.insert(template_id.clone(), template).is_some() {
+                return Err(TemplateProviderError::Invalid(format!(
+                    "template ID {template_id} is configured more than once"
+                )));
+            }
+        }
+        if catalog.is_empty() {
+            return Err(TemplateProviderError::Invalid(
+                "at least one template policy is required".to_string(),
+            ));
+        }
+        Ok(Self { templates: catalog })
+    }
+
+    pub fn contains(&self, template_id: &str) -> bool {
+        self.templates.contains_key(template_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.templates.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.templates.is_empty()
+    }
+}
+
+#[async_trait]
+impl TemplateProvider for StaticTemplateProvider {
+    async fn resolve(&self, template_id: &str) -> TemplateProviderResult<ResolvedTemplate> {
+        self.templates
+            .get(template_id)
+            .cloned()
+            .ok_or_else(|| TemplateProviderError::NotFound(template_id.to_string()))
+    }
+}
+
+fn validate_template(template_id: &str, template: &ResolvedTemplate) -> TemplateProviderResult<()> {
+    if template_id.is_empty()
+        || template_id.len() > 128
+        || template_id.chars().any(char::is_whitespace)
+    {
+        return Err(TemplateProviderError::Invalid(format!(
+            "template ID {template_id:?} is invalid"
+        )));
+    }
+    if template.config.image.trim().is_empty() {
+        return Err(TemplateProviderError::Invalid(format!(
+            "template {template_id} has no OCI image"
+        )));
+    }
+    if template.envd_version.trim().is_empty() {
+        return Err(TemplateProviderError::Invalid(format!(
+            "template {template_id} has no envd version"
+        )));
+    }
+    template.routing.validate().map_err(|error| {
+        TemplateProviderError::Invalid(format!(
+            "template {template_id} has an invalid route policy: {error}"
+        ))
+    })?;
+    resolve_execution(&template.config).map_err(|error| {
+        TemplateProviderError::Invalid(format!(
+            "template {template_id} has an invalid execution policy: {error}"
+        ))
+    })?;
+    Ok(())
+}

--- a/src/compat/src/production/tests.rs
+++ b/src/compat/src/production/tests.rs
@@ -1,0 +1,226 @@
+use std::path::Path;
+
+use a3s_box_core::ExecutionIsolation;
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::control::{SandboxIdentityProvider, TemplateProvider, TokenScope};
+use crate::http::CredentialHash;
+use crate::routing::{CODE_INTERPRETER_PORT, ENVD_PORT};
+
+use super::config::E2bCompatConfig;
+use super::{E2bCompatService, E2bConfigError, UuidSandboxIdentityProvider};
+
+fn parse_config(root: &Path) -> E2bCompatConfig {
+    E2bCompatConfig::parse_with_environment(&acl_config(root), test_environment).unwrap()
+}
+
+fn acl_config(root: &Path) -> String {
+    let database = acl_path(&root.join("lifecycle.sqlite3"));
+    let runtime_home = acl_path(&root.join("runtime"));
+    let runtime_state = acl_path(&root.join("managed-executions.json"));
+    let hash = CredentialHash::derive("e2b_a1b2c3", 100_000, &[3; 16]).unwrap();
+    format!(
+        r#"
+e2b_compat {{
+  api_listen = "127.0.0.1:3001"
+  api_public_url = "https://api.box.example.com"
+  sandbox_domain = "box.example.com"
+  database_path = "{database}"
+  runtime_home = "{runtime_home}"
+  runtime_state_path = "{runtime_state}"
+  max_json_bytes = 2097152
+
+  supervisor {{
+    interval_seconds = 5
+    batch_size = 100
+    reconciliation_page_size = 200
+  }}
+
+  account "primary" {{
+    scheme = "api_key"
+    owner_id = "owner-production"
+    client_id = "client-production"
+    hash = "{hash}"
+  }}
+
+  token_key "2026-07" {{
+    version = 7
+    active = true
+    encryption_key = env("TOKEN_ENCRYPTION")
+    digest_key = env("TOKEN_DIGEST")
+  }}
+
+  template_policy "fixture-template" {{
+    image = "alpine:3.20"
+    envd_version = "0.1.3"
+    isolation = "sandbox"
+    network = "none"
+    command = ["/bin/sh", "-c", "while :; do sleep 60; done"]
+    read_only = false
+    stdin_open = false
+
+    resources {{
+      vcpus = 2
+      memory_mb = 512
+      disk_mb = 1024
+    }}
+
+    route {{
+      port = 49983
+      token_scope = "envd"
+    }}
+
+    route {{
+      port = 49999
+      token_scope = "traffic"
+    }}
+  }}
+}}
+"#
+    )
+}
+
+fn acl_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn test_environment(name: &str) -> Option<String> {
+    match name {
+        "TOKEN_ENCRYPTION" => Some(hex::encode([7_u8; 32])),
+        "TOKEN_DIGEST" => Some(hex::encode([8_u8; 32])),
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn parses_acl_into_strict_runtime_credentials_and_template_policy() {
+    let root = tempfile::tempdir().unwrap();
+    let config = parse_config(root.path());
+
+    assert_eq!(config.api_listen().to_string(), "127.0.0.1:3001");
+    assert_eq!(
+        config.api_public_url().as_str(),
+        "https://api.box.example.com/"
+    );
+    assert_eq!(config.sandbox_domain(), "box.example.com");
+    assert_eq!(config.supervisor().batch_size().get(), 100);
+    assert_eq!(config.templates.len(), 1);
+    let template = config.templates.resolve("fixture-template").await.unwrap();
+    assert_eq!(template.config.isolation, ExecutionIsolation::Sandbox);
+    assert_eq!(template.config.image, "alpine:3.20");
+    assert_eq!(template.config.resources.memory_mb, 512);
+    assert_eq!(
+        template.routing.token_scope(ENVD_PORT),
+        Some(TokenScope::Envd)
+    );
+    assert_eq!(
+        template.routing.token_scope(CODE_INTERPRETER_PORT),
+        Some(TokenScope::Traffic)
+    );
+
+    let debug = format!("{config:?}");
+    assert!(!debug.contains(&hex::encode([7_u8; 32])));
+    assert!(!debug.contains(&hex::encode([8_u8; 32])));
+    assert!(!debug.contains("e2b_a1b2c3"));
+}
+
+#[test]
+fn rejects_plaintext_token_keys_missing_environment_and_unknown_fields() {
+    let root = tempfile::tempdir().unwrap();
+    let input = acl_config(root.path());
+
+    let plaintext = input.replace(
+        "env(\"TOKEN_ENCRYPTION\")",
+        &format!("\"{}\"", hex::encode([7_u8; 32])),
+    );
+    assert!(
+        E2bCompatConfig::parse_with_environment(&plaintext, test_environment)
+            .unwrap_err()
+            .to_string()
+            .contains("must use env")
+    );
+
+    let missing = E2bCompatConfig::parse_with_environment(&input, |_| None).unwrap_err();
+    assert!(missing.to_string().contains("TOKEN_ENCRYPTION"));
+    assert!(!missing.to_string().contains(&hex::encode([7_u8; 32])));
+
+    let unknown = input.replace(
+        "max_json_bytes = 2097152",
+        "max_json_bytes = 2097152\n  accidental_backend = \"unsafe\"",
+    );
+    assert!(
+        E2bCompatConfig::parse_with_environment(&unknown, test_environment)
+            .unwrap_err()
+            .to_string()
+            .contains("unknown attribute accidental_backend")
+    );
+}
+
+#[tokio::test]
+async fn loader_requires_the_acl_extension_before_reading() {
+    let root = tempfile::tempdir().unwrap();
+    let error = E2bCompatConfig::load(root.path().join("service.conf"))
+        .await
+        .unwrap_err();
+    assert!(matches!(error, E2bConfigError::InvalidExtension(_)));
+}
+
+#[test]
+fn uuid_identity_provider_generates_valid_independent_ids() {
+    let provider = UuidSandboxIdentityProvider;
+    let first = provider.next_identity().unwrap();
+    let second = provider.next_identity().unwrap();
+
+    assert!(first.sandbox_id.as_str().starts_with("sandbox-"));
+    assert!(first.operation_id.as_str().starts_with("e2b-create-"));
+    assert_ne!(first.sandbox_id, second.sandbox_id);
+    assert_ne!(first.operation_id, second.operation_id);
+}
+
+#[tokio::test]
+async fn production_composition_wires_auth_sqlite_routing_and_supervision_without_launching_runtime(
+) {
+    let root = tempfile::tempdir().unwrap();
+    let service = E2bCompatService::build(parse_config(root.path()))
+        .await
+        .unwrap();
+    assert_eq!(service.listen().to_string(), "127.0.0.1:3001");
+    assert_eq!(service.sandbox_domain(), "box.example.com");
+    assert!(service
+        .route_parser()
+        .parse_host(
+            "49983-sandbox-example.box.example.com",
+            &axum::http::HeaderMap::new(),
+        )
+        .is_ok());
+    let report = service.reconcile_startup().await.unwrap();
+    assert_eq!(report.examined, 0);
+
+    let unauthenticated = service
+        .router()
+        .oneshot(
+            Request::builder()
+                .uri("/v2/sandboxes")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+
+    let authenticated = service
+        .router()
+        .oneshot(
+            Request::builder()
+                .uri("/v2/sandboxes")
+                .header("x-api-key", "e2b_a1b2c3")
+                .header(header::ACCEPT, "application/json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(authenticated.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## Summary

- add the production a3s-box-e2b process configured exclusively through .acl files parsed by the pinned a3s-acl revision
- compose SQLite lifecycle state, the canonical LocalExecutionManager, hashed accounts, rotating encrypted sandbox tokens, static template policy, route parsing and leases, startup reconciliation, periodic expiry reaping, and graceful shutdown
- require token key material through env("VARIABLE") references and reject literal keys, unknown fields, invalid paths, duplicate versions, and unsafe template policy
- add a destructive A3S OS smoke covering real HTTP create, certified crun Sandbox start, service restart recovery, connect, timeout replacement, kill, and resource cleanup
- keep full_compatibility=false while TLS, envd, and the remaining black-box matrix are incomplete

## Validation

Run from a Git-fetched worktree on the A3S OS production server:

- cargo test --locked -p a3s-box-compat (72 passed)
- cargo clippy --locked -p a3s-box-compat --all-targets -- -D warnings
- cargo run --locked -p a3s-box-compat --bin a3s-box-e2b-contract -- verify
- cargo fmt --all --check
- scripts/e2b-production-smoke.sh against a real certified crun Sandbox, including service restart recovery and cleanup