### PR TITLE
fix(e2b): report terminal sandbox health

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,10 @@ modification and runs them against the ACL-configured production process and
 real `crun` Sandboxes. Python sync, Python async, and TypeScript each pass
 create, connect, filtered list, timeout replacement, kill, and not-found
 behavior; both Code Interpreter packages also pass production lifecycle create
-and cleanup. Each running Python sync/async, TypeScript, and Code Interpreter
-object also calls its official `is_running`/`isRunning` method through the
-production TLS gateway and host-side envd health broker. This matrix does not
+and cleanup. Each Python sync/async, TypeScript, and Code Interpreter object
+also calls its official `is_running`/`isRunning` method through the production
+TLS gateway and host-side envd health broker before and after kill, returning
+`true` while running and `false` after termination. This matrix does not
 exercise envd commands, files, PTY, or interpreter execution.
 
 Managed creation requests also persist a typed caller policy for names,
@@ -391,20 +392,22 @@ downstream client uses HTTP/2; the origin is not required to provide h2c.
 Port `49983` is owned by a host-side broker rather than the workload. Its first
 implemented endpoint is authenticated `GET /health`: the broker re-inspects the
 leased execution ID and generation and returns `204` only while that exact
-execution is running. Other routed ports continue through the fenced Sandbox
-network-namespace proxy.
+execution is running. After kill, a scope-valid envd token receives the terminal
+`502` response expected by the official SDK running-state methods, while an
+invalid token remains unauthorized and no live route lease is issued. Other
+routed ports continue through the fenced Sandbox network-namespace proxy.
 
 An A3S OS production smoke test exercises this path on a real `crun` OCI
 Sandbox created with `--isolation sandbox`. It verifies lifecycle operations,
 host envd health over both TLS route forms, a real traffic-token-protected
 workload service on port `49999`, HTTP/2-to-HTTP/1.1 translation, invalid and
 scope-swapped token denial, service-restart recovery, stale-route fencing after
-kill, structured-log drainage, and complete runtime cleanup. The same A3S OS
-gate runs the unchanged official clients through the health route. Failed runs
-preserve the Sandbox PID, `crun` state, OCI bundle, and service logs for
-diagnosis. The remaining envd HTTP endpoints, ConnectRPC commands/filesystem,
-PTY, public-port matrix, and Code Interpreter execution suites remain open
-release gates.
+kill, authenticated terminal health, structured-log drainage, and complete
+runtime cleanup. The same A3S OS gate runs the unchanged official clients
+through both running and post-kill health checks. Failed runs preserve the
+Sandbox PID, `crun` state, OCI bundle, and service logs for diagnosis. The
+remaining envd HTTP endpoints, ConnectRPC commands/filesystem, PTY, public-port
+matrix, and Code Interpreter execution suites remain open release gates.
 
 The server, native Python/TypeScript packages, and unchanged-official-client
 black-box suites follow the phased design in

--- a/compat/e2b/README.md
+++ b/compat/e2b/README.md
@@ -85,9 +85,11 @@ HTTP/1.1 and HTTP/2 streaming proxying, CORS preflight, upgrades, bounded
 connections, and generation-fenced access to real Sandbox loopback ports. A
 host-side broker now implements authenticated envd `GET /health`; it returns
 `204` only after the runtime manager confirms the leased execution ID and
-generation are still running. The remaining pinned envd HTTP and ConnectRPC
-protocols are still required before the manifest can set
-`full_compatibility=true`.
+generation are still running, and returns the official-client terminal `502`
+for a killed lifecycle record only after validating its envd token. Invalid
+tokens remain unauthorized, and no live route lease is reopened. The remaining
+pinned envd HTTP and ConnectRPC protocols are still required before the manifest
+can set `full_compatibility=true`.
 
 The destructive A3S OS integration harness is
 [`scripts/e2b-production-smoke.sh`](../../scripts/e2b-production-smoke.sh). It
