### PR TITLE
test(e2b): add production official-client lifecycle gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,14 @@ generation-fenced transitions and restart reconciliation; and a canonical
 runtime `ExecutionManager` with a production VM/Sandbox backend. CI runs the
 pinned official Python sync/async, TypeScript, and Code Interpreter clients
 against the router through an in-memory repository and fake execution manager.
+An opt-in A3S OS gate now installs those same checksum-pinned packages without
+modification and runs them against the ACL-configured production process and
+real `crun` Sandboxes. Python sync, Python async, and TypeScript each pass
+create, connect, filtered list, timeout replacement, kill, and not-found
+behavior; both Code Interpreter packages also pass production lifecycle create
+and cleanup. This matrix exercises the public lifecycle clients, not envd or
+interpreter execution.
+
 Managed creation requests also persist a typed caller policy for names,
 restart and health behavior, logging, stop behavior, and local resource
 metadata. An idempotent retry therefore cannot silently reuse a reservation
@@ -385,8 +393,9 @@ both TLS route forms, HTTP/2-to-HTTP/1.1 translation, invalid and scope-swapped
 token denial, service-restart recovery, stale-route fencing after kill,
 structured-log drainage, and complete runtime cleanup. Failed runs preserve
 the Sandbox PID, `crun` state, OCI bundle, and service logs for diagnosis. The
-envd/ConnectRPC implementation and the complete unchanged-official-client
-Sandbox suite remain open release gates.
+envd/ConnectRPC implementation and the unchanged-official-client command,
+filesystem, PTY, public-port, and Code Interpreter execution suites remain open
+release gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/compat/e2b/README.md
+++ b/compat/e2b/README.md
@@ -90,4 +90,9 @@ The destructive A3S OS integration harness is
 [`scripts/e2b-production-smoke.sh`](../../scripts/e2b-production-smoke.sh). It
 requires a dedicated runtime home and explicit acknowledgement, and verifies a
 real Sandbox lifecycle, TLS direct/shared routing, token-scope denial, service
-restart recovery, stale-route fencing, and resource cleanup.
+restart recovery, stale-route fencing, and resource cleanup. With
+`A3S_BOX_E2B_OFFICIAL_CLIENTS=1`, it additionally runs the checksum-pinned,
+unchanged Python sync, Python async, TypeScript, and Code Interpreter packages
+through the production lifecycle listener and verifies cleanup of every real
+`crun` execution. That optional matrix does not exercise envd commands, files,
+PTY, or interpreter execution.

--- a/compat/e2b/fixtures/official-clients/README.md
+++ b/compat/e2b/fixtures/official-clients/README.md
@@ -50,3 +50,28 @@ integrity values in `upstream.lock.json` before use. Direct downloads use a
 Generated JSON Lines files are compatibility evidence, not server
 implementations. The Rust control plane must satisfy them without adding A3S
 fields to upstream requests or responses.
+
+## Production lifecycle gate
+
+`run_production.py` installs the same checksum-pinned artifacts and runs the
+unchanged Python sync, Python async, TypeScript, and Code Interpreter packages
+against an already-running production compatibility service:
+
+```bash
+E2B_API_KEY=e2b_a1b2c3 \
+python3 compat/e2b/fixtures/official-clients/run_production.py \
+  --api-url http://127.0.0.1:38081 \
+  --domain box.example.com \
+  --template fixture-template \
+  --artifact-cache /path/to/verified-artifacts
+```
+
+On an A3S OS host, `scripts/e2b-production-smoke.sh` can make this matrix part
+of the destructive real-Sandbox gate by setting
+`A3S_BOX_E2B_OFFICIAL_CLIENTS=1`. Hosts without `ensurepip` can additionally
+set `A3S_BOX_E2B_PIP_BOOTSTRAP_WHEEL`; the wheel is used through `PYTHONPATH`
+and is not installed into the host Python environment.
+
+This gate proves production lifecycle behavior and cleanup through the public
+clients. It does not claim envd command, filesystem, PTY, or Code Interpreter
+execution compatibility; those require their separate data-plane suites.

