### PR TITLE
feat(e2b): add host envd health broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,10 @@ modification and runs them against the ACL-configured production process and
 real `crun` Sandboxes. Python sync, Python async, and TypeScript each pass
 create, connect, filtered list, timeout replacement, kill, and not-found
 behavior; both Code Interpreter packages also pass production lifecycle create
-and cleanup. This matrix exercises the public lifecycle clients, not envd or
-interpreter execution.
+and cleanup. Each running Python sync/async, TypeScript, and Code Interpreter
+object also calls its official `is_running`/`isRunning` method through the
+production TLS gateway and host-side envd health broker. This matrix does not
+exercise envd commands, files, PTY, or interpreter execution.
 
 Managed creation requests also persist a typed caller policy for names,
 restart and health behavior, logging, stop behavior, and local resource
@@ -355,7 +357,7 @@ that structured Sandbox logs retain both stdout and stderr, drain final records
 before natural-exit or auto-remove archival, and leave no generation log worker,
 crun state, box directory, or socket behind.
 
-The first production E2B data-plane slice is now implemented, while the full
+The first production E2B data-plane slices are now implemented, while the full
 envd surface remains incomplete. CLI `create` persists its reservation and
 complete caller policy through the canonical manager, and the first `start` of
 that reservation consumes its persisted generation through the same manager.
@@ -386,15 +388,22 @@ strips edge credentials, and enters the real `crun` network namespace through a
 generation- and PID-fenced connector. As with the official E2B sandbox proxy,
 the plaintext Sandbox origin is contacted with HTTP/1.1, including when the
 downstream client uses HTTP/2; the origin is not required to provide h2c.
+Port `49983` is owned by a host-side broker rather than the workload. Its first
+implemented endpoint is authenticated `GET /health`: the broker re-inspects the
+leased execution ID and generation and returns `204` only while that exact
+execution is running. Other routed ports continue through the fenced Sandbox
+network-namespace proxy.
 
 An A3S OS production smoke test exercises this path on a real `crun` OCI
 Sandbox created with `--isolation sandbox`. It verifies lifecycle operations,
-both TLS route forms, HTTP/2-to-HTTP/1.1 translation, invalid and scope-swapped
-token denial, service-restart recovery, stale-route fencing after kill,
-structured-log drainage, and complete runtime cleanup. Failed runs preserve
-the Sandbox PID, `crun` state, OCI bundle, and service logs for diagnosis. The
-envd/ConnectRPC implementation and the unchanged-official-client command,
-filesystem, PTY, public-port, and Code Interpreter execution suites remain open
+host envd health over both TLS route forms, a real traffic-token-protected
+workload service on port `49999`, HTTP/2-to-HTTP/1.1 translation, invalid and
+scope-swapped token denial, service-restart recovery, stale-route fencing after
+kill, structured-log drainage, and complete runtime cleanup. The same A3S OS
+gate runs the unchanged official clients through the health route. Failed runs
+preserve the Sandbox PID, `crun` state, OCI bundle, and service logs for
+diagnosis. The remaining envd HTTP endpoints, ConnectRPC commands/filesystem,
+PTY, public-port matrix, and Code Interpreter execution suites remain open
 release gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client

--- a/compat/e2b/README.md
+++ b/compat/e2b/README.md
@@ -82,17 +82,22 @@ The validated schema and an operator example are documented in
 This process exposes the lifecycle control subset plus an authenticated
 wildcard TLS data-plane edge. The edge supports direct and shared route forms,
 HTTP/1.1 and HTTP/2 streaming proxying, CORS preflight, upgrades, bounded
-connections, and generation-fenced access to real Sandbox loopback ports. The
-pinned envd/ConnectRPC protocols and remaining data-plane behavior are still
-required before the manifest can set `full_compatibility=true`.
+connections, and generation-fenced access to real Sandbox loopback ports. A
+host-side broker now implements authenticated envd `GET /health`; it returns
+`204` only after the runtime manager confirms the leased execution ID and
+generation are still running. The remaining pinned envd HTTP and ConnectRPC
+protocols are still required before the manifest can set
+`full_compatibility=true`.
 
 The destructive A3S OS integration harness is
 [`scripts/e2b-production-smoke.sh`](../../scripts/e2b-production-smoke.sh). It
 requires a dedicated runtime home and explicit acknowledgement, and verifies a
 real Sandbox lifecycle, TLS direct/shared routing, token-scope denial, service
-restart recovery, stale-route fencing, and resource cleanup. With
+restart recovery, host envd health, a traffic-scoped workload service on port
+`49999`, stale-route fencing, and resource cleanup. With
 `A3S_BOX_E2B_OFFICIAL_CLIENTS=1`, it additionally runs the checksum-pinned,
 unchanged Python sync, Python async, TypeScript, and Code Interpreter packages
-through the production lifecycle listener and verifies cleanup of every real
+through the production lifecycle listener, calls their official running-state
+health methods through the TLS gateway, and verifies cleanup of every real
 `crun` execution. That optional matrix does not exercise envd commands, files,
 PTY, or interpreter execution.

--- a/compat/e2b/fixtures/official-clients/README.md
+++ b/compat/e2b/fixtures/official-clients/README.md
@@ -51,7 +51,7 @@ Generated JSON Lines files are compatibility evidence, not server
 implementations. The Rust control plane must satisfy them without adding A3S
 fields to upstream requests or responses.
 
-## Production lifecycle gate
+## Production lifecycle and health gate
 
 `run_production.py` installs the same checksum-pinned artifacts and runs the
 unchanged Python sync, Python async, TypeScript, and Code Interpreter packages
@@ -72,6 +72,13 @@ of the destructive real-Sandbox gate by setting
 set `A3S_BOX_E2B_PIP_BOOTSTRAP_WHEEL`; the wheel is used through `PYTHONPATH`
 and is not installed into the host Python environment.
 
-This gate proves production lifecycle behavior and cleanup through the public
-clients. It does not claim envd command, filesystem, PTY, or Code Interpreter
-execution compatibility; those require their separate data-plane suites.
+Official-client health calls use standard HTTPS port `443`, so the configured
+wildcard sandbox domain must resolve to the gateway listener. The smoke accepts
+`A3S_BOX_E2B_GATEWAY_SMOKE_ADDRESS` for a loopback-only listener when a host
+already reserves IPv4 port 443; for example, `::1` with a `box.localhost`
+domain keeps the gate local while preserving normal TLS hostname behavior.
+
+This gate proves production lifecycle behavior, running-state envd health, and
+cleanup through the public clients. It does not claim envd command,
+filesystem, PTY, post-kill health, or Code Interpreter execution compatibility;
+those require their separate data-plane suites.