@@ -98,6 +100,6 @@ restart recovery, host envd health, a traffic-scoped workload service on port
 `A3S_BOX_E2B_OFFICIAL_CLIENTS=1`, it additionally runs the checksum-pinned,
 unchanged Python sync, Python async, TypeScript, and Code Interpreter packages
 through the production lifecycle listener, calls their official running-state
-health methods through the TLS gateway, and verifies cleanup of every real
-`crun` execution. That optional matrix does not exercise envd commands, files,
-PTY, or interpreter execution.
+health methods through the TLS gateway before and after kill, and verifies
+cleanup of every real `crun` execution. That optional matrix does not exercise
+envd commands, files, PTY, or interpreter execution.

--- a/compat/e2b/fixtures/official-clients/README.md
+++ b/compat/e2b/fixtures/official-clients/README.md
@@ -78,7 +78,7 @@ wildcard sandbox domain must resolve to the gateway listener. The smoke accepts
 already reserves IPv4 port 443; for example, `::1` with a `box.localhost`
 domain keeps the gate local while preserving normal TLS hostname behavior.
 
-This gate proves production lifecycle behavior, running-state envd health, and
-cleanup through the public clients. It does not claim envd command,
-filesystem, PTY, post-kill health, or Code Interpreter execution compatibility;
-those require their separate data-plane suites.
+This gate proves production lifecycle behavior, running and post-kill envd
+health, and cleanup through the public clients. It does not claim envd command,
+filesystem, PTY, or Code Interpreter execution compatibility; those require
+their separate data-plane suites.

--- a/compat/e2b/fixtures/official-clients/production_python_client.py
+++ b/compat/e2b/fixtures/official-clients/production_python_client.py
@@ -61,6 +61,8 @@ def run_sync(api_url: str, domain: str, template: str) -> None:
         sandbox.set_timeout(30)
         if not sandbox.kill():
             raise AssertionError("kill did not terminate the production sandbox")
+        if sandbox.is_running():
+            raise AssertionError("envd health reported the killed sandbox as running")
 
         missing_id = "missing-production-python-sync"
         if Sandbox.kill(missing_id, **options):
@@ -81,6 +83,8 @@ def run_sync(api_url: str, domain: str, template: str) -> None:
             raise AssertionError("Code Interpreter envd health check failed")
         if not interpreter.kill():
             raise AssertionError("Code Interpreter lifecycle kill failed")
+        if interpreter.is_running():
+            raise AssertionError("Code Interpreter remained running after kill")
     finally:
         if interpreter is not None:
             Sandbox.kill(interpreter.sandbox_id, **options)
@@ -120,6 +124,8 @@ async def run_async(api_url: str, domain: str, template: str) -> None:
         await sandbox.set_timeout(30)
         if not await sandbox.kill():
             raise AssertionError("kill did not terminate the production sandbox")
+        if await sandbox.is_running():
+            raise AssertionError("envd health reported the killed sandbox as running")
 
         missing_id = "missing-production-python-async"
         if await AsyncSandbox.kill(missing_id, **options):
@@ -140,6 +146,8 @@ async def run_async(api_url: str, domain: str, template: str) -> None:
             raise AssertionError("async Code Interpreter envd health check failed")
         if not await interpreter.kill():
             raise AssertionError("Code Interpreter lifecycle kill failed")
+        if await interpreter.is_running():
+            raise AssertionError("async Code Interpreter remained running after kill")
     finally:
         if interpreter is not None:
             await AsyncSandbox.kill(interpreter.sandbox_id, **options)

--- a/compat/e2b/fixtures/official-clients/production_typescript_client.mjs
+++ b/compat/e2b/fixtures/official-clients/production_typescript_client.mjs
@@ -42,6 +42,7 @@ try {
 
   await sandbox.setTimeout(30_000)
   assert.equal(await sandbox.kill(), true)
+  assert.equal(await sandbox.isRunning(), false)
 
   const missingId = 'missing-production-typescript'
   assert.equal(await Sandbox.kill(missingId, connection), false)
@@ -57,6 +58,7 @@ try {
   })
   assert.equal(await interpreter.isRunning(), true)
   assert.equal(await interpreter.kill(), true)