--- a/compat/e2b/fixtures/official-clients/production_python_client.py
+++ b/compat/e2b/fixtures/official-clients/production_python_client.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Exercise unchanged official Python clients against a production service."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from typing import Any
+
+from e2b import (
+    AsyncSandbox,
+    Sandbox,
+    SandboxNotFoundException,
+    SandboxQuery,
+    SandboxState,
+)
+from e2b_code_interpreter import AsyncSandbox as AsyncCodeInterpreter
+from e2b_code_interpreter import Sandbox as CodeInterpreter
+
+
+def connection(api_url: str, domain: str) -> dict[str, Any]:
+    api_key = os.environ.get("E2B_API_KEY")
+    if not api_key:
+        raise RuntimeError("E2B_API_KEY is required")
+    return {"api_key": api_key, "api_url": api_url, "domain": domain}
+
+
+def assert_listed(items: list[Any], sandbox_id: str) -> None:
+    if not any(item.sandbox_id == sandbox_id for item in items):
+        raise AssertionError(f"sandbox {sandbox_id} was absent from the filtered list")
+
+
+def run_sync(api_url: str, domain: str, template: str) -> None:
+    options = connection(api_url, domain)
+    metadata = {"client": "python-sync", "suite": "production-official"}
+    sandbox: Sandbox | None = None
+    interpreter: CodeInterpreter | None = None
+    try:
+        sandbox = Sandbox.create(
+            template,
+            timeout=60,
+            metadata=metadata,
+            envs={"OFFICIAL_CLIENT": "python-sync"},
+            secure=True,
+            allow_internet_access=False,
+            **options,
+        )
+        connected = Sandbox.connect(sandbox.sandbox_id, timeout=45, **options)
+        if connected.sandbox_id != sandbox.sandbox_id:
+            raise AssertionError("connect returned a different sandbox ID")
+
+        paginator = Sandbox.list(
+            query=SandboxQuery(metadata=metadata, state=[SandboxState.RUNNING]),
+            limit=20,
+            **options,
+        )
+        assert_listed(paginator.next_items(), sandbox.sandbox_id)
+        sandbox.set_timeout(30)
+        if not sandbox.kill():
+            raise AssertionError("kill did not terminate the production sandbox")
+
+        missing_id = "missing-production-python-sync"
+        if Sandbox.kill(missing_id, **options):
+            raise AssertionError("kill reported success for a missing sandbox")
+        try:
+            Sandbox.connect(missing_id, **options)
+        except SandboxNotFoundException:
+            pass
+        else:
+            raise AssertionError("missing sandbox connect did not raise not-found")
+
+        interpreter = CodeInterpreter.create(
+            timeout=60,
+            metadata={"client": "python-code-interpreter"},
+            **options,
+        )
+        if not interpreter.kill():
+            raise AssertionError("Code Interpreter lifecycle kill failed")
+    finally:
+        if interpreter is not None:
+            Sandbox.kill(interpreter.sandbox_id, **options)
+        if sandbox is not None:
+            Sandbox.kill(sandbox.sandbox_id, **options)
+
+
+async def run_async(api_url: str, domain: str, template: str) -> None:
+    options = connection(api_url, domain)
+    metadata = {"client": "python-async", "suite": "production-official"}
+    sandbox: AsyncSandbox | None = None
+    interpreter: AsyncCodeInterpreter | None = None
+    try:
+        sandbox = await AsyncSandbox.create(
+            template,
+            timeout=60,
+            metadata=metadata,
+            envs={"OFFICIAL_CLIENT": "python-async"},
+            secure=True,
+            allow_internet_access=False,
+            **options,
+        )
+        connected = await AsyncSandbox.connect(
+            sandbox.sandbox_id, timeout=45, **options
+        )
+        if connected.sandbox_id != sandbox.sandbox_id:
+            raise AssertionError("connect returned a different sandbox ID")
+
+        paginator = AsyncSandbox.list(
+            query=SandboxQuery(metadata=metadata, state=[SandboxState.RUNNING]),
+            limit=20,
+            **options,
+        )
+        assert_listed(await paginator.next_items(), sandbox.sandbox_id)
+        await sandbox.set_timeout(30)
+        if not await sandbox.kill():
+            raise AssertionError("kill did not terminate the production sandbox")
+
+        missing_id = "missing-production-python-async"
+        if await AsyncSandbox.kill(missing_id, **options):
+            raise AssertionError("kill reported success for a missing sandbox")
+        try:
+            await AsyncSandbox.connect(missing_id, **options)
+        except SandboxNotFoundException:
+            pass
+        else:
+            raise AssertionError("missing sandbox connect did not raise not-found")
+
+        interpreter = await AsyncCodeInterpreter.create(
+            timeout=60,
+            metadata={"client": "python-async-code-interpreter"},
+            **options,
+        )
+        if not await interpreter.kill():
+            raise AssertionError("Code Interpreter lifecycle kill failed")
+    finally:
+        if interpreter is not None:
+            await AsyncSandbox.kill(interpreter.sandbox_id, **options)
+        if sandbox is not None:
+            await AsyncSandbox.kill(sandbox.sandbox_id, **options)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["sync", "async"])
+    parser.add_argument("api_url")
+    parser.add_argument("domain")
+    parser.add_argument("template")
+    args = parser.parse_args()
+    if args.mode == "sync":
+        run_sync(args.api_url, args.domain, args.template)
+    else:
+        asyncio.run(run_async(args.api_url, args.domain, args.template))
+
+
+if __name__ == "__main__":
+    main()

