### PR TITLE
fix(runtime): gate Unix execution sessions

### DIFF
--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -9,6 +9,7 @@ mod record;
 mod recovery;
 mod resources;
 mod restart;
+#[cfg(unix)]
 mod session;
 mod store;
 mod support;

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -21,6 +21,10 @@ mod vm_process;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use a3s_box_core::{
+    ExecutionGeneration, ExecutionId, ExecutionManagerError, ExecutionManagerResult,
+};
+
 pub use backend::{LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation};
 use record::{build_managed_record, status_from_record};
 use store::RuntimeUpdate;
@@ -52,6 +56,39 @@ impl LocalExecutionManager {
 
     pub fn state_path(&self) -> &std::path::Path {
         self.store.path()
+    }
+
+    pub(super) async fn require_running_record(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<BoxRecord> {
+        let record = self
+            .get(execution_id)
+            .await?
+            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+        support::require_generation(&record, execution_id, generation)?;
+        if support::managed_state(&record)? != ManagedExecutionState::Running {
+            return Err(ExecutionManagerError::Conflict {
+                execution_id: execution_id.clone(),
+                message: "execution is not running".to_string(),
+            });
+        }
+        if record.exec_socket_path.as_os_str().is_empty() {
+            return Err(ExecutionManagerError::Internal(format!(
+                "execution {execution_id} has no exec endpoint"
+            )));
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let pid = record
+                .pid
+                .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+            if !crate::process::is_process_alive_with_identity(pid, record.pid_start_time) {
+                return Err(ExecutionManagerError::NotFound(execution_id.clone()));
+            }
+        }
+        Ok(record)
     }
 
     #[cfg(feature = "vm")]

--- a/src/runtime/src/local_execution/session.rs
+++ b/src/runtime/src/local_execution/session.rs
@@ -10,8 +10,7 @@ use a3s_box_core::{
 };
 use async_trait::async_trait;
 
-use super::support::{managed_state, require_generation};
-use super::{LocalExecutionManager, ManagedExecutionState};
+use super::LocalExecutionManager;
 use crate::{
     BoxRecord, ExecClient, PtyClient, StreamingExec, StreamingExecInput, StreamingPty,
     StreamingPtyInput,
@@ -92,39 +91,6 @@ impl ExecutionSessionManager for LocalExecutionManager {
 }
 
 impl LocalExecutionManager {
-    pub(super) async fn require_running_record(
-        &self,
-        execution_id: &ExecutionId,
-        generation: ExecutionGeneration,
-    ) -> ExecutionManagerResult<BoxRecord> {
-        let record = self
-            .get(execution_id)
-            .await?
-            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
-        require_generation(&record, execution_id, generation)?;
-        if managed_state(&record)? != ManagedExecutionState::Running {
-            return Err(ExecutionManagerError::Conflict {
-                execution_id: execution_id.clone(),
-                message: "execution is not running".to_string(),
-            });
-        }
-        if record.exec_socket_path.as_os_str().is_empty() {
-            return Err(ExecutionManagerError::Internal(format!(
-                "execution {execution_id} has no exec endpoint"
-            )));
-        }
-        #[cfg(target_os = "linux")]
-        {
-            let pid = record
-                .pid
-                .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
-            if !crate::process::is_process_alive_with_identity(pid, record.pid_start_time) {
-                return Err(ExecutionManagerError::NotFound(execution_id.clone()));
-            }
-        }
-        Ok(record)
-    }
-
     async fn bind_exec(
         &self,
         execution_id: &ExecutionId,


### PR DESCRIPTION
## Summary

Gate the local execution-session transport on Unix. It depends on Unix domain sockets and Unix-only `ExecClient`/`PtyClient` exports, but was compiled unconditionally after PR #100.

## Evidence

PR #100 post-merge CI showed the Windows WHPX build failing in `local_execution/session.rs` because those Unix-only types and `tokio::net::UnixStream` do not exist on Windows. Linux x86_64 and macOS ARM64 compiled the same revision; Linux ARM64 failed earlier while fetching Ubuntu packages from `ports.ubuntu.com`.

This one-line platform gate restores the existing Windows CLI/WHPX build boundary without changing Unix behavior.
