### PR TITLE
feat(e2b): add TLS Sandbox data-plane gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,39 +347,46 @@ that structured Sandbox logs retain both stdout and stderr, drain final records
 before natural-exit or auto-remove archival, and leave no generation log worker,
 crun state, box directory, or socket behind.
 
-Those protocol and runtime tests are not yet a complete E2B data-plane path. CLI
-`create` now persists its reservation and complete caller policy through the
-canonical manager, and the first `start` of that reservation consumes its
-persisted generation through the same manager. The production backend prepares
-named-volume and network ownership idempotently and rolls back only resources
-acquired by a failed start attempt. Ordinary `start` does not revive a terminal
-managed execution. CLI `restart` now uses a durable two-phase operation that
-terminates the old runtime before advancing the generation, recovers ambiguous
-kill/start responses from backend evidence, and rebinds local resources without
-duplicating ownership. CLI `run` now reserves and starts through the same
-manager, freezes image-defined health and stop defaults into the durable
-request, and leaves network, volume, rootfs, stop, and auto-remove ownership to
-the managed backend. The Rust SDK now exposes typed create, start, run, inspect,
-pause, resume, restart, kill, and reconciliation calls through that same
-manager. Production credential providers now store account keys as salted
-PBKDF2-SHA256 hashes and protect scope-separated sandbox tokens with
-AES-256-GCM, independent HMAC validation, and versioned key rotation. The
-`a3s-box-e2b` process reads only `.acl` configuration through `a3s-acl` and
-composes those providers with SQLite lifecycle state, the canonical runtime
-manager, startup reconciliation, periodic expiry reaping, and graceful
-shutdown. Its A3S OS smoke creates a real `crun` Sandbox through HTTP, restarts
-the service, reconnects to the preserved execution, updates its timeout, kills
-it, and verifies runtime cleanup. Route policy is now persisted with each
-lifecycle record, and strict wildcard/shared parsing projects generation-,
-expiry-, port-, and token-scope-fenced leases without a second mutable routing
-state. The production process now also terminates wildcard TLS, accepts both
-direct and shared sandbox routes, validates those immutable leases, strips edge
-credentials, and proxies HTTP/1.1 or HTTP/2 streams through a generation- and
-PID-fenced connection to the real `crun` network namespace. Its A3S OS smoke
-reaches a service on Sandbox loopback through both TLS route forms, rejects
-invalid and scope-swapped tokens, preserves the route across service restart,
-and fences it after kill. The envd/ConnectRPC implementation and the real
-official-client Sandbox suite remain open gates.
+The first production E2B data-plane slice is now implemented, while the full
+envd surface remains incomplete. CLI `create` persists its reservation and
+complete caller policy through the canonical manager, and the first `start` of
+that reservation consumes its persisted generation through the same manager.
+The production backend prepares named-volume and network ownership
+idempotently and rolls back only resources acquired by a failed start attempt.
+Ordinary `start` does not revive a terminal managed execution. CLI `restart`
+uses a durable two-phase operation that terminates the old runtime before
+advancing the generation, recovers ambiguous kill/start responses from backend
+evidence, and rebinds local resources without duplicating ownership. CLI `run`
+reserves and starts through the same manager, freezes image-defined health and
+stop defaults into the durable request, and leaves network, volume, rootfs,
+stop, and auto-remove ownership to the managed backend. The Rust SDK exposes
+typed create, start, run, inspect, pause, resume, restart, kill, and
+reconciliation calls through that same manager.
+
+The `a3s-box-e2b` process accepts only `.acl` configuration parsed by `a3s-acl`.
+It composes SQLite lifecycle state, the canonical runtime manager, production
+credential providers, startup reconciliation, periodic expiry reaping, and
+graceful shutdown. Account keys use salted PBKDF2-SHA256 hashes; scope-separated
+sandbox tokens use AES-256-GCM, independent HMAC validation, and versioned key
+rotation. Route policy is persisted with each lifecycle record, and strict
+wildcard/shared parsing projects immutable leases fenced by generation, expiry,
+port, and token scope without a second mutable routing state.
+
+The production wildcard TLS gateway supports HTTP/1.1 and HTTP/2 clients over
+both direct and shared sandbox routes. It validates each lease, applies CORS,
+strips edge credentials, and enters the real `crun` network namespace through a
+generation- and PID-fenced connector. As with the official E2B sandbox proxy,
+the plaintext Sandbox origin is contacted with HTTP/1.1, including when the
+downstream client uses HTTP/2; the origin is not required to provide h2c.
+
+An A3S OS production smoke test exercises this path on a real `crun` OCI
+Sandbox created with `--isolation sandbox`. It verifies lifecycle operations,
+both TLS route forms, HTTP/2-to-HTTP/1.1 translation, invalid and scope-swapped
+token denial, service-restart recovery, stale-route fencing after kill,
+structured-log drainage, and complete runtime cleanup. Failed runs preserve
+the Sandbox PID, `crun` state, OCI bundle, and service logs for diagnosis. The
+envd/ConnectRPC implementation and the complete unchanged-official-client
+Sandbox suite remain open release gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ that structured Sandbox logs retain both stdout and stderr, drain final records
 before natural-exit or auto-remove archival, and leave no generation log worker,
 crun state, box directory, or socket behind.
 
-Those protocol and runtime tests are not yet a complete TLS data-plane path. CLI
+Those protocol and runtime tests are not yet a complete E2B data-plane path. CLI
 `create` now persists its reservation and complete caller policy through the
 canonical manager, and the first `start` of that reservation consumes its
 persisted generation through the same manager. The production backend prepares
@@ -372,8 +372,14 @@ the service, reconnects to the preserved execution, updates its timeout, kills
 it, and verifies runtime cleanup. Route policy is now persisted with each
 lifecycle record, and strict wildcard/shared parsing projects generation-,
 expiry-, port-, and token-scope-fenced leases without a second mutable routing
-state. The wildcard TLS gateway, envd data plane, and the real official-client
-Sandbox suite remain open gates.
+state. The production process now also terminates wildcard TLS, accepts both
+direct and shared sandbox routes, validates those immutable leases, strips edge
+credentials, and proxies HTTP/1.1 or HTTP/2 streams through a generation- and
+PID-fenced connection to the real `crun` network namespace. Its A3S OS smoke
+reaches a service on Sandbox loopback through both TLS route forms, rejects
+invalid and scope-swapped tokens, preserves the route across service restart,
+and fences it after kill. The envd/ConnectRPC implementation and the real
+official-client Sandbox suite remain open gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/compat/e2b/README.md
+++ b/compat/e2b/README.md
@@ -79,11 +79,15 @@ cargo run --locked -p a3s-box-compat --bin a3s-box-e2b -- \
 
 The validated schema and an operator example are documented in
 [`docs/e2b-compatible-sdk-design.md`](../../docs/e2b-compatible-sdk-design.md#configuration).
-This process currently exposes the lifecycle control subset. The wildcard TLS
-gateway and sandbox data-plane protocols remain required before the manifest
-can set `full_compatibility=true`.
+This process exposes the lifecycle control subset plus an authenticated
+wildcard TLS data-plane edge. The edge supports direct and shared route forms,
+HTTP/1.1 and HTTP/2 streaming proxying, CORS preflight, upgrades, bounded
+connections, and generation-fenced access to real Sandbox loopback ports. The
+pinned envd/ConnectRPC protocols and remaining data-plane behavior are still
+required before the manifest can set `full_compatibility=true`.
 
 The destructive A3S OS integration harness is
 [`scripts/e2b-production-smoke.sh`](../../scripts/e2b-production-smoke.sh). It
 requires a dedicated runtime home and explicit acknowledgement, and verifies a
-real Sandbox lifecycle, service restart recovery, and resource cleanup.
+real Sandbox lifecycle, TLS direct/shared routing, token-scope denial, service
+restart recovery, stale-route fencing, and resource cleanup.

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,7 +1,7 @@
 # E2B Protocol Compatibility and SDK Design
 
-Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 4 complete;
-slice 5 control-service composition complete, TLS data plane pending)**
+Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 6 complete;
+TLS routing reaches real Sandbox ports, envd protocol implementation pending)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -22,16 +22,18 @@ unversioned claim.
 | Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, startup reconciliation, and periodic reaping are composed into the production service; an A3S OS smoke preserves a running record across process restart | Exercise host-reboot recovery end to end |
 | Runtime lifecycle | The production compatibility process uses the canonical `LocalExecutionManager`; an A3S OS smoke creates through HTTP, starts through certified `crun`, reconnects after service restart, replaces timeout, kills, and verifies box, runtime-state, and socket cleanup | Complete the host-reboot and official-client matrices |
-| Credentials and routing | ACL config wires salted PBKDF2-SHA256 account hashes, scope-bound AES-256-GCM sandbox tokens, independent HMAC validation, versioned key rotation, strict direct/shared parsing, and durable-record-projected generation-fenced leases | Add the TLS data-plane gateway and exercise routed traffic through it |
+| Credentials and routing | ACL config wires salted PBKDF2-SHA256 account hashes, scope-bound AES-256-GCM sandbox tokens, independent HMAC validation, versioned key rotation, strict direct/shared parsing, durable-record-projected generation-fenced leases, wildcard TLS termination, and a generation/PID-fenced Sandbox network-namespace connector | Add certificate rotation and exercise every HTTP/2, Connect, WebSocket, and stream case in the complete matrix |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
-The lifecycle control path is now composed and exercised against a real
-Sandbox on A3S OS. That smoke uses HTTP requests rather than the pinned
-official SDKs, and it does not traverse the wildcard TLS or sandbox data-plane
-gateway. The unchanged-client fixture still uses an in-memory repository and
-fake execution manager. These are complementary results rather than the full
-black-box compatibility matrix, so `full_compatibility=false` remains
-mandatory.
+The lifecycle control path and authenticated wildcard/shared TLS routes are
+composed and exercised against a real Sandbox on A3S OS. The smoke reaches a
+service bound to the Sandbox loopback interface, rejects invalid and
+scope-swapped tokens, survives a compatibility-service restart, and fences the
+route after kill. It still uses direct HTTP requests rather than the pinned
+official SDKs, and the unchanged-client fixture still uses an in-memory
+repository and fake execution manager. These are complementary results rather
+than the full black-box compatibility matrix, so `full_compatibility=false`
+remains mandatory.
 
 ## Executive decision
 