--- a/compat/e2b/fixtures/official-clients/production_typescript_client.mjs
+++ b/compat/e2b/fixtures/official-clients/production_typescript_client.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/** Exercise the unchanged official TypeScript clients against production. */
+
+import assert from 'node:assert/strict'
+import { Sandbox, SandboxNotFoundError } from 'e2b'
+import { Sandbox as CodeInterpreter } from '@e2b/code-interpreter'
+
+const [apiUrl, domain, template] = process.argv.slice(2)
+const apiKey = process.env.E2B_API_KEY
+if (!apiUrl || !domain || !template || !apiKey) {
+  throw new Error('API URL, domain, template, and E2B_API_KEY are required')
+}
+
+const connection = { apiKey, apiUrl, domain }
+const metadata = { client: 'typescript', suite: 'production-official' }
+let sandbox
+let interpreter
+
+try {
+  sandbox = await Sandbox.create(template, {
+    ...connection,
+    timeoutMs: 60_000,
+    metadata,
+    envs: { OFFICIAL_CLIENT: 'typescript' },
+    secure: true,
+    allowInternetAccess: false,
+  })
+  const connected = await Sandbox.connect(sandbox.sandboxId, {
+    ...connection,
+    timeoutMs: 45_000,
+  })
+  assert.equal(connected.sandboxId, sandbox.sandboxId)
+
+  const paginator = Sandbox.list({
+    ...connection,
+    query: { metadata, state: ['running'] },
+    limit: 20,
+  })
+  const listed = await paginator.nextItems()
+  assert.ok(listed.some((item) => item.sandboxId === sandbox.sandboxId))
+
+  await sandbox.setTimeout(30_000)
+  assert.equal(await sandbox.kill(), true)
+
+  const missingId = 'missing-production-typescript'
+  assert.equal(await Sandbox.kill(missingId, connection), false)
+  await assert.rejects(
+    Sandbox.connect(missingId, connection),
+    SandboxNotFoundError
+  )
+
+  interpreter = await CodeInterpreter.create({
+    ...connection,
+    timeoutMs: 60_000,
+    metadata: { client: 'typescript-code-interpreter' },
+  })
+  assert.equal(await interpreter.kill(), true)
+} finally {
+  if (interpreter) {
+    await Sandbox.kill(interpreter.sandboxId, connection)
+  }
+  if (sandbox) {
+    await Sandbox.kill(sandbox.sandboxId, connection)
+  }
+}