+  assert.equal(await interpreter.isRunning(), false)
 } finally {
   if (interpreter) {
     await Sandbox.kill(interpreter.sandboxId, connection)

--- a/docs/e2b-compatible-sdk-design.md
+++ b/docs/e2b-compatible-sdk-design.md
@@ -1,8 +1,8 @@
 # E2B Protocol Compatibility and SDK Design
 
 Status: **Phase 1 complete; Phase 2 in progress (slices 1 through 6 and the
-production official-client lifecycle gate complete; first host envd health
-slice complete)**
+production official-client lifecycle gate complete; authenticated running and
+terminal envd health slice complete)**
 
 Implementation evidence starts in [`compat/e2b/`](../compat/e2b/README.md).
 The pinned contract manifest intentionally reports `full_compatibility=false`;
@@ -24,19 +24,20 @@ unversioned claim.
 | Durable control state | SQLite WAL migrations, strict record validation, compare-and-swap transitions, generation-fenced expiry claims, startup reconciliation, and periodic reaping are composed into the production service; an A3S OS smoke preserves a running record across process restart | Exercise host-reboot recovery end to end |
 | Runtime lifecycle | The production compatibility process uses the canonical `LocalExecutionManager`; A3S OS smoke coverage and unchanged official clients create through HTTP, start through certified `crun`, reconnect, replace timeout, kill, and verify box, runtime-state, and socket cleanup | Complete host-reboot recovery and the official-client data-plane matrices |
 | Credentials and routing | ACL config wires salted PBKDF2-SHA256 account hashes, scope-bound AES-256-GCM sandbox tokens, independent HMAC validation, versioned key rotation, strict direct/shared parsing, durable-record-projected generation-fenced leases, wildcard TLS termination, and a generation/PID-fenced Sandbox network-namespace connector | Add certificate rotation and exercise every HTTP/2, Connect, WebSocket, and stream case in the complete matrix |
-| envd HTTP | A host-side broker implements authenticated `GET /health`; after route/token validation it re-inspects the exact execution ID and generation and returns `204` only for `Running`; unchanged official Python sync/async, TypeScript, and Code Interpreter objects pass their running-state health methods over production TLS | Implement `/metrics`, `/init`, `/envs`, file-content routes, and post-kill `is_running`/`isRunning` behavior |
+| envd HTTP | A host-side broker implements authenticated `GET /health`; after route/token validation it re-inspects the exact execution ID and generation and returns `204` only for `Running`; a valid envd token receives terminal `502` after kill without reopening a route lease, while invalid tokens remain unauthorized; unchanged official Python sync/async, TypeScript, and Code Interpreter objects pass `is_running`/`isRunning` before and after kill over production TLS | Implement `/metrics`, `/init`, `/envs`, and file-content routes |
 | Commands and SDK surface | Pinned Process/Filesystem descriptors and Python/TypeScript public-export inventories prevent unreviewed drift | Implement ConnectRPC, PTY, signed URLs, Code Interpreter/MCP streams, the remaining public control surface, and native convenience packages |
 
 The lifecycle control path and authenticated wildcard/shared TLS routes are
 composed and exercised against a real Sandbox on A3S OS. The smoke reaches a
 traffic-scoped service on Sandbox loopback port `49999`, while envd health on
 port `49983` stays in the host broker. It rejects invalid and scope-swapped
-tokens, survives a compatibility-service restart, and fences the route after
-kill. A separate production gate now runs the checksum-pinned official Python
+tokens, survives a compatibility-service restart, fences workload traffic after
+kill, and preserves authenticated terminal health without reopening a live
+lease. A separate production gate now runs the checksum-pinned official Python
 sync, Python async, TypeScript, and Code Interpreter packages unchanged against
-the ACL-configured service and real `crun` Sandboxes. Their running-state
-health methods traverse the wildcard TLS gateway and host envd broker, and the
-gate verifies complete cleanup. The fixture gate still uses an in-memory
+the ACL-configured service and real `crun` Sandboxes. Their running and
+post-kill health methods traverse the wildcard TLS gateway and host envd broker,
+and the gate verifies complete cleanup. The fixture gate still uses an in-memory
 repository and fake execution manager, and the remaining envd/ConnectRPC
 operations are not covered. These are complementary results rather than the
 full black-box compatibility matrix, so `full_compatibility=false` remains
@@ -308,15 +309,18 @@ The envd-compatible service is a host-side broker backed by the existing A3S
 control protocols. Keeping it outside the workload prevents the workload from
 replacing the compatibility endpoint or stealing its access token.
 
-The first broker route is implemented: after the gateway resolves an
-authenticated `49983` lease, `GET /health` calls `ExecutionManager::inspect`
-and compares the returned execution ID, generation, and `Running` state with
-that lease. Exact live evidence returns an empty `204`; once a lease has been
-issued, runtime evidence that becomes missing, stopped, or generation-stale
-returns `502`, while an unavailable inspector returns `503`. Other envd routes
-currently return `404` and remain explicit release gates. Workload traffic on
-every non-envd route continues through the existing generation- and PID-fenced
-network-namespace connector.
+The first broker route is implemented: the gateway authenticates a `49983`
+`GET /health` request against the durable lifecycle record before disclosing
+state. For a running record it issues a generation-fenced lease, calls
+`ExecutionManager::inspect`, and compares the returned execution ID, generation,
+and `Running` state with that lease. Exact live evidence returns an empty `204`;
+runtime evidence that becomes missing, stopped, or generation-stale returns
+`502`, while an unavailable inspector returns `503`. For a killed record, a
+valid envd token receives the terminal `502` expected by the official clients
+without issuing a live lease or opening a connector; an invalid token remains
+`401`. Other envd routes currently return `404` and remain explicit release
+gates. Workload traffic on every non-envd route continues through the existing
+generation- and PID-fenced network-namespace connector.
 
 It translates:
 
@@ -893,8 +897,8 @@ Phase 2 is delivered as small, immediately merged changes:
    stale-route fencing against a real `--isolation sandbox` execution.
 7. **In progress:** the unmodified official clients now pass their lifecycle
    flows through the production control listener and real Sandbox runtime, and
-   their running-state health methods pass through the production TLS listener
-   and host envd broker. Implement the remaining pinned envd HTTP and
+   their running and post-kill health methods pass through the production TLS
+   listener and host envd broker. Implement the remaining pinned envd HTTP and
    ConnectRPC protocols, then extend the same clients through command,
    filesystem, PTY, public-port, and interpreter operations.
 
@@ -975,11 +979,12 @@ durable repository, production execution manager, credentials, routing, and
 lifecycle HTTP router are now composed in one ACL-configured process. The real
 create/connect/list/timeout/kill matrix now passes through that production
 control listener and real Sandbox executions. Returned official-client Sandbox
-objects now traverse the production TLS listener for running-state envd health,
-but the Phase 2 gate remains closed until the remaining envd, ConnectRPC, PTY,
-public-port, interpreter, and MCP matrices pass. Passing the fake manager in
-slice 2, the direct runtime smoke in slice 4, and the production health clients
-are complementary evidence, not proof of the missing data-plane behavior.
+objects now traverse the production TLS listener for running and post-kill envd
+health, but the Phase 2 gate remains closed until the remaining envd,
+ConnectRPC, PTY, public-port, interpreter, and MCP matrices pass. Passing the
+fake manager in slice 2, the direct runtime smoke in slice 4, and the production
+health clients are complementary evidence, not proof of the missing data-plane
+behavior.
 
 Slice 2 evidence includes exact recorder drift checks plus live requests from
 the pinned, unmodified clients to the Rust router. The live gate was also run
@@ -992,11 +997,10 @@ The production lifecycle gate reuses the artifact checksums from
 `upstream.lock.json` and runs the published Python sync, Python async,
 TypeScript, and Code Interpreter packages without source changes. On A3S OS it
 has passed create, reconnect, filtered list, timeout replacement, kill,
-not-found mapping, Code Interpreter lifecycle creation, running-state
+not-found mapping, Code Interpreter lifecycle creation, running and post-kill
 `is_running`/`isRunning` over authenticated wildcard TLS, and cleanup for every
 real `crun` execution. It intentionally does not count Code Interpreter object
-creation or health as interpreter execution compatibility, and post-kill health
-remains outside this slice.
+creation or health as interpreter execution compatibility.
 
 The Slice 3 persistence batch uses a bundled SQLite build through a dedicated
 asynchronous connection thread. Versioned migrations create a STRICT table in

--- a/scripts/e2b-production-smoke.sh
+++ b/scripts/e2b-production-smoke.sh
@@ -408,8 +408,12 @@ CONNECT_RESPONSE="$STATE_DIR/connect.json"
   fail 'timeout replacement did not return HTTP 204'
 [[ "$(status_request DELETE "/sandboxes/$SANDBOX_ID" /dev/null)" == "204" ]] ||
   fail 'kill did not return HTTP 204'
-[[ "$(gateway_status "$DIRECT_HOST" /dev/null X-Access-Token "$ENVD_TOKEN")" == "404" ]] ||
-  fail 'stale TLS route remained available after kill'
+[[ "$(gateway_status "$DIRECT_HOST" /dev/null X-Access-Token "$ENVD_TOKEN")" == "502" ]] ||
+  fail 'authenticated envd health did not report the killed sandbox as stopped'
+[[ "$(gateway_status "$DIRECT_HOST" /dev/null X-Access-Token wrong-token)" == "401" ]] ||
+  fail 'terminal envd health accepted an invalid token'
+[[ "$(gateway_status "$TRAFFIC_HOST" /dev/null E2B-Traffic-Access-Token "$TRAFFIC_TOKEN")" == "404" ]] ||
+  fail 'stale TLS traffic route remained available after kill'
 
 EXECUTION_ID="$(python3 - "$STATE_DIR/managed-executions.json" "$SANDBOX_ID" <<'PY'
 import json

--- a/src/compat/src/envd/mod.rs
+++ b/src/compat/src/envd/mod.rs
@@ -39,6 +39,10 @@ impl EnvdBroker {
         .await
     }
 
+    pub(crate) fn inactive_health(&self) -> Response<Body> {
+        sandbox_not_running()
+    }
+
     async fn dispatch(
         &self,
         method: &Method,

--- a/src/compat/src/gateway/proxy.rs
+++ b/src/compat/src/gateway/proxy.rs
@@ -20,9 +20,9 @@ use tracing::debug;
 
 use crate::envd::EnvdBroker;
 use crate::routing::{
-    RouteLeaseError, RouteLeaseService, RouteParseError, SandboxRouteParser,
-    ENVD_ACCESS_TOKEN_HEADER, ENVD_PORT, SANDBOX_ID_HEADER, SANDBOX_PORT_HEADER,
-    TRAFFIC_ACCESS_TOKEN_HEADER,
+    EnvdHealthResolution, ParsedSandboxRoute, RouteLeaseError, RouteLeaseService, RouteParseError,
+    SandboxRouteParser, ENVD_ACCESS_TOKEN_HEADER, ENVD_PORT, SANDBOX_ID_HEADER,
+    SANDBOX_PORT_HEADER, TRAFFIC_ACCESS_TOKEN_HEADER,
 };
 
 const ACCESS_CONTROL_REQUEST_METHOD: &str = "access-control-request-method";
@@ -75,6 +75,22 @@ impl DataPlaneProxy {
             return preflight_response(request.headers());
         }
 
+        if is_envd_health(&request, &route) {
+            let resolution = match self
+                .leases
+                .resolve_envd_health(&route, request.headers())
+                .await
+            {
+                Ok(resolution) => resolution,
+                Err(error) => return with_cors(error_response(ProxyFailure::Lease(error)), cors),
+            };
+            let response = match resolution {
+                EnvdHealthResolution::Running(lease) => self.envd.handle(request, &lease).await,
+                EnvdHealthResolution::Inactive => self.envd.inactive_health(),
+            };
+            return with_cors(response, cors);
+        }
+
         let lease = match self.leases.resolve(&route, request.headers()).await {
             Ok(lease) => lease,
             Err(error) => return with_cors(error_response(ProxyFailure::Lease(error)), cors),
@@ -104,6 +120,12 @@ impl DataPlaneProxy {
             }
         }
     }
+}
+
+fn is_envd_health(request: &Request<Body>, route: &ParsedSandboxRoute) -> bool {
+    route.port.get() == ENVD_PORT
+        && request.method() == Method::GET
+        && request.uri().path() == "/health"
 }
 
 async fn proxy_upstream(

--- a/src/compat/src/gateway/tests.rs
+++ b/src/compat/src/gateway/tests.rs
@@ -121,6 +121,7 @@ struct Harness {
     proxy: DataPlaneProxy,
     parser: SandboxRouteParser,
     leases: RouteLeaseService,
+    repository: Arc<MemorySandboxRepository>,
     executions: Arc<RunningExecutionManager>,
     connector: Arc<TcpConnector>,
     sandbox_id: SandboxId,
@@ -212,7 +213,7 @@ impl Harness {
         });
         let repository = Arc::new(MemorySandboxRepository::default());
         repository.insert(record).await.unwrap();
-        let leases = RouteLeaseService::new(repository, tokens, Arc::new(FixedClock(now)));
+        let leases = RouteLeaseService::new(repository.clone(), tokens, Arc::new(FixedClock(now)));
         let connector = Arc::new(TcpConnector {
             address,
             calls: Arc::new(Mutex::new(Vec::new())),
@@ -229,6 +230,7 @@ impl Harness {
             proxy,
             parser,
             leases,
+            repository,
             executions,
             connector,
             sandbox_id,
@@ -256,6 +258,18 @@ impl Harness {
 
     fn call_count(&self) -> usize {
         self.connector.calls.lock().unwrap().len()
+    }
+
+    fn health_request(&self, token: &SecretToken) -> Request<Body> {
+        Request::builder()
+            .uri("/health")
+            .header(
+                HOST,
+                format!("{}-{}.box.example.com", ENVD_PORT, self.sandbox_id),
+            )
+            .header(ENVD_ACCESS_TOKEN_HEADER, token.expose_secret())
+            .body(Body::empty())
+            .unwrap()
     }
 }
 
@@ -398,6 +412,57 @@ async fn shared_routes_and_browser_preflight_use_the_same_validated_parser() {
     assert_eq!(
         harness.proxy.handle(shared).await.status(),
         StatusCode::NO_CONTENT
+    );
+    assert_eq!(harness.call_count(), 0);
+}
+
+#[tokio::test]
+async fn authenticated_terminal_health_returns_false_without_reopening_traffic_routes() {
+    let harness = Harness::new().await;
+    let mut record = harness
+        .repository
+        .get(&harness.sandbox_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let expected = record.generation();
+    record.begin_kill().unwrap();
+    harness
+        .repository
+        .compare_and_swap(&harness.sandbox_id, expected, record.clone())
+        .await
+        .unwrap();
+    let expected = record.generation();
+    record.mark_killed().unwrap();
+    harness
+        .repository
+        .compare_and_swap(&harness.sandbox_id, expected, record)
+        .await
+        .unwrap();
+
+    let inactive = harness
+        .proxy
+        .handle(harness.health_request(&harness.envd_token))
+        .await;
+    assert_eq!(inactive.status(), StatusCode::BAD_GATEWAY);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(inactive.into_body()).await.unwrap()).unwrap();
+    assert_eq!(body["code"], "SANDBOX_NOT_RUNNING");
+
+    let unauthorized = harness
+        .proxy
+        .handle(harness.health_request(&harness.traffic_token))
+        .await;
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+    let traffic = harness.direct_request(
+        CODE_INTERPRETER_PORT,
+        TRAFFIC_ACCESS_TOKEN_HEADER,
+        &harness.traffic_token,
+    );
+    assert_eq!(
+        harness.proxy.handle(traffic).await.status(),
+        StatusCode::NOT_FOUND
     );
     assert_eq!(harness.call_count(), 0);
 }

--- a/src/compat/src/routing/lease.rs
+++ b/src/compat/src/routing/lease.rs
@@ -28,6 +28,12 @@ pub struct RouteLease {
     expires_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvdHealthResolution {
+    Running(RouteLease),
+    Inactive,
+}
+
 impl RouteLease {
     pub fn sandbox_id(&self) -> &SandboxId {
         &self.sandbox_id
@@ -105,10 +111,7 @@ impl RouteLeaseService {
         if record.expires_at() <= now {
             return Err(RouteLeaseError::Expired);
         }
-        let token_scope = record
-            .routing()
-            .token_scope(route.port.get())
-            .ok_or(RouteLeaseError::PortDenied)?;
+        let token_scope = self.verify_route_token(&record, route, headers).await?;
         let execution_id = record
             .execution_id()
             .cloned()
@@ -116,14 +119,6 @@ impl RouteLeaseService {
         let execution_generation = record
             .execution_generation()
             .ok_or(RouteLeaseError::InvalidRecord)?;
-        let presented = presented_token(headers, token_scope)?;
-        let stored = match token_scope {
-            TokenScope::Envd => &record.credentials().envd,
-            TokenScope::Traffic => &record.credentials().traffic,
-        };
-        if !self.tokens.verify(token_scope, &presented, stored).await? {
-            return Err(RouteLeaseError::Unauthorized);
-        }
         Ok(RouteLease {
             sandbox_id: record.sandbox_id().clone(),
             execution_id,
@@ -133,6 +128,70 @@ impl RouteLeaseService {
             token_scope,
             expires_at: record.expires_at(),
         })
+    }
+
+    /// Resolve an authenticated envd health request without issuing a live
+    /// route lease for an inactive or expired sandbox.
+    ///
+    /// This preserves the official client's `502 -> false` behavior after a
+    /// successful kill while ensuring an invalid token cannot probe terminal
+    /// sandbox state. All other data-plane requests continue to require a live
+    /// [`RouteLease`].
+    pub async fn resolve_envd_health(
+        &self,
+        route: &ParsedSandboxRoute,
+        headers: &HeaderMap,
+    ) -> RouteLeaseResult<EnvdHealthResolution> {
+        let record = self
+            .repository
+            .get(&route.sandbox_id)
+            .await?
+            .ok_or(RouteLeaseError::NotFound)?;
+        let token_scope = self.verify_route_token(&record, route, headers).await?;
+        if token_scope != TokenScope::Envd {
+            return Err(RouteLeaseError::PortDenied);
+        }
+        let now = self.clock.now();
+        if record.state() != LifecycleState::Running || record.expires_at() <= now {
+            return Ok(EnvdHealthResolution::Inactive);
+        }
+        let execution_id = record
+            .execution_id()
+            .cloned()
+            .ok_or(RouteLeaseError::InvalidRecord)?;
+        let execution_generation = record
+            .execution_generation()
+            .ok_or(RouteLeaseError::InvalidRecord)?;
+        Ok(EnvdHealthResolution::Running(RouteLease {
+            sandbox_id: record.sandbox_id().clone(),
+            execution_id,
+            sandbox_generation: record.generation(),
+            execution_generation,
+            port: route.port,
+            token_scope,
+            expires_at: record.expires_at(),
+        }))
+    }
+
+    async fn verify_route_token(
+        &self,
+        record: &SandboxRecord,
+        route: &ParsedSandboxRoute,
+        headers: &HeaderMap,
+    ) -> RouteLeaseResult<TokenScope> {
+        let token_scope = record
+            .routing()
+            .token_scope(route.port.get())
+            .ok_or(RouteLeaseError::PortDenied)?;
+        let presented = presented_token(headers, token_scope)?;
+        let stored = match token_scope {
+            TokenScope::Envd => &record.credentials().envd,
+            TokenScope::Traffic => &record.credentials().traffic,
+        };
+        if !self.tokens.verify(token_scope, &presented, stored).await? {
+            return Err(RouteLeaseError::Unauthorized);
+        }
+        Ok(token_scope)
     }
 }
 
@@ -315,6 +374,17 @@ mod tests {
             .unwrap();
         assert_eq!(envd.token_scope(), TokenScope::Envd);
         assert_eq!(envd.execution_id().as_str(), "execution-route-1");
+        assert!(matches!(
+            harness
+                .service
+                .resolve_envd_health(
+                    &harness.route(ENVD_PORT),
+                    &token_headers(ENVD_ACCESS_TOKEN_HEADER, &harness.envd_secret),
+                )
+                .await
+                .unwrap(),
+            EnvdHealthResolution::Running(lease) if lease == envd
+        ));
 
         let traffic = harness
             .service
@@ -399,6 +469,13 @@ mod tests {
         record.begin_kill().unwrap();
         harness
             .repository
+            .compare_and_swap(&harness.sandbox_id, expected, record.clone())
+            .await
+            .unwrap();
+        let expected = record.generation();
+        record.mark_killed().unwrap();
+        harness
+            .repository
             .compare_and_swap(&harness.sandbox_id, expected, record)
             .await
             .unwrap();
@@ -411,6 +488,27 @@ mod tests {
                 )
                 .await,
             Err(RouteLeaseError::Inactive)
+        ));
+        assert_eq!(
+            harness
+                .service
+                .resolve_envd_health(
+                    &harness.route(ENVD_PORT),
+                    &token_headers(ENVD_ACCESS_TOKEN_HEADER, &harness.envd_secret),
+                )
+                .await
+                .unwrap(),
+            EnvdHealthResolution::Inactive
+        );
+        assert!(matches!(
+            harness
+                .service
+                .resolve_envd_health(
+                    &harness.route(ENVD_PORT),
+                    &token_headers(ENVD_ACCESS_TOKEN_HEADER, &harness.traffic_secret),
+                )
+                .await,
+            Err(RouteLeaseError::Unauthorized)
         ));
     }
 

--- a/src/compat/src/routing/mod.rs
+++ b/src/compat/src/routing/mod.rs
@@ -3,8 +3,8 @@ mod parser;
 mod policy;
 
 pub use lease::{
-    RouteLease, RouteLeaseError, RouteLeaseResult, RouteLeaseService, ENVD_ACCESS_TOKEN_HEADER,
-    TRAFFIC_ACCESS_TOKEN_HEADER,
+    EnvdHealthResolution, RouteLease, RouteLeaseError, RouteLeaseResult, RouteLeaseService,
+    ENVD_ACCESS_TOKEN_HEADER, TRAFFIC_ACCESS_TOKEN_HEADER,
 };
 pub use parser::{
     ParsedSandboxRoute, RouteForm, RouteParseError, RouteParseResult, SandboxDomain,


### PR DESCRIPTION
## Summary

- preserve authenticated envd health after sandbox termination without reopening a live route
- make official Python, TypeScript, and Code Interpreter running-state methods return false after kill
- document only the capability proven by the A3S OS production gate

## Validation

- A3S OS: cargo test -p a3s-box-compat (83 passed)
- A3S OS: real crun + OCI production smoke with Python sync/async, TypeScript, and both Code Interpreter packages
- verified invalid terminal envd tokens remain unauthorized, traffic routes remain fenced, and runtime resources are cleaned up

The compatibility manifest remains full_compatibility=false.