### PR TITLE
fix(compat): gate runtime envd publication on readiness

### DIFF
--- a/.github/workflows/e2b-runtime-image.yml
+++ b/.github/workflows/e2b-runtime-image.yml
@@ -45,12 +45,12 @@ jobs:
             type=sha,format=long
             type=raw,value=edge,enable={{is_default_branch}}
 
-      - name: Build and push the multi-architecture image
+      - name: Build and push the runtime image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: deploy/e2b/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/deploy/e2b/README.md
+++ b/deploy/e2b/README.md
@@ -10,9 +10,10 @@ The build pins:
 - Code Interpreter commit `5aeca43fe3fae2df260b1fb17c71fed5b5dac852`;
 - the JavaScript kernel commit declared in the Dockerfile.
 
-The image starts envd on port `49983`, initializes its default user and working
-directory, and starts the Code Interpreter service on port `49999`. A production
-ACL template selects the in-Sandbox daemon explicitly:
+The image waits for Jupyter and the Code Interpreter service on port `49999`
+before it starts envd on port `49983` and initializes envd's default user and
+working directory. A production ACL template selects the in-Sandbox daemon
+explicitly:
 
 ```acl
 template_policy "code-interpreter-v1" {

--- a/deploy/e2b/entrypoint.sh
+++ b/deploy/e2b/entrypoint.sh
@@ -11,10 +11,30 @@ terminate() {
 }
 trap terminate EXIT INT TERM
 
-/usr/local/bin/envd -isnotfc -no-cgroups &
-children+=("$!")
+wait_for_service() {
+  local name="$1"
+  local url="$2"
+  local pid="$3"
 
-/usr/bin/python3 /usr/local/lib/a3s-box-e2b/init-envd.py
+  for attempt in {1..150}; do
+    if curl --fail --silent --output /dev/null "${url}"; then
+      return 0
+    fi
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      local status=0
+      wait "${pid}" || status=$?
+      echo "${name} exited before becoming healthy with status ${status}" >&2
+      if ((status == 0)); then
+        status=1
+      fi
+      return "${status}"
+    fi
+    sleep 0.2
+  done
+
+  echo "${name} did not become healthy within 30 seconds" >&2
+  return 1
+}
 
 runuser -u user -- env \
   HOME=/home/user \
@@ -23,17 +43,9 @@ runuser -u user -- env \
   --IdentityProvider.token= \
   --ServerApp.root_dir=/home/user &
 children+=("$!")
+jupyter_pid="$!"
 
-for attempt in {1..150}; do
-  if curl --fail --silent --output /dev/null http://127.0.0.1:8888/api/status; then
-    break
-  fi
-  if ((attempt == 150)); then
-    echo "Jupyter did not become healthy within 30 seconds" >&2
-    exit 1
-  fi
-  sleep 0.2
-done
+wait_for_service "Jupyter" "http://127.0.0.1:8888/api/status" "${jupyter_pid}"
 
 runuser -u user -- env \
   HOME=/home/user \
@@ -48,6 +60,17 @@ runuser -u user -- env \
   --no-use-colors \
   --timeout-keep-alive 640 &
 children+=("$!")
+code_interpreter_pid="$!"
+
+wait_for_service \
+  "Code Interpreter" \
+  "http://127.0.0.1:49999/health" \
+  "${code_interpreter_pid}"
+
+/usr/local/bin/envd -isnotfc -no-cgroups &
+children+=("$!")
+
+/usr/bin/python3 /usr/local/lib/a3s-box-e2b/init-envd.py
 
 set +e
 wait -n "${children[@]}"

--- a/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
+++ b/src/compat/src/bin/a3s-box-e2b-fixture-server.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
+use std::num::NonZeroU16;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
 
 use a3s_box_compat::control::{
     Clock, ControlService, ControlServiceDependencies, IdentityProviderResult, IssuedToken,
@@ -17,8 +19,8 @@ use a3s_box_compat::http::{
 use a3s_box_core::{
     resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionId,
     ExecutionIsolation, ExecutionLease, ExecutionManager, ExecutionManagerError,
-    ExecutionManagerResult, ExecutionReservation, ExecutionState, ExecutionStatus, KillOutcome,
-    OperationId, ReconcileOutcome, ResourceConfig,
+    ExecutionManagerResult, ExecutionPortConnector, ExecutionPortStream, ExecutionReservation,
+    ExecutionState, ExecutionStatus, KillOutcome, OperationId, ReconcileOutcome, ResourceConfig,
 };
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
@@ -39,9 +41,11 @@ async fn run() -> Result<()> {
     let port_file = parse_port_file()?;
     let clock = Arc::new(FixedClock(fixture_time()?));
     let tokens = Arc::new(FixtureTokens);
+    let executions = Arc::new(FixtureExecutionManager::new(clock.clone()));
     let service = Arc::new(ControlService::new(ControlServiceDependencies {
         repository: Arc::new(MemorySandboxRepository::default()),
-        executions: Arc::new(FixtureExecutionManager::new(clock.clone())),
+        executions: executions.clone(),
+        ports: executions,
         clock,
         identities: Arc::new(FixtureIdentities::default()),
         templates: Arc::new(FixtureTemplates),
@@ -460,5 +464,18 @@ impl ExecutionManager for FixtureExecutionManager {
             }
             ExecutionState::Stopped | ExecutionState::Failed => ReconcileOutcome::Failed,
         })
+    }
+}
+
+#[async_trait]
+impl ExecutionPortConnector for FixtureExecutionManager {
+    async fn connect_port(
+        &self,
+        execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        _port: NonZeroU16,
+        _timeout: Duration,
+    ) -> ExecutionManagerResult<ExecutionPortStream> {
+        Err(ExecutionManagerError::NotFound(execution_id.clone()))
     }
 }

--- a/src/compat/src/control/service.rs
+++ b/src/compat/src/control/service.rs
@@ -1,17 +1,26 @@
 use std::collections::BTreeMap;
+use std::num::NonZeroU16;
 use std::sync::Arc;
 
-use a3s_box_core::{resolve_execution, CreateExecutionRequest, ExecutionManager, NetworkMode};
+use a3s_box_core::{
+    resolve_execution, CreateExecutionRequest, ExecutionLease, ExecutionManager,
+    ExecutionManagerError, ExecutionPortConnector, NetworkMode,
+};
 use chrono::{DateTime, Duration, Utc};
 use thiserror::Error;
 
 use super::{
-    Clock, CompareAndSwapResult, IdentityProviderError, LifecycleError, LifecycleFailure,
+    Clock, CompareAndSwapResult, EnvdMode, IdentityProviderError, LifecycleError, LifecycleFailure,
     LifecyclePolicy, LifecycleState, NewSandboxRecord, RepositoryError, SandboxCredentials,
     SandboxIdentityProvider, SandboxListFilter, SandboxPage, SandboxRecord, SandboxRepository,
     SecretToken, TemplateProvider, TemplateProviderError, TokenIssuer, TokenIssuerError,
     TokenResolver, TokenScope,
 };
+use crate::routing::ENVD_PORT;
+
+const RUNTIME_ENVD_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const RUNTIME_ENVD_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
+const RUNTIME_ENVD_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
 #[derive(Debug, Clone)]
 pub struct CreateSandboxRequest {
@@ -79,6 +88,7 @@ pub type ControlServiceResult<T> = std::result::Result<T, ControlServiceError>;
 pub struct ControlService {
     repository: Arc<dyn SandboxRepository>,
     executions: Arc<dyn ExecutionManager>,
+    ports: Arc<dyn ExecutionPortConnector>,
     clock: Arc<dyn Clock>,
     identities: Arc<dyn SandboxIdentityProvider>,
     templates: Arc<dyn TemplateProvider>,
@@ -89,6 +99,7 @@ pub struct ControlService {
 pub struct ControlServiceDependencies {
     pub repository: Arc<dyn SandboxRepository>,
     pub executions: Arc<dyn ExecutionManager>,
+    pub ports: Arc<dyn ExecutionPortConnector>,
     pub clock: Arc<dyn Clock>,
     pub identities: Arc<dyn SandboxIdentityProvider>,
     pub templates: Arc<dyn TemplateProvider>,
@@ -101,6 +112,7 @@ impl ControlService {
         Self {
             repository: dependencies.repository,
             executions: dependencies.executions,
+            ports: dependencies.ports,
             clock: dependencies.clock,
             identities: dependencies.identities,
             templates: dependencies.templates,
@@ -180,6 +192,24 @@ impl ControlService {
                 return Err(error.into());
             }
         };
+        if template.envd_mode == EnvdMode::Runtime {
+            if let Err(readiness_error) = self.wait_for_runtime_envd(&lease).await {
+                let cleanup = self
+                    .executions
+                    .kill(&lease.execution_id, lease.generation)
+                    .await;
+                let expected = record.generation();
+                record.mark_failed(LifecycleFailure::RuntimeFailed)?;
+                self.replace(expected, record).await?;
+                return Err(match cleanup {
+                    Ok(_) => readiness_error,
+                    Err(cleanup_error) => ExecutionManagerError::Internal(format!(
+                        "{readiness_error}; runtime cleanup failed: {cleanup_error}"
+                    )),
+                }
+                .into());
+            }
+        }
 
         let expected = record.generation();
         if let Err(error) = record.mark_running(lease) {
@@ -195,6 +225,44 @@ impl ControlService {
             traffic_access_token: traffic.secret,
             disposition: ConnectionDisposition::Created,
         })
+    }
+
+    async fn wait_for_runtime_envd(
+        &self,
+        lease: &ExecutionLease,
+    ) -> Result<(), ExecutionManagerError> {
+        let port = NonZeroU16::new(ENVD_PORT).ok_or_else(|| {
+            ExecutionManagerError::Internal("envd port must be non-zero".to_string())
+        })?;
+        let deadline = tokio::time::Instant::now() + RUNTIME_ENVD_READY_TIMEOUT;
+        loop {
+            let last_error = match self
+                .ports
+                .connect_port(
+                    &lease.execution_id,
+                    lease.generation,
+                    port,
+                    RUNTIME_ENVD_CONNECT_TIMEOUT,
+                )
+                .await
+            {
+                Ok(stream) => {
+                    drop(stream);
+                    return Ok(());
+                }
+                Err(error @ ExecutionManagerError::InvalidRequest(_))
+                | Err(error @ ExecutionManagerError::Internal(_)) => return Err(error),
+                Err(error) => error,
+            };
+            if tokio::time::Instant::now() >= deadline {
+                return Err(ExecutionManagerError::Unavailable(format!(
+                    "runtime envd did not become ready within {} seconds: {}",
+                    RUNTIME_ENVD_READY_TIMEOUT.as_secs(),
+                    last_error
+                )));
+            }
+            tokio::time::sleep(RUNTIME_ENVD_RETRY_INTERVAL).await;
+        }
     }
 
     pub async fn connect(

--- a/src/compat/src/control/service_tests.rs
+++ b/src/compat/src/control/service_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroU32;
 
+use a3s_box_core::{ExecutionManagerError, ExecutionState};
 use chrono::Duration;
 
 use super::test_support::{assert_sandbox_request, create_request, test_time, TestHarness};
@@ -120,6 +121,58 @@ async fn failed_runtime_create_is_not_published() {
         harness.service.create(create_request("owner-1")).await,
         Err(ControlServiceError::Execution(_))
     ));
+    let sandbox_id = SandboxId::new("sandbox-1").unwrap();
+    assert!(matches!(
+        harness.service.get("owner-1", &sandbox_id).await,
+        Err(ControlServiceError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn runtime_envd_is_ready_before_the_sandbox_is_published() {
+    let harness = TestHarness::new();
+    let mut request = create_request("owner-1");
+    request.template_id = "runtime-envd-template".to_string();
+
+    let created = harness.service.create(request).await.unwrap();
+
+    assert_eq!(created.record.state(), LifecycleState::Running);
+    assert_eq!(created.record.envd_mode(), EnvdMode::Runtime);
+    assert_eq!(
+        harness.executions.port_requests(),
+        vec![(
+            "execution-operation-1".to_string(),
+            1,
+            crate::routing::ENVD_PORT,
+        )]
+    );
+}
+
+#[tokio::test]
+async fn permanent_runtime_envd_failure_stops_and_hides_the_execution() {
+    let harness = TestHarness::new();
+    harness.executions.fail_ports();
+    let mut request = create_request("owner-1");
+    request.template_id = "runtime-envd-template".to_string();
+
+    assert!(matches!(
+        harness.service.create(request).await,
+        Err(ControlServiceError::Execution(
+            ExecutionManagerError::InvalidRequest(_)
+        ))
+    ));
+    assert_eq!(
+        harness.executions.port_requests(),
+        vec![(
+            "execution-operation-1".to_string(),
+            1,
+            crate::routing::ENVD_PORT,
+        )]
+    );
+    assert_eq!(
+        harness.executions.execution_state("execution-operation-1"),
+        Some(ExecutionState::Stopped)
+    );
     let sandbox_id = SandboxId::new("sandbox-1").unwrap();
     assert!(matches!(
         harness.service.get("owner-1", &sandbox_id).await,

--- a/src/compat/src/control/test_support.rs
+++ b/src/compat/src/control/test_support.rs
@@ -1,12 +1,15 @@
 use std::collections::BTreeMap;
+use std::num::NonZeroU16;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use a3s_box_core::{
     resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionId,
     ExecutionIsolation, ExecutionLease, ExecutionManager, ExecutionManagerError,
-    ExecutionManagerResult, ExecutionReservation, ExecutionState, ExecutionStatus, KillOutcome,
-    NetworkMode, OperationId, ReconcileOutcome, ResourceConfig,
+    ExecutionManagerResult, ExecutionPortConnector, ExecutionPortStream, ExecutionReservation,
+    ExecutionState, ExecutionStatus, KillOutcome, NetworkMode, OperationId, ReconcileOutcome,
+    ResourceConfig,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
@@ -27,6 +30,7 @@ impl TestHarness {
         let service = Arc::new(ControlService::new(ControlServiceDependencies {
             repository: Arc::new(MemorySandboxRepository::default()),
             executions: executions.clone(),
+            ports: executions.clone(),
             clock,
             identities: Arc::new(TestIdentities::default()),
             templates: Arc::new(TestTemplates),
@@ -97,7 +101,10 @@ struct TestTemplates;
 #[async_trait]
 impl TemplateProvider for TestTemplates {
     async fn resolve(&self, template_id: &str) -> TemplateProviderResult<ResolvedTemplate> {
-        if template_id != "fixture-template" && template_id != "code-interpreter-v1" {
+        if !matches!(
+            template_id,
+            "fixture-template" | "code-interpreter-v1" | "runtime-envd-template"
+        ) {
             return Err(TemplateProviderError::NotFound(template_id.to_string()));
         }
         Ok(ResolvedTemplate {
@@ -112,7 +119,11 @@ impl TemplateProvider for TestTemplates {
                 ..BoxConfig::default()
             },
             envd_version: "0.1.3".to_string(),
-            envd_mode: EnvdMode::Broker,
+            envd_mode: if template_id == "runtime-envd-template" {
+                EnvdMode::Runtime
+            } else {
+                EnvdMode::Broker
+            },
             routing: if template_id == "code-interpreter-v1" {
                 crate::routing::SandboxRoutePolicy::default()
                     .with_port(crate::routing::CODE_INTERPRETER_PORT, TokenScope::Traffic)
@@ -169,6 +180,8 @@ struct TestExecution {
 pub(crate) struct RecordingExecutionManager {
     clock: Arc<dyn Clock>,
     fail_create: AtomicBool,
+    fail_ports: AtomicBool,
+    port_requests: Mutex<Vec<(String, u64, u16)>>,
     requests: Mutex<Vec<CreateExecutionRequest>>,
     operations: Mutex<BTreeMap<String, String>>,
     executions: Mutex<BTreeMap<String, TestExecution>>,
@@ -179,6 +192,8 @@ impl RecordingExecutionManager {
         Self {
             clock,
             fail_create: AtomicBool::new(false),
+            fail_ports: AtomicBool::new(false),
+            port_requests: Mutex::new(Vec::new()),
             requests: Mutex::new(Vec::new()),
             operations: Mutex::new(BTreeMap::new()),
             executions: Mutex::new(BTreeMap::new()),
@@ -193,6 +208,22 @@ impl RecordingExecutionManager {
         self.fail_create.store(true, Ordering::Relaxed);
     }
 
+    pub fn fail_ports(&self) {
+        self.fail_ports.store(true, Ordering::Relaxed);
+    }
+
+    pub fn port_requests(&self) -> Vec<(String, u64, u16)> {
+        self.port_requests.lock().unwrap().clone()
+    }
+
+    pub fn execution_state(&self, execution_id: &str) -> Option<ExecutionState> {
+        self.executions
+            .lock()
+            .unwrap()
+            .get(execution_id)
+            .map(|execution| execution.state)
+    }
+
     fn reservation(execution: &TestExecution) -> ExecutionReservation {
         ExecutionReservation {
             execution_id: execution.lease.execution_id.clone(),
@@ -201,6 +232,31 @@ impl RecordingExecutionManager {
             resources: execution.lease.resources.clone(),
             created_at: execution.lease.started_at,
         }
+    }
+}
+
+#[async_trait]
+impl ExecutionPortConnector for RecordingExecutionManager {
+    async fn connect_port(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+        port: NonZeroU16,
+        _timeout: Duration,
+    ) -> ExecutionManagerResult<ExecutionPortStream> {
+        self.port_requests.lock().unwrap().push((
+            execution_id.to_string(),
+            generation.get(),
+            port.get(),
+        ));
+        if self.fail_ports.load(Ordering::Relaxed) {
+            return Err(ExecutionManagerError::InvalidRequest(
+                "test runtime envd is unavailable".to_string(),
+            ));
+        }
+        let (stream, peer) = tokio::io::duplex(64);
+        drop(peer);
+        Ok(Box::pin(stream))
     }
 }
 

--- a/src/compat/src/production/service.rs
+++ b/src/compat/src/production/service.rs
@@ -65,6 +65,7 @@ impl E2bCompatService {
         let control = Arc::new(ControlService::new(ControlServiceDependencies {
             repository: repository.clone(),
             executions: executions.clone(),
+            ports: port_connector.clone(),
             clock: clock.clone(),
             identities: Arc::new(UuidSandboxIdentityProvider),
             templates,


### PR DESCRIPTION
## Summary
- wait for runtime envd port 49983 before publishing a Sandbox as running
- stop and hide executions whose in-Sandbox envd cannot become ready
- start Jupyter and Code Interpreter before envd in the pinned OCI runtime image
- build feature-branch images for linux/amd64 and retain multi-architecture main builds

## Validation
- `cargo fmt --all`
- `bash -n deploy/e2b/entrypoint.sh`
- local builds and runtime tests intentionally skipped; GitHub CI and A3S OS production validation are the authoritative checks