--- a/compat/e2b/fixtures/official-clients/run_production.py
+++ b/compat/e2b/fixtures/official-clients/run_production.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Run pinned official clients against an already-running production service."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from run_fixtures import (
+    FIXTURE_DIR,
+    load_artifacts,
+    prepare_python,
+    prepare_typescript,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--api-url", required=True)
+    parser.add_argument("--domain", required=True)
+    parser.add_argument("--template", required=True)
+    parser.add_argument("--pip-bootstrap-wheel", type=Path)
+    parser.add_argument("--artifact-cache", type=Path)
+    args = parser.parse_args()
+
+    if not os.environ.get("E2B_API_KEY"):
+        raise RuntimeError("E2B_API_KEY is required")
+
+    artifacts = load_artifacts()
+    with tempfile.TemporaryDirectory(
+        prefix="a3s-e2b-production-official-clients-"
+    ) as directory:
+        temp = Path(directory)
+        python = prepare_python(
+            temp,
+            artifacts,
+            args.pip_bootstrap_wheel,
+            args.artifact_cache,
+        )
+        typescript_client = prepare_typescript(temp, artifacts, args.artifact_cache)
+        shutil.copyfile(
+            FIXTURE_DIR / "production_typescript_client.mjs", typescript_client
+        )
+
+        python_client = FIXTURE_DIR / "production_python_client.py"
+        common = [args.api_url, args.domain, args.template]
+        subprocess.run(
+            [str(python), str(python_client), "sync", *common], check=True
+        )
+        subprocess.run(
+            [str(python), str(python_client), "async", *common], check=True
+        )
+        subprocess.run(["node", str(typescript_client), *common], check=True)
+
+    print(
+        "Official production clients passed: Python sync, Python async, "
+        "TypeScript, and Code Interpreter lifecycle"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,7 +1,8 @@
 # E2B Protocol Compatibility and SDK Design
 
-Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 6 complete;
-TLS routing reaches real Sandbox ports, envd protocol implementation pending)**
+Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 6 and the
+production official-client lifecycle gate complete; envd implementation
+pending)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -19,9 +20,9 @@ unversioned claim.
 | Area | Implemented evidence | Remaining gate |
 | --- | --- | --- |
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
-| Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against the Rust fixture server | Run the same unchanged clients through the production service and a real Sandbox execution |
+| Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against both the Rust fixture server and the production service with real `crun` Sandbox executions | Extend the unchanged-client matrix through envd and the production TLS data plane |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, startup reconciliation, and periodic reaping are composed into the production service; an A3S OS smoke preserves a running record across process restart | Exercise host-reboot recovery end to end |
-| Runtime lifecycle | The production compatibility process uses the canonical `LocalExecutionManager`; an A3S OS smoke creates through HTTP, starts through certified `crun`, reconnects after service restart, replaces timeout, kills, and verifies box, runtime-state, and socket cleanup | Complete the host-reboot and official-client matrices |
+| Runtime lifecycle | The production compatibility process uses the canonical `LocalExecutionManager`; A3S OS smoke coverage and unchanged official clients create through HTTP, start through certified `crun`, reconnect, replace timeout, kill, and verify box, runtime-state, and socket cleanup | Complete host-reboot recovery and the official-client data-plane matrices |
 | Credentials and routing | ACL config wires salted PBKDF2-SHA256 account hashes, scope-bound AES-256-GCM sandbox tokens, independent HMAC validation, versioned key rotation, strict direct/shared parsing, durable-record-projected generation-fenced leases, wildcard TLS termination, and a generation/PID-fenced Sandbox network-namespace connector | Add certificate rotation and exercise every HTTP/2, Connect, WebSocket, and stream case in the complete matrix |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
@@ -29,11 +30,14 @@ The lifecycle control path and authenticated wildcard/shared TLS routes are
 composed and exercised against a real Sandbox on A3S OS. The smoke reaches a
 service bound to the Sandbox loopback interface, rejects invalid and
 scope-swapped tokens, survives a compatibility-service restart, and fences the
-route after kill. It still uses direct HTTP requests rather than the pinned
-official SDKs, and the unchanged-client fixture still uses an in-memory
-repository and fake execution manager. These are complementary results rather
-than the full black-box compatibility matrix, so `full_compatibility=false`
-remains mandatory.
+route after kill. Those TLS assertions use direct HTTP requests. A separate
+production lifecycle gate now runs the checksum-pinned official Python sync,
+Python async, TypeScript, and Code Interpreter packages unchanged against the
+ACL-configured service and real `crun` Sandboxes, including complete cleanup.
+Those clients do not call envd in this lifecycle matrix, while the fixture gate
+still uses an in-memory repository and fake execution manager. These are
+complementary results rather than the full black-box compatibility matrix, so
+`full_compatibility=false` remains mandatory.
 
 ## Executive decision
 
@@ -866,8 +870,10 @@ Phase 2 is delivered as small, immediately merged changes:
    namespace on a disposable OS thread. Pull the merge commit on an A3S OS
    server and prove direct/shared routing, restart recovery, scope denial, and
    stale-route fencing against a real `--isolation sandbox` execution.