@@ -562,6 +564,16 @@ e2b_compat {
   runtime_home     = "/var/lib/a3s"
   runtime_state_path = "/var/lib/a3s-box/e2b/managed-executions.json"
 
+  gateway {
+    listen                   = "0.0.0.0:443"
+    tls_certificate_path     = "/etc/a3s-box/tls/sandbox-chain.pem"
+    tls_private_key_path     = "/etc/a3s-box/tls/sandbox-key.pem"
+    max_connections          = 4096
+    handshake_timeout_ms     = 5000
+    connect_timeout_ms       = 2000
+    drain_timeout_seconds    = 30
+  }
+
   supervisor {
     interval_seconds          = 5
     batch_size                = 100
@@ -603,11 +615,13 @@ e2b_compat {
 
 The envd port and envd token scope are added when omitted. Runtime paths,
 credentials, key versions, template execution policy, resources, and routed
-ports are validated before the listener opens. Startup runs durable lifecycle
-reconciliation; a bounded supervisor then reaps expired records until graceful
-shutdown. The control listener remains behind the deployment TLS edge in this
-slice. Wildcard TLS termination and the sandbox data-plane proxy are the next
-focused slice.
+ports and TLS settings are validated before either listener opens. Startup
+runs durable lifecycle reconciliation; a bounded supervisor then reaps expired
+records until graceful shutdown. The control listener remains behind the
+deployment TLS edge. The separate wildcard TLS listener accepts HTTP/1.1 and
+HTTP/2, validates every direct or shared route and token before opening an
+upstream connection, strips edge credentials, preserves streaming bodies and
+trailers, bridges HTTP upgrades, and drains bounded connections on shutdown.
 
 ## Repository boundaries
 
@@ -843,11 +857,17 @@ Phase 2 is delivered as small, immediately merged changes:
    lifecycle; switch CLI create to the same reservation path; switch CLI
    start/restart/run and the Rust SDK to the same implementation with behavior
    parity tests.
-5. **In progress:** production account credentials, sandbox token providers,
+5. **Complete:** production account credentials, sandbox token providers,
    generation-fenced route leases, validated wildcard/shared parsing, and the
-   ACL-configured service binary are complete. Add the TLS data-plane gateway.
-   Pull each merge commit on an A3S OS server and run the unmodified official
-   clients against real `--isolation sandbox` executions.
+   ACL-configured service binary.
+6. **Complete:** add wildcard TLS termination, bounded HTTP/1.1 and HTTP/2
+   reverse proxying, CORS preflight, credential stripping, upgrade bridging,
+   and a Linux connector that enters the generation-fenced `crun` network
+   namespace on a disposable OS thread. Pull the merge commit on an A3S OS
+   server and prove direct/shared routing, restart recovery, scope denial, and
+   stale-route fencing against a real `--isolation sandbox` execution.
+7. **In progress:** implement the pinned envd HTTP and ConnectRPC protocols,
+   then run the unmodified official clients through the production listeners.
 
 The runtime foundation of slice 4 is complete. The persisted execution record
 is the canonical schema shared by the CLI and Rust SDK, preventing either

--- a/scripts/e2b-production-smoke.sh
+++ b/scripts/e2b-production-smoke.sh
@@ -7,6 +7,7 @@ CREDENTIAL_HASH='pbkdf2-sha256$100000$03030303030303030303030303030303$6ea6a4ae2
 TOKEN_ENCRYPTION="$(printf '07%.0s' {1..32})"
 TOKEN_DIGEST="$(printf '08%.0s' {1..32})"
 PORT="${A3S_BOX_E2B_SMOKE_PORT:-38081}"
+GATEWAY_PORT="${A3S_BOX_E2B_GATEWAY_SMOKE_PORT:-38443}"
 IMAGE="${A3S_BOX_SMOKE_IMAGE:-alpine:3.20}"
 
 fail() {
@@ -28,14 +29,22 @@ fail() {
 [[ -x "$A3S_HOME/bin/a3s-box-shim" ]] || fail 'shim is missing'
 [[ "$PORT" =~ ^[0-9]+$ && "$PORT" -gt 0 && "$PORT" -le 65535 ]] ||
   fail 'A3S_BOX_E2B_SMOKE_PORT must be a valid TCP port'
+[[ "$GATEWAY_PORT" =~ ^[0-9]+$ && "$GATEWAY_PORT" -gt 0 && "$GATEWAY_PORT" -le 65535 ]] ||
+  fail 'A3S_BOX_E2B_GATEWAY_SMOKE_PORT must be a valid TCP port'
+[[ "$GATEWAY_PORT" != "$PORT" ]] || fail 'control and gateway ports must differ'
+command -v openssl >/dev/null || fail 'openssl is required for the TLS gateway smoke'
 
 umask 077
 STATE_DIR="$A3S_HOME/e2b-compat-smoke"
 CONFIG="$STATE_DIR/service.acl"
 LOG="$STATE_DIR/service.log"
+TLS_CERT="$STATE_DIR/gateway-cert.pem"
+TLS_KEY="$STATE_DIR/gateway-key.pem"
 BASE_URL="http://127.0.0.1:$PORT"
 SERVICE_PID=""
 SANDBOX_ID=""
+ENVD_TOKEN=""
+TRAFFIC_TOKEN=""
 
 stop_service() {
   if [[ -n "$SERVICE_PID" ]] && kill -0 "$SERVICE_PID" 2>/dev/null; then
@@ -93,6 +102,40 @@ status_request() {
   curl "${arguments[@]}" "$BASE_URL$path"
 }
 
+gateway_status() {
+  local host="$1"
+  local output="$2"
+  local token_header="$3"
+  local token="$4"
+  shift 4
+  curl --silent --show-error --output "$output" --write-out '%{http_code}' \
+    --cacert "$TLS_CERT" \
+    --resolve "$host:$GATEWAY_PORT:127.0.0.1" \
+    --header "$token_header: $token" \
+    "$@" "https://$host:$GATEWAY_PORT/health"
+}
+
+wait_gateway_ready() {
+  local host="$1"
+  local attempts=0
+  local status=""
+  while (( attempts < 100 )); do
+    status="$(gateway_status "$host" "$STATE_DIR/gateway-body.txt" X-Access-Token "$ENVD_TOKEN" || true)"
+    if [[ "$status" == "200" ]]; then
+      return 0
+    fi
+    if [[ -n "$SERVICE_PID" ]] && ! kill -0 "$SERVICE_PID" 2>/dev/null; then
+      tail -100 "$LOG" >&2 || true
+      return 1
+    fi
+    attempts=$((attempts + 1))
+    sleep 0.1
+  done
+  printf 'gateway readiness timed out with HTTP %s\n' "$status" >&2
+  tail -100 "$LOG" >&2 || true
+  return 1
+}
+
 json_field() {
   python3 - "$1" "$2" <<'PY'
 import json
@@ -124,6 +167,10 @@ trap cleanup EXIT INT TERM
 
 rm -rf "$STATE_DIR"
 mkdir -p "$STATE_DIR"
+openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
+  -subj '/CN=*.box.example.com' \
+  -addext 'subjectAltName=DNS:*.box.example.com,DNS:sandbox.box.example.com' \
+  -keyout "$TLS_KEY" -out "$TLS_CERT" >/dev/null 2>&1
 cat >"$CONFIG" <<EOF
 e2b_compat {
   api_listen = "127.0.0.1:$PORT"
@@ -132,6 +179,16 @@ e2b_compat {
   database_path = "$STATE_DIR/lifecycle.sqlite3"
   runtime_home = "$A3S_HOME"
   runtime_state_path = "$STATE_DIR/managed-executions.json"
+
+  gateway {
+    listen = "127.0.0.1:$GATEWAY_PORT"
+    tls_certificate_path = "$TLS_CERT"
+    tls_private_key_path = "$TLS_KEY"
+    max_connections = 128
+    handshake_timeout_ms = 5000
+    connect_timeout_ms = 2000
+    drain_timeout_seconds = 5
+  }
 
   supervisor {
     interval_seconds = 1
@@ -158,7 +215,7 @@ e2b_compat {
     envd_version = "0.1.3"
     isolation = "sandbox"
     network = "none"
-    command = ["/bin/sh", "-c", "while :; do sleep 60; done"]
+    command = ["/bin/sh", "-c", "mkdir -p /tmp/e2b-smoke && echo sandbox-data-plane > /tmp/e2b-smoke/health && exec busybox httpd -f -p 49983 -h /tmp/e2b-smoke"]
 
     resources {
       vcpus = 2
@@ -184,10 +241,26 @@ SANDBOX_ID="$(json_field "$CREATE_RESPONSE" sandboxID)"
 [[ "$SANDBOX_ID" == sandbox-* ]] || fail 'create returned an invalid sandbox ID'
 [[ "$(json_field "$CREATE_RESPONSE" domain)" == "box.example.com" ]] ||
   fail 'create returned the wrong sandbox domain'
-[[ -n "$(json_field "$CREATE_RESPONSE" envdAccessToken)" ]] ||
+ENVD_TOKEN="$(json_field "$CREATE_RESPONSE" envdAccessToken)"
+TRAFFIC_TOKEN="$(json_field "$CREATE_RESPONSE" trafficAccessToken)"
+[[ -n "$ENVD_TOKEN" ]] ||
   fail 'create omitted the envd access token'
-[[ -n "$(json_field "$CREATE_RESPONSE" trafficAccessToken)" ]] ||
+[[ -n "$TRAFFIC_TOKEN" ]] ||
   fail 'create omitted the traffic access token'
+
+DIRECT_HOST="49983-$SANDBOX_ID.box.example.com"
+wait_gateway_ready "$DIRECT_HOST" || fail 'TLS direct route did not become ready'
+[[ "$(cat "$STATE_DIR/gateway-body.txt")" == "sandbox-data-plane" ]] ||
+  fail 'TLS gateway returned the wrong Sandbox response body'
+[[ "$(gateway_status "$DIRECT_HOST" /dev/null X-Access-Token wrong-token)" == "401" ]] ||
+  fail 'TLS gateway accepted an invalid envd token'
+[[ "$(gateway_status "$DIRECT_HOST" /dev/null E2B-Traffic-Access-Token "$TRAFFIC_TOKEN")" == "401" ]] ||
+  fail 'TLS gateway accepted a traffic token for the envd scope'
+[[ "$(gateway_status sandbox.box.example.com "$STATE_DIR/shared-body.txt" X-Access-Token "$ENVD_TOKEN" \
+  --header "E2b-Sandbox-Id: $SANDBOX_ID" --header 'E2b-Sandbox-Port: 49983')" == "200" ]] ||
+  fail 'TLS shared route did not return HTTP 200'
+[[ "$(cat "$STATE_DIR/shared-body.txt")" == "sandbox-data-plane" ]] ||
+  fail 'TLS shared route returned the wrong Sandbox response body'
 
 DETAIL_RESPONSE="$STATE_DIR/detail.json"
 [[ "$(status_request GET "/sandboxes/$SANDBOX_ID" "$DETAIL_RESPONSE")" == "200" ]] ||
@@ -202,6 +275,7 @@ start_service
   fail 'sandbox was unavailable after service restart'
 [[ "$(json_field "$DETAIL_RESPONSE" state)" == "running" ]] ||
   fail 'startup reconciliation did not preserve the running sandbox'
+wait_gateway_ready "$DIRECT_HOST" || fail 'TLS route was unavailable after service restart'
 
 CONNECT_RESPONSE="$STATE_DIR/connect.json"
 [[ "$(status_request POST "/sandboxes/$SANDBOX_ID/connect" "$CONNECT_RESPONSE" '{"timeout":45}')" == "200" ]] ||
@@ -213,6 +287,8 @@ CONNECT_RESPONSE="$STATE_DIR/connect.json"
   fail 'timeout replacement did not return HTTP 204'
 [[ "$(status_request DELETE "/sandboxes/$SANDBOX_ID" /dev/null)" == "204" ]] ||
   fail 'kill did not return HTTP 204'
+[[ "$(gateway_status "$DIRECT_HOST" /dev/null X-Access-Token "$ENVD_TOKEN")" == "404" ]] ||
+  fail 'stale TLS route remained available after kill'
 
 EXECUTION_ID="$(python3 - "$STATE_DIR/managed-executions.json" "$SANDBOX_ID" <<'PY'
 import json
@@ -237,4 +313,4 @@ PY
 
 SANDBOX_ID=""
 stop_service
-printf 'E2B production smoke passed: lifecycle, restart recovery, credentials, and cleanup\n'
+printf 'E2B production smoke passed: lifecycle, TLS data plane, restart recovery, credentials, and cleanup\n'

--- a/scripts/e2b-production-smoke.sh
+++ b/scripts/e2b-production-smoke.sh
@@ -152,10 +152,66 @@ print(value)
 PY
 }
 
+preserve_failure_diagnostics() {
+  local diagnostics="$STATE_DIR/failure-diagnostics"
+  local records="$STATE_DIR/managed-executions.json"
+  mkdir -p "$diagnostics"
+  [[ -f "$records" ]] || return 0
+
+  while IFS=$'\t' read -r execution_id pid pid_start_time; do
+    [[ -n "$execution_id" && "$execution_id" != *[!a-zA-Z0-9._-]* ]] || continue
+    local execution_diagnostics="$diagnostics/$execution_id"
+    local box_dir="$A3S_HOME/boxes/$execution_id"
+    local runtime_root="$A3S_HOME/run/crun/$execution_id"
+    mkdir -p "$execution_diagnostics"
+    printf 'pid=%s\npid_start_time=%s\n' "$pid" "$pid_start_time" \
+      >"$execution_diagnostics/process-identity.txt"
+    if [[ "$pid" =~ ^[0-9]+$ && -r "/proc/$pid/stat" ]]; then
+      cp "/proc/$pid/stat" "$execution_diagnostics/proc-stat.txt" || true
+      readlink "/proc/$pid/ns/net" \
+        >"$execution_diagnostics/network-namespace.txt" 2>&1 || true
+    fi
+    if [[ -d "$box_dir/logs" ]]; then
+      cp -a "$box_dir/logs" "$execution_diagnostics/logs" || true
+    fi
+    for relative_path in \
+      sandbox/runtime.json \
+      sandbox/bundle/config.json \
+      sandbox/bundle/execution-plan.json \
+      sandbox/bundle/capabilities.json; do
+      if [[ -f "$box_dir/$relative_path" ]]; then
+        mkdir -p "$execution_diagnostics/$(dirname "$relative_path")"
+        cp "$box_dir/$relative_path" \
+          "$execution_diagnostics/$relative_path" || true
+      fi
+    done
+    "$A3S_BOX_CRUN_PATH" --root "$runtime_root" state "$execution_id" \
+      >"$execution_diagnostics/crun-state.json" \
+      2>"$execution_diagnostics/crun-state.stderr" || true
+  done < <(python3 - "$records" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    records = json.load(source)
+for record in records:
+    print(
+        record.get("id", ""),
+        record.get("pid") or "",
+        record.get("pid_start_time") or "",
+        sep="\t",
+    )
+PY
+)
+}
+
 cleanup() {
   local exit_code=$?
   trap - EXIT INT TERM
   set +e
+  if [[ "$exit_code" -ne 0 && "${A3S_BOX_E2B_KEEP_STATE_ON_FAILURE:-}" == "1" ]]; then
+    preserve_failure_diagnostics
+  fi
   if [[ -n "$SANDBOX_ID" ]]; then
     if [[ -z "$SERVICE_PID" ]] || ! kill -0 "$SERVICE_PID" 2>/dev/null; then
       start_service >/dev/null 2>&1

--- a/scripts/e2b-production-smoke.sh
+++ b/scripts/e2b-production-smoke.sh
@@ -12,6 +12,9 @@ IMAGE="${A3S_BOX_SMOKE_IMAGE:-alpine:3.20}"
 
 fail() {
   printf 'E2B production smoke failed: %s\n' "$*" >&2
+  if [[ -n "${LOG:-}" && -f "$LOG" ]]; then
+    tail -100 "$LOG" >&2 || true
+  fi
   exit 1
 }
 
@@ -81,7 +84,7 @@ start_service() {
     A3S_BOX_CRUN_PATH="$A3S_BOX_CRUN_PATH" \
     TOKEN_ENCRYPTION="$TOKEN_ENCRYPTION" \
     TOKEN_DIGEST="$TOKEN_DIGEST" \
-    RUST_LOG="a3s_box_compat=info" \
+    RUST_LOG="${RUST_LOG:-a3s_box_compat=info}" \
     "$A3S_BOX_E2B_BIN" --config "$CONFIG" >"$LOG" 2>&1 &
   SERVICE_PID=$!
   wait_ready
@@ -160,7 +163,11 @@ cleanup() {
     status_request DELETE "/sandboxes/$SANDBOX_ID" /dev/null >/dev/null 2>&1
   fi
   stop_service
-  rm -rf "$STATE_DIR"
+  if [[ "$exit_code" -ne 0 && "${A3S_BOX_E2B_KEEP_STATE_ON_FAILURE:-}" == "1" ]]; then
+    printf 'Preserved failed smoke state at %s\n' "$STATE_DIR" >&2
+  else
+    rm -rf "$STATE_DIR"
+  fi
   exit "$exit_code"
 }
 trap cleanup EXIT INT TERM

--- a/scripts/e2b-production-smoke.sh
+++ b/scripts/e2b-production-smoke.sh
@@ -9,6 +9,9 @@ TOKEN_DIGEST="$(printf '08%.0s' {1..32})"
 PORT="${A3S_BOX_E2B_SMOKE_PORT:-38081}"
 GATEWAY_PORT="${A3S_BOX_E2B_GATEWAY_SMOKE_PORT:-38443}"
 IMAGE="${A3S_BOX_SMOKE_IMAGE:-alpine:3.20}"
+# A dependency-free HTTP/1.1 responder used with BusyBox nc -e. Alpine's
+# BusyBox build does not guarantee the optional httpd applet.
+HTTP_RESPONDER_B64='IyEvYmluL3NoCndoaWxlIElGUz0gcmVhZCAtciBsaW5lOyBkbwogIFsgIiRsaW5lIiA9ICIkKHByaW50ZiAnXHInKSIgXSAmJiBicmVhawpkb25lCmJvZHk9J3NhbmRib3gtZGF0YS1wbGFuZScKcHJpbnRmICdIVFRQLzEuMSAyMDAgT0tcclxuQ29udGVudC1MZW5ndGg6ICVzXHJcbkNvbm5lY3Rpb246IGNsb3NlXHJcbkNvbnRlbnQtVHlwZTogdGV4dC9wbGFpblxyXG5cclxuJXMnICIkeyNib2R5fSIgIiRib2R5Igo='
 
 fail() {
   printf 'E2B production smoke failed: %s\n' "$*" >&2
@@ -278,7 +281,7 @@ e2b_compat {
     envd_version = "0.1.3"
     isolation = "sandbox"
     network = "none"
-    command = ["/bin/sh", "-c", "mkdir -p /tmp/e2b-smoke && echo sandbox-data-plane > /tmp/e2b-smoke/health && exec busybox httpd -f -p 49983 -h /tmp/e2b-smoke"]
+    command = ["/bin/sh", "-c", "mkdir -p /tmp/e2b-smoke && printf '%s' '$HTTP_RESPONDER_B64' | /bin/busybox base64 -d > /tmp/e2b-smoke/respond && chmod 755 /tmp/e2b-smoke/respond && exec /bin/busybox nc -lk -p 49983 -e /tmp/e2b-smoke/respond"]
 
     resources {
       vcpus = 2

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -55,7 +55,11 @@ dependencies = [
  "hyper 0.14.32",
  "prost",
  "prost-types",
+ "rcgen",
  "ring",
+ "rustls",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -64,6 +68,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-rusqlite",
+ "tokio-rustls",
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
@@ -2903,7 +2908,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3052,6 +3057,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src/compat/Cargo.toml
+++ b/src/compat/Cargo.toml
@@ -21,6 +21,9 @@ hyper = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 ring = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = "2"
+rustls-pki-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -28,6 +31,7 @@ sha2 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-rustls = { workspace = true }
 tokio-rusqlite = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -35,6 +39,7 @@ url = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+rcgen = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 
 [[bin]]

--- a/src/compat/src/gateway/mod.rs
+++ b/src/compat/src/gateway/mod.rs
@@ -1,0 +1,235 @@
+mod proxy;
+mod tls;
+
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use a3s_box_core::ExecutionPortConnector;
+use hyper::server::conn::Http;
+use hyper::service::service_fn;
+use rustls::ServerConfig;
+use thiserror::Error;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinSet;
+use tokio::time;
+use tokio_rustls::TlsAcceptor;
+use tracing::{debug, warn};
+
+use crate::routing::{RouteLeaseService, SandboxRouteParser};
+
+pub use proxy::DataPlaneProxy;
+
+/// Startup-validated TLS listener and bounded proxy settings.
+#[derive(Debug, Clone)]
+pub struct DataPlaneGatewayConfig {
+    pub(crate) listen: SocketAddr,
+    pub(crate) certificate_path: PathBuf,
+    pub(crate) private_key_path: PathBuf,
+    pub(crate) max_connections: NonZeroUsize,
+    pub(crate) handshake_timeout: Duration,
+    pub(crate) connect_timeout: Duration,
+    pub(crate) drain_timeout: Duration,
+}
+
+impl DataPlaneGatewayConfig {
+    pub const fn listen(&self) -> SocketAddr {
+        self.listen
+    }
+
+    pub const fn max_connections(&self) -> NonZeroUsize {
+        self.max_connections
+    }
+
+    pub const fn handshake_timeout(&self) -> Duration {
+        self.handshake_timeout
+    }
+
+    pub const fn connect_timeout(&self) -> Duration {
+        self.connect_timeout
+    }
+
+    pub const fn drain_timeout(&self) -> Duration {
+        self.drain_timeout
+    }
+}
+
+#[derive(Clone)]
+pub struct DataPlaneGateway {
+    config: DataPlaneGatewayConfig,
+    tls: Arc<ServerConfig>,
+    proxy: DataPlaneProxy,
+}
+
+impl DataPlaneGateway {
+    pub async fn build(
+        config: DataPlaneGatewayConfig,
+        parser: SandboxRouteParser,
+        leases: RouteLeaseService,
+        connector: Arc<dyn ExecutionPortConnector>,
+    ) -> DataPlaneGatewayResult<Self> {
+        let tls =
+            tls::load_server_config(&config.certificate_path, &config.private_key_path).await?;
+        let proxy = DataPlaneProxy::new(parser, leases, connector, config.connect_timeout);
+        Ok(Self { config, tls, proxy })
+    }
+
+    pub const fn listen(&self) -> SocketAddr {
+        self.config.listen
+    }
+
+    pub fn proxy(&self) -> DataPlaneProxy {
+        self.proxy.clone()
+    }
+
+    pub async fn serve(
+        self,
+        listener: TcpListener,
+        mut shutdown: watch::Receiver<bool>,
+    ) -> DataPlaneGatewayResult<()> {
+        let semaphore = Arc::new(Semaphore::new(self.config.max_connections.get()));
+        let acceptor = TlsAcceptor::from(self.tls.clone());
+        let mut connections = JoinSet::new();
+
+        loop {
+            let permit = tokio::select! {
+                changed = shutdown.changed() => {
+                    if changed.is_err() || *shutdown.borrow() {
+                        break;
+                    }
+                    continue;
+                }
+                permit = semaphore.clone().acquire_owned() => {
+                    permit.map_err(|_| DataPlaneGatewayError::ConnectionLimiterClosed)?
+                }
+            };
+            let accepted = tokio::select! {
+                changed = shutdown.changed() => {
+                    drop(permit);
+                    if changed.is_err() || *shutdown.borrow() {
+                        break;
+                    }
+                    continue;
+                }
+                accepted = listener.accept() => accepted,
+            };
+            let (socket, peer) = accepted.map_err(DataPlaneGatewayError::Accept)?;
+            let acceptor = acceptor.clone();
+            let proxy = self.proxy.clone();
+            let connection_shutdown = shutdown.clone();
+            let handshake_timeout = self.config.handshake_timeout;
+            connections.spawn(async move {
+                serve_connection(
+                    socket,
+                    peer,
+                    acceptor,
+                    proxy,
+                    handshake_timeout,
+                    connection_shutdown,
+                    permit,
+                )
+                .await;
+            });
+
+            while connections.try_join_next().is_some() {}
+        }
+
+        drain_connections(&mut connections, self.config.drain_timeout).await;
+        Ok(())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn serve_connection(
+    socket: TcpStream,
+    peer: SocketAddr,
+    acceptor: TlsAcceptor,
+    proxy: DataPlaneProxy,
+    handshake_timeout: Duration,
+    mut shutdown: watch::Receiver<bool>,
+    _permit: OwnedSemaphorePermit,
+) {
+    let tls = match time::timeout(handshake_timeout, acceptor.accept(socket)).await {
+        Ok(Ok(tls)) => tls,
+        Ok(Err(error)) => {
+            debug!(%peer, %error, "sandbox data-plane TLS handshake rejected");
+            return;
+        }
+        Err(_) => {
+            debug!(%peer, "sandbox data-plane TLS handshake timed out");
+            return;
+        }
+    };
+    let service = service_fn(move |request| {
+        let proxy = proxy.clone();
+        async move { Ok::<_, std::convert::Infallible>(proxy.handle(request).await) }
+    });
+    let mut http = Http::new();
+    http.http1_keep_alive(true)
+        .http1_half_close(true)
+        .http2_adaptive_window(true);
+    let connection = http.serve_connection(tls, service).with_upgrades();
+    tokio::pin!(connection);
+    tokio::select! {
+        result = &mut connection => {
+            if let Err(error) = result {
+                debug!(%peer, %error, "sandbox data-plane connection closed with an HTTP error");
+            }
+        }
+        changed = shutdown.changed() => {
+            if changed.is_err() || *shutdown.borrow() {
+                connection.as_mut().graceful_shutdown();
+                if let Err(error) = connection.await {
+                    debug!(%peer, %error, "sandbox data-plane connection failed while draining");
+                }
+            }
+        }
+    }
+}
+
+async fn drain_connections(connections: &mut JoinSet<()>, timeout: Duration) {
+    let drain = async { while connections.join_next().await.is_some() {} };
+    if time::timeout(timeout, drain).await.is_err() {
+        let remaining = connections.len();
+        warn!(
+            remaining,
+            "aborting sandbox data-plane connections after drain timeout"
+        );
+        connections.abort_all();
+        while connections.join_next().await.is_some() {}
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DataPlaneGatewayError {
+    #[error("failed to read TLS certificate {path}: {source}")]
+    ReadCertificate {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to read TLS private key {path}: {source}")]
+    ReadPrivateKey {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("TLS certificate file contains no certificates: {0}")]
+    MissingCertificate(PathBuf),
+    #[error("TLS private key file contains no supported private key: {0}")]
+    MissingPrivateKey(PathBuf),
+    #[error("invalid TLS certificate or private key: {0}")]
+    InvalidTls(#[source] rustls::Error),
+    #[error("failed to accept a sandbox data-plane connection: {0}")]
+    Accept(#[source] std::io::Error),
+    #[error("sandbox data-plane connection limiter closed unexpectedly")]
+    ConnectionLimiterClosed,
+}
+
+pub type DataPlaneGatewayResult<T> = std::result::Result<T, DataPlaneGatewayError>;
+
+#[cfg(test)]
+mod tests;

--- a/src/compat/src/gateway/proxy.rs
+++ b/src/compat/src/gateway/proxy.rs
@@ -100,17 +100,16 @@ async fn proxy_upstream(
     request: &mut Request<Body>,
     stream: ExecutionPortStream,
 ) -> Result<Response<Body>, ProxyFailure> {
-    let version = request.version();
-    let upgrade = is_upgrade(request.headers(), version);
+    let downstream_version = request.version();
+    let upgrade = is_upgrade(request.headers(), downstream_version);
     let downstream_upgrade = upgrade.then(|| hyper::upgrade::on(&mut *request));
-    normalize_uri(request)?;
-    sanitize_request_headers(request.headers_mut(), version, upgrade);
+    normalize_http1_upstream(request)?;
+    sanitize_request_headers(request.headers_mut(), downstream_version, upgrade);
+    // Downstream ALPN does not describe the plaintext Sandbox origin. E2B's
+    // data plane translates both HTTP/1.1 and HTTP/2 clients to HTTP/1.1 here.
+    *request.version_mut() = Version::HTTP_11;
 
-    let mut builder = conn::Builder::new();
-    if version == Version::HTTP_2 {
-        builder.http2_only(true);
-    }
-    let (mut sender, connection) = builder.handshake(stream).await?;
+    let (mut sender, connection) = conn::Builder::new().handshake(stream).await?;
     tokio::spawn(async move {
         if let Err(error) = connection.await {
             debug!(%error, "sandbox data-plane upstream connection closed");
@@ -119,7 +118,11 @@ async fn proxy_upstream(
     let outbound = std::mem::replace(request, Request::new(Body::empty()));
     let mut response = sender.send_request(outbound).await?;
     let switched_protocols = response.status() == StatusCode::SWITCHING_PROTOCOLS && upgrade;
-    sanitize_response_headers(response.headers_mut(), version, switched_protocols);
+    sanitize_response_headers(
+        response.headers_mut(),
+        downstream_version,
+        switched_protocols,
+    );
 
     if let Some(downstream_upgrade) = downstream_upgrade.filter(|_| switched_protocols) {
         let upstream_upgrade = hyper::upgrade::on(&mut response);
@@ -140,31 +143,26 @@ async fn proxy_upstream(
     Ok(response)
 }
 
-fn normalize_uri(request: &mut Request<Body>) -> Result<(), ProxyFailure> {
+fn normalize_http1_upstream(request: &mut Request<Body>) -> Result<(), ProxyFailure> {
+    let authority = request
+        .uri()
+        .authority()
+        .map(|value| value.as_str().to_string());
     let path_and_query = request
         .uri()
         .path_and_query()
         .map(|value| value.as_str())
         .unwrap_or("/")
         .to_string();
-    if request.version() == Version::HTTP_2 {
-        if request.uri().scheme().is_some() && request.uri().authority().is_some() {
-            return Ok(());
-        }
-        let authority = request
-            .headers()
-            .get(HOST)
-            .ok_or(ProxyFailure::InvalidUpstreamUri)?
-            .to_str()
-            .map_err(|_| ProxyFailure::InvalidUpstreamUri)?;
-        *request.uri_mut() = format!("https://{authority}{path_and_query}")
-            .parse::<Uri>()
-            .map_err(|_| ProxyFailure::InvalidUpstreamUri)?;
-    } else {
-        *request.uri_mut() = path_and_query
-            .parse::<Uri>()
-            .map_err(|_| ProxyFailure::InvalidUpstreamUri)?;
+    if !request.headers().contains_key(HOST) {
+        let authority = authority.ok_or(ProxyFailure::InvalidUpstreamUri)?;
+        let host =
+            HeaderValue::from_str(&authority).map_err(|_| ProxyFailure::InvalidUpstreamUri)?;
+        request.headers_mut().insert(HOST, host);
     }
+    *request.uri_mut() = path_and_query
+        .parse::<Uri>()
+        .map_err(|_| ProxyFailure::InvalidUpstreamUri)?;
     Ok(())
 }
 

--- a/src/compat/src/gateway/proxy.rs
+++ b/src/compat/src/gateway/proxy.rs
@@ -1,0 +1,395 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use a3s_box_core::{ExecutionManagerError, ExecutionPortConnector, ExecutionPortStream};
+use axum::body::Body;
+use axum::http::header::{
+    ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+    ACCESS_CONTROL_EXPOSE_HEADERS, ACCESS_CONTROL_MAX_AGE, CONNECTION, CONTENT_TYPE, HOST, ORIGIN,
+    TE, TRAILER, TRANSFER_ENCODING, UPGRADE,
+};
+use axum::http::{
+    HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode, Uri, Version,
+};
+use hyper::client::conn;
+use thiserror::Error;
+use tokio::io::copy_bidirectional;
+use tracing::debug;
+
+use crate::routing::{
+    RouteLeaseError, RouteLeaseService, RouteParseError, SandboxRouteParser,
+    ENVD_ACCESS_TOKEN_HEADER, SANDBOX_ID_HEADER, SANDBOX_PORT_HEADER, TRAFFIC_ACCESS_TOKEN_HEADER,
+};
+
+const ACCESS_CONTROL_REQUEST_METHOD: &str = "access-control-request-method";
+const ACCESS_CONTROL_REQUEST_HEADERS: &str = "access-control-request-headers";
+const FORWARDED: &str = "forwarded";
+const X_FORWARDED_FOR: &str = "x-forwarded-for";
+const X_FORWARDED_HOST: &str = "x-forwarded-host";
+const X_FORWARDED_PORT: &str = "x-forwarded-port";
+const X_FORWARDED_PROTO: &str = "x-forwarded-proto";
+const PROXY_CONNECTION: &str = "proxy-connection";
+const PROXY_AUTHENTICATE: &str = "proxy-authenticate";
+const PROXY_AUTHORIZATION: &str = "proxy-authorization";
+const KEEP_ALIVE: &str = "keep-alive";
+const EXPOSED_HEADERS: &str =
+    "Grpc-Status, Grpc-Message, Grpc-Status-Details-Bin, Connect-Content-Encoding, Trailer";
+
+#[derive(Clone)]
+pub struct DataPlaneProxy {
+    parser: SandboxRouteParser,
+    leases: RouteLeaseService,
+    connector: Arc<dyn ExecutionPortConnector>,
+    connect_timeout: Duration,
+}
+
+impl DataPlaneProxy {
+    pub(crate) fn new(
+        parser: SandboxRouteParser,
+        leases: RouteLeaseService,
+        connector: Arc<dyn ExecutionPortConnector>,
+        connect_timeout: Duration,
+    ) -> Self {
+        Self {
+            parser,
+            leases,
+            connector,
+            connect_timeout,
+        }
+    }
+
+    pub async fn handle(&self, mut request: Request<Body>) -> Response<Body> {
+        let cors = request.headers().contains_key(ORIGIN);
+        let route = match self.parser.parse_uri(request.uri(), request.headers()) {
+            Ok(route) => route,
+            Err(error) => return with_cors(error_response(ProxyFailure::Route(error)), cors),
+        };
+        if is_cors_preflight(&request) {
+            return preflight_response(request.headers());
+        }
+
+        let lease = match self.leases.resolve(&route, request.headers()).await {
+            Ok(lease) => lease,
+            Err(error) => return with_cors(error_response(ProxyFailure::Lease(error)), cors),
+        };
+        let stream = match self
+            .connector
+            .connect_port(
+                lease.execution_id(),
+                lease.execution_generation(),
+                lease.port(),
+                self.connect_timeout,
+            )
+            .await
+        {
+            Ok(stream) => stream,
+            Err(error) => return with_cors(error_response(ProxyFailure::Connect(error)), cors),
+        };
+
+        match proxy_upstream(&mut request, stream).await {
+            Ok(response) => with_cors(response, cors),
+            Err(error) => {
+                debug!(%error, "sandbox data-plane upstream request failed");
+                with_cors(error_response(error), cors)
+            }
+        }
+    }
+}
+
+async fn proxy_upstream(
+    request: &mut Request<Body>,
+    stream: ExecutionPortStream,
+) -> Result<Response<Body>, ProxyFailure> {
+    let version = request.version();
+    let upgrade = is_upgrade(request.headers(), version);
+    let downstream_upgrade = upgrade.then(|| hyper::upgrade::on(&mut *request));
+    normalize_uri(request)?;
+    sanitize_request_headers(request.headers_mut(), version, upgrade);
+
+    let mut builder = conn::Builder::new();
+    if version == Version::HTTP_2 {
+        builder.http2_only(true);
+    }
+    let (mut sender, connection) = builder.handshake(stream).await?;
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            debug!(%error, "sandbox data-plane upstream connection closed");
+        }
+    });
+    let outbound = std::mem::replace(request, Request::new(Body::empty()));
+    let mut response = sender.send_request(outbound).await?;
+    let switched_protocols = response.status() == StatusCode::SWITCHING_PROTOCOLS && upgrade;
+    sanitize_response_headers(response.headers_mut(), version, switched_protocols);
+
+    if let Some(downstream_upgrade) = downstream_upgrade.filter(|_| switched_protocols) {
+        let upstream_upgrade = hyper::upgrade::on(&mut response);
+        tokio::spawn(async move {
+            let (mut downstream, mut upstream) =
+                match tokio::try_join!(downstream_upgrade, upstream_upgrade) {
+                    Ok(upgrades) => upgrades,
+                    Err(error) => {
+                        debug!(%error, "sandbox data-plane protocol upgrade failed");
+                        return;
+                    }
+                };
+            if let Err(error) = copy_bidirectional(&mut downstream, &mut upstream).await {
+                debug!(%error, "sandbox data-plane upgraded stream closed");
+            }
+        });
+    }
+    Ok(response)
+}
+
+fn normalize_uri(request: &mut Request<Body>) -> Result<(), ProxyFailure> {
+    let path_and_query = request
+        .uri()
+        .path_and_query()
+        .map(|value| value.as_str())
+        .unwrap_or("/")
+        .to_string();
+    if request.version() == Version::HTTP_2 {
+        if request.uri().scheme().is_some() && request.uri().authority().is_some() {
+            return Ok(());
+        }
+        let authority = request
+            .headers()
+            .get(HOST)
+            .ok_or(ProxyFailure::InvalidUpstreamUri)?
+            .to_str()
+            .map_err(|_| ProxyFailure::InvalidUpstreamUri)?;
+        *request.uri_mut() = format!("https://{authority}{path_and_query}")
+            .parse::<Uri>()
+            .map_err(|_| ProxyFailure::InvalidUpstreamUri)?;
+    } else {
+        *request.uri_mut() = path_and_query
+            .parse::<Uri>()
+            .map_err(|_| ProxyFailure::InvalidUpstreamUri)?;
+    }
+    Ok(())
+}
+
+fn sanitize_request_headers(headers: &mut HeaderMap, version: Version, upgrade: bool) {
+    for name in [
+        ENVD_ACCESS_TOKEN_HEADER,
+        TRAFFIC_ACCESS_TOKEN_HEADER,
+        SANDBOX_ID_HEADER,
+        SANDBOX_PORT_HEADER,
+        FORWARDED,
+        X_FORWARDED_FOR,
+        X_FORWARDED_HOST,
+        X_FORWARDED_PORT,
+        X_FORWARDED_PROTO,
+    ] {
+        headers.remove(name);
+    }
+    let original_host = headers.get(HOST).cloned();
+    strip_hop_headers(headers, version, upgrade);
+    headers.insert(X_FORWARDED_PROTO, HeaderValue::from_static("https"));
+    if let Some(host) = original_host {
+        headers.insert(X_FORWARDED_HOST, host);
+    }
+}
+
+fn sanitize_response_headers(headers: &mut HeaderMap, version: Version, upgrade: bool) {
+    strip_hop_headers(headers, version, upgrade);
+}
+
+fn strip_hop_headers(headers: &mut HeaderMap, version: Version, upgrade: bool) {
+    let nominated = connection_header_names(headers);
+    for name in nominated {
+        if !upgrade || (name != UPGRADE && name != CONNECTION) {
+            headers.remove(name);
+        }
+    }
+    for name in [
+        HeaderName::from_static(PROXY_CONNECTION),
+        HeaderName::from_static(PROXY_AUTHENTICATE),
+        HeaderName::from_static(PROXY_AUTHORIZATION),
+        HeaderName::from_static(KEEP_ALIVE),
+        TRANSFER_ENCODING,
+    ] {
+        headers.remove(name);
+    }
+    if !upgrade || version == Version::HTTP_2 {
+        headers.remove(CONNECTION);
+        headers.remove(UPGRADE);
+    }
+    if version == Version::HTTP_2 && headers.get(TE) != Some(&HeaderValue::from_static("trailers"))
+    {
+        headers.remove(TE);
+    }
+    if version == Version::HTTP_2 {
+        // HTTP/2 carries trailers without the HTTP/1.1 Trailer declaration.
+        headers.remove(TRAILER);
+    }
+}
+
+fn connection_header_names(headers: &HeaderMap) -> Vec<HeaderName> {
+    headers
+        .get_all(CONNECTION)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .filter_map(|value| value.trim().parse::<HeaderName>().ok())
+        .collect()
+}
+
+fn is_upgrade(headers: &HeaderMap, version: Version) -> bool {
+    version != Version::HTTP_2
+        && headers.contains_key(UPGRADE)
+        && headers
+            .get_all(CONNECTION)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .any(|value| value.trim().eq_ignore_ascii_case("upgrade"))
+}
+
+fn is_cors_preflight(request: &Request<Body>) -> bool {
+    request.method() == Method::OPTIONS
+        && request.headers().contains_key(ORIGIN)
+        && request
+            .headers()
+            .contains_key(ACCESS_CONTROL_REQUEST_METHOD)
+}
+
+fn preflight_response(request_headers: &HeaderMap) -> Response<Body> {
+    let method = request_headers
+        .get(ACCESS_CONTROL_REQUEST_METHOD)
+        .cloned()
+        .unwrap_or_else(|| HeaderValue::from_static("GET, POST, PUT, PATCH, DELETE, OPTIONS"));
+    let headers = request_headers
+        .get(ACCESS_CONTROL_REQUEST_HEADERS)
+        .cloned()
+        .unwrap_or_else(|| {
+            HeaderValue::from_static(
+                "Authorization, Content-Type, X-Access-Token, E2B-Traffic-Access-Token, E2b-Sandbox-Id, E2b-Sandbox-Port, Connect-Protocol-Version, Connect-Timeout-Ms",
+            )
+        });
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = StatusCode::NO_CONTENT;
+    response
+        .headers_mut()
+        .insert(ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static("*"));
+    response
+        .headers_mut()
+        .insert(ACCESS_CONTROL_ALLOW_METHODS, method);
+    response
+        .headers_mut()
+        .insert(ACCESS_CONTROL_ALLOW_HEADERS, headers);
+    response
+        .headers_mut()
+        .insert(ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static("600"));
+    response
+}
+
+fn with_cors(mut response: Response<Body>, enabled: bool) -> Response<Body> {
+    if enabled {
+        response
+            .headers_mut()
+            .insert(ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static("*"));
+        response.headers_mut().insert(
+            ACCESS_CONTROL_EXPOSE_HEADERS,
+            HeaderValue::from_static(EXPOSED_HEADERS),
+        );
+    }
+    response
+}
+
+fn error_response(error: ProxyFailure) -> Response<Body> {
+    let (status, code, message) = error.public_error();
+    let body = serde_json::json!({ "code": code, "message": message }).to_string();
+    let mut response = Response::new(Body::from(body));
+    *response.status_mut() = status;
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    response
+}
+
+#[derive(Debug, Error)]
+enum ProxyFailure {
+    #[error(transparent)]
+    Route(#[from] RouteParseError),
+    #[error(transparent)]
+    Lease(#[from] RouteLeaseError),
+    #[error(transparent)]
+    Connect(#[from] ExecutionManagerError),
+    #[error("sandbox upstream URI is invalid")]
+    InvalidUpstreamUri,
+    #[error("sandbox upstream HTTP transport failed: {0}")]
+    Upstream(#[from] hyper::Error),
+}
+
+impl ProxyFailure {
+    fn public_error(&self) -> (StatusCode, &'static str, &'static str) {
+        match self {
+            Self::Route(RouteParseError::UnsupportedHost) => (
+                StatusCode::NOT_FOUND,
+                "ROUTE_NOT_FOUND",
+                "Sandbox route not found",
+            ),
+            Self::Route(_) => (
+                StatusCode::BAD_REQUEST,
+                "INVALID_ROUTE",
+                "Sandbox route is invalid",
+            ),
+            Self::Lease(
+                RouteLeaseError::MissingToken
+                | RouteLeaseError::InvalidToken
+                | RouteLeaseError::Unauthorized,
+            ) => (
+                StatusCode::UNAUTHORIZED,
+                "UNAUTHORIZED",
+                "Sandbox access token is invalid",
+            ),
+            Self::Lease(
+                RouteLeaseError::NotFound
+                | RouteLeaseError::Inactive
+                | RouteLeaseError::Expired
+                | RouteLeaseError::PortDenied,
+            ) => (
+                StatusCode::NOT_FOUND,
+                "ROUTE_NOT_FOUND",
+                "Sandbox route not found",
+            ),
+            Self::Lease(RouteLeaseError::InvalidRecord) => (
+                StatusCode::BAD_GATEWAY,
+                "INVALID_SANDBOX_STATE",
+                "Sandbox runtime state is invalid",
+            ),
+            Self::Lease(RouteLeaseError::Repository(_) | RouteLeaseError::Token(_)) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "ROUTE_UNAVAILABLE",
+                "Sandbox route is temporarily unavailable",
+            ),
+            Self::Connect(ExecutionManagerError::InvalidRequest(_)) => (
+                StatusCode::BAD_REQUEST,
+                "INVALID_UPSTREAM",
+                "Sandbox upstream request is invalid",
+            ),
+            Self::Connect(ExecutionManagerError::NotFound(_)) => (
+                StatusCode::NOT_FOUND,
+                "RUNTIME_NOT_FOUND",
+                "Sandbox runtime not found",
+            ),
+            Self::Connect(ExecutionManagerError::Conflict { .. }) => (
+                StatusCode::CONFLICT,
+                "STALE_RUNTIME",
+                "Sandbox runtime generation changed",
+            ),
+            Self::Connect(ExecutionManagerError::Unavailable(_)) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "UPSTREAM_UNAVAILABLE",
+                "Sandbox upstream is unavailable",
+            ),
+            Self::Connect(ExecutionManagerError::Internal(_))
+            | Self::InvalidUpstreamUri
+            | Self::Upstream(_) => (
+                StatusCode::BAD_GATEWAY,
+                "UPSTREAM_FAILURE",
+                "Sandbox upstream request failed",
+            ),
+        }
+    }
+}

--- a/src/compat/src/gateway/tests.rs
+++ b/src/compat/src/gateway/tests.rs
@@ -1,0 +1,376 @@
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::num::{NonZeroU16, NonZeroUsize};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use a3s_box_core::{
+    resolve_execution, BoxConfig, ExecutionGeneration, ExecutionId, ExecutionIsolation,
+    ExecutionLease, ExecutionManagerError, ExecutionManagerResult, ExecutionPortConnector,
+    ExecutionPortStream, OperationId,
+};
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::header::{HOST, ORIGIN};
+use axum::http::{HeaderValue, Method, Request, Response, StatusCode};
+use chrono::{DateTime, TimeZone, Utc};
+use hyper::body::to_bytes;
+use hyper::service::service_fn;
+use rustls::pki_types::ServerName;
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::control::{
+    Clock, LifecyclePolicy, MemorySandboxRepository, NewSandboxRecord, OnTimeoutAction,
+    RotatingTokenProvider, SandboxCredentials, SandboxId, SandboxRecord, SandboxRepository,
+    SecretToken, TokenIssuer, TokenKeyMaterial, TokenScope,
+};
+use crate::routing::{
+    RouteLeaseService, SandboxDomain, SandboxRouteParser, SandboxRoutePolicy,
+    CODE_INTERPRETER_PORT, ENVD_ACCESS_TOKEN_HEADER, ENVD_PORT, SANDBOX_ID_HEADER,
+    SANDBOX_PORT_HEADER, TRAFFIC_ACCESS_TOKEN_HEADER,
+};
+
+use super::{DataPlaneGateway, DataPlaneGatewayConfig, DataPlaneProxy};
+
+struct FixedClock(DateTime<Utc>);
+
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+#[derive(Clone)]
+struct TcpConnector {
+    address: SocketAddr,
+    calls: Arc<Mutex<Vec<(String, u64, u16)>>>,
+}
+
+#[async_trait]
+impl ExecutionPortConnector for TcpConnector {
+    async fn connect_port(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+        port: NonZeroU16,
+        _timeout: Duration,
+    ) -> ExecutionManagerResult<ExecutionPortStream> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((execution_id.to_string(), generation.get(), port.get()));
+        let stream = TcpStream::connect(self.address)
+            .await
+            .map_err(|error| ExecutionManagerError::Unavailable(error.to_string()))?;
+        Ok(Box::pin(stream))
+    }
+}
+
+struct Harness {
+    proxy: DataPlaneProxy,
+    parser: SandboxRouteParser,
+    leases: RouteLeaseService,
+    connector: Arc<TcpConnector>,
+    sandbox_id: SandboxId,
+    envd_token: SecretToken,
+    traffic_token: SecretToken,
+    upstream: tokio::task::JoinHandle<()>,
+}
+
+impl Harness {
+    async fn new() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let upstream = tokio::spawn(async move {
+            loop {
+                let Ok((socket, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let service = service_fn(upstream_response);
+                    let _ = hyper::server::conn::Http::new()
+                        .serve_connection(socket, service)
+                        .with_upgrades()
+                        .await;
+                });
+            }
+        });
+
+        let now = Utc
+            .with_ymd_and_hms(2026, 7, 15, 16, 0, 0)
+            .single()
+            .unwrap();
+        let tokens = Arc::new(
+            RotatingTokenProvider::new(1, [TokenKeyMaterial::new(1, &[7; 32], &[8; 32]).unwrap()])
+                .unwrap(),
+        );
+        let envd = tokens.issue(TokenScope::Envd).await.unwrap();
+        let traffic = tokens.issue(TokenScope::Traffic).await.unwrap();
+        let sandbox_id = SandboxId::new("sandbox-gateway-1").unwrap();
+        let mut config = BoxConfig {
+            isolation: ExecutionIsolation::Sandbox,
+            image: "alpine:3.20".to_string(),
+            ..BoxConfig::default()
+        };
+        config.network = a3s_box_core::NetworkMode::None;
+        let plan = resolve_execution(&config).unwrap();
+        let routing = SandboxRoutePolicy::default()
+            .with_port(CODE_INTERPRETER_PORT, TokenScope::Traffic)
+            .unwrap();
+        let mut record = SandboxRecord::creating(NewSandboxRecord {
+            sandbox_id: sandbox_id.clone(),
+            operation_id: OperationId::new("operation-gateway-1").unwrap(),
+            owner_id: "owner-gateway".to_string(),
+            template_id: "gateway-template".to_string(),
+            plan: plan.clone(),
+            resources: config.resources.clone(),
+            lifecycle: LifecyclePolicy {
+                on_timeout: OnTimeoutAction::Kill,
+                auto_resume: false,
+                keep_memory_on_pause: false,
+            },
+            created_at: now,
+            expires_at: now + chrono::Duration::minutes(5),
+            metadata: BTreeMap::new(),
+            envd_version: "0.1.3".to_string(),
+            secure: true,
+            allow_internet_access: Some(false),
+            credentials: SandboxCredentials {
+                envd: envd.stored,
+                traffic: traffic.stored,
+            },
+            routing,
+        })
+        .unwrap();
+        record
+            .mark_running(ExecutionLease {
+                execution_id: ExecutionId::new("execution-gateway-1").unwrap(),
+                generation: ExecutionGeneration::INITIAL,
+                plan,
+                resources: config.resources,
+                started_at: now,
+            })
+            .unwrap();
+        let repository = Arc::new(MemorySandboxRepository::default());
+        repository.insert(record).await.unwrap();
+        let leases = RouteLeaseService::new(repository, tokens, Arc::new(FixedClock(now)));
+        let connector = Arc::new(TcpConnector {
+            address,
+            calls: Arc::new(Mutex::new(Vec::new())),
+        });
+        let parser = SandboxRouteParser::new(SandboxDomain::new("box.example.com").unwrap());
+        let proxy = DataPlaneProxy::new(
+            parser.clone(),
+            leases.clone(),
+            connector.clone(),
+            Duration::from_secs(2),
+        );
+        Self {
+            proxy,
+            parser,
+            leases,
+            connector,
+            sandbox_id,
+            envd_token: envd.secret,
+            traffic_token: traffic.secret,
+            upstream,
+        }
+    }
+
+    fn direct_request(
+        &self,
+        port: u16,
+        token_header: &'static str,
+        token: &SecretToken,
+    ) -> Request<Body> {
+        Request::builder()
+            .method(Method::POST)
+            .uri("/echo?value=one")
+            .header(HOST, format!("{port}-{}.box.example.com", self.sandbox_id))
+            .header(token_header, token.expose_secret())
+            .header("x-forwarded-for", "203.0.113.5")
+            .body(Body::from("hello-data-plane"))
+            .unwrap()
+    }
+
+    fn call_count(&self) -> usize {
+        self.connector.calls.lock().unwrap().len()
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.upstream.abort();
+    }
+}
+
+async fn upstream_response(
+    request: Request<Body>,
+) -> Result<Response<Body>, std::convert::Infallible> {
+    let method = request.method().to_string();
+    let uri = request.uri().to_string();
+    let headers = request.headers().clone();
+    let body = to_bytes(request.into_body()).await.unwrap();
+    let value = serde_json::json!({
+        "method": method,
+        "uri": uri,
+        "body": String::from_utf8_lossy(&body),
+        "envdTokenForwarded": headers.contains_key(ENVD_ACCESS_TOKEN_HEADER),
+        "trafficTokenForwarded": headers.contains_key(TRAFFIC_ACCESS_TOKEN_HEADER),
+        "sandboxIdForwarded": headers.contains_key(SANDBOX_ID_HEADER),
+        "sandboxPortForwarded": headers.contains_key(SANDBOX_PORT_HEADER),
+        "forwardedProto": headers.get("x-forwarded-proto").and_then(|value| value.to_str().ok()),
+        "forwardedHost": headers.get("x-forwarded-host").and_then(|value| value.to_str().ok()),
+        "forwardedFor": headers.get("x-forwarded-for").and_then(|value| value.to_str().ok()),
+    });
+    let mut response = Response::new(Body::from(value.to_string()));
+    response
+        .headers_mut()
+        .insert("content-type", HeaderValue::from_static("application/json"));
+    Ok(response)
+}
+
+#[tokio::test]
+async fn authenticated_direct_route_proxies_stream_and_strips_edge_credentials() {
+    let harness = Harness::new().await;
+    let request = harness.direct_request(ENVD_PORT, ENVD_ACCESS_TOKEN_HEADER, &harness.envd_token);
+    let response = harness.proxy.handle(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(response.into_body()).await.unwrap()).unwrap();
+    assert_eq!(body["method"], "POST");
+    assert_eq!(body["uri"], "/echo?value=one");
+    assert_eq!(body["body"], "hello-data-plane");
+    assert_eq!(body["envdTokenForwarded"], false);
+    assert_eq!(body["trafficTokenForwarded"], false);
+    assert_eq!(body["sandboxIdForwarded"], false);
+    assert_eq!(body["sandboxPortForwarded"], false);
+    assert_eq!(body["forwardedProto"], "https");
+    assert!(body["forwardedHost"]
+        .as_str()
+        .unwrap()
+        .starts_with("49983-sandbox-gateway-1"));
+    assert!(body["forwardedFor"].is_null());
+    assert_eq!(harness.call_count(), 1);
+}
+
+#[tokio::test]
+async fn token_scope_is_checked_before_opening_an_upstream_connection() {
+    let harness = Harness::new().await;
+    let swapped = harness.direct_request(
+        CODE_INTERPRETER_PORT,
+        TRAFFIC_ACCESS_TOKEN_HEADER,
+        &harness.envd_token,
+    );
+    assert_eq!(
+        harness.proxy.handle(swapped).await.status(),
+        StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(harness.call_count(), 0);
+
+    let valid = harness.direct_request(
+        CODE_INTERPRETER_PORT,
+        TRAFFIC_ACCESS_TOKEN_HEADER,
+        &harness.traffic_token,
+    );
+    assert_eq!(harness.proxy.handle(valid).await.status(), StatusCode::OK);
+    assert_eq!(harness.call_count(), 1);
+}
+
+#[tokio::test]
+async fn shared_routes_and_browser_preflight_use_the_same_validated_parser() {
+    let harness = Harness::new().await;
+    let preflight = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/health")
+        .header(HOST, "sandbox.box.example.com")
+        .header(SANDBOX_ID_HEADER, harness.sandbox_id.as_str())
+        .header(SANDBOX_PORT_HEADER, ENVD_PORT.to_string())
+        .header(ORIGIN, "https://app.example.com")
+        .header("access-control-request-method", "GET")
+        .header("access-control-request-headers", "X-Access-Token")
+        .body(Body::empty())
+        .unwrap();
+    let response = harness.proxy.handle(preflight).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(response.headers()["access-control-allow-origin"], "*");
+    assert_eq!(harness.call_count(), 0);
+
+    let shared = Request::builder()
+        .uri("/health")
+        .header(HOST, "sandbox.box.example.com")
+        .header(SANDBOX_ID_HEADER, harness.sandbox_id.as_str())
+        .header(SANDBOX_PORT_HEADER, ENVD_PORT.to_string())
+        .header(ENVD_ACCESS_TOKEN_HEADER, harness.envd_token.expose_secret())
+        .body(Body::empty())
+        .unwrap();
+    assert_eq!(harness.proxy.handle(shared).await.status(), StatusCode::OK);
+    assert_eq!(harness.call_count(), 1);
+}
+
+#[tokio::test]
+async fn wildcard_tls_listener_serves_an_authenticated_route() {
+    let harness = Harness::new().await;
+    let temporary = tempfile::tempdir().unwrap();
+    let rcgen::CertifiedKey { cert, key_pair } = rcgen::generate_simple_self_signed(vec![
+        "*.box.example.com".to_string(),
+        "sandbox.box.example.com".to_string(),
+    ])
+    .unwrap();
+    let certificate_path = temporary.path().join("certificate.pem");
+    let private_key_path = temporary.path().join("private-key.pem");
+    std::fs::write(&certificate_path, cert.pem()).unwrap();
+    std::fs::write(&private_key_path, key_pair.serialize_pem()).unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let config = DataPlaneGatewayConfig {
+        listen: address,
+        certificate_path,
+        private_key_path,
+        max_connections: NonZeroUsize::new(16).unwrap(),
+        handshake_timeout: Duration::from_secs(2),
+        connect_timeout: Duration::from_secs(2),
+        drain_timeout: Duration::from_secs(2),
+    };
+    let gateway = DataPlaneGateway::build(
+        config,
+        harness.parser.clone(),
+        harness.leases.clone(),
+        harness.connector.clone(),
+    )
+    .await
+    .unwrap();
+    let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(false);
+    let gateway_task = tokio::spawn(gateway.serve(listener, shutdown_receiver));
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let mut roots = rustls::RootCertStore::empty();
+    roots.add(cert.der().clone()).unwrap();
+    let mut client_config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    client_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(client_config));
+    let host = format!("{}-{}.box.example.com", ENVD_PORT, harness.sandbox_id);
+    let tcp = TcpStream::connect(address).await.unwrap();
+    let tls = connector
+        .connect(ServerName::try_from(host.clone()).unwrap(), tcp)
+        .await
+        .unwrap();
+    let (mut sender, connection) = hyper::client::conn::handshake(tls).await.unwrap();
+    let client_task = tokio::spawn(connection);
+    let request = Request::builder()
+        .uri("/echo")
+        .header(HOST, host)
+        .header(ENVD_ACCESS_TOKEN_HEADER, harness.envd_token.expose_secret())
+        .body(Body::from("tls"))
+        .unwrap();
+    let response = sender.send_request(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let _ = to_bytes(response.into_body()).await.unwrap();
+    drop(sender);
+    client_task.await.unwrap().unwrap();
+    shutdown_sender.send(true).unwrap();
+    gateway_task.await.unwrap().unwrap();
+}

--- a/src/compat/src/gateway/tests.rs
+++ b/src/compat/src/gateway/tests.rs
@@ -12,7 +12,7 @@ use a3s_box_core::{
 use async_trait::async_trait;
 use axum::body::Body;
 use axum::http::header::{HOST, ORIGIN};
-use axum::http::{HeaderValue, Method, Request, Response, StatusCode};
+use axum::http::{HeaderValue, Method, Request, Response, StatusCode, Version};
 use chrono::{DateTime, TimeZone, Utc};
 use hyper::body::to_bytes;
 use hyper::service::service_fn;
@@ -88,10 +88,9 @@ impl Harness {
                 };
                 tokio::spawn(async move {
                     let service = service_fn(upstream_response);
-                    let _ = hyper::server::conn::Http::new()
-                        .serve_connection(socket, service)
-                        .with_upgrades()
-                        .await;
+                    let mut http = hyper::server::conn::Http::new();
+                    http.http1_only(true);
+                    let _ = http.serve_connection(socket, service).with_upgrades().await;
                 });
             }
         });
@@ -209,11 +208,13 @@ async fn upstream_response(
 ) -> Result<Response<Body>, std::convert::Infallible> {
     let method = request.method().to_string();
     let uri = request.uri().to_string();
+    let version = format!("{:?}", request.version());
     let headers = request.headers().clone();
     let body = to_bytes(request.into_body()).await.unwrap();
     let value = serde_json::json!({
         "method": method,
         "uri": uri,
+        "version": version,
         "body": String::from_utf8_lossy(&body),
         "envdTokenForwarded": headers.contains_key(ENVD_ACCESS_TOKEN_HEADER),
         "trafficTokenForwarded": headers.contains_key(TRAFFIC_ACCESS_TOKEN_HEADER),
@@ -228,6 +229,21 @@ async fn upstream_response(
         .headers_mut()
         .insert("content-type", HeaderValue::from_static("application/json"));
     Ok(response)
+}
+
+#[tokio::test]
+async fn translates_downstream_http2_to_plaintext_http1_upstream() {
+    let harness = Harness::new().await;
+    let mut request =
+        harness.direct_request(ENVD_PORT, ENVD_ACCESS_TOKEN_HEADER, &harness.envd_token);
+    *request.version_mut() = Version::HTTP_2;
+
+    let response = harness.proxy.handle(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(response.into_body()).await.unwrap()).unwrap();
+    assert_eq!(body["version"], "HTTP/1.1");
+    assert_eq!(harness.call_count(), 1);
 }
 
 #[tokio::test]

--- a/src/compat/src/gateway/tests.rs
+++ b/src/compat/src/gateway/tests.rs
@@ -215,6 +215,7 @@ async fn upstream_response(
         "method": method,
         "uri": uri,
         "version": version,
+        "host": headers.get(HOST).and_then(|value| value.to_str().ok()),
         "body": String::from_utf8_lossy(&body),
         "envdTokenForwarded": headers.contains_key(ENVD_ACCESS_TOKEN_HEADER),
         "trafficTokenForwarded": headers.contains_key(TRAFFIC_ACCESS_TOKEN_HEADER),
@@ -236,6 +237,10 @@ async fn translates_downstream_http2_to_plaintext_http1_upstream() {
     let harness = Harness::new().await;
     let mut request =
         harness.direct_request(ENVD_PORT, ENVD_ACCESS_TOKEN_HEADER, &harness.envd_token);
+    let authority = request.headers_mut().remove(HOST).unwrap();
+    *request.uri_mut() = format!("https://{}/echo?value=one", authority.to_str().unwrap())
+        .parse()
+        .unwrap();
     *request.version_mut() = Version::HTTP_2;
 
     let response = harness.proxy.handle(request).await;
@@ -243,6 +248,7 @@ async fn translates_downstream_http2_to_plaintext_http1_upstream() {
     let body: serde_json::Value =
         serde_json::from_slice(&to_bytes(response.into_body()).await.unwrap()).unwrap();
     assert_eq!(body["version"], "HTTP/1.1");
+    assert_eq!(body["host"], authority.to_str().unwrap());
     assert_eq!(harness.call_count(), 1);
 }
 

--- a/src/compat/src/gateway/tls.rs
+++ b/src/compat/src/gateway/tls.rs
@@ -1,0 +1,89 @@
+use std::io::Cursor;
+use std::path::Path;
+use std::sync::Arc;
+
+use rustls::ServerConfig;
+
+use super::{DataPlaneGatewayError, DataPlaneGatewayResult};
+
+const MAX_TLS_FILE_BYTES: u64 = 4 * 1024 * 1024;
+
+pub(super) async fn load_server_config(
+    certificate_path: &Path,
+    private_key_path: &Path,
+) -> DataPlaneGatewayResult<Arc<ServerConfig>> {
+    let certificate_bytes = read_limited(certificate_path, true).await?;
+    let private_key_bytes = read_limited(private_key_path, false).await?;
+
+    let certificates = rustls_pemfile::certs(&mut Cursor::new(certificate_bytes))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| DataPlaneGatewayError::ReadCertificate {
+            path: certificate_path.to_path_buf(),
+            source,
+        })?;
+    if certificates.is_empty() {
+        return Err(DataPlaneGatewayError::MissingCertificate(
+            certificate_path.to_path_buf(),
+        ));
+    }
+    let private_key = rustls_pemfile::private_key(&mut Cursor::new(private_key_bytes))
+        .map_err(|source| DataPlaneGatewayError::ReadPrivateKey {
+            path: private_key_path.to_path_buf(),
+            source,
+        })?
+        .ok_or_else(|| DataPlaneGatewayError::MissingPrivateKey(private_key_path.to_path_buf()))?;
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let mut config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certificates, private_key)
+        .map_err(DataPlaneGatewayError::InvalidTls)?;
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    Ok(Arc::new(config))
+}
+
+async fn read_limited(path: &Path, certificate: bool) -> DataPlaneGatewayResult<Vec<u8>> {
+    let metadata = tokio::fs::metadata(path).await.map_err(|source| {
+        if certificate {
+            DataPlaneGatewayError::ReadCertificate {
+                path: path.to_path_buf(),
+                source,
+            }
+        } else {
+            DataPlaneGatewayError::ReadPrivateKey {
+                path: path.to_path_buf(),
+                source,
+            }
+        }
+    })?;
+    if !metadata.is_file() || metadata.len() == 0 || metadata.len() > MAX_TLS_FILE_BYTES {
+        let source = std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("TLS file must be a non-empty regular file no larger than {MAX_TLS_FILE_BYTES} bytes"),
+        );
+        return Err(if certificate {
+            DataPlaneGatewayError::ReadCertificate {
+                path: path.to_path_buf(),
+                source,
+            }
+        } else {
+            DataPlaneGatewayError::ReadPrivateKey {
+                path: path.to_path_buf(),
+                source,
+            }
+        });
+    }
+    tokio::fs::read(path).await.map_err(|source| {
+        if certificate {
+            DataPlaneGatewayError::ReadCertificate {
+                path: path.to_path_buf(),
+                source,
+            }
+        } else {
+            DataPlaneGatewayError::ReadPrivateKey {
+                path: path.to_path_buf(),
+                source,
+            }
+        }
+    })
+}

--- a/src/compat/src/lib.rs
+++ b/src/compat/src/lib.rs
@@ -8,6 +8,7 @@ mod openapi;
 mod proto;
 
 pub mod control;
+pub mod gateway;
 pub mod http;
 pub mod production;
 pub mod routing;

--- a/src/compat/src/production/config.rs
+++ b/src/compat/src/production/config.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::fmt;
 use std::net::SocketAddr;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
@@ -11,6 +11,7 @@ use thiserror::Error;
 use url::Url;
 
 use crate::control::{ResolvedTemplate, TokenKeyMaterial, TokenScope};
+use crate::gateway::DataPlaneGatewayConfig;
 use crate::http::{CredentialHash, CredentialScheme, HashedAccountCredential};
 use crate::routing::{SandboxDomain, SandboxRoutePolicy, ENVD_PORT};
 
@@ -55,6 +56,7 @@ pub struct E2bCompatConfig {
     pub(crate) runtime_home: PathBuf,
     pub(crate) runtime_state_path: PathBuf,
     pub(crate) max_json_bytes: usize,
+    pub(crate) gateway: DataPlaneGatewayConfig,
     pub(crate) supervisor: SupervisorConfig,
     pub(crate) credentials: Vec<HashedAccountCredential>,
     pub(crate) active_token_version: u32,
@@ -114,6 +116,10 @@ impl E2bCompatConfig {
         self.supervisor
     }
 
+    pub fn gateway(&self) -> &DataPlaneGatewayConfig {
+        &self.gateway
+    }
+
     pub(super) fn parse_with_environment<F>(
         input: &str,
         mut environment: F,
@@ -137,6 +143,7 @@ impl fmt::Debug for E2bCompatConfig {
             .field("runtime_home", &self.runtime_home)
             .field("runtime_state_path", &self.runtime_state_path)
             .field("max_json_bytes", &self.max_json_bytes)
+            .field("gateway", &self.gateway)
             .field("supervisor", &self.supervisor)
             .field("credential_count", &self.credentials.len())
             .field("active_token_version", &self.active_token_version)
@@ -186,7 +193,13 @@ where
             "runtime_state_path",
             "max_json_bytes",
         ],
-        &["supervisor", "account", "token_key", "template_policy"],
+        &[
+            "supervisor",
+            "gateway",
+            "account",
+            "token_key",
+            "template_policy",
+        ],
         "e2b_compat",
     )?;
 
@@ -216,6 +229,12 @@ where
     }
 
     let supervisor = parse_supervisor(single_child(root, "supervisor", "e2b_compat")?)?;
+    let gateway = parse_gateway(single_child(root, "gateway", "e2b_compat")?)?;
+    if gateway.listen == api_listen {
+        return Err(invalid(
+            "e2b_compat.gateway.listen must differ from e2b_compat.api_listen",
+        ));
+    }
     let credentials = parse_credentials(children(root, "account"))?;
     let (active_token_version, token_keys) =
         parse_token_keys(children(root, "token_key"), environment)?;
@@ -231,11 +250,83 @@ where
         runtime_home,
         runtime_state_path,
         max_json_bytes,
+        gateway,
         supervisor,
         credentials,
         active_token_version,
         token_keys,
         templates,
+    })
+}
+
+fn parse_gateway(block: &Block) -> E2bConfigResult<DataPlaneGatewayConfig> {
+    const MAX_CONNECTIONS: usize = 100_000;
+    const MAX_TIMEOUT_MILLISECONDS: u64 = 60_000;
+    const MAX_DRAIN_SECONDS: u64 = 300;
+
+    let context = "e2b_compat.gateway";
+    require_no_labels(block, context)?;
+    ensure_shape(
+        block,
+        &[
+            "listen",
+            "tls_certificate_path",
+            "tls_private_key_path",
+            "max_connections",
+            "handshake_timeout_ms",
+            "connect_timeout_ms",
+            "drain_timeout_seconds",
+        ],
+        &[],
+        context,
+    )?;
+    let listen = required_string(block, "listen", context)?
+        .parse::<SocketAddr>()
+        .map_err(|_| invalid("e2b_compat.gateway.listen must be an IP socket address"))?;
+    if listen.port() == 0 {
+        return Err(invalid("e2b_compat.gateway.listen port must be non-zero"));
+    }
+    let certificate_path = required_absolute_path(block, "tls_certificate_path", context)?;
+    let private_key_path = required_absolute_path(block, "tls_private_key_path", context)?;
+    if certificate_path == private_key_path {
+        return Err(invalid(
+            "e2b_compat.gateway TLS certificate and private key paths must differ",
+        ));
+    }
+    let max_connections = NonZeroUsize::new(required_usize(block, "max_connections", context)?)
+        .filter(|value| value.get() <= MAX_CONNECTIONS)
+        .ok_or_else(|| {
+            invalid(format!(
+                "{context}.max_connections must be between 1 and {MAX_CONNECTIONS}"
+            ))
+        })?;
+    let handshake_timeout_ms = required_u64(block, "handshake_timeout_ms", context)?;
+    let connect_timeout_ms = required_u64(block, "connect_timeout_ms", context)?;
+    if !(100..=MAX_TIMEOUT_MILLISECONDS).contains(&handshake_timeout_ms) {
+        return Err(invalid(format!(
+            "{context}.handshake_timeout_ms must be between 100 and {MAX_TIMEOUT_MILLISECONDS}"
+        )));
+    }
+    if !(10..=MAX_TIMEOUT_MILLISECONDS).contains(&connect_timeout_ms) {
+        return Err(invalid(format!(
+            "{context}.connect_timeout_ms must be between 10 and {MAX_TIMEOUT_MILLISECONDS}"
+        )));
+    }
+    let drain_timeout_seconds = required_u64(block, "drain_timeout_seconds", context)?;
+    if !(1..=MAX_DRAIN_SECONDS).contains(&drain_timeout_seconds) {
+        return Err(invalid(format!(
+            "{context}.drain_timeout_seconds must be between 1 and {MAX_DRAIN_SECONDS}"
+        )));
+    }
+
+    Ok(DataPlaneGatewayConfig {
+        listen,
+        certificate_path,
+        private_key_path,
+        max_connections,
+        handshake_timeout: Duration::from_millis(handshake_timeout_ms),
+        connect_timeout: Duration::from_millis(connect_timeout_ms),
+        drain_timeout: Duration::from_secs(drain_timeout_seconds),
     })
 }
 
@@ -759,6 +850,12 @@ fn optional_usize(block: &Block, field: &str, context: &str) -> E2bConfigResult<
                 .map_err(|_| invalid(format!("{context}.{field} exceeds the platform range")))
         })
         .transpose()
+}
+
+fn required_usize(block: &Block, field: &str, context: &str) -> E2bConfigResult<usize> {
+    let value = required_u64(block, field, context)?;
+    usize::try_from(value)
+        .map_err(|_| invalid(format!("{context}.{field} exceeds the platform range")))
 }
 
 fn number_as_u64(value: &Value, field: &str, context: &str) -> E2bConfigResult<u64> {

--- a/src/compat/src/production/service.rs
+++ b/src/compat/src/production/service.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use a3s_box_core::ExecutionManager;
+use a3s_box_core::{ExecutionManager, ExecutionPortConnector};
 use a3s_box_runtime::LocalExecutionManager;
 use axum::Router;
 use thiserror::Error;
@@ -17,6 +17,7 @@ use crate::control::{
     RotatingTokenProvider, SandboxRepository, SqliteSandboxRepository, SystemClock,
     TokenIssuerError,
 };
+use crate::gateway::{DataPlaneGateway, DataPlaneGatewayError};
 use crate::http::{
     lifecycle_router, CredentialHashError, HashedCredentialVerifier, LifecycleHttpConfig,
     LifecycleHttpState, RejectingCursorDecoder,
@@ -28,9 +29,11 @@ use super::{E2bCompatConfig, SupervisorConfig, UuidSandboxIdentityProvider};
 /// Production service with one canonical lifecycle store and runtime manager.
 pub struct E2bCompatService {
     listen: SocketAddr,
+    gateway_listen: SocketAddr,
     public_url: Url,
     sandbox_domain: String,
     router: Router,
+    gateway: DataPlaneGateway,
     supervisor: LifecycleSupervisor,
     supervisor_config: SupervisorConfig,
     route_parser: SandboxRouteParser,
@@ -44,11 +47,12 @@ impl E2bCompatService {
         prepare_parent(&config.runtime_state_path).await?;
 
         let repository = Arc::new(SqliteSandboxRepository::open(&config.database_path).await?);
-        let executions: Arc<dyn ExecutionManager> =
-            Arc::new(LocalExecutionManager::with_vm_backend(
-                &config.runtime_state_path,
-                &config.runtime_home,
-            ));
+        let local_executions = Arc::new(LocalExecutionManager::with_vm_backend(
+            &config.runtime_state_path,
+            &config.runtime_home,
+        ));
+        let executions: Arc<dyn ExecutionManager> = local_executions.clone();
+        let port_connector: Arc<dyn ExecutionPortConnector> = local_executions;
         let clock = Arc::new(SystemClock);
         let tokens = Arc::new(RotatingTokenProvider::new(
             config.active_token_version,
@@ -84,12 +88,21 @@ impl E2bCompatService {
                 max_json_bytes: config.max_json_bytes,
             },
         ));
+        let gateway = DataPlaneGateway::build(
+            config.gateway.clone(),
+            route_parser.clone(),
+            route_leases.clone(),
+            port_connector,
+        )
+        .await?;
 
         Ok(Self {
             listen: config.api_listen,
+            gateway_listen: gateway.listen(),
             public_url: config.api_public_url,
             sandbox_domain,
             router,
+            gateway,
             supervisor,
             supervisor_config: config.supervisor,
             route_parser,
@@ -103,6 +116,10 @@ impl E2bCompatService {
 
     pub fn public_url(&self) -> &Url {
         &self.public_url
+    }
+
+    pub fn gateway_listen(&self) -> SocketAddr {
+        self.gateway_listen
     }
 
     pub fn sandbox_domain(&self) -> &str {
@@ -141,6 +158,12 @@ impl E2bCompatService {
                 address: self.listen,
                 source,
             })?;
+        let gateway_listener = tokio::net::TcpListener::bind(self.gateway_listen)
+            .await
+            .map_err(|source| E2bServiceError::Bind {
+                address: self.gateway_listen,
+                source,
+            })?;
         let listener = listener
             .into_std()
             .map_err(|source| E2bServiceError::Bind {
@@ -155,6 +178,10 @@ impl E2bCompatService {
             supervisor_config,
             shutdown_receiver.clone(),
         ));
+        let mut gateway = Box::pin(
+            self.gateway
+                .serve(gateway_listener, shutdown_receiver.clone()),
+        );
         let mut server = Box::pin(
             axum::Server::from_tcp(listener)
                 .map_err(E2bServiceError::Listener)?
@@ -166,32 +193,70 @@ impl E2bCompatService {
             listen = %local_address,
             public_url = %self.public_url,
             sandbox_domain = %self.sandbox_domain,
+            gateway_listen = %self.gateway_listen,
             "E2B compatibility service started"
         );
 
-        tokio::select! {
+        let termination = tokio::select! {
             signal = shutdown_signal() => {
-                signal?;
-                info!("shutdown signal received");
-                request_shutdown(&shutdown_sender);
-                server.await.map_err(E2bServiceError::Server)?;
-                join_maintenance(maintenance.await)?
+                Termination::Signal(signal)
             }
             server_result = &mut server => {
-                request_shutdown(&shutdown_sender);
-                let maintenance_result = maintenance.await;
-                server_result.map_err(E2bServiceError::Server)?;
-                join_maintenance(maintenance_result)?
+                Termination::Control(server_result)
+            }
+            gateway_result = &mut gateway => {
+                Termination::Gateway(gateway_result)
             }
             maintenance_result = &mut maintenance => {
-                request_shutdown(&shutdown_sender);
-                server.await.map_err(E2bServiceError::Server)?;
-                join_maintenance(maintenance_result)?
+                Termination::Maintenance(maintenance_result)
+            }
+        };
+        request_shutdown(&shutdown_sender);
+        match termination {
+            Termination::Signal(signal) => {
+                if signal.is_ok() {
+                    info!("shutdown signal received");
+                }
+                let control = server.await;
+                let gateway_result = gateway.await;
+                let maintenance_result = maintenance.await;
+                signal?;
+                control.map_err(E2bServiceError::Server)?;
+                gateway_result?;
+                join_maintenance(maintenance_result)?;
+            }
+            Termination::Control(control) => {
+                let gateway_result = gateway.await;
+                let maintenance_result = maintenance.await;
+                control.map_err(E2bServiceError::Server)?;
+                gateway_result?;
+                join_maintenance(maintenance_result)?;
+            }
+            Termination::Gateway(gateway_result) => {
+                let control = server.await;
+                let maintenance_result = maintenance.await;
+                gateway_result?;
+                control.map_err(E2bServiceError::Server)?;
+                join_maintenance(maintenance_result)?;
+            }
+            Termination::Maintenance(maintenance_result) => {
+                let control = server.await;
+                let gateway_result = gateway.await;
+                join_maintenance(maintenance_result)?;
+                control.map_err(E2bServiceError::Server)?;
+                gateway_result?;
             }
         }
         info!("E2B compatibility service stopped");
         Ok(())
     }
+}
+
+enum Termination {
+    Signal(E2bServiceResult<()>),
+    Control(Result<(), hyper::Error>),
+    Gateway(Result<(), DataPlaneGatewayError>),
+    Maintenance(Result<E2bServiceResult<()>, tokio::task::JoinError>),
 }
 
 async fn run_maintenance(
@@ -336,6 +401,8 @@ pub enum E2bServiceError {
     Token(#[from] TokenIssuerError),
     #[error(transparent)]
     Supervisor(#[from] LifecycleSupervisorError),
+    #[error(transparent)]
+    Gateway(#[from] DataPlaneGatewayError),
 }
 
 pub type E2bServiceResult<T> = std::result::Result<T, E2bServiceError>;

--- a/src/compat/src/production/tests.rs
+++ b/src/compat/src/production/tests.rs
@@ -13,6 +13,7 @@ use super::config::E2bCompatConfig;
 use super::{E2bCompatService, E2bConfigError, UuidSandboxIdentityProvider};
 
 fn parse_config(root: &Path) -> E2bCompatConfig {
+    write_test_tls(root);
     E2bCompatConfig::parse_with_environment(&acl_config(root), test_environment).unwrap()
 }
 
@@ -20,6 +21,8 @@ fn acl_config(root: &Path) -> String {
     let database = acl_path(&root.join("lifecycle.sqlite3"));
     let runtime_home = acl_path(&root.join("runtime"));
     let runtime_state = acl_path(&root.join("managed-executions.json"));
+    let certificate = acl_path(&root.join("gateway-cert.pem"));
+    let private_key = acl_path(&root.join("gateway-key.pem"));
     let hash = CredentialHash::derive("e2b_a1b2c3", 100_000, &[3; 16]).unwrap();
     format!(
         r#"
@@ -31,6 +34,16 @@ e2b_compat {{
   runtime_home = "{runtime_home}"
   runtime_state_path = "{runtime_state}"
   max_json_bytes = 2097152
+
+  gateway {{
+    listen = "127.0.0.1:3002"
+    tls_certificate_path = "{certificate}"
+    tls_private_key_path = "{private_key}"
+    max_connections = 1024
+    handshake_timeout_ms = 5000
+    connect_timeout_ms = 2000
+    drain_timeout_seconds = 10
+  }}
 
   supervisor {{
     interval_seconds = 5
@@ -82,6 +95,16 @@ e2b_compat {{
     )
 }
 
+fn write_test_tls(root: &Path) {
+    let rcgen::CertifiedKey { cert, key_pair } = rcgen::generate_simple_self_signed(vec![
+        "*.box.example.com".to_string(),
+        "sandbox.box.example.com".to_string(),
+    ])
+    .unwrap();
+    std::fs::write(root.join("gateway-cert.pem"), cert.pem()).unwrap();
+    std::fs::write(root.join("gateway-key.pem"), key_pair.serialize_pem()).unwrap();
+}
+
 fn acl_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
@@ -105,6 +128,8 @@ async fn parses_acl_into_strict_runtime_credentials_and_template_policy() {
         "https://api.box.example.com/"
     );
     assert_eq!(config.sandbox_domain(), "box.example.com");
+    assert_eq!(config.gateway().listen().to_string(), "127.0.0.1:3002");
+    assert_eq!(config.gateway().max_connections().get(), 1024);
     assert_eq!(config.supervisor().batch_size().get(), 100);
     assert_eq!(config.templates.len(), 1);
     let template = config.templates.resolve("fixture-template").await.unwrap();
@@ -158,6 +183,53 @@ fn rejects_plaintext_token_keys_missing_environment_and_unknown_fields() {
     );
 }
 
+#[test]
+fn rejects_missing_or_unsafe_gateway_configuration() {
+    let root = tempfile::tempdir().unwrap();
+    let input = acl_config(root.path());
+
+    let missing = input.replace(
+        &input[input.find("  gateway {").unwrap()..input.find("  supervisor {").unwrap()],
+        "",
+    );
+    assert!(
+        E2bCompatConfig::parse_with_environment(&missing, test_environment)
+            .unwrap_err()
+            .to_string()
+            .contains("gateway block is required")
+    );
+
+    let same_listener = input.replace("listen = \"127.0.0.1:3002\"", "listen = \"127.0.0.1:3001\"");
+    assert!(
+        E2bCompatConfig::parse_with_environment(&same_listener, test_environment)
+            .unwrap_err()
+            .to_string()
+            .contains("must differ")
+    );
+
+    let relative_key = input.replace(
+        &format!(
+            "tls_private_key_path = \"{}\"",
+            acl_path(&root.path().join("gateway-key.pem"))
+        ),
+        "tls_private_key_path = \"gateway-key.pem\"",
+    );
+    assert!(
+        E2bCompatConfig::parse_with_environment(&relative_key, test_environment)
+            .unwrap_err()
+            .to_string()
+            .contains("absolute normalized path")
+    );
+
+    let unbounded = input.replace("max_connections = 1024", "max_connections = 0");
+    assert!(
+        E2bCompatConfig::parse_with_environment(&unbounded, test_environment)
+            .unwrap_err()
+            .to_string()
+            .contains("max_connections must be between")
+    );
+}
+
 #[tokio::test]
 async fn loader_requires_the_acl_extension_before_reading() {
     let root = tempfile::tempdir().unwrap();
@@ -187,6 +259,7 @@ async fn production_composition_wires_auth_sqlite_routing_and_supervision_withou
         .await
         .unwrap();
     assert_eq!(service.listen().to_string(), "127.0.0.1:3001");
+    assert_eq!(service.gateway_listen().to_string(), "127.0.0.1:3002");
     assert_eq!(service.sandbox_domain(), "box.example.com");
     assert!(service
         .route_parser()

--- a/src/compat/src/routing/parser.rs
+++ b/src/compat/src/routing/parser.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use axum::http::header::HOST;
 use axum::http::uri::Authority;
+use axum::http::Uri;
 use axum::http::{HeaderMap, HeaderName};
 use thiserror::Error;
 
@@ -75,6 +76,30 @@ impl SandboxRouteParser {
         self.parse_host(host, headers)
     }
 
+    /// Parse either an HTTP/1.1 Host header or an HTTP/2 `:authority` URI.
+    /// When both forms are present they must identify the same DNS host.
+    pub fn parse_uri(
+        &self,
+        uri: &Uri,
+        headers: &HeaderMap,
+    ) -> RouteParseResult<ParsedSandboxRoute> {
+        let header_authority = single_header(headers, &HOST)?;
+        let uri_authority = uri.authority().map(Authority::as_str);
+        let authority = match (header_authority, uri_authority) {
+            (None, None) => return Err(RouteParseError::MissingHost),
+            (Some(authority), None) | (None, Some(authority)) => authority,
+            (Some(header), Some(uri)) => {
+                let header_host = parse_authority_host(header)?;
+                let uri_host = parse_authority_host(uri)?;
+                if !header_host.eq_ignore_ascii_case(&uri_host) {
+                    return Err(RouteParseError::ConflictingAuthority);
+                }
+                header
+            }
+        };
+        self.parse_host(authority, headers)
+    }
+
     pub fn parse_host(
         &self,
         authority: &str,
@@ -110,6 +135,12 @@ impl SandboxRouteParser {
             form: RouteForm::Direct,
         })
     }
+}
+
+fn parse_authority_host(authority: &str) -> RouteParseResult<String> {
+    Authority::from_str(authority)
+        .map(|authority| authority.host().to_string())
+        .map_err(|_| RouteParseError::InvalidHost)
 }
 
 fn route_headers(headers: &HeaderMap) -> RouteParseResult<Option<(SandboxId, NonZeroU16)>> {
@@ -195,6 +226,8 @@ pub enum RouteParseError {
     InvalidRouteHeaders,
     #[error("sandbox route headers conflict with the direct hostname")]
     ConflictingRouteHeaders,
+    #[error("Host and HTTP/2 authority identify different sandbox domains")]
+    ConflictingAuthority,
     #[error("routing header is duplicated")]
     DuplicateHeader,
 }
@@ -296,5 +329,21 @@ mod tests {
         for valid in ["localhost", "box.example", "sandbox-1.box.example"] {
             assert!(SandboxDomain::new(valid).is_ok(), "rejected {valid}");
         }
+    }
+
+    #[test]
+    fn parses_http2_authority_and_rejects_conflicting_host() {
+        let uri = "https://49983-sandbox-abc.box.example.com/health"
+            .parse::<Uri>()
+            .unwrap();
+        let route = parser().parse_uri(&uri, &HeaderMap::new()).unwrap();
+        assert_eq!(route.sandbox_id.as_str(), "sandbox-abc");
+        assert_eq!(route.port.get(), 49_983);
+
+        let conflicting = headers("49983-sandbox-other.box.example.com");
+        assert_eq!(
+            parser().parse_uri(&uri, &conflicting).unwrap_err(),
+            RouteParseError::ConflictingAuthority
+        );
     }
 }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -62,11 +62,12 @@ pub use tee::{detect_tee, is_tee_available, TeeCapability, TeeType};
 pub use traits::{
     AuditSink, CacheBackend, CacheEntry, CacheStats, CreateExecutionRequest, CredentialProvider,
     EventBus, ExecutionGeneration, ExecutionHealthCheck, ExecutionId, ExecutionLease,
-    ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionRecordPolicy,
-    ExecutionReservation, ExecutionRestartPolicy, ExecutionState, ExecutionStatus, ImageRegistry,
-    ImageStoreBackend, KillOutcome, MetricsCollector, NetworkStoreBackend, NoopMetrics,
-    OperationId, PulledImage, ReconcileOutcome, RestartExecutionOptions, SnapshotStoreBackend,
-    StoredImage, VolumeStoreBackend,
+    ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionPortConnector,
+    ExecutionPortIo, ExecutionPortStream, ExecutionRecordPolicy, ExecutionReservation,
+    ExecutionRestartPolicy, ExecutionState, ExecutionStatus, ImageRegistry, ImageStoreBackend,
+    KillOutcome, MetricsCollector, NetworkStoreBackend, NoopMetrics, OperationId, PulledImage,
+    ReconcileOutcome, RestartExecutionOptions, SnapshotStoreBackend, StoredImage,
+    VolumeStoreBackend,
 };
 pub use vmm::{
     Entrypoint, FsMount, InstanceSpec, NetworkInstanceConfig, TeeInstanceConfig, VmHandler,

--- a/src/core/src/traits/execution.rs
+++ b/src/core/src/traits/execution.rs
@@ -1,11 +1,15 @@
 //! Backend-neutral lifecycle interface for managed A3S executions.
 
 use std::collections::BTreeMap;
+use std::num::NonZeroU16;
+use std::pin::Pin;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::config::{BoxConfig, ResourceConfig};
 use crate::execution::ResolvedExecutionPlan;
@@ -371,6 +375,29 @@ pub enum ExecutionManagerError {
 }
 
 pub type ExecutionManagerResult<T> = std::result::Result<T, ExecutionManagerError>;
+
+/// Bidirectional byte stream connected to one generation-fenced workload port.
+pub trait ExecutionPortIo: AsyncRead + AsyncWrite + Send + Unpin {}
+
+impl<T> ExecutionPortIo for T where T: AsyncRead + AsyncWrite + Send + Unpin {}
+
+pub type ExecutionPortStream = Pin<Box<dyn ExecutionPortIo>>;
+
+/// Backend-neutral connector used by data-plane gateways.
+///
+/// Implementations must validate the execution generation atomically with
+/// selecting the live runtime. A connector must never fall back to another
+/// execution or generation when the requested runtime is unavailable.
+#[async_trait]
+pub trait ExecutionPortConnector: Send + Sync {
+    async fn connect_port(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+        port: NonZeroU16,
+        timeout: Duration,
+    ) -> ExecutionManagerResult<ExecutionPortStream>;
+}
 
 /// Backend-neutral lifecycle facade shared by the CLI, SDK, and remote service.
 #[async_trait]

--- a/src/core/src/traits/mod.rs
+++ b/src/core/src/traits/mod.rs
@@ -19,9 +19,10 @@ pub use credential::CredentialProvider;
 pub use event::EventBus;
 pub use execution::{
     CreateExecutionRequest, ExecutionGeneration, ExecutionHealthCheck, ExecutionId, ExecutionLease,
-    ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionRecordPolicy,
-    ExecutionReservation, ExecutionRestartPolicy, ExecutionState, ExecutionStatus, KillOutcome,
-    OperationId, ReconcileOutcome, RestartExecutionOptions,
+    ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionPortConnector,
+    ExecutionPortIo, ExecutionPortStream, ExecutionRecordPolicy, ExecutionReservation,
+    ExecutionRestartPolicy, ExecutionState, ExecutionStatus, KillOutcome, OperationId,
+    ReconcileOutcome, RestartExecutionOptions,
 };
 pub use metrics::{MetricsCollector, NoopMetrics};
 pub use registry::{ImageRegistry, PulledImage};

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -4,6 +4,7 @@ mod api;
 mod backend;
 mod create;
 mod operations;
+mod port;
 mod record;
 mod recovery;
 mod resources;

--- a/src/runtime/src/local_execution/port.rs
+++ b/src/runtime/src/local_execution/port.rs
@@ -1,0 +1,195 @@
+use std::num::NonZeroU16;
+use std::time::Duration;
+
+use a3s_box_core::{
+    ExecutionBackend, ExecutionGeneration, ExecutionId, ExecutionManagerError,
+    ExecutionManagerResult, ExecutionPortConnector, ExecutionPortStream,
+};
+use async_trait::async_trait;
+
+use super::support::{managed_state, require_generation};
+use super::{LocalExecutionManager, ManagedExecutionState};
+use crate::BoxRecord;
+
+#[async_trait]
+impl ExecutionPortConnector for LocalExecutionManager {
+    async fn connect_port(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+        port: NonZeroU16,
+        timeout: Duration,
+    ) -> ExecutionManagerResult<ExecutionPortStream> {
+        if timeout.is_zero() {
+            return Err(ExecutionManagerError::InvalidRequest(
+                "port connection timeout must be non-zero".to_string(),
+            ));
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let record = self.require_connectable(execution_id, generation).await?;
+            let pid = record
+                .pid
+                .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+            let pid_start_time = record.pid_start_time;
+            if !crate::process::is_process_alive_with_identity(pid, pid_start_time) {
+                return Err(ExecutionManagerError::NotFound(execution_id.clone()));
+            }
+
+            let stream = connect_in_network_namespace(
+                execution_id.clone(),
+                pid,
+                pid_start_time,
+                port,
+                timeout,
+            )
+            .await?;
+
+            // The lifecycle may have advanced while the blocking connect was in
+            // flight. Re-read the canonical record before publishing the stream.
+            let current = self.require_connectable(execution_id, generation).await?;
+            if current.pid != Some(pid)
+                || current.pid_start_time != pid_start_time
+                || !crate::process::is_process_alive_with_identity(pid, pid_start_time)
+            {
+                return Err(ExecutionManagerError::Conflict {
+                    execution_id: execution_id.clone(),
+                    message: "runtime generation changed while connecting its data plane"
+                        .to_string(),
+                });
+            }
+            return Ok(Box::pin(stream));
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (execution_id, generation, port, timeout);
+            Err(ExecutionManagerError::Unavailable(
+                "Sandbox port connections require Linux network namespaces".to_string(),
+            ))
+        }
+    }
+}
+
+impl LocalExecutionManager {
+    async fn require_connectable(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<BoxRecord> {
+        let record = self
+            .get(execution_id)
+            .await?
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        require_generation(&record, execution_id, generation)?;
+        if managed_state(&record)? != ManagedExecutionState::Running {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id.clone(),
+                message: "execution is not running".to_string(),
+            });
+        }
+        let backend = record
+            .managed_execution
+            .as_ref()
+            .map(|metadata| metadata.plan.backend)
+            .ok_or_else(|| {
+                ExecutionManagerError::Internal(format!(
+                    "execution {execution_id} has no managed execution plan"
+                ))
+            })?;
+        if backend != ExecutionBackend::Crun {
+            return Err(ExecutionManagerError::Unavailable(format!(
+                "execution {execution_id} does not expose a Sandbox network namespace"
+            )));
+        }
+        Ok(record)
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn connect_in_network_namespace(
+    execution_id: ExecutionId,
+    pid: u32,
+    pid_start_time: Option<u64>,
+    port: NonZeroU16,
+    timeout: Duration,
+) -> ExecutionManagerResult<tokio::net::TcpStream> {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name(format!("a3s-port-{pid}-{}", port.get()))
+        .spawn(move || {
+            let result = connect_in_network_namespace_blocking(
+                &execution_id,
+                pid,
+                pid_start_time,
+                port,
+                timeout,
+            );
+            let _ = sender.send(result);
+        })
+        .map_err(|error| {
+            ExecutionManagerError::Unavailable(format!(
+                "failed to start Sandbox port connector: {error}"
+            ))
+        })?;
+
+    let stream = receiver.await.map_err(|_| {
+        ExecutionManagerError::Internal(
+            "Sandbox port connector exited without a result".to_string(),
+        )
+    })??;
+    tokio::net::TcpStream::from_std(stream).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to register Sandbox port stream with Tokio: {error}"
+        ))
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn connect_in_network_namespace_blocking(
+    execution_id: &ExecutionId,
+    pid: u32,
+    pid_start_time: Option<u64>,
+    port: NonZeroU16,
+    timeout: Duration,
+) -> ExecutionManagerResult<std::net::TcpStream> {
+    use std::fs::File;
+    use std::os::fd::AsRawFd;
+
+    if !crate::process::is_process_alive_with_identity(pid, pid_start_time) {
+        return Err(ExecutionManagerError::NotFound(execution_id.clone()));
+    }
+    let namespace_path = format!("/proc/{pid}/ns/net");
+    let namespace = File::open(&namespace_path).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to open Sandbox network namespace {namespace_path}: {error}"
+        ))
+    })?;
+    let result = unsafe { libc::setns(namespace.as_raw_fd(), libc::CLONE_NEWNET) };
+    if result != 0 {
+        return Err(ExecutionManagerError::Unavailable(format!(
+            "failed to enter Sandbox network namespace for PID {pid}: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    if !crate::process::is_process_alive_with_identity(pid, pid_start_time) {
+        return Err(ExecutionManagerError::Unavailable(
+            "Sandbox runtime exited while entering its network namespace".to_string(),
+        ));
+    }
+
+    let address = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port.get()));
+    let stream = std::net::TcpStream::connect_timeout(&address, timeout).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to connect to Sandbox loopback port {}: {error}",
+            port.get()
+        ))
+    })?;
+    stream.set_nonblocking(true).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to configure Sandbox port stream: {error}"
+        ))
+    })?;
+    Ok(stream)
+}


### PR DESCRIPTION
## Summary

- add the wildcard TLS E2B data-plane gateway for direct and shared Sandbox routes
- proxy HTTP/1.1 and HTTP/2 downstream requests to plaintext HTTP/1.1 Sandbox origins through generation- and PID-fenced network-namespace connectors
- enforce immutable route leases, token scopes, CORS, edge-header stripping, graceful shutdown, and connection limits
- keep production configuration ACL-only through a3s-acl
- preserve crun, OCI bundle, PID, and service-log evidence when the production smoke fails

## Validation

- cargo fmt --all -- --check
- a3s-box-compat: 79 tests passed
- Core, Runtime, and Compat clippy with -D warnings
- E2B contract verifier
- HTTP/2-to-HTTP/1.1 gateway regression test
- A3S OS production smoke on real crun + OCI with --isolation sandbox