### PR TITLE
feat(compat): route E2B services through runtime envd

### DIFF
--- a/.github/workflows/e2b-runtime-image.yml
+++ b/.github/workflows/e2b-runtime-image.yml
@@ -1,0 +1,60 @@
+name: E2B Runtime Image
+
+on:
+  push:
+    branches:
+      - main
+      - "feat/e2b-*"
+    paths:
+      - "deploy/e2b/**"
+      - ".github/workflows/e2b-runtime-image.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: e2b-runtime-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/a3s-lab/box-e2b-runtime
+          tags: |
+            type=sha,format=long
+            type=raw,value=edge,enable={{is_default_branch}}
+
+      - name: Build and push the multi-architecture image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/e2b/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=e2b-runtime
+          cache-to: type=gha,mode=max,scope=e2b-runtime
+          provenance: mode=max
+          sbom: true

--- a/deploy/e2b/Dockerfile
+++ b/deploy/e2b/Dockerfile
@@ -1,0 +1,123 @@
+# syntax=docker/dockerfile:1.7
+
+ARG GO_IMAGE=golang:1.26.3-bookworm
+ARG RUNTIME_IMAGE=node:20-bookworm-slim
+
+FROM ${GO_IMAGE} AS envd-builder
+
+ARG TARGETARCH
+ARG E2B_INFRA_COMMIT=fda7bef1095afb909197e272c0a8a123797f0bfb
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+RUN git init /src/infra \
+    && git -C /src/infra remote add origin https://github.com/e2b-dev/infra.git \
+    && git -C /src/infra fetch --depth=1 origin "${E2B_INFRA_COMMIT}" \
+    && git -C /src/infra checkout --detach FETCH_HEAD \
+    && test "$(git -C /src/infra rev-parse HEAD)" = "${E2B_INFRA_COMMIT}" \
+    && grep -F 'const Version = "0.6.9"' /src/infra/packages/envd/pkg/version.go
+WORKDIR /src/infra/packages/envd
+RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" \
+    go build -trimpath -buildvcs=false -a \
+    -ldflags "-X=main.commitSHA=${E2B_INFRA_COMMIT} -s -w -buildid=" \
+    -o /out/envd .
+
+FROM debian:bookworm-slim AS code-interpreter-source
+
+ARG CODE_INTERPRETER_COMMIT=5aeca43fe3fae2df260b1fb17c71fed5b5dac852
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+RUN git init /src/code-interpreter \
+    && git -C /src/code-interpreter remote add origin https://github.com/e2b-dev/code-interpreter.git \
+    && git -C /src/code-interpreter fetch --depth=1 origin "${CODE_INTERPRETER_COMMIT}" \
+    && git -C /src/code-interpreter checkout --detach FETCH_HEAD \
+    && test "$(git -C /src/code-interpreter rev-parse HEAD)" = "${CODE_INTERPRETER_COMMIT}"
+
+FROM ${RUNTIME_IMAGE}
+
+ARG E2B_INFRA_COMMIT=fda7bef1095afb909197e272c0a8a123797f0bfb
+ARG CODE_INTERPRETER_COMMIT=5aeca43fe3fae2df260b1fb17c71fed5b5dac852
+ARG IJAVASCRIPT_COMMIT=79cb7d56dcfe0df9ff55eff0ca4dc920a6dcc361
+
+LABEL org.opencontainers.image.title="A3S Box E2B runtime template" \
+      org.opencontainers.image.description="Pinned envd and Code Interpreter services for A3S Box Sandboxes" \
+      org.opencontainers.image.source="https://github.com/A3S-Lab/Box" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      io.a3s.e2b.infra.commit="${E2B_INFRA_COMMIT}" \
+      io.a3s.e2b.code-interpreter.commit="${CODE_INTERPRETER_COMMIT}" \
+      io.a3s.e2b.envd.version="0.6.9"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN printf 'Acquire::Retries "5";\nAcquire::https::Timeout "30";\n' \
+      >/etc/apt/apt.conf.d/80-a3s-retries \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+      bash build-essential ca-certificates curl git python3 python3-pip python3-venv \
+      sudo tini util-linux \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/a3s/e2b/jupyter/bin:/opt/a3s/e2b/code-interpreter/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN python3 -m venv /opt/a3s/e2b/jupyter \
+    && /opt/a3s/e2b/jupyter/bin/pip install \
+      e2b-charts==1.0.0 \
+      ipykernel==6.31.0 \
+      ipython==9.15.0 \
+      jupyter-server==2.20.0 \
+      matplotlib==3.10.9 \
+      numpy==2.3.5 \
+      orjson==3.11.9 \
+      pandas==2.2.3 \
+      pillow==12.2.0 \
+    && /opt/a3s/e2b/jupyter/bin/ipython kernel install --name python3 --prefix /usr/local \
+    && npm install --global --unsafe-perm \
+      "git+https://github.com/e2b-dev/ijavascript.git#${IJAVASCRIPT_COMMIT}" \
+    && ijsinstall --install=global
+
+COPY --from=envd-builder /out/envd /usr/local/bin/envd
+COPY --from=code-interpreter-source /src/code-interpreter/template/server/ \
+    /opt/a3s/e2b/code-interpreter/
+COPY --from=code-interpreter-source /src/code-interpreter/template/jupyter_server_config.py \
+    /opt/a3s/e2b/config/jupyter_server_config.py
+COPY --from=code-interpreter-source /src/code-interpreter/template/ipython_kernel_config.py \
+    /opt/a3s/e2b/config/ipython_kernel_config.py
+COPY --from=code-interpreter-source /src/code-interpreter/template/startup_scripts/ \
+    /opt/a3s/e2b/config/startup/
+COPY --from=code-interpreter-source /src/code-interpreter/LICENSE \
+    /usr/share/licenses/e2b-code-interpreter/LICENSE
+COPY --from=envd-builder /src/infra/LICENSE /usr/share/licenses/e2b-infra/LICENSE
+
+RUN python3 -m venv /opt/a3s/e2b/code-interpreter/.venv \
+    && /opt/a3s/e2b/code-interpreter/.venv/bin/pip install \
+      -r /opt/a3s/e2b/code-interpreter/requirements.txt \
+    && useradd --create-home --shell /bin/bash user \
+    && install -d -o user -g user \
+      /home/user/.ipython/profile_default/startup \
+      /home/user/.jupyter \
+    && cp /opt/a3s/e2b/config/jupyter_server_config.py \
+      /home/user/.jupyter/jupyter_server_config.py \
+    && cp /opt/a3s/e2b/config/ipython_kernel_config.py \
+      /home/user/.ipython/profile_default/ipython_kernel_config.py \
+    && cp /opt/a3s/e2b/config/startup/* \
+      /home/user/.ipython/profile_default/startup/ \
+    && chown -R user:user /home/user \
+    && printf 'user ALL=(ALL) NOPASSWD: ALL\n' >/etc/sudoers.d/a3s-box-user \
+    && chmod 0440 /etc/sudoers.d/a3s-box-user \
+    && ln -s /usr/bin/python3 /usr/local/bin/python \
+    && envd -version | grep -Fx '0.6.9'
+
+COPY deploy/e2b/init-envd.py /usr/local/lib/a3s-box-e2b/init-envd.py
+COPY deploy/e2b/entrypoint.sh /usr/local/bin/a3s-box-e2b-entrypoint
+
+RUN chmod 0755 /usr/local/bin/a3s-box-e2b-entrypoint \
+    && chmod 0644 /usr/local/lib/a3s-box-e2b/init-envd.py
+
+WORKDIR /home/user
+EXPOSE 49983 49999
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/a3s-box-e2b-entrypoint"]

--- a/deploy/e2b/README.md
+++ b/deploy/e2b/README.md
@@ -1,0 +1,44 @@
+# E2B Runtime OCI Template
+
+This directory defines the OCI image used by an A3S Box template whose envd
+service runs inside a `--isolation sandbox` execution. The image is built by
+GitHub Actions; it is not intended to be built on developer workstations.
+
+The build pins:
+
+- E2B infra commit `fda7bef1095afb909197e272c0a8a123797f0bfb` and envd `0.6.9`;
+- Code Interpreter commit `5aeca43fe3fae2df260b1fb17c71fed5b5dac852`;
+- the JavaScript kernel commit declared in the Dockerfile.
+
+The image starts envd on port `49983`, initializes its default user and working
+directory, and starts the Code Interpreter service on port `49999`. A production
+ACL template selects the in-Sandbox daemon explicitly:
+
+```acl
+template_policy "code-interpreter-v1" {
+  image        = "ghcr.io/a3s-lab/box-e2b-runtime:<immutable-tag>"
+  envd_version = "0.6.9"
+  envd_mode    = "runtime"
+  isolation    = "sandbox"
+
+  resources {
+    vcpus    = 2
+    memory_mb = 2048
+    disk_mb   = 8192
+  }
+
+  route {
+    port        = 49983
+    token_scope = "envd"
+  }
+
+  route {
+    port        = 49999
+    token_scope = "traffic"
+  }
+}
+```
+
+Use an immutable image tag or digest in production. Edge access tokens are
+validated by the A3S compatibility gateway and are not forwarded into the
+Sandbox service.

--- a/deploy/e2b/entrypoint.sh
+++ b/deploy/e2b/entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+children=()
+
+terminate() {
+  if ((${#children[@]})); then
+    kill -TERM "${children[@]}" 2>/dev/null || true
+    wait "${children[@]}" 2>/dev/null || true
+  fi
+}
+trap terminate EXIT INT TERM
+
+/usr/local/bin/envd -isnotfc -no-cgroups &
+children+=("$!")
+
+/usr/bin/python3 /usr/local/lib/a3s-box-e2b/init-envd.py
+
+runuser -u user -- env \
+  HOME=/home/user \
+  PATH="${PATH}" \
+  /opt/a3s/e2b/jupyter/bin/jupyter server \
+  --IdentityProvider.token= \
+  --ServerApp.root_dir=/home/user &
+children+=("$!")
+
+for attempt in {1..150}; do
+  if curl --fail --silent --output /dev/null http://127.0.0.1:8888/api/status; then
+    break
+  fi
+  if ((attempt == 150)); then
+    echo "Jupyter did not become healthy within 30 seconds" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+
+runuser -u user -- env \
+  HOME=/home/user \
+  PATH="${PATH}" \
+  /opt/a3s/e2b/code-interpreter/.venv/bin/uvicorn \
+  main:app \
+  --app-dir /opt/a3s/e2b/code-interpreter \
+  --host 0.0.0.0 \
+  --port 49999 \
+  --workers 1 \
+  --no-access-log \
+  --no-use-colors \
+  --timeout-keep-alive 640 &
+children+=("$!")
+
+set +e
+wait -n "${children[@]}"
+status=$?
+set -e
+echo "An E2B runtime service exited with status ${status}" >&2
+exit "${status}"

--- a/deploy/e2b/init-envd.py
+++ b/deploy/e2b/init-envd.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+
+ENVD_URL = "http://127.0.0.1:49983"
+INTERNAL_ENVIRONMENT = {
+    "A3S_BOOTSTRAP_MODE",
+    "A3S_EXEC_LISTENER_FD",
+    "A3S_INIT_LOG_FD",
+    "A3S_PTY_LISTENER_FD",
+    "HOSTNAME",
+    "PWD",
+    "SHLVL",
+    "_",
+}
+
+
+def wait_for_envd() -> None:
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{ENVD_URL}/health", timeout=1) as response:
+                if 200 <= response.status < 300:
+                    return
+        except (OSError, urllib.error.URLError):
+            pass
+        time.sleep(0.05)
+    raise TimeoutError("envd did not become healthy within 30 seconds")
+
+
+def initialize_envd() -> None:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in INTERNAL_ENVIRONMENT
+    }
+    body = json.dumps(
+        {
+            "defaultUser": "user",
+            "defaultWorkdir": "/home/user",
+            "envVars": environment,
+        },
+        separators=(",", ":"),
+    ).encode()
+    request = urllib.request.Request(
+        f"{ENVD_URL}/init",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        if response.status != 204:
+            raise RuntimeError(f"envd initialization returned HTTP {response.status}")
+
+
+if __name__ == "__main__":
+    wait_for_envd()
+    initialize_envd()

--- a/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
+++ b/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
@@ -151,6 +151,7 @@ impl TemplateProvider for FixtureTemplates {
                 ..BoxConfig::default()
             },
             envd_version: "0.1.3".to_string(),
+            envd_mode: a3s_box_compat::control::EnvdMode::Broker,
             routing: if template_id == "code-interpreter-v1" {
                 a3s_box_compat::routing::SandboxRoutePolicy::default()
                     .with_port(

--- a/src/compat/src/control/mod.rs
+++ b/src/compat/src/control/mod.rs
@@ -19,8 +19,8 @@ pub use model::{
     OnTimeoutAction, PublicSandboxState, SandboxGeneration, SandboxId, SandboxRecord,
 };
 pub use ports::{
-    Clock, IdentityProviderError, IdentityProviderResult, ResolvedTemplate, SandboxIdentity,
-    SandboxIdentityProvider, SystemClock, TemplateProvider, TemplateProviderError,
+    Clock, EnvdMode, IdentityProviderError, IdentityProviderResult, ResolvedTemplate,
+    SandboxIdentity, SandboxIdentityProvider, SystemClock, TemplateProvider, TemplateProviderError,
     TemplateProviderResult,
 };
 pub use repository::{

--- a/src/compat/src/control/model.rs
+++ b/src/compat/src/control/model.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use super::credential::SandboxCredentials;
+use super::{credential::SandboxCredentials, EnvdMode};
 use crate::routing::SandboxRoutePolicy;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -161,6 +161,7 @@ pub struct NewSandboxRecord {
     pub expires_at: DateTime<Utc>,
     pub metadata: BTreeMap<String, String>,
     pub envd_version: String,
+    pub envd_mode: EnvdMode,
     pub secure: bool,
     pub allow_internet_access: Option<bool>,
     pub credentials: SandboxCredentials,
@@ -185,6 +186,8 @@ pub struct SandboxRecord {
     expires_at: DateTime<Utc>,
     metadata: BTreeMap<String, String>,
     envd_version: String,
+    #[serde(default)]
+    envd_mode: EnvdMode,
     secure: bool,
     allow_internet_access: Option<bool>,
     credentials: SandboxCredentials,
@@ -223,6 +226,7 @@ impl SandboxRecord {
             expires_at: new.expires_at,
             metadata: new.metadata,
             envd_version: new.envd_version,
+            envd_mode: new.envd_mode,
             secure: new.secure,
             allow_internet_access: new.allow_internet_access,
             credentials: new.credentials,
@@ -293,6 +297,10 @@ impl SandboxRecord {
 
     pub fn envd_version(&self) -> &str {
         &self.envd_version
+    }
+
+    pub const fn envd_mode(&self) -> EnvdMode {
+        self.envd_mode
     }
 
     pub const fn secure(&self) -> bool {

--- a/src/compat/src/control/ports.rs
+++ b/src/compat/src/control/ports.rs
@@ -1,6 +1,7 @@
 use a3s_box_core::{BoxConfig, OperationId};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::SandboxId;
@@ -37,10 +38,19 @@ pub trait SandboxIdentityProvider: Send + Sync {
     fn next_identity(&self) -> IdentityProviderResult<SandboxIdentity>;
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvdMode {
+    #[default]
+    Broker,
+    Runtime,
+}
+
 #[derive(Debug, Clone)]
 pub struct ResolvedTemplate {
     pub config: BoxConfig,
     pub envd_version: String,
+    pub envd_mode: EnvdMode,
     pub routing: SandboxRoutePolicy,
 }
 

--- a/src/compat/src/control/service.rs
+++ b/src/compat/src/control/service.rs
@@ -150,6 +150,7 @@ impl ControlService {
             expires_at,
             metadata: request.metadata.clone(),
             envd_version: template.envd_version,
+            envd_mode: template.envd_mode,
             secure: request.secure,
             allow_internet_access: request.allow_internet_access,
             credentials: SandboxCredentials {

--- a/src/compat/src/control/sqlite/tests.rs
+++ b/src/compat/src/control/sqlite/tests.rs
@@ -10,8 +10,8 @@ use tempfile::tempdir;
 
 use super::*;
 use crate::control::{
-    LifecyclePolicy, NewSandboxRecord, OnTimeoutAction, PublicSandboxState, SandboxCredentials,
-    StoredToken,
+    EnvdMode, LifecyclePolicy, NewSandboxRecord, OnTimeoutAction, PublicSandboxState,
+    SandboxCredentials, StoredToken,
 };
 
 fn instant(second: u32) -> DateTime<Utc> {
@@ -76,6 +76,7 @@ fn running_record_at(
         expires_at: created_at + Duration::seconds(300),
         metadata,
         envd_version: "0.1.3".to_string(),
+        envd_mode: EnvdMode::Broker,
         secure: true,
         allow_internet_access: Some(false),
         credentials: SandboxCredentials {

--- a/src/compat/src/control/supervisor_tests.rs
+++ b/src/compat/src/control/supervisor_tests.rs
@@ -52,6 +52,7 @@ fn creating_record(sandbox_id: &str, action: OnTimeoutAction) -> (SandboxRecord,
         expires_at: instant(10),
         metadata: BTreeMap::new(),
         envd_version: "0.1.3".to_string(),
+        envd_mode: EnvdMode::Broker,
         secure: true,
         allow_internet_access: Some(false),
         credentials: SandboxCredentials {

--- a/src/compat/src/control/test_support.rs
+++ b/src/compat/src/control/test_support.rs
@@ -112,6 +112,7 @@ impl TemplateProvider for TestTemplates {
                 ..BoxConfig::default()
             },
             envd_version: "0.1.3".to_string(),
+            envd_mode: EnvdMode::Broker,
             routing: if template_id == "code-interpreter-v1" {
                 crate::routing::SandboxRoutePolicy::default()
                     .with_port(crate::routing::CODE_INTERPRETER_PORT, TokenScope::Traffic)

--- a/src/compat/src/control/tests.rs
+++ b/src/compat/src/control/tests.rs
@@ -47,6 +47,7 @@ fn creating_record_with_timeout_action(id: &str, on_timeout: OnTimeoutAction) ->
         expires_at: instant(0) + Duration::seconds(300),
         metadata: BTreeMap::from([("team".to_string(), "fixture".to_string())]),
         envd_version: "0.1.3".to_string(),
+        envd_mode: EnvdMode::Broker,
         secure: true,
         allow_internet_access: Some(false),
         credentials: SandboxCredentials {
@@ -242,12 +243,14 @@ fn persisted_control_identifiers_preserve_invariants() {
 }
 
 #[test]
-fn records_written_before_route_policies_default_to_envd_only() {
+fn records_written_before_route_policies_and_envd_modes_use_broker_defaults() {
     let record = creating_record("legacy-route-record");
     let mut value = serde_json::to_value(record).unwrap();
     value.as_object_mut().unwrap().remove("routing");
+    value.as_object_mut().unwrap().remove("envd_mode");
 
     let restored: SandboxRecord = serde_json::from_value(value).unwrap();
+    assert_eq!(restored.envd_mode(), EnvdMode::Broker);
     assert_eq!(
         restored.routing().token_scope(crate::routing::ENVD_PORT),
         Some(TokenScope::Envd)

--- a/src/compat/src/gateway/proxy.rs
+++ b/src/compat/src/gateway/proxy.rs
@@ -19,6 +19,7 @@ use thiserror::Error;
 use tokio::io::copy_bidirectional;
 use tracing::debug;
 
+use crate::control::EnvdMode;
 use crate::envd::EnvdBroker;
 use crate::routing::{
     EnvdHealthResolution, ParsedSandboxRoute, RouteLeaseError, RouteLeaseService, RouteParseError,
@@ -87,7 +88,12 @@ impl DataPlaneProxy {
                 Err(error) => return with_cors(error_response(ProxyFailure::Lease(error)), cors),
             };
             let response = match resolution {
-                EnvdHealthResolution::Running(lease) => self.envd.handle(request, &lease).await,
+                EnvdHealthResolution::Running(lease) => {
+                    if lease.envd_mode() == EnvdMode::Runtime {
+                        return with_cors(self.proxy_runtime(&mut request, &lease).await, cors);
+                    }
+                    self.envd.handle(request, &lease).await
+                }
                 EnvdHealthResolution::Inactive => self.envd.inactive_health(),
             };
             return with_cors(response, cors);
@@ -97,9 +103,17 @@ impl DataPlaneProxy {
             Ok(lease) => lease,
             Err(error) => return with_cors(error_response(ProxyFailure::Lease(error)), cors),
         };
-        if lease.port().get() == ENVD_PORT {
+        if lease.port().get() == ENVD_PORT && lease.envd_mode() == EnvdMode::Broker {
             return with_cors(self.envd.handle(request, &lease).await, cors);
         }
+        with_cors(self.proxy_runtime(&mut request, &lease).await, cors)
+    }
+
+    async fn proxy_runtime(
+        &self,
+        request: &mut Request<Body>,
+        lease: &crate::routing::RouteLease,
+    ) -> Response<Body> {
         let stream = match self
             .connector
             .connect_port(
@@ -111,14 +125,14 @@ impl DataPlaneProxy {
             .await
         {
             Ok(stream) => stream,
-            Err(error) => return with_cors(error_response(ProxyFailure::Connect(error)), cors),
+            Err(error) => return error_response(ProxyFailure::Connect(error)),
         };
 
-        match proxy_upstream(&mut request, stream).await {
-            Ok(response) => with_cors(response, cors),
+        match proxy_upstream(request, stream).await {
+            Ok(response) => response,
             Err(error) => {
                 debug!(%error, "sandbox data-plane upstream request failed");
-                with_cors(error_response(error), cors)
+                error_response(error)
             }
         }
     }

--- a/src/compat/src/gateway/tests.rs
+++ b/src/compat/src/gateway/tests.rs
@@ -23,7 +23,7 @@ use rustls::pki_types::ServerName;
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::control::{
-    Clock, LifecyclePolicy, MemorySandboxRepository, NewSandboxRecord, OnTimeoutAction,
+    Clock, EnvdMode, LifecyclePolicy, MemorySandboxRepository, NewSandboxRecord, OnTimeoutAction,
     RotatingTokenProvider, SandboxCredentials, SandboxId, SandboxRecord, SandboxRepository,
     SecretToken, TokenIssuer, TokenKeyMaterial, TokenScope,
 };
@@ -173,6 +173,10 @@ struct Harness {
 
 impl Harness {
     async fn new() -> Self {
+        Self::new_with_envd_mode(EnvdMode::Broker).await
+    }
+
+    async fn new_with_envd_mode(envd_mode: EnvdMode) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let upstream = tokio::spawn(async move {
@@ -226,6 +230,7 @@ impl Harness {
             expires_at: now + chrono::Duration::minutes(5),
             metadata: BTreeMap::new(),
             envd_version: "0.1.3".to_string(),
+            envd_mode,
             secure: true,
             allow_internet_access: Some(false),
             credentials: SandboxCredentials {
@@ -402,6 +407,52 @@ async fn authenticated_direct_route_proxies_stream_and_strips_edge_credentials()
 }
 
 #[tokio::test]
+async fn runtime_envd_routes_health_process_and_filesystem_to_the_sandbox() {
+    let harness = Harness::new_with_envd_mode(EnvdMode::Runtime).await;
+
+    let health = harness
+        .proxy
+        .handle(harness.health_request(&harness.envd_token))
+        .await;
+    assert_eq!(health.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(health.into_body()).await.unwrap()).unwrap();
+    assert_eq!(body["uri"], "/health");
+    assert_eq!(body["envdTokenForwarded"], false);
+
+    for path in [
+        "/process.Process/Start",
+        "/filesystem.Filesystem/MakeDir",
+        "/files?path=%2Ftmp%2Ffixture",
+    ] {
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri(path)
+            .header(
+                HOST,
+                format!("{}-{}.box.example.com", ENVD_PORT, harness.sandbox_id),
+            )
+            .header(ENVD_ACCESS_TOKEN_HEADER, harness.envd_token.expose_secret())
+            .header(SANDBOX_ID_HEADER, harness.sandbox_id.as_str())
+            .header(SANDBOX_PORT_HEADER, ENVD_PORT.to_string())
+            .body(Body::from("runtime-envd"))
+            .unwrap();
+        let response = harness.proxy.handle(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body()).await.unwrap()).unwrap();
+        assert_eq!(body["uri"], path);
+        assert_eq!(body["envdTokenForwarded"], false);
+        assert_eq!(body["sandboxIdForwarded"], false);
+        assert_eq!(body["sandboxPortForwarded"], false);
+    }
+
+    let calls = harness.connector.calls.lock().unwrap().clone();
+    assert_eq!(calls.len(), 4);
+    assert!(calls.iter().all(|(_, _, port)| *port == ENVD_PORT));
+}
+
+#[tokio::test]
 async fn token_scope_is_checked_before_opening_an_upstream_connection() {
     let harness = Harness::new().await;
     let swapped = harness.direct_request(
@@ -460,7 +511,7 @@ async fn shared_routes_and_browser_preflight_use_the_same_validated_parser() {
 
 #[tokio::test]
 async fn authenticated_terminal_health_returns_false_without_reopening_traffic_routes() {
-    let harness = Harness::new().await;
+    let harness = Harness::new_with_envd_mode(EnvdMode::Runtime).await;
     let mut record = harness
         .repository
         .get(&harness.sandbox_id)

--- a/src/compat/src/production/config.rs
+++ b/src/compat/src/production/config.rs
@@ -10,7 +10,7 @@ use a3s_box_core::{BoxConfig, ExecutionIsolation, NetworkMode, ResourceConfig};
 use thiserror::Error;
 use url::Url;
 
-use crate::control::{ResolvedTemplate, TokenKeyMaterial, TokenScope};
+use crate::control::{EnvdMode, ResolvedTemplate, TokenKeyMaterial, TokenScope};
 use crate::gateway::DataPlaneGatewayConfig;
 use crate::http::{CredentialHash, CredentialScheme, HashedAccountCredential};
 use crate::routing::{SandboxDomain, SandboxRoutePolicy, ENVD_PORT};
@@ -554,6 +554,7 @@ fn parse_templates(blocks: Vec<&Block>) -> E2bConfigResult<Vec<(String, Resolved
             &[
                 "image",
                 "envd_version",
+                "envd_mode",
                 "isolation",
                 "network",
                 "command",
@@ -574,6 +575,15 @@ fn parse_templates(blocks: Vec<&Block>) -> E2bConfigResult<Vec<(String, Resolved
             )));
         }
         let envd_version = required_nonempty_string(block, "envd_version", &context, 128)?;
+        let envd_mode = match optional_string(block, "envd_mode", &context)?.as_deref() {
+            None | Some("broker") => EnvdMode::Broker,
+            Some("runtime") => EnvdMode::Runtime,
+            Some(_) => {
+                return Err(invalid(format!(
+                    "{context}.envd_mode must be broker or runtime"
+                )))
+            }
+        };
         let isolation = match optional_string(block, "isolation", &context)?.as_deref() {
             None => ExecutionIsolation::Microvm,
             Some("sandbox") => ExecutionIsolation::Sandbox,
@@ -618,6 +628,7 @@ fn parse_templates(blocks: Vec<&Block>) -> E2bConfigResult<Vec<(String, Resolved
                     ..BoxConfig::default()
                 },
                 envd_version,
+                envd_mode,
                 routing,
             },
         ));

--- a/src/compat/src/production/tests.rs
+++ b/src/compat/src/production/tests.rs
@@ -5,7 +5,7 @@ use axum::body::Body;
 use axum::http::{header, Request, StatusCode};
 use tower::ServiceExt;
 
-use crate::control::{SandboxIdentityProvider, TemplateProvider, TokenScope};
+use crate::control::{EnvdMode, SandboxIdentityProvider, TemplateProvider, TokenScope};
 use crate::http::CredentialHash;
 use crate::routing::{CODE_INTERPRETER_PORT, ENVD_PORT};
 
@@ -68,6 +68,7 @@ e2b_compat {{
   template_policy "fixture-template" {{
     image = "alpine:3.20"
     envd_version = "0.1.3"
+    envd_mode = "runtime"
     isolation = "sandbox"
     network = "none"
     command = ["/bin/sh", "-c", "while :; do sleep 60; done"]
@@ -136,6 +137,7 @@ async fn parses_acl_into_strict_runtime_credentials_and_template_policy() {
     assert_eq!(template.config.isolation, ExecutionIsolation::Sandbox);
     assert_eq!(template.config.image, "alpine:3.20");
     assert_eq!(template.config.resources.memory_mb, 512);
+    assert_eq!(template.envd_mode, EnvdMode::Runtime);
     assert_eq!(
         template.routing.token_scope(ENVD_PORT),
         Some(TokenScope::Envd)
@@ -180,6 +182,24 @@ fn rejects_plaintext_token_keys_missing_environment_and_unknown_fields() {
             .unwrap_err()
             .to_string()
             .contains("unknown attribute accidental_backend")
+    );
+}
+
+#[tokio::test]
+async fn defaults_templates_to_broker_envd_and_rejects_unknown_modes() {
+    let root = tempfile::tempdir().unwrap();
+    let input = acl_config(root.path());
+    let broker = input.replace("    envd_mode = \"runtime\"\n", "");
+    let config = E2bCompatConfig::parse_with_environment(&broker, test_environment).unwrap();
+    let template = config.templates.resolve("fixture-template").await.unwrap();
+    assert_eq!(template.envd_mode, EnvdMode::Broker);
+
+    let invalid = input.replace("envd_mode = \"runtime\"", "envd_mode = \"sidecar\"");
+    assert!(
+        E2bCompatConfig::parse_with_environment(&invalid, test_environment)
+            .unwrap_err()
+            .to_string()
+            .contains("envd_mode must be broker or runtime")
     );
 }
 

--- a/src/compat/src/routing/lease.rs
+++ b/src/compat/src/routing/lease.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use thiserror::Error;
 
 use crate::control::{
-    Clock, LifecycleState, RepositoryError, SandboxGeneration, SandboxId, SandboxRecord,
+    Clock, EnvdMode, LifecycleState, RepositoryError, SandboxGeneration, SandboxId, SandboxRecord,
     SandboxRepository, SecretToken, TokenIssuerError, TokenScope, TokenVerifier,
 };
 
@@ -25,6 +25,7 @@ pub struct RouteLease {
     execution_generation: ExecutionGeneration,
     port: NonZeroU16,
     token_scope: TokenScope,
+    envd_mode: EnvdMode,
     expires_at: DateTime<Utc>,
 }
 
@@ -59,6 +60,10 @@ impl RouteLease {
         self.token_scope
     }
 
+    pub const fn envd_mode(&self) -> EnvdMode {
+        self.envd_mode
+    }
+
     pub const fn expires_at(&self) -> DateTime<Utc> {
         self.expires_at
     }
@@ -70,6 +75,7 @@ impl RouteLease {
             && record.execution_id() == Some(&self.execution_id)
             && record.execution_generation() == Some(self.execution_generation)
             && record.expires_at() > now
+            && record.envd_mode() == self.envd_mode
             && record.routing().token_scope(self.port.get()) == Some(self.token_scope)
     }
 }
@@ -126,6 +132,7 @@ impl RouteLeaseService {
             execution_generation,
             port: route.port,
             token_scope,
+            envd_mode: record.envd_mode(),
             expires_at: record.expires_at(),
         })
     }
@@ -169,6 +176,7 @@ impl RouteLeaseService {
             execution_generation,
             port: route.port,
             token_scope,
+            envd_mode: record.envd_mode(),
             expires_at: record.expires_at(),
         }))
     }
@@ -314,6 +322,7 @@ mod tests {
                 expires_at: now + Duration::minutes(5),
                 metadata: BTreeMap::new(),
                 envd_version: "0.1.3".to_string(),
+                envd_mode: EnvdMode::Broker,
                 secure: true,
                 allow_internet_access: Some(false),
                 credentials: SandboxCredentials {


### PR DESCRIPTION
## Summary
- add explicit ACL `envd_mode` with backward-compatible host broker default
- proxy runtime envd Process, Filesystem, `/files`, and health traffic into the generation-fenced Sandbox network namespace
- build a pinned envd 0.6.9 + Code Interpreter OCI template only in GitHub Actions

## Validation
- `cargo fmt --all`
- A3S OS production server: `A3S_DEPS_STUB=1 cargo test -p a3s-box-compat` — 87 passed
- GitHub CI: format, clippy, unit tests, E2B contract, and unchanged official-client fixture passed
- multi-architecture GHCR image build and real-crun image validation are pending

`full_compatibility` remains false; README claims will be updated only after observed production results.