-7. **In progress:** implement the pinned envd HTTP and ConnectRPC protocols,
-   then run the unmodified official clients through the production listeners.
+7. **In progress:** the unmodified official clients now pass their lifecycle
+   flows through the production control listener and real Sandbox runtime;
+   implement the pinned envd HTTP and ConnectRPC protocols, then extend those
+   clients through the production TLS data-plane listener.
 
 The runtime foundation of slice 4 is complete. The persisted execution record
 is the canonical schema shared by the CLI and Rust SDK, preventing either
@@ -943,11 +949,13 @@ runtime cleanup through the real Sandbox backend without invoking the CLI.
 
 Each slice must pass its focused tests and repository CI before merge. The
 durable repository, production execution manager, credentials, routing, and
-lifecycle HTTP router are now composed in one ACL-configured process. The
-Phase 2 gate remains closed until the real create/connect/list/timeout/kill
-matrix also traverses the production TLS and sandbox data planes. Passing the
-fake manager in slice 2 and passing the direct runtime smoke in slice 4 remain
-complementary evidence, not that missing end-to-end proof.
+lifecycle HTTP router are now composed in one ACL-configured process. The real
+create/connect/list/timeout/kill matrix now passes through that production
+control listener and real Sandbox executions. The Phase 2 gate remains closed
+until the returned official-client Sandbox objects also traverse the
+production TLS envd/data-plane listener. Passing the fake manager in slice 2,
+the direct runtime smoke in slice 4, and the production lifecycle clients are
+complementary evidence, not proof of the missing data-plane behavior.
 
 Slice 2 evidence includes exact recorder drift checks plus live requests from
 the pinned, unmodified clients to the Rust router. The live gate was also run
@@ -955,6 +963,14 @@ on an A3S OS host before merge. It covers authentication, owner isolation,
 create, connect, get, list filtering, timeout replacement, kill, not-found
 mapping, and Code Interpreter creation. It does not change the manifest's
 `full_compatibility=false` value.
+
+The production lifecycle gate reuses the artifact checksums from
+`upstream.lock.json` and runs the published Python sync, Python async,
+TypeScript, and Code Interpreter packages without source changes. On A3S OS it
+has passed create, reconnect, filtered list, timeout replacement, kill,
+not-found mapping, Code Interpreter lifecycle creation, and cleanup for every
+real `crun` execution. It intentionally does not count Code Interpreter object
+creation as interpreter execution compatibility.
 
 The Slice 3 persistence batch uses a bundled SQLite build through a dedicated
 asynchronous connection thread. Versioned migrations create a STRICT table in

--- a/scripts/e2b-production-smoke.sh
+++ b/scripts/e2b-production-smoke.sh
@@ -9,6 +9,8 @@ TOKEN_DIGEST="$(printf '08%.0s' {1..32})"
 PORT="${A3S_BOX_E2B_SMOKE_PORT:-38081}"
 GATEWAY_PORT="${A3S_BOX_E2B_GATEWAY_SMOKE_PORT:-38443}"
 IMAGE="${A3S_BOX_SMOKE_IMAGE:-alpine:3.20}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+OFFICIAL_CLIENT_RUNNER="${A3S_BOX_E2B_OFFICIAL_CLIENT_RUNNER:-$SCRIPT_DIR/../compat/e2b/fixtures/official-clients/run_production.py}"
 # A dependency-free HTTP/1.1 responder used with BusyBox nc -e. Alpine's
 # BusyBox build does not guarantee the optional httpd applet.
 HTTP_RESPONDER_B64='IyEvYmluL3NoCndoaWxlIElGUz0gcmVhZCAtciBsaW5lOyBkbwogIFsgIiRsaW5lIiA9ICIkKHByaW50ZiAnXHInKSIgXSAmJiBicmVhawpkb25lCmJvZHk9J3NhbmRib3gtZGF0YS1wbGFuZScKcHJpbnRmICdIVFRQLzEuMSAyMDAgT0tcclxuQ29udGVudC1MZW5ndGg6ICVzXHJcbkNvbm5lY3Rpb246IGNsb3NlXHJcbkNvbnRlbnQtVHlwZTogdGV4dC9wbGFpblxyXG5cclxuJXMnICIkeyNib2R5fSIgIiRib2R5Igo='
@@ -294,6 +296,25 @@ e2b_compat {
       token_scope = "traffic"
     }
   }