--- a/compat/e2b/fixtures/official-clients/production_python_client.py
+++ b/compat/e2b/fixtures/official-clients/production_python_client.py
@@ -49,6 +49,8 @@ def run_sync(api_url: str, domain: str, template: str) -> None:
         connected = Sandbox.connect(sandbox.sandbox_id, timeout=45, **options)
         if connected.sandbox_id != sandbox.sandbox_id:
             raise AssertionError("connect returned a different sandbox ID")
+        if not sandbox.is_running():
+            raise AssertionError("envd health reported the running sandbox as stopped")
 
         paginator = Sandbox.list(
             query=SandboxQuery(metadata=metadata, state=[SandboxState.RUNNING]),
@@ -75,6 +77,8 @@ def run_sync(api_url: str, domain: str, template: str) -> None:
             metadata={"client": "python-code-interpreter"},
             **options,
         )
+        if not interpreter.is_running():
+            raise AssertionError("Code Interpreter envd health check failed")
         if not interpreter.kill():
             raise AssertionError("Code Interpreter lifecycle kill failed")
     finally:
@@ -104,6 +108,8 @@ async def run_async(api_url: str, domain: str, template: str) -> None:
         )
         if connected.sandbox_id != sandbox.sandbox_id:
             raise AssertionError("connect returned a different sandbox ID")
+        if not await sandbox.is_running():
+            raise AssertionError("envd health reported the running sandbox as stopped")
 
         paginator = AsyncSandbox.list(
             query=SandboxQuery(metadata=metadata, state=[SandboxState.RUNNING]),
@@ -130,6 +136,8 @@ async def run_async(api_url: str, domain: str, template: str) -> None:
             metadata={"client": "python-async-code-interpreter"},
             **options,
         )
+        if not await interpreter.is_running():
+            raise AssertionError("async Code Interpreter envd health check failed")
         if not await interpreter.kill():
             raise AssertionError("Code Interpreter lifecycle kill failed")
     finally:

--- a/compat/e2b/fixtures/official-clients/production_typescript_client.mjs
+++ b/compat/e2b/fixtures/official-clients/production_typescript_client.mjs
@@ -30,6 +30,7 @@ try {
     timeoutMs: 45_000,
   })
   assert.equal(connected.sandboxId, sandbox.sandboxId)
+  assert.equal(await sandbox.isRunning(), true)
 
   const paginator = Sandbox.list({
     ...connection,
@@ -54,6 +55,7 @@ try {
     timeoutMs: 60_000,
     metadata: { client: 'typescript-code-interpreter' },
   })
+  assert.equal(await interpreter.isRunning(), true)
   assert.equal(await interpreter.kill(), true)
 } finally {
   if (interpreter) {

--- a/compat/e2b/fixtures/official-clients/run_production.py
+++ b/compat/e2b/fixtures/official-clients/run_production.py
@@ -58,7 +58,7 @@ def main() -> None:
 
     print(
         "Official production clients passed: Python sync, Python async, "
-        "TypeScript, and Code Interpreter lifecycle"
+        "TypeScript, Code Interpreter lifecycle, and envd health"
     )
 
 

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,8 +1,8 @@
 # E2B Protocol Compatibility and SDK Design
 
 Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 6 and the
-production official-client lifecycle gate complete; envd implementation
-pending)**
+production official-client lifecycle gate complete; first host envd health
+slice complete)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -20,24 +20,27 @@ unversioned claim.
 | Area | Implemented evidence | Remaining gate |
 | --- | --- | --- |
 | Pinned contract | Vendored control, envd, volume-content, Process, Filesystem, MCP, public-export, and package artifacts with generated digests | Keep the manifest pinned and regenerate it only through reviewed upstream updates |
-| Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against both the Rust fixture server and the production service with real `crun` Sandbox executions | Extend the unchanged-client matrix through envd and the production TLS data plane |
+| Lifecycle protocol | Owner-scoped create, connect, get, list, timeout, and kill routes; unchanged pinned Python sync/async, TypeScript, and Code Interpreter clients pass against both the Rust fixture server and the production service with real `crun` Sandbox executions | Extend the unchanged-client matrix through command, filesystem, PTY, public-port, and interpreter operations |
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, startup reconciliation, and periodic reaping are composed into the production service; an A3S OS smoke preserves a running record across process restart | Exercise host-reboot recovery end to end |
 | Runtime lifecycle | The production compatibility process uses the canonical `LocalExecutionManager`; A3S OS smoke coverage and unchanged official clients create through HTTP, start through certified `crun`, reconnect, replace timeout, kill, and verify box, runtime-state, and socket cleanup | Complete host-reboot recovery and the official-client data-plane matrices |
 | Credentials and routing | ACL config wires salted PBKDF2-SHA256 account hashes, scope-bound AES-256-GCM sandbox tokens, independent HMAC validation, versioned key rotation, strict direct/shared parsing, durable-record-projected generation-fenced leases, wildcard TLS termination, and a generation/PID-fenced Sandbox network-namespace connector | Add certificate rotation and exercise every HTTP/2, Connect, WebSocket, and stream case in the complete matrix |
-| Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement envd HTTP, ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
+| envd HTTP | A host-side broker implements authenticated `GET /health`; after route/token validation it re-inspects the exact execution ID and generation and returns `204` only for `Running`; unchanged official Python sync/async, TypeScript, and Code Interpreter objects pass their running-state health methods over production TLS | Implement `/metrics`, `/init`, `/envs`, file-content routes, and post-kill `is_running`/`isRunning` behavior |
+| Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
 The lifecycle control path and authenticated wildcard/shared TLS routes are
 composed and exercised against a real Sandbox on A3S OS. The smoke reaches a
-service bound to the Sandbox loopback interface, rejects invalid and
-scope-swapped tokens, survives a compatibility-service restart, and fences the
-route after kill. Those TLS assertions use direct HTTP requests. A separate
-production lifecycle gate now runs the checksum-pinned official Python sync,
-Python async, TypeScript, and Code Interpreter packages unchanged against the
-ACL-configured service and real `crun` Sandboxes, including complete cleanup.
-Those clients do not call envd in this lifecycle matrix, while the fixture gate
-still uses an in-memory repository and fake execution manager. These are
-complementary results rather than the full black-box compatibility matrix, so
-`full_compatibility=false` remains mandatory.
+traffic-scoped service on Sandbox loopback port `49999`, while envd health on
+port `49983` stays in the host broker. It rejects invalid and scope-swapped
+tokens, survives a compatibility-service restart, and fences the route after
+kill. A separate production gate now runs the checksum-pinned official Python
+sync, Python async, TypeScript, and Code Interpreter packages unchanged against
+the ACL-configured service and real `crun` Sandboxes. Their running-state
+health methods traverse the wildcard TLS gateway and host envd broker, and the
+gate verifies complete cleanup. The fixture gate still uses an in-memory
+repository and fake execution manager, and the remaining envd/ConnectRPC
+operations are not covered. These are complementary results rather than the
+full black-box compatibility matrix, so `full_compatibility=false` remains
+mandatory.
 
 ## Executive decision
 