+
+  template_policy "code-interpreter-v1" {
+    image = "$IMAGE"
+    envd_version = "0.1.3"
+    isolation = "sandbox"
+    network = "none"
+    command = ["/bin/sh", "-c", "mkdir -p /tmp/e2b-smoke && printf '%s' '$HTTP_RESPONDER_B64' | /bin/busybox base64 -d > /tmp/e2b-smoke/respond && chmod 755 /tmp/e2b-smoke/respond && exec /bin/busybox nc -lk -p 49983 -e /tmp/e2b-smoke/respond"]
+
+    resources {
+      vcpus = 2
+      memory_mb = 512
+      disk_mb = 1024
+    }
+
+    route {
+      port = 49999
+      token_scope = "traffic"
+    }
+  }
 }
 EOF
 
@@ -378,5 +399,49 @@ PY
 [[ ! -e "/tmp/a3s-box-sockets/$EXECUTION_ID" ]] || fail 'runtime socket directory leaked after kill'
 
 SANDBOX_ID=""
+
+if [[ "${A3S_BOX_E2B_OFFICIAL_CLIENTS:-}" == "1" ]]; then
+  [[ -f "$OFFICIAL_CLIENT_RUNNER" ]] ||
+    fail "official-client runner is missing: $OFFICIAL_CLIENT_RUNNER"
+  OFFICIAL_CLIENT_ARGS=(
+    --api-url "$BASE_URL"
+    --domain box.example.com
+    --template fixture-template
+  )
+  if [[ -n "${A3S_BOX_E2B_PIP_BOOTSTRAP_WHEEL:-}" ]]; then
+    OFFICIAL_CLIENT_ARGS+=(
+      --pip-bootstrap-wheel "$A3S_BOX_E2B_PIP_BOOTSTRAP_WHEEL"
+    )
+  fi
+  if [[ -n "${A3S_BOX_E2B_ARTIFACT_CACHE:-}" ]]; then
+    OFFICIAL_CLIENT_ARGS+=(--artifact-cache "$A3S_BOX_E2B_ARTIFACT_CACHE")
+  fi
+  E2B_API_KEY="$API_KEY" \
+    "${A3S_BOX_E2B_OFFICIAL_PYTHON:-python3}" \
+    "$OFFICIAL_CLIENT_RUNNER" "${OFFICIAL_CLIENT_ARGS[@]}"
+
+  python3 - "$STATE_DIR/managed-executions.json" "$A3S_HOME" <<'PY'
+import json
+import pathlib
+import sys
+
+records_path = pathlib.Path(sys.argv[1])
+home = pathlib.Path(sys.argv[2])
+with records_path.open(encoding="utf-8") as source:
+    records = json.load(source)
+for record in records:
+    execution_id = record["id"]
+    if record.get("status") != "stopped":
+        raise SystemExit(f"managed execution {execution_id} is not stopped")
+    for path in (
+        home / "boxes" / execution_id,
+        home / "run" / "crun" / execution_id,
+        pathlib.Path("/tmp/a3s-box-sockets") / execution_id,
+    ):
+        if path.exists():
+            raise SystemExit(f"runtime resource leaked after official clients: {path}")
+PY
+fi
+
 stop_service
-printf 'E2B production smoke passed: lifecycle, TLS data plane, restart recovery, credentials, and cleanup\n'
+printf 'E2B production smoke passed: lifecycle, TLS data plane, restart recovery, credentials, official clients when enabled, and cleanup\n'


### PR DESCRIPTION
## Summary

- run checksum-pinned, unchanged official Python sync, Python async, TypeScript, and Code Interpreter clients against the production lifecycle listener
- create and clean real crun OCI Sandboxes through the ACL-configured A3S Box service
- make the client matrix an opt-in part of the destructive A3S OS smoke gate
- document the verified lifecycle boundary without claiming envd or interpreter execution compatibility

## Validation

- A3S OS production smoke with real crun + OCI --isolation sandbox: passed
- official Python sync lifecycle: passed
- official Python async lifecycle: passed
- official TypeScript lifecycle: passed
- official Python and TypeScript Code Interpreter lifecycle create/kill: passed
- all Box directories, crun state, sockets, listeners, and smoke state cleaned
- shell, Python, TypeScript, and diff syntax checks: passed