@@ -304,6 +307,16 @@ separate format outside this compatibility surface.
 The envd-compatible service is a host-side broker backed by the existing A3S
 control protocols. Keeping it outside the workload prevents the workload from
 replacing the compatibility endpoint or stealing its access token.
+
+The first broker route is implemented: after the gateway resolves an
+authenticated `49983` lease, `GET /health` calls `ExecutionManager::inspect`
+and compares the returned execution ID, generation, and `Running` state with
+that lease. Exact live evidence returns an empty `204`; once a lease has been
+issued, runtime evidence that becomes missing, stopped, or generation-stale
+returns `502`, while an unavailable inspector returns `503`. Other envd routes
+currently return `404` and remain explicit release gates. Workload traffic on
+every non-envd route continues through the existing generation- and PID-fenced
+network-namespace connector.
 
 It translates:
 
@@ -744,9 +757,17 @@ src/compat/src/
     policy.rs         # persisted exact-port and token-scope policy
     lease.rs          # generation-fenced sandbox route projection
     parser.rs         # wildcard host and explicit-header validation
+  envd/
+    mod.rs             # host broker and generation-fenced health route
+  gateway/
+    mod.rs             # bounded TLS listener and graceful connection drain
+    proxy.rs           # traffic proxy and envd broker dispatch
+    tls.rs             # certificate and private-key loading
+  production/
+    service.rs         # control, broker, gateway, runtime, and supervisor wiring
   bin/
     a3s-box-e2b-fixture-server.rs # deterministic protocol fixture
-    a3s-box-e2b.rs                # planned production composition root
+    a3s-box-e2b.rs                # production composition root
 ```
 
 No handler accesses the database or runtime directly. Handlers authenticate,
@@ -871,9 +892,11 @@ Phase 2 is delivered as small, immediately merged changes:
    server and prove direct/shared routing, restart recovery, scope denial, and
    stale-route fencing against a real `--isolation sandbox` execution.
 7. **In progress:** the unmodified official clients now pass their lifecycle
-   flows through the production control listener and real Sandbox runtime;
-   implement the pinned envd HTTP and ConnectRPC protocols, then extend those
-   clients through the production TLS data-plane listener.
+   flows through the production control listener and real Sandbox runtime, and
+   their running-state health methods pass through the production TLS listener
+   and host envd broker. Implement the remaining pinned envd HTTP and
+   ConnectRPC protocols, then extend the same clients through command,
+   filesystem, PTY, public-port, and interpreter operations.
 
 The runtime foundation of slice 4 is complete. The persisted execution record
 is the canonical schema shared by the CLI and Rust SDK, preventing either
@@ -951,11 +974,12 @@ Each slice must pass its focused tests and repository CI before merge. The
 durable repository, production execution manager, credentials, routing, and
 lifecycle HTTP router are now composed in one ACL-configured process. The real
 create/connect/list/timeout/kill matrix now passes through that production
-control listener and real Sandbox executions. The Phase 2 gate remains closed
-until the returned official-client Sandbox objects also traverse the
-production TLS envd/data-plane listener. Passing the fake manager in slice 2,
-the direct runtime smoke in slice 4, and the production lifecycle clients are
-complementary evidence, not proof of the missing data-plane behavior.
+control listener and real Sandbox executions. Returned official-client Sandbox
+objects now traverse the production TLS listener for running-state envd health,
+but the Phase 2 gate remains closed until the remaining envd, ConnectRPC, PTY,
+public-port, interpreter, and MCP matrices pass. Passing the fake manager in
+slice 2, the direct runtime smoke in slice 4, and the production health clients
+are complementary evidence, not proof of the missing data-plane behavior.
 
 Slice 2 evidence includes exact recorder drift checks plus live requests from
 the pinned, unmodified clients to the Rust router. The live gate was also run
@@ -968,9 +992,11 @@ The production lifecycle gate reuses the artifact checksums from
 `upstream.lock.json` and runs the published Python sync, Python async,
 TypeScript, and Code Interpreter packages without source changes. On A3S OS it
 has passed create, reconnect, filtered list, timeout replacement, kill,
-not-found mapping, Code Interpreter lifecycle creation, and cleanup for every
+not-found mapping, Code Interpreter lifecycle creation, running-state
+`is_running`/`isRunning` over authenticated wildcard TLS, and cleanup for every
 real `crun` execution. It intentionally does not count Code Interpreter object
-creation as interpreter execution compatibility.
+creation or health as interpreter execution compatibility, and post-kill health
+remains outside this slice.
 
 The Slice 3 persistence batch uses a bundled SQLite build through a dedicated
 asynchronous connection thread. Versioned migrations create a STRICT table in

--- a/scripts/e2b-production-smoke.sh
+++ b/scripts/e2b-production-smoke.sh
@@ -8,6 +8,8 @@ TOKEN_ENCRYPTION="$(printf '07%.0s' {1..32})"
 TOKEN_DIGEST="$(printf '08%.0s' {1..32})"
 PORT="${A3S_BOX_E2B_SMOKE_PORT:-38081}"
 GATEWAY_PORT="${A3S_BOX_E2B_GATEWAY_SMOKE_PORT:-38443}"
+GATEWAY_ADDRESS="${A3S_BOX_E2B_GATEWAY_SMOKE_ADDRESS:-127.0.0.1}"
+SANDBOX_DOMAIN="${A3S_BOX_E2B_SANDBOX_DOMAIN:-box.example.com}"
 IMAGE="${A3S_BOX_SMOKE_IMAGE:-alpine:3.20}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 OFFICIAL_CLIENT_RUNNER="${A3S_BOX_E2B_OFFICIAL_CLIENT_RUNNER:-$SCRIPT_DIR/../compat/e2b/fixtures/official-clients/run_production.py}"
@@ -40,7 +42,30 @@ fail() {
 [[ "$GATEWAY_PORT" =~ ^[0-9]+$ && "$GATEWAY_PORT" -gt 0 && "$GATEWAY_PORT" -le 65535 ]] ||
   fail 'A3S_BOX_E2B_GATEWAY_SMOKE_PORT must be a valid TCP port'
 [[ "$GATEWAY_PORT" != "$PORT" ]] || fail 'control and gateway ports must differ'
+if [[ "$GATEWAY_ADDRESS" == *:* ]]; then
+  GATEWAY_LISTEN="[$GATEWAY_ADDRESS]:$GATEWAY_PORT"
+  GATEWAY_RESOLVE="[$GATEWAY_ADDRESS]"
+else
+  GATEWAY_LISTEN="$GATEWAY_ADDRESS:$GATEWAY_PORT"
+  GATEWAY_RESOLVE="$GATEWAY_ADDRESS"
+fi
+if ! python3 - "$GATEWAY_ADDRESS" <<'PY'
+import ipaddress
+import sys
+
+address = ipaddress.ip_address(sys.argv[1])
+if not address.is_loopback:
+    raise SystemExit(1)
+PY
+then
+  fail 'A3S_BOX_E2B_GATEWAY_SMOKE_ADDRESS must be a loopback IP address'
+fi
+[[ "$SANDBOX_DOMAIN" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?$ ]] ||
+  fail 'A3S_BOX_E2B_SANDBOX_DOMAIN must be a DNS name'
 command -v openssl >/dev/null || fail 'openssl is required for the TLS gateway smoke'
+if [[ "${A3S_BOX_E2B_OFFICIAL_CLIENTS:-}" == "1" && "$GATEWAY_PORT" != "443" ]]; then
+  fail 'official-client envd health requires A3S_BOX_E2B_GATEWAY_SMOKE_PORT=443'
+fi
 
 umask 077
 STATE_DIR="$A3S_HOME/e2b-compat-smoke"
@@ -117,8 +142,9 @@ gateway_status() {
   local token="$4"
   shift 4
   curl --silent --show-error --output "$output" --write-out '%{http_code}' \
+    --noproxy '*' \
     --cacert "$TLS_CERT" \
-    --resolve "$host:$GATEWAY_PORT:127.0.0.1" \
+    --resolve "$host:$GATEWAY_PORT:$GATEWAY_RESOLVE" \
     --header "$token_header: $token" \
     "$@" "https://$host:$GATEWAY_PORT/health"
 }
@@ -129,7 +155,7 @@ wait_gateway_ready() {
   local status=""
   while (( attempts < 100 )); do
     status="$(gateway_status "$host" "$STATE_DIR/gateway-body.txt" X-Access-Token "$ENVD_TOKEN" || true)"
-    if [[ "$status" == "200" ]]; then
+    if [[ "$status" == "204" ]]; then
       return 0
     fi
     if [[ -n "$SERVICE_PID" ]] && ! kill -0 "$SERVICE_PID" 2>/dev/null; then
@@ -236,20 +262,20 @@ trap cleanup EXIT INT TERM
 rm -rf "$STATE_DIR"
 mkdir -p "$STATE_DIR"
 openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
-  -subj '/CN=*.box.example.com' \
-  -addext 'subjectAltName=DNS:*.box.example.com,DNS:sandbox.box.example.com' \
+  -subj "/CN=*.$SANDBOX_DOMAIN" \
+  -addext "subjectAltName=DNS:*.$SANDBOX_DOMAIN,DNS:sandbox.$SANDBOX_DOMAIN" \
   -keyout "$TLS_KEY" -out "$TLS_CERT" >/dev/null 2>&1
 cat >"$CONFIG" <<EOF
 e2b_compat {
   api_listen = "127.0.0.1:$PORT"
   api_public_url = "$BASE_URL"
-  sandbox_domain = "box.example.com"
+  sandbox_domain = "$SANDBOX_DOMAIN"
   database_path = "$STATE_DIR/lifecycle.sqlite3"
   runtime_home = "$A3S_HOME"
   runtime_state_path = "$STATE_DIR/managed-executions.json"
 
   gateway {
-    listen = "127.0.0.1:$GATEWAY_PORT"
+    listen = "$GATEWAY_LISTEN"
     tls_certificate_path = "$TLS_CERT"
     tls_private_key_path = "$TLS_KEY"
     max_connections = 128
@@ -283,7 +309,7 @@ e2b_compat {
     envd_version = "0.1.3"
     isolation = "sandbox"
     network = "none"
-    command = ["/bin/sh", "-c", "mkdir -p /tmp/e2b-smoke && printf '%s' '$HTTP_RESPONDER_B64' | /bin/busybox base64 -d > /tmp/e2b-smoke/respond && chmod 755 /tmp/e2b-smoke/respond && exec /bin/busybox nc -lk -p 49983 -e /tmp/e2b-smoke/respond"]
+    command = ["/bin/sh", "-c", "mkdir -p /tmp/e2b-smoke && printf '%s' '$HTTP_RESPONDER_B64' | /bin/busybox base64 -d > /tmp/e2b-smoke/respond && chmod 755 /tmp/e2b-smoke/respond && exec /bin/busybox nc -lk -p 49999 -e /tmp/e2b-smoke/respond"]
 
     resources {
       vcpus = 2
@@ -302,7 +328,7 @@ e2b_compat {
     envd_version = "0.1.3"
     isolation = "sandbox"
     network = "none"
-    command = ["/bin/sh", "-c", "mkdir -p /tmp/e2b-smoke && printf '%s' '$HTTP_RESPONDER_B64' | /bin/busybox base64 -d > /tmp/e2b-smoke/respond && chmod 755 /tmp/e2b-smoke/respond && exec /bin/busybox nc -lk -p 49983 -e /tmp/e2b-smoke/respond"]
+    command = ["/bin/sh", "-c", "mkdir -p /tmp/e2b-smoke && printf '%s' '$HTTP_RESPONDER_B64' | /bin/busybox base64 -d > /tmp/e2b-smoke/respond && chmod 755 /tmp/e2b-smoke/respond && exec /bin/busybox nc -lk -p 49999 -e /tmp/e2b-smoke/respond"]
 
     resources {
       vcpus = 2
@@ -326,7 +352,7 @@ CREATE_STATUS="$(status_request POST /sandboxes "$CREATE_RESPONSE" \
 [[ "$CREATE_STATUS" == "201" ]] || fail "create returned HTTP $CREATE_STATUS"
 SANDBOX_ID="$(json_field "$CREATE_RESPONSE" sandboxID)"
 [[ "$SANDBOX_ID" == sandbox-* ]] || fail 'create returned an invalid sandbox ID'
-[[ "$(json_field "$CREATE_RESPONSE" domain)" == "box.example.com" ]] ||
+[[ "$(json_field "$CREATE_RESPONSE" domain)" == "$SANDBOX_DOMAIN" ]] ||
   fail 'create returned the wrong sandbox domain'
 ENVD_TOKEN="$(json_field "$CREATE_RESPONSE" envdAccessToken)"
 TRAFFIC_TOKEN="$(json_field "$CREATE_RESPONSE" trafficAccessToken)"
@@ -335,19 +361,27 @@ TRAFFIC_TOKEN="$(json_field "$CREATE_RESPONSE" trafficAccessToken)"
 [[ -n "$TRAFFIC_TOKEN" ]] ||
   fail 'create omitted the traffic access token'
 
-DIRECT_HOST="49983-$SANDBOX_ID.box.example.com"
+DIRECT_HOST="49983-$SANDBOX_ID.$SANDBOX_DOMAIN"
 wait_gateway_ready "$DIRECT_HOST" || fail 'TLS direct route did not become ready'
-[[ "$(cat "$STATE_DIR/gateway-body.txt")" == "sandbox-data-plane" ]] ||
-  fail 'TLS gateway returned the wrong Sandbox response body'
+[[ ! -s "$STATE_DIR/gateway-body.txt" ]] ||
+  fail 'envd health returned an unexpected response body'
 [[ "$(gateway_status "$DIRECT_HOST" /dev/null X-Access-Token wrong-token)" == "401" ]] ||
   fail 'TLS gateway accepted an invalid envd token'
 [[ "$(gateway_status "$DIRECT_HOST" /dev/null E2B-Traffic-Access-Token "$TRAFFIC_TOKEN")" == "401" ]] ||
   fail 'TLS gateway accepted a traffic token for the envd scope'
-[[ "$(gateway_status sandbox.box.example.com "$STATE_DIR/shared-body.txt" X-Access-Token "$ENVD_TOKEN" \
-  --header "E2b-Sandbox-Id: $SANDBOX_ID" --header 'E2b-Sandbox-Port: 49983')" == "200" ]] ||
-  fail 'TLS shared route did not return HTTP 200'
-[[ "$(cat "$STATE_DIR/shared-body.txt")" == "sandbox-data-plane" ]] ||
-  fail 'TLS shared route returned the wrong Sandbox response body'
+[[ "$(gateway_status "sandbox.$SANDBOX_DOMAIN" "$STATE_DIR/shared-body.txt" X-Access-Token "$ENVD_TOKEN" \
+  --header "E2b-Sandbox-Id: $SANDBOX_ID" --header 'E2b-Sandbox-Port: 49983')" == "204" ]] ||
+  fail 'TLS shared envd route did not return HTTP 204'
+[[ ! -s "$STATE_DIR/shared-body.txt" ]] ||
+  fail 'TLS shared envd health returned an unexpected response body'
+
+TRAFFIC_HOST="49999-$SANDBOX_ID.$SANDBOX_DOMAIN"
+[[ "$(gateway_status "$TRAFFIC_HOST" "$STATE_DIR/traffic-body.txt" E2B-Traffic-Access-Token "$TRAFFIC_TOKEN")" == "200" ]] ||
+  fail 'TLS traffic route did not return HTTP 200'
+[[ "$(cat "$STATE_DIR/traffic-body.txt")" == "sandbox-data-plane" ]] ||
+  fail 'TLS traffic route returned the wrong Sandbox response body'
+[[ "$(gateway_status "$TRAFFIC_HOST" /dev/null E2B-Traffic-Access-Token "$ENVD_TOKEN")" == "401" ]] ||
+  fail 'TLS traffic route accepted an envd token'
 
 DETAIL_RESPONSE="$STATE_DIR/detail.json"
 [[ "$(status_request GET "/sandboxes/$SANDBOX_ID" "$DETAIL_RESPONSE")" == "200" ]] ||
@@ -405,7 +439,7 @@ if [[ "${A3S_BOX_E2B_OFFICIAL_CLIENTS:-}" == "1" ]]; then
     fail "official-client runner is missing: $OFFICIAL_CLIENT_RUNNER"
   OFFICIAL_CLIENT_ARGS=(
     --api-url "$BASE_URL"
-    --domain box.example.com
+    --domain "$SANDBOX_DOMAIN"
     --template fixture-template
   )
   if [[ -n "${A3S_BOX_E2B_PIP_BOOTSTRAP_WHEEL:-}" ]]; then
@@ -416,7 +450,12 @@ if [[ "${A3S_BOX_E2B_OFFICIAL_CLIENTS:-}" == "1" ]]; then
   if [[ -n "${A3S_BOX_E2B_ARTIFACT_CACHE:-}" ]]; then
     OFFICIAL_CLIENT_ARGS+=(--artifact-cache "$A3S_BOX_E2B_ARTIFACT_CACHE")
   fi
+  SMOKE_NO_PROXY="${NO_PROXY:+$NO_PROXY,}$SANDBOX_DOMAIN,.$SANDBOX_DOMAIN,127.0.0.1,localhost"
   E2B_API_KEY="$API_KEY" \
+    SSL_CERT_FILE="$TLS_CERT" \
+    NODE_EXTRA_CA_CERTS="$TLS_CERT" \
+    NO_PROXY="$SMOKE_NO_PROXY" \
+    no_proxy="$SMOKE_NO_PROXY" \
     "${A3S_BOX_E2B_OFFICIAL_PYTHON:-python3}" \
     "$OFFICIAL_CLIENT_RUNNER" "${OFFICIAL_CLIENT_ARGS[@]}"
 
@@ -444,4 +483,4 @@ PY
 fi
 
 stop_service
-printf 'E2B production smoke passed: lifecycle, TLS data plane, restart recovery, credentials, official clients when enabled, and cleanup\n'
+printf 'E2B production smoke passed: lifecycle, host envd health, TLS traffic proxy, restart recovery, credentials, official clients when enabled, and cleanup\n'

--- a/src/compat/src/envd/mod.rs
+++ b/src/compat/src/envd/mod.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use a3s_box_core::{
+    ExecutionGeneration, ExecutionId, ExecutionManager, ExecutionManagerError, ExecutionState,
+};
+use axum::body::Body;
+use axum::http::header::{ALLOW, CONTENT_TYPE};
+use axum::http::{HeaderValue, Method, Request, Response, StatusCode};
+use tracing::debug;
+
+use crate::routing::RouteLease;
+
+/// Host-side implementation of the pinned envd HTTP surface.
+///
+/// The broker receives only requests that already passed sandbox route and
+/// token validation. Runtime state is checked again against the immutable
+/// execution generation in that route lease before a response is returned.
+#[derive(Clone)]
+pub struct EnvdBroker {
+    executions: Arc<dyn ExecutionManager>,
+}
+
+impl EnvdBroker {
+    pub fn new(executions: Arc<dyn ExecutionManager>) -> Self {
+        Self { executions }
+    }
+
+    pub(crate) async fn handle(
+        &self,
+        request: Request<Body>,
+        lease: &RouteLease,
+    ) -> Response<Body> {
+        self.dispatch(
+            request.method(),
+            request.uri().path(),
+            lease.execution_id(),
+            lease.execution_generation(),
+        )
+        .await
+    }
+
+    async fn dispatch(
+        &self,
+        method: &Method,
+        path: &str,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> Response<Body> {
+        if path != "/health" {
+            return json_response(
+                StatusCode::NOT_FOUND,
+                "ENVD_ROUTE_NOT_FOUND",
+                "envd route not found",
+            );
+        }
+        if method != Method::GET {
+            let mut response = json_response(
+                StatusCode::METHOD_NOT_ALLOWED,
+                "METHOD_NOT_ALLOWED",
+                "method not allowed",
+            );
+            response
+                .headers_mut()
+                .insert(ALLOW, HeaderValue::from_static("GET"));
+            return response;
+        }
+
+        match self.executions.inspect(execution_id).await {
+            Ok(status)
+                if status.execution_id == *execution_id
+                    && status.generation == generation
+                    && status.state == ExecutionState::Running =>
+            {
+                let mut response = Response::new(Body::empty());
+                *response.status_mut() = StatusCode::NO_CONTENT;
+                response
+            }
+            Ok(status) => {
+                debug!(
+                    execution_id = %execution_id,
+                    lease_generation = generation.get(),
+                    observed_execution_id = %status.execution_id,
+                    observed_generation = status.generation.get(),
+                    observed_state = ?status.state,
+                    "envd health rejected stale or inactive runtime evidence"
+                );
+                sandbox_not_running()
+            }
+            Err(ExecutionManagerError::NotFound(_) | ExecutionManagerError::Conflict { .. }) => {
+                sandbox_not_running()
+            }
+            Err(error) => {
+                debug!(%execution_id, %error, "envd health runtime inspection failed");
+                json_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "ENVD_UNAVAILABLE",
+                    "envd is temporarily unavailable",
+                )
+            }
+        }
+    }
+}
+
+fn sandbox_not_running() -> Response<Body> {
+    json_response(
+        StatusCode::BAD_GATEWAY,
+        "SANDBOX_NOT_RUNNING",
+        "sandbox is not running",
+    )
+}
+
+fn json_response(status: StatusCode, code: &'static str, message: &'static str) -> Response<Body> {
+    let body = serde_json::json!({ "code": code, "message": message }).to_string();
+    let mut response = Response::new(Body::from(body));
+    *response.status_mut() = status;
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    response
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/compat/src/envd/tests.rs
+++ b/src/compat/src/envd/tests.rs
@@ -1,0 +1,185 @@
+use std::sync::{Arc, Mutex};
+
+use a3s_box_core::{
+    resolve_execution, BoxConfig, ExecutionGeneration, ExecutionId, ExecutionLease,
+    ExecutionManager, ExecutionManagerError, ExecutionManagerResult, ExecutionState,
+    ExecutionStatus, KillOutcome, OperationId, ReconcileOutcome,
+};
+use async_trait::async_trait;
+use axum::http::{Method, StatusCode};
+
+use super::EnvdBroker;
+
+#[derive(Clone)]
+enum Inspection {
+    Status(ExecutionStatus),
+    NotFound,
+    Unavailable,
+}
+
+struct InspectOnlyManager {
+    inspection: Mutex<Inspection>,
+}
+
+impl InspectOnlyManager {
+    fn new(inspection: Inspection) -> Self {
+        Self {
+            inspection: Mutex::new(inspection),
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionManager for InspectOnlyManager {
+    async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
+        match self.inspection.lock().unwrap().clone() {
+            Inspection::Status(status) => Ok(status),
+            Inspection::NotFound => Err(ExecutionManagerError::NotFound(execution_id.clone())),
+            Inspection::Unavailable => Err(ExecutionManagerError::Unavailable(
+                "test inspector unavailable".to_string(),
+            )),
+        }
+    }
+
+    async fn pause(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        _keep_memory: bool,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        Err(unsupported())
+    }
+
+    async fn resume(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        Err(unsupported())
+    }
+
+    async fn kill(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        Err(unsupported())
+    }
+
+    async fn reconcile(
+        &self,
+        _operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ReconcileOutcome> {
+        Err(unsupported())
+    }
+}
+
+fn unsupported() -> ExecutionManagerError {
+    ExecutionManagerError::Unavailable("unsupported test operation".to_string())
+}
+
+fn status(state: ExecutionState, generation: ExecutionGeneration) -> ExecutionStatus {
+    ExecutionStatus {
+        execution_id: ExecutionId::new("execution-envd-1").unwrap(),
+        generation,
+        state,
+        plan: resolve_execution(&BoxConfig::default()).unwrap(),
+    }
+}
+
+fn broker(inspection: Inspection) -> EnvdBroker {
+    EnvdBroker::new(Arc::new(InspectOnlyManager::new(inspection)))
+}
+
+#[tokio::test]
+async fn health_requires_exact_running_execution_generation() {
+    let execution_id = ExecutionId::new("execution-envd-1").unwrap();
+    let response = broker(Inspection::Status(status(
+        ExecutionState::Running,
+        ExecutionGeneration::INITIAL,
+    )))
+    .dispatch(
+        &Method::GET,
+        "/health",
+        &execution_id,
+        ExecutionGeneration::INITIAL,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let response = broker(Inspection::Status(status(
+        ExecutionState::Running,
+        ExecutionGeneration::new(2).unwrap(),
+    )))
+    .dispatch(
+        &Method::GET,
+        "/health",
+        &execution_id,
+        ExecutionGeneration::INITIAL,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+    let response = broker(Inspection::Status(status(
+        ExecutionState::Stopped,
+        ExecutionGeneration::INITIAL,
+    )))
+    .dispatch(
+        &Method::GET,
+        "/health",
+        &execution_id,
+        ExecutionGeneration::INITIAL,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+}
+
+#[tokio::test]
+async fn health_distinguishes_missing_runtime_from_inspector_outage() {
+    let execution_id = ExecutionId::new("execution-envd-1").unwrap();
+    let missing = broker(Inspection::NotFound)
+        .dispatch(
+            &Method::GET,
+            "/health",
+            &execution_id,
+            ExecutionGeneration::INITIAL,
+        )
+        .await;
+    assert_eq!(missing.status(), StatusCode::BAD_GATEWAY);
+
+    let unavailable = broker(Inspection::Unavailable)
+        .dispatch(
+            &Method::GET,
+            "/health",
+            &execution_id,
+            ExecutionGeneration::INITIAL,
+        )
+        .await;
+    assert_eq!(unavailable.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn broker_rejects_unimplemented_routes_and_methods_without_inspection() {
+    let execution_id = ExecutionId::new("execution-envd-1").unwrap();
+    let broker = broker(Inspection::Unavailable);
+    let missing = broker
+        .dispatch(
+            &Method::GET,
+            "/metrics",
+            &execution_id,
+            ExecutionGeneration::INITIAL,
+        )
+        .await;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+    let wrong_method = broker
+        .dispatch(
+            &Method::POST,
+            "/health",
+            &execution_id,
+            ExecutionGeneration::INITIAL,
+        )
+        .await;
+    assert_eq!(wrong_method.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(wrong_method.headers()["allow"], "GET");
+}

--- a/src/compat/src/gateway/mod.rs
+++ b/src/compat/src/gateway/mod.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use a3s_box_core::ExecutionPortConnector;
+use a3s_box_core::{ExecutionManager, ExecutionPortConnector};
 use hyper::server::conn::Http;
 use hyper::service::service_fn;
 use rustls::ServerConfig;
@@ -69,11 +69,18 @@ impl DataPlaneGateway {
         config: DataPlaneGatewayConfig,
         parser: SandboxRouteParser,
         leases: RouteLeaseService,
+        executions: Arc<dyn ExecutionManager>,
         connector: Arc<dyn ExecutionPortConnector>,
     ) -> DataPlaneGatewayResult<Self> {
         let tls =
             tls::load_server_config(&config.certificate_path, &config.private_key_path).await?;
-        let proxy = DataPlaneProxy::new(parser, leases, connector, config.connect_timeout);
+        let proxy = DataPlaneProxy::new(
+            parser,
+            leases,
+            executions,
+            connector,
+            config.connect_timeout,
+        );
         Ok(Self { config, tls, proxy })
     }
 

--- a/src/compat/src/gateway/proxy.rs
+++ b/src/compat/src/gateway/proxy.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use a3s_box_core::{ExecutionManagerError, ExecutionPortConnector, ExecutionPortStream};
+use a3s_box_core::{
+    ExecutionManager, ExecutionManagerError, ExecutionPortConnector, ExecutionPortStream,
+};
 use axum::body::Body;
 use axum::http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -16,9 +18,11 @@ use thiserror::Error;
 use tokio::io::copy_bidirectional;
 use tracing::debug;
 
+use crate::envd::EnvdBroker;
 use crate::routing::{
     RouteLeaseError, RouteLeaseService, RouteParseError, SandboxRouteParser,
-    ENVD_ACCESS_TOKEN_HEADER, SANDBOX_ID_HEADER, SANDBOX_PORT_HEADER, TRAFFIC_ACCESS_TOKEN_HEADER,
+    ENVD_ACCESS_TOKEN_HEADER, ENVD_PORT, SANDBOX_ID_HEADER, SANDBOX_PORT_HEADER,
+    TRAFFIC_ACCESS_TOKEN_HEADER,
 };
 
 const ACCESS_CONTROL_REQUEST_METHOD: &str = "access-control-request-method";
@@ -39,6 +43,7 @@ const EXPOSED_HEADERS: &str =
 pub struct DataPlaneProxy {
     parser: SandboxRouteParser,
     leases: RouteLeaseService,
+    envd: EnvdBroker,
     connector: Arc<dyn ExecutionPortConnector>,
     connect_timeout: Duration,
 }
@@ -47,12 +52,14 @@ impl DataPlaneProxy {
     pub(crate) fn new(
         parser: SandboxRouteParser,
         leases: RouteLeaseService,
+        executions: Arc<dyn ExecutionManager>,
         connector: Arc<dyn ExecutionPortConnector>,
         connect_timeout: Duration,
     ) -> Self {
         Self {
             parser,
             leases,
+            envd: EnvdBroker::new(executions),
             connector,
             connect_timeout,
         }
@@ -72,6 +79,9 @@ impl DataPlaneProxy {
             Ok(lease) => lease,
             Err(error) => return with_cors(error_response(ProxyFailure::Lease(error)), cors),
         };
+        if lease.port().get() == ENVD_PORT {
+            return with_cors(self.envd.handle(request, &lease).await, cors);
+        }
         let stream = match self
             .connector
             .connect_port(

--- a/src/compat/src/gateway/tests.rs
+++ b/src/compat/src/gateway/tests.rs
@@ -6,8 +6,9 @@ use std::time::Duration;
 
 use a3s_box_core::{
     resolve_execution, BoxConfig, ExecutionGeneration, ExecutionId, ExecutionIsolation,
-    ExecutionLease, ExecutionManagerError, ExecutionManagerResult, ExecutionPortConnector,
-    ExecutionPortStream, OperationId,
+    ExecutionLease, ExecutionManager, ExecutionManagerError, ExecutionManagerResult,
+    ExecutionPortConnector, ExecutionPortStream, ExecutionState, ExecutionStatus, KillOutcome,
+    OperationId, ReconcileOutcome,
 };
 use async_trait::async_trait;
 use axum::body::Body;
@@ -66,10 +67,61 @@ impl ExecutionPortConnector for TcpConnector {
     }
 }
 
+struct RunningExecutionManager {
+    status: ExecutionStatus,
+}
+
+#[async_trait]
+impl ExecutionManager for RunningExecutionManager {
+    async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
+        if execution_id != &self.status.execution_id {
+            return Err(ExecutionManagerError::NotFound(execution_id.clone()));
+        }
+        Ok(self.status.clone())
+    }
+
+    async fn pause(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        _keep_memory: bool,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        Err(unsupported_manager_operation())
+    }
+
+    async fn resume(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        Err(unsupported_manager_operation())
+    }
+
+    async fn kill(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        Err(unsupported_manager_operation())
+    }
+
+    async fn reconcile(
+        &self,
+        _operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ReconcileOutcome> {
+        Err(unsupported_manager_operation())
+    }
+}
+
+fn unsupported_manager_operation() -> ExecutionManagerError {
+    ExecutionManagerError::Unavailable("unsupported test manager operation".to_string())
+}
+
 struct Harness {
     proxy: DataPlaneProxy,
     parser: SandboxRouteParser,
     leases: RouteLeaseService,
+    executions: Arc<RunningExecutionManager>,
     connector: Arc<TcpConnector>,
     sandbox_id: SandboxId,
     envd_token: SecretToken,
@@ -145,11 +197,19 @@ impl Harness {
             .mark_running(ExecutionLease {
                 execution_id: ExecutionId::new("execution-gateway-1").unwrap(),
                 generation: ExecutionGeneration::INITIAL,
-                plan,
+                plan: plan.clone(),
                 resources: config.resources,
                 started_at: now,
             })
             .unwrap();
+        let executions = Arc::new(RunningExecutionManager {
+            status: ExecutionStatus {
+                execution_id: ExecutionId::new("execution-gateway-1").unwrap(),
+                generation: ExecutionGeneration::INITIAL,
+                state: ExecutionState::Running,
+                plan: plan.clone(),
+            },
+        });
         let repository = Arc::new(MemorySandboxRepository::default());
         repository.insert(record).await.unwrap();
         let leases = RouteLeaseService::new(repository, tokens, Arc::new(FixedClock(now)));
@@ -161,6 +221,7 @@ impl Harness {
         let proxy = DataPlaneProxy::new(
             parser.clone(),
             leases.clone(),
+            executions.clone(),
             connector.clone(),
             Duration::from_secs(2),
         );
@@ -168,6 +229,7 @@ impl Harness {
             proxy,
             parser,
             leases,
+            executions,
             connector,
             sandbox_id,
             envd_token: envd.secret,
@@ -235,8 +297,11 @@ async fn upstream_response(
 #[tokio::test]
 async fn translates_downstream_http2_to_plaintext_http1_upstream() {
     let harness = Harness::new().await;
-    let mut request =
-        harness.direct_request(ENVD_PORT, ENVD_ACCESS_TOKEN_HEADER, &harness.envd_token);
+    let mut request = harness.direct_request(
+        CODE_INTERPRETER_PORT,
+        TRAFFIC_ACCESS_TOKEN_HEADER,
+        &harness.traffic_token,
+    );
     let authority = request.headers_mut().remove(HOST).unwrap();
     *request.uri_mut() = format!("https://{}/echo?value=one", authority.to_str().unwrap())
         .parse()
@@ -255,7 +320,11 @@ async fn translates_downstream_http2_to_plaintext_http1_upstream() {
 #[tokio::test]
 async fn authenticated_direct_route_proxies_stream_and_strips_edge_credentials() {
     let harness = Harness::new().await;
-    let request = harness.direct_request(ENVD_PORT, ENVD_ACCESS_TOKEN_HEADER, &harness.envd_token);
+    let request = harness.direct_request(
+        CODE_INTERPRETER_PORT,
+        TRAFFIC_ACCESS_TOKEN_HEADER,
+        &harness.traffic_token,
+    );
     let response = harness.proxy.handle(request).await;
     assert_eq!(response.status(), StatusCode::OK);
     let body: serde_json::Value =
@@ -271,7 +340,7 @@ async fn authenticated_direct_route_proxies_stream_and_strips_edge_credentials()
     assert!(body["forwardedHost"]
         .as_str()
         .unwrap()
-        .starts_with("49983-sandbox-gateway-1"));
+        .starts_with("49999-sandbox-gateway-1"));
     assert!(body["forwardedFor"].is_null());
     assert_eq!(harness.call_count(), 1);
 }
@@ -326,8 +395,11 @@ async fn shared_routes_and_browser_preflight_use_the_same_validated_parser() {
         .header(ENVD_ACCESS_TOKEN_HEADER, harness.envd_token.expose_secret())
         .body(Body::empty())
         .unwrap();
-    assert_eq!(harness.proxy.handle(shared).await.status(), StatusCode::OK);
-    assert_eq!(harness.call_count(), 1);
+    assert_eq!(
+        harness.proxy.handle(shared).await.status(),
+        StatusCode::NO_CONTENT
+    );
+    assert_eq!(harness.call_count(), 0);
 }
 
 #[tokio::test]
@@ -359,6 +431,7 @@ async fn wildcard_tls_listener_serves_an_authenticated_route() {
         config,
         harness.parser.clone(),
         harness.leases.clone(),
+        harness.executions.clone(),
         harness.connector.clone(),
     )
     .await
@@ -383,13 +456,13 @@ async fn wildcard_tls_listener_serves_an_authenticated_route() {
     let (mut sender, connection) = hyper::client::conn::handshake(tls).await.unwrap();
     let client_task = tokio::spawn(connection);
     let request = Request::builder()
-        .uri("/echo")
+        .uri("/health")
         .header(HOST, host)
         .header(ENVD_ACCESS_TOKEN_HEADER, harness.envd_token.expose_secret())
-        .body(Body::from("tls"))
+        .body(Body::empty())
         .unwrap();
     let response = sender.send_request(request).await.unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
     let _ = to_bytes(response.into_body()).await.unwrap();
     drop(sender);
     client_task.await.unwrap().unwrap();

--- a/src/compat/src/lib.rs
+++ b/src/compat/src/lib.rs
@@ -8,6 +8,7 @@ mod openapi;
 mod proto;
 
 pub mod control;
+pub mod envd;
 pub mod gateway;
 pub mod http;
 pub mod production;

--- a/src/compat/src/production/service.rs
+++ b/src/compat/src/production/service.rs
@@ -72,7 +72,7 @@ impl E2bCompatService {
         }));
         let supervisor = LifecycleSupervisor::new(LifecycleSupervisorDependencies {
             repository: repository.clone(),
-            executions,
+            executions: executions.clone(),
             clock: clock.clone(),
         });
         let route_parser = SandboxRouteParser::new(config.sandbox_domain.clone());
@@ -92,6 +92,7 @@ impl E2bCompatService {
             config.gateway.clone(),
             route_parser.clone(),
             route_leases.clone(),
+            executions,
             port_connector,
         )
         .await?;


### PR DESCRIPTION
## Summary

- route authenticated envd port 49983 requests to a host-side broker
- implement generation-fenced `GET /health` with canonical `ExecutionManager` inspection
- keep traffic ports on the existing generation/PID-fenced Sandbox network-namespace proxy
- extend the production smoke and unchanged official clients through real TLS health calls
- update README and compatibility design to the observed subset while keeping `full_compatibility=false`

## Validation

- A3S OS: `cargo test -p a3s-box-compat` (82 passed)
- A3S OS: real `crun + OCI` Sandbox production smoke with `--isolation sandbox`
- A3S OS: TLS direct/shared envd health and traffic-scoped port 49999 proxy
- A3S OS: unchanged pinned Python sync/async, TypeScript, and both Code Interpreter packages call running-state health successfully
- smoke verified Box directory, crun state, listener, and per-execution socket cleanup

No local Docker, OrbStack, or runtime was used.
