### PR TITLE
fix(runtime): make registry pulls resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- **Resilient and observable registry blob pulls.** Configuration and layer
+  transfers now use bounded capped-exponential retries, exact HTTP Range resume,
+  configurable no-progress deadlines, and bounded concurrent layer downloads.
+  Structured progress reports actual bytes, attempts, and retry delays. Before
+  atomic publication, declared size and SHA-256 remain mandatory; verified
+  blobs can be reused across indexed image layouts through safe reflink/copy
+  staging, while same-size corrupt candidates are rejected and downloaded.
 - **Multi-platform OCI archive loading.** `load` now resolves direct and nested
   OCI or Docker image indexes to an explicit `--platform`, defaulting to Linux
   on the host architecture. It verifies declared sizes and SHA-256 digests for

--- a/README.md
+++ b/README.md
@@ -134,8 +134,10 @@ stated under [SDKs and Compatibility](#sdks-and-compatibility).
   default and opt-in shared-kernel Sandbox execution through certified `crun`
 - **Docker-like lifecycle**: Create, start, stop, restart, kill, pause, wait,
   remove, inspect, exec, PTY, attach, logs, health checks, and restart policies
-- **OCI image workflow**: Pull, push, authenticate, verify digests and optional
-  cosign signatures, tag, inspect, save, load, import, remove, and cache images
+- **OCI image workflow**: Pull with bounded retry, Range resume, concurrent
+  layers, and verified cross-image blob reuse; push, authenticate, verify
+  digests and optional cosign signatures, tag, inspect, save, load, import,
+  remove, and cache images
 - **Image builds**: Build a documented Dockerfile/Containerfile subset with
   multi-stage builds, layer caching, selected `RUN --mount` forms, BuildKit VM
   execution on macOS, and warm-pool execution
@@ -161,7 +163,7 @@ stated under [SDKs and Compatibility](#sdks-and-compatibility).
 | MicroVM runtime | libkrun-backed OCI execution on Linux/KVM and Apple Silicon/HVF | Primary local runtime. Each box has its own guest kernel. Host-backed validation is required for releases. |
 | OCI Sandbox | Explicit `--isolation sandbox` execution through certified `crun 1.28` on Linux | Preview. Shares the host kernel, never replaces or emulates MicroVM isolation, and still has open security-negative and performance release gates. |
 | Lifecycle and exec | Foreground/detached runs, managed create/start/restart/kill, exec, PTY, logs, health, wait, and cleanup | Implemented for MicroVM. The managed Sandbox path and its structured logs are implemented, while complete parity and adversarial validation remain in progress. |
-| OCI images | Registry pull/push, credentials, digest verification, optional cosign verification/signing, local cache, indexed archive selection, and tag operations | Implemented. `load` selects one Linux platform from direct or nested OCI indexes and verifies the selected manifest, config, and layers before publishing it. Registry-dependent paths still require end-to-end validation against the target registry. |
+| OCI images | Resumable bounded registry pulls, concurrent layers, verified cross-image blob reuse, push, credentials, digest verification, optional cosign verification/signing, indexed archive selection, and tag operations | Implemented. `pull` validates declared size and SHA-256 before atomic blob publication; `load` selects one Linux platform from direct or nested OCI indexes and verifies the selected manifest, config, and layers before publishing it. Registry throughput and redirect behavior still require validation against each production registry. |
 | Dockerfile builds | Built-in Dockerfile subset, layer cache, BuildKit-in-MicroVM, and warm-pool `RUN` execution | Implemented subset, not a full Buildx replacement. One target platform is recorded per build. |
 | Storage | Bind mounts, named volumes, tmpfs, `cp`, `diff`, `export`, `commit`, filesystem snapshots, and CoW restore | Implemented. Filesystem snapshots do not contain live VM RAM or device state. |
 | Networking and Compose | TSI, bridge networks, TCP publishing, peer discovery, and Compose lifecycle/config/logs | Implemented subset for MicroVM workloads. UDP publishing, host-IP binds, ranges, and live network hot-plug are not implemented. |
@@ -365,6 +367,35 @@ configuration, or explicit registry environment credentials. Manifest,
 configuration, and layer digests are checked during pull. Authentication is
 retained only across same-origin redirects, and decompression limits protect
 image and build extraction.
+
+Registry configuration and layer transfers use a bounded retry policy. A
+partial blob is resumed with `Range: bytes=<offset>-` when the registry returns
+`206 Partial Content`; a registry that ignores Range and returns `200 OK`
+causes the partial file to be reset before the full response is written. Each
+authentication, response-header, body-chunk, and file-write wait has a
+no-progress deadline. Independent layers are downloaded concurrently up to the
+configured bound, and `a3s-box pull` reports actual downloaded bytes, retry
+attempts, backoff delays, cache reuse, and completion.
+
+Before any blob becomes visible, its declared size and canonical SHA-256 digest
+must match. The image store also searches indexed image layouts for matching
+configuration and layer blobs. A candidate is materialized through a Linux
+reflink when supported or a private byte copy otherwise, verified again, and
+published atomically without linking the destination directly to the source
+cache entry.
+
+| Registry pull setting | Default | Meaning |
+| --- | ---: | --- |
+| `A3S_REGISTRY_PULL_MAX_ATTEMPTS` | `4` | Total attempts per config or layer, including the first request |
+| `A3S_REGISTRY_PULL_RETRY_INITIAL_MS` | `250` | Initial transient-failure backoff |
+| `A3S_REGISTRY_PULL_RETRY_MAX_MS` | `4000` | Exponential-backoff cap |
+| `A3S_REGISTRY_PULL_NO_PROGRESS_TIMEOUT_SECS` | `30` | Maximum wait without header, body, or file-write progress |
+| `A3S_REGISTRY_PULL_MAX_CONCURRENT` | `4` | Maximum simultaneous layer downloads |
+
+All overrides must be positive, and the maximum retry delay must not be lower
+than the initial delay. Invalid overrides are ignored in favor of safe
+defaults. Rust callers can supply the same validated policy explicitly with
+`RegistryPullPolicy::try_new` and `ImagePuller::with_pull_policy`.
 
 `load` accepts direct manifests and nested OCI or Docker image indexes. It
 selects `--platform OS/ARCH[/VARIANT]`, defaulting to Linux on the host

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -86,6 +86,41 @@ new login session:
 sudo usermod -aG kvm "$USER"
 ```
 
+## Resilient registry pull validation
+
+The deterministic fault-injection suite proves interrupted-body Range resume,
+no-progress timeout, the exact retry bound, layer concurrency, actual-byte
+progress, verified cross-image reuse, and corrupt-candidate fallback without
+depending on an external registry:
+
+```bash
+cargo test -p a3s-box-runtime resilient_pull_tests
+```
+
+Run a separate live-registry smoke on an enrolled Linux host before release.
+Use a dedicated state directory so the result cannot be satisfied by an
+unrelated cached manifest:
+
+```bash
+export A3S_HOME=/var/tmp/a3s-box-registry-smoke
+export A3S_BOX_REGISTRY_SMOKE_IMAGE=ghcr.io/example/large-image:release-candidate
+export A3S_REGISTRY_PULL_MAX_ATTEMPTS=4
+export A3S_REGISTRY_PULL_RETRY_INITIAL_MS=250
+export A3S_REGISTRY_PULL_RETRY_MAX_MS=4000
+export A3S_REGISTRY_PULL_NO_PROGRESS_TIMEOUT_SECS=30
+export A3S_REGISTRY_PULL_MAX_CONCURRENT=4
+
+timeout 900 a3s-box pull "$A3S_BOX_REGISTRY_SMOKE_IMAGE"
+```
+
+The command must either finish with verified content or fail within the
+configured attempt and no-progress bounds with the downloaded offset in its
+error. Progress output must show actual transferred bytes rather than only the
+declared layer size. If the registry interrupts a response, the next request
+must use the persisted offset; if it does not support Range, the client must
+restart that blob safely. Keep authentication and redirect checks in the
+fixture suite because credentials must never be forwarded to another origin.
+
 ## Linux Dockerfile `RUN` smoke
 
 Dockerfile `RUN` uses an isolated Linux chroot path. It is intentionally

--- a/docs/production-cluster-tests.md
+++ b/docs/production-cluster-tests.md
@@ -188,7 +188,7 @@ Run this matrix on a canary cohort first, then on the full selected cohort.
 | Kubernetes lifecycle | create/delete 100 `runtimeClassName: a3s-box` Jobs | all Jobs complete; no kubelet or shim crash loop |
 | Exec | `kubectl exec` and `a3s-box exec` against long-lived boxes | stdout, stderr, TTY, and exit code are correct |
 | Logs | high-volume stdout and log rotation | logs are ordered enough for diagnosis and no writer deadlock occurs |
-| Images | pull from mirror, load offline archive, cache reuse | no unbounded image-store growth after prune |
+| Images | bounded live pull with retry/Range resume, cross-image blob reuse, mirror pull, offline load, and prune | pulls complete or fail inside policy bounds with actual-byte evidence; shared verified layers are not downloaded again; no unbounded image-store growth after prune |
 | Networking | in-pod localhost where bridge is expected; service reachability where Kubernetes provides it | documented networking mode behavior matches reality |
 | Volumes | emptyDir/hostPath-style CRI mounts plus CLI named volumes | data is visible for the intended lifetime and removed after cleanup |
 | Restart | box restart policy and kubelet pod restart | state transitions are visible and cleanup remains bounded |

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "ecdsa",
  "filetime",
  "flate2",
+ "futures",
  "hex",
  "libc",
  "oci-distribution",

--- a/src/cli/src/commands/pull.rs
+++ b/src/cli/src/commands/pull.rs
@@ -46,11 +46,8 @@ pub async fn execute(args: PullArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     if !args.quiet {
         println!("Pulling {}...", args.image);
-        puller = puller.with_progress_fn(std::sync::Arc::new(|current, total, digest, size| {
-            println!(
-                "{}",
-                format_pull_progress_line(current, total, digest, size)
-            );
+        puller = puller.with_progress_event_fn(std::sync::Arc::new(|progress| {
+            println!("{}", format_pull_progress_line(&progress));
         }));
     }
     let image = puller.pull(&args.image).await?;
@@ -87,22 +84,41 @@ fn signature_policy_from_args(args: &PullArgs) -> a3s_box_runtime::SignaturePoli
     }
 }
 
-fn format_pull_progress_line(current: usize, total: usize, digest: &str, size: i64) -> String {
+fn format_pull_progress_line(progress: &a3s_box_runtime::PullProgress) -> String {
+    use a3s_box_runtime::PullProgressState;
+
+    let digest = &progress.digest;
     let short = &digest[digest.len().saturating_sub(12)..];
-    if size < 0 {
-        format!(
-            "  [{current}/{total}] {short}: {} ✓",
-            format_layer_size(-size)
-        )
-    } else {
-        format!(
-            "  [{current}/{total}] {short}: Pulling {}...",
-            format_layer_size(size)
-        )
+    let prefix = format!(
+        "  [{}/{}] {short}",
+        progress.current_layer, progress.total_layers
+    );
+    match progress.state {
+        PullProgressState::Downloading => format!(
+            "{prefix}: {} / {} downloaded",
+            format_layer_size(progress.downloaded_bytes),
+            format_layer_size(progress.total_bytes)
+        ),
+        PullProgressState::Retrying => format!(
+            "{prefix}: retry {}/{} from {} / {} after {} ms",
+            progress.attempt,
+            progress.max_attempts,
+            format_layer_size(progress.downloaded_bytes),
+            format_layer_size(progress.total_bytes),
+            progress.retry_delay_ms.unwrap_or(0)
+        ),
+        PullProgressState::Reused => {
+            format!("{prefix}: {} reused ✓", format_layer_size(progress.total_bytes))
+        }
+        PullProgressState::Complete => format!(
+            "{prefix}: {} / {} downloaded ✓",
+            format_layer_size(progress.downloaded_bytes),
+            format_layer_size(progress.total_bytes)
+        ),
     }
 }
 
-fn format_layer_size(size: i64) -> String {
+fn format_layer_size(size: u64) -> String {
     if size >= 1_048_576 {
         format!("{:.1} MB", size as f64 / 1_048_576.0)
     } else if size >= 1024 {
@@ -186,12 +202,32 @@ mod tests {
     #[test]
     fn format_pull_progress_line_truncates_digest_and_marks_completion() {
         assert_eq!(
-            format_pull_progress_line(2, 5, "sha256:0123456789abcdef", 2048),
-            "  [2/5] 456789abcdef: Pulling 2.0 KB..."
+            format_pull_progress_line(&a3s_box_runtime::PullProgress {
+                current_layer: 2,
+                total_layers: 5,
+                digest: "sha256:0123456789abcdef".to_string(),
+                downloaded_bytes: 2048,
+                total_bytes: 4096,
+                attempt: 1,
+                max_attempts: 4,
+                retry_delay_ms: None,
+                state: a3s_box_runtime::PullProgressState::Downloading,
+            }),
+            "  [2/5] 456789abcdef: 2.0 KB / 4.0 KB downloaded"
         );
         assert_eq!(
-            format_pull_progress_line(2, 5, "abc", -512),
-            "  [2/5] abc: 512 B ✓"
+            format_pull_progress_line(&a3s_box_runtime::PullProgress {
+                current_layer: 2,
+                total_layers: 5,
+                digest: "abc".to_string(),
+                downloaded_bytes: 512,
+                total_bytes: 512,
+                attempt: 2,
+                max_attempts: 4,
+                retry_delay_ms: None,
+                state: a3s_box_runtime::PullProgressState::Complete,
+            }),
+            "  [2/5] abc: 512 B / 512 B downloaded ✓"
         );
     }
 }

--- a/src/cli/src/commands/pull.rs
+++ b/src/cli/src/commands/pull.rs
@@ -108,7 +108,10 @@ fn format_pull_progress_line(progress: &a3s_box_runtime::PullProgress) -> String
             progress.retry_delay_ms.unwrap_or(0)
         ),
         PullProgressState::Reused => {
-            format!("{prefix}: {} reused ✓", format_layer_size(progress.total_bytes))
+            format!(
+                "{prefix}: {} reused ✓",
+                format_layer_size(progress.total_bytes)
+            )
         }
         PullProgressState::Complete => format!(
             "{prefix}: {} / {} downloaded ✓",

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -32,6 +32,7 @@ a3s-transport = { workspace = true }
 # Async runtime
 tokio = { workspace = true }
 async-trait = { workspace = true }
+futures = { workspace = true }
 
 # Serialization
 serde = { workspace = true }

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -93,7 +93,10 @@ pub use network::NetworkStore;
 // OCI images
 pub use a3s_box_core::StoredImage;
 pub use oci::{CredentialStore, PushResult, RegistryProtocol, RegistryPusher};
-pub use oci::{ImagePuller, ImageReference, ImageStore, RegistryAuth};
+pub use oci::{
+    ImagePuller, ImageReference, ImageStore, PullProgress, PullProgressEventFn, PullProgressState,
+    RegistryAuth, RegistryPullPolicy,
+};
 pub use oci::{OciImage, SignResult, SignaturePolicy};
 
 // Metrics

--- a/src/runtime/src/oci/mod.rs
+++ b/src/runtime/src/oci/mod.rs
@@ -44,7 +44,10 @@ pub use image::{OciHealthCheck, OciImage, OciImageConfig};
 pub use layers::extract_layer;
 pub use pull::ImagePuller;
 pub use reference::ImageReference;
-pub use registry::{PushResult, RegistryAuth, RegistryProtocol, RegistryPusher};
+pub use registry::{
+    PullProgress, PullProgressEventFn, PullProgressState, PushResult, RegistryAuth,
+    RegistryProtocol, RegistryPullPolicy, RegistryPusher,
+};
 pub use rootfs::OciRootfsBuilder;
 pub use signing::{SignResult, SignaturePolicy, VerifyResult};
 pub use store::ImageStore;

--- a/src/runtime/src/oci/pull.rs
+++ b/src/runtime/src/oci/pull.rs
@@ -12,9 +12,7 @@ use a3s_box_core::StoredImage;
 
 use super::image::OciImage;
 use super::reference::ImageReference;
-use super::registry::{
-    PullProgressEventFn, RegistryAuth, RegistryPullPolicy, RegistryPuller,
-};
+use super::registry::{PullProgressEventFn, RegistryAuth, RegistryPullPolicy, RegistryPuller};
 use super::store::ImageStore;
 
 /// Callback type for layer pull progress: `(current, total, digest, size_bytes)`.

--- a/src/runtime/src/oci/pull.rs
+++ b/src/runtime/src/oci/pull.rs
@@ -12,7 +12,9 @@ use a3s_box_core::StoredImage;
 
 use super::image::OciImage;
 use super::reference::ImageReference;
-use super::registry::{RegistryAuth, RegistryPuller};
+use super::registry::{
+    PullProgressEventFn, RegistryAuth, RegistryPullPolicy, RegistryPuller,
+};
 use super::store::ImageStore;
 
 /// Callback type for layer pull progress: `(current, total, digest, size_bytes)`.
@@ -114,6 +116,18 @@ impl ImagePuller {
     /// Set a layer progress callback: `(current, total, digest, size_bytes)`.
     pub fn with_progress_fn(mut self, f: PullProgressFn) -> Self {
         self.puller = self.puller.with_progress_fn(f);
+        self
+    }
+
+    /// Set a structured layer progress callback with actual downloaded bytes.
+    pub fn with_progress_event_fn(mut self, f: PullProgressEventFn) -> Self {
+        self.puller = self.puller.with_progress_event_fn(f);
+        self
+    }
+
+    /// Override bounded registry retry, timeout, and concurrency settings.
+    pub fn with_pull_policy(mut self, policy: RegistryPullPolicy) -> Self {
+        self.puller = self.puller.with_pull_policy(policy);
         self
     }
 
@@ -261,7 +275,11 @@ impl ImagePuller {
         // pulls (network error, signature failure, disk error) don't accumulate
         // under store_dir/tmp — each can be hundreds of MB and is never counted
         // toward the cache size or evicted by the LRU.
-        if let Err(e) = self.puller.pull(&fetch, &tmp_dir).await {
+        if let Err(e) = self
+            .puller
+            .pull_with_store(&fetch, &tmp_dir, Some(&self.store))
+            .await
+        {
             let _ = std::fs::remove_dir_all(&tmp_dir);
             return Err(e);
         }

--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -303,10 +303,6 @@ impl RegistryPuller {
     /// - `oci-layout`
     /// - `index.json`
     /// - `blobs/sha256/...`
-    pub async fn pull(&self, reference: &ImageReference, target_dir: &Path) -> Result<PathBuf> {
-        self.pull_with_store(reference, target_dir, None).await
-    }
-
     pub(crate) async fn pull_with_store(
         &self,
         reference: &ImageReference,

--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -1773,3 +1773,5 @@ mod tests {
 
 #[cfg(test)]
 mod basic_pull_tests;
+#[cfg(test)]
+mod resilient_pull_tests;

--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -17,14 +17,20 @@ use oci_reqwest::header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, LOCATION};
 use super::credentials::CredentialStore;
 use super::reference::ImageReference;
 use super::signing::{verify_image_signature, SignaturePolicy, VerifyResult};
+use super::store::ImageStore;
 
 mod basic_pull;
 mod blob_pull;
+mod content;
+mod policy;
+mod progress;
+
+pub use policy::RegistryPullPolicy;
+pub use progress::{PullProgress, PullProgressEventFn, PullProgressState};
 
 use basic_pull::{BasicImageManifest, BasicPullClient};
 #[cfg(test)]
 use blob_pull::HashingFileWriter;
-use blob_pull::{stream_and_verify_blob, BlobPullTransport};
 
 const REGISTRY_PROTOCOL_ENV: &str = "A3S_REGISTRY_PROTOCOL";
 const MANIFEST_ACCEPT: &str = "application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json";
@@ -202,6 +208,12 @@ pub(crate) struct RegistryPuller {
     signature_policy: SignaturePolicy,
     /// Optional layer progress callback: (current, total, digest, size_bytes).
     progress_fn: Option<PullProgressFn>,
+    /// Optional structured progress callback with actual downloaded bytes.
+    progress_event_fn: Option<PullProgressEventFn>,
+    /// Bounded retry, timeout, and concurrency settings for blob transfers.
+    pull_policy: RegistryPullPolicy,
+    /// Shared HTTP connection pool for resumable blob requests.
+    blob_http: oci_reqwest::Client,
 }
 
 impl Default for RegistryPuller {
@@ -255,6 +267,9 @@ impl RegistryPuller {
             target_arch,
             signature_policy: SignaturePolicy::default(),
             progress_fn: None,
+            progress_event_fn: None,
+            pull_policy: RegistryPullPolicy::from_env(),
+            blob_http: oci_reqwest::Client::new(),
         }
     }
 
@@ -270,6 +285,18 @@ impl RegistryPuller {
         self
     }
 
+    /// Set a structured progress callback that reports actual downloaded bytes.
+    pub fn with_progress_event_fn(mut self, f: PullProgressEventFn) -> Self {
+        self.progress_event_fn = Some(f);
+        self
+    }
+
+    /// Override bounded registry transfer settings.
+    pub fn with_pull_policy(mut self, policy: RegistryPullPolicy) -> Self {
+        self.pull_policy = policy;
+        self
+    }
+
     /// Pull an image and write it as an OCI image layout to `target_dir`.
     ///
     /// The resulting directory will contain:
@@ -277,6 +304,15 @@ impl RegistryPuller {
     /// - `index.json`
     /// - `blobs/sha256/...`
     pub async fn pull(&self, reference: &ImageReference, target_dir: &Path) -> Result<PathBuf> {
+        self.pull_with_store(reference, target_dir, None).await
+    }
+
+    pub(crate) async fn pull_with_store(
+        &self,
+        reference: &ImageReference,
+        target_dir: &Path,
+        blob_store: Option<&ImageStore>,
+    ) -> Result<PathBuf> {
         let oci_ref = self.to_oci_reference(reference)?;
 
         tracing::info!(
@@ -350,6 +386,7 @@ impl RegistryPuller {
             &image_manifest,
             &blobs_dir,
             pulled_manifest.used_basic,
+            blob_store,
         )
         .await?;
 
@@ -508,84 +545,6 @@ impl RegistryPuller {
                 registry_error_summary(fallback_error, &self.auth)
             ),
         }
-    }
-
-    /// Pull config and layers for an image manifest, writing blobs to disk.
-    async fn pull_image_content(
-        &self,
-        reference: &ImageReference,
-        oci_ref: &Reference,
-        manifest: &OciImageManifest,
-        blobs_dir: &Path,
-        force_basic: bool,
-    ) -> Result<()> {
-        let basic_client = if self.auth.basic_credentials().is_some() {
-            Some(
-                self.basic_pull_client(reference)
-                    .map_err(|error| BoxError::RegistryError {
-                        registry: reference.registry.clone(),
-                        message: format!(
-                            "Failed to prepare authenticated blob pull: {}",
-                            registry_error_summary(&error, &self.auth)
-                        ),
-                    })?,
-            )
-        } else {
-            None
-        };
-        let transport = BlobPullTransport {
-            client: &self.client,
-            oci_ref,
-            basic_client: basic_client.as_ref(),
-            force_basic,
-            auth: &self.auth,
-            registry: &reference.registry,
-        };
-
-        // Stream the config blob to disk, verifying its digest on the fly.
-        // pull_blob delivers raw bytes without validation, so the streaming
-        // hasher both bounds memory and guards against a buggy/malicious
-        // registry or a corrupted transfer being stored content-addressed and
-        // later extracted into the guest.
-        let config_descriptor = &manifest.config;
-        let config_digest_hex = validated_digest_hex(&config_descriptor.digest)?;
-        stream_and_verify_blob(
-            &transport,
-            config_descriptor,
-            &blobs_dir.join(config_digest_hex),
-            "config blob",
-        )
-        .await?;
-
-        // Pull layer blobs
-        let total = manifest.layers.len();
-        for (idx, layer) in manifest.layers.iter().enumerate() {
-            tracing::debug!(
-                digest = %layer.digest,
-                size = layer.size,
-                "Pulling layer"
-            );
-
-            if let Some(ref f) = self.progress_fn {
-                f(idx + 1, total, &layer.digest, layer.size);
-            }
-
-            let layer_digest_hex = validated_digest_hex(&layer.digest)?;
-            stream_and_verify_blob(
-                &transport,
-                layer,
-                &blobs_dir.join(layer_digest_hex),
-                "layer",
-            )
-            .await?;
-
-            // Call progress callback again with negative size to signal completion
-            if let Some(ref f) = self.progress_fn {
-                f(idx + 1, total, &layer.digest, -(layer.size));
-            }
-        }
-
-        Ok(())
     }
 
     /// Convert an ImageReference to an oci-distribution Reference.

--- a/src/runtime/src/oci/registry/basic_pull.rs
+++ b/src/runtime/src/oci/registry/basic_pull.rs
@@ -1,15 +1,14 @@
 use oci_distribution::errors::OciDistributionError;
 use oci_distribution::manifest::{
-    OciDescriptor, OciImageManifest, OciManifest, IMAGE_MANIFEST_LIST_MEDIA_TYPE,
-    IMAGE_MANIFEST_MEDIA_TYPE, OCI_IMAGE_INDEX_MEDIA_TYPE, OCI_IMAGE_MEDIA_TYPE,
+    OciImageManifest, OciManifest, IMAGE_MANIFEST_LIST_MEDIA_TYPE, IMAGE_MANIFEST_MEDIA_TYPE,
+    OCI_IMAGE_INDEX_MEDIA_TYPE, OCI_IMAGE_MEDIA_TYPE,
 };
 use oci_reqwest::header::ACCEPT;
 use sha2::Digest as _;
-use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use super::{
-    registry_base_url, registry_blob_url, registry_manifest_url, ImageReference, RegistryAuth,
-    RegistryProtocol, MANIFEST_ACCEPT,
+    registry_base_url, registry_manifest_url, ImageReference, RegistryAuth, RegistryProtocol,
+    MANIFEST_ACCEPT,
 };
 
 pub(super) struct BasicImageManifest {
@@ -119,30 +118,6 @@ impl BasicPullClient {
                 }
             }
         }
-    }
-
-    pub(super) async fn pull_blob<W>(
-        &self,
-        descriptor: &OciDescriptor,
-        writer: &mut W,
-    ) -> std::result::Result<(), OciDistributionError>
-    where
-        W: AsyncWrite + Unpin,
-    {
-        validate_sha256_digest(&descriptor.digest)?;
-        let url = registry_blob_url(&self.base, &self.repository, &descriptor.digest)?;
-        let response = self
-            .http
-            .get(url.clone())
-            .basic_auth(&self.username, Some(&self.password))
-            .send()
-            .await?;
-        let mut response = ensure_pull_status(response, url.as_str())?;
-
-        while let Some(chunk) = response.chunk().await? {
-            writer.write_all(&chunk).await?;
-        }
-        Ok(())
     }
 
     async fn fetch_manifest(

--- a/src/runtime/src/oci/registry/basic_pull_tests.rs
+++ b/src/runtime/src/oci/registry/basic_pull_tests.rs
@@ -477,7 +477,7 @@ async fn basic_challenge_pull_resolves_index_streams_blobs_and_follows_redirect(
         fixture.index_digest
     );
     puller
-        .pull(&fixture.reference, target.path())
+        .pull_with_store(&fixture.reference, target.path(), None)
         .await
         .unwrap();
 
@@ -556,7 +556,7 @@ async fn cross_origin_blob_redirect_does_not_forward_basic_credentials() {
     let target = tempfile::tempdir().unwrap();
 
     puller
-        .pull(&fixture.reference, target.path())
+        .pull_with_store(&fixture.reference, target.path(), None)
         .await
         .unwrap();
 
@@ -578,7 +578,7 @@ async fn blob_unauthorized_after_public_manifest_retries_with_basic() {
     let target = tempfile::tempdir().unwrap();
 
     puller
-        .pull(&fixture.reference, target.path())
+        .pull_with_store(&fixture.reference, target.path(), None)
         .await
         .unwrap();
 
@@ -690,7 +690,7 @@ async fn basic_pull_rejects_corrupted_layer_and_removes_partial_blob() {
     let target = tempfile::tempdir().unwrap();
 
     let message = puller
-        .pull(&fixture.reference, target.path())
+        .pull_with_store(&fixture.reference, target.path(), None)
         .await
         .unwrap_err()
         .to_string();

--- a/src/runtime/src/oci/registry/blob_pull.rs
+++ b/src/runtime/src/oci/registry/blob_pull.rs
@@ -266,7 +266,7 @@ pub(super) async fn stream_and_verify_blob(
             )),
             Ok(()) if !writer.current_hex().eq_ignore_ascii_case(expected_hex) => {
                 Some(http::AttemptFailure::retryable_reset(format!(
-                    "digest mismatch after receiving {expected_size} bytes"
+                    "{what} digest mismatch after receiving {expected_size} bytes"
                 )))
             }
             Ok(()) => {
@@ -290,21 +290,26 @@ pub(super) async fn stream_and_verify_blob(
                 format!("Failed to pull {what}: transfer ended without a terminal result"),
             ));
         };
+        let failed_downloaded_bytes = writer.bytes_written();
+        if !failure.retryable || attempt == transport.policy.max_attempts() {
+            if failure.reset_partial {
+                drop(writer);
+                let _ = tokio::fs::remove_file(&tmp).await;
+            }
+            return Err(blob_validation_error(
+                transport.registry,
+                format!(
+                    "Failed to pull {what} after {attempt} attempt(s); downloaded {} of {expected_size} bytes: {}",
+                    failed_downloaded_bytes,
+                    failure.message
+                ),
+            ));
+        }
         if failure.reset_partial {
             writer
                 .reset()
                 .await
                 .map_err(|error| blob_io_error(transport.registry, what, "reset", error))?;
-        }
-        if !failure.retryable || attempt == transport.policy.max_attempts() {
-            return Err(blob_validation_error(
-                transport.registry,
-                format!(
-                    "Failed to pull {what} after {attempt} attempt(s); downloaded {} of {expected_size} bytes: {}",
-                    writer.bytes_written(),
-                    failure.message
-                ),
-            ));
         }
 
         writer
@@ -321,6 +326,7 @@ pub(super) async fn stream_and_verify_blob(
             attempt,
             next_attempt = attempt + 1,
             downloaded_bytes = writer.bytes_written(),
+            failed_downloaded_bytes,
             retry_delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
             error = %failure.message,
             "Retrying registry blob transfer"

--- a/src/runtime/src/oci/registry/blob_pull.rs
+++ b/src/runtime/src/oci/registry/blob_pull.rs
@@ -44,6 +44,7 @@ impl HashingFileWriter {
 
         let mut file = tokio::fs::OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(path)

--- a/src/runtime/src/oci/registry/blob_pull.rs
+++ b/src/runtime/src/oci/registry/blob_pull.rs
@@ -54,12 +54,16 @@ impl HashingFileWriter {
                     path.display()
                 ))
             })?;
-        let mut bytes_written = file.metadata().await.map_err(|error| {
-            BoxError::OciImageError(format!(
-                "Failed to inspect registry partial blob {}: {error}",
-                path.display()
-            ))
-        })?.len();
+        let mut bytes_written = file
+            .metadata()
+            .await
+            .map_err(|error| {
+                BoxError::OciImageError(format!(
+                    "Failed to inspect registry partial blob {}: {error}",
+                    path.display()
+                ))
+            })?
+            .len();
         if bytes_written > expected_size {
             file.set_len(0).await.map_err(|error| {
                 BoxError::OciImageError(format!(
@@ -185,10 +189,12 @@ pub(super) async fn stream_and_verify_blob(
     what: &str,
     mut progress: Option<ProgressReporter>,
 ) -> Result<()> {
-    let expected_size = u64::try_from(descriptor.size).map_err(|_| blob_validation_error(
-        transport.registry,
-        format!("{what} has a negative declared size ({})", descriptor.size),
-    ))?;
+    let expected_size = u64::try_from(descriptor.size).map_err(|_| {
+        blob_validation_error(
+            transport.registry,
+            format!("{what} has a negative declared size ({})", descriptor.size),
+        )
+    })?;
     let expected_hex = descriptor
         .digest
         .strip_prefix("sha256:")
@@ -245,12 +251,12 @@ pub(super) async fn stream_and_verify_blob(
         .await;
 
         let failure = match attempt_result {
-            Ok(()) if writer.bytes_written() < expected_size => Some(http::AttemptFailure::retryable(
-                format!(
+            Ok(()) if writer.bytes_written() < expected_size => {
+                Some(http::AttemptFailure::retryable(format!(
                     "response ended after {} of {expected_size} bytes",
                     writer.bytes_written()
-                ),
-            )),
+                )))
+            }
             Ok(()) if writer.bytes_written() > expected_size => Some(http::AttemptFailure::fatal(
                 format!(
                     "response exceeded declared size {expected_size} bytes (received {})",

--- a/src/runtime/src/oci/registry/blob_pull.rs
+++ b/src/runtime/src/oci/registry/blob_pull.rs
@@ -1,12 +1,14 @@
 use std::path::Path;
 
 use a3s_box_core::error::{BoxError, Result};
-use oci_distribution::errors::OciDistributionError;
 use oci_distribution::manifest::OciDescriptor;
 use oci_distribution::{Client, Reference};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
-use super::basic_pull::BasicPullClient;
-use super::{is_unauthorized_registry_error, registry_error_summary, RegistryAuth};
+use super::progress::ProgressReporter;
+use super::{ImageReference, RegistryAuth, RegistryProtocol, RegistryPullPolicy};
+
+mod http;
 
 /// An `AsyncWrite` that streams bytes straight to a file while computing its
 /// SHA-256 and size, so a pulled blob is never fully buffered in memory.
@@ -17,6 +19,7 @@ pub(super) struct HashingFileWriter {
 }
 
 impl HashingFileWriter {
+    #[cfg(test)]
     pub(super) fn new(file: tokio::fs::File) -> Self {
         use sha2::Digest as _;
 
@@ -27,14 +30,102 @@ impl HashingFileWriter {
         }
     }
 
-    fn bytes_written(&self) -> u64 {
+    async fn open_resumable(path: &Path, expected_size: u64) -> Result<Self> {
+        use sha2::Digest as _;
+
+        if let Ok(metadata) = tokio::fs::symlink_metadata(path).await {
+            if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+                return Err(BoxError::OciImageError(format!(
+                    "Registry partial blob is not a regular file: {}",
+                    path.display()
+                )));
+            }
+        }
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .await
+            .map_err(|error| {
+                BoxError::OciImageError(format!(
+                    "Failed to open registry partial blob {}: {error}",
+                    path.display()
+                ))
+            })?;
+        let mut bytes_written = file.metadata().await.map_err(|error| {
+            BoxError::OciImageError(format!(
+                "Failed to inspect registry partial blob {}: {error}",
+                path.display()
+            ))
+        })?.len();
+        if bytes_written > expected_size {
+            file.set_len(0).await.map_err(|error| {
+                BoxError::OciImageError(format!(
+                    "Failed to reset oversized registry partial blob {}: {error}",
+                    path.display()
+                ))
+            })?;
+            bytes_written = 0;
+        }
+
+        file.seek(std::io::SeekFrom::Start(0))
+            .await
+            .map_err(|error| blob_file_error(path, "seek", error))?;
+        let mut hasher = sha2::Sha256::new();
+        let mut remaining = bytes_written;
+        let mut buffer = [0_u8; 64 * 1024];
+        while remaining > 0 {
+            let limit = usize::try_from(remaining.min(buffer.len() as u64)).unwrap_or(buffer.len());
+            let read = file
+                .read(&mut buffer[..limit])
+                .await
+                .map_err(|error| blob_file_error(path, "rehash", error))?;
+            if read == 0 {
+                return Err(BoxError::OciImageError(format!(
+                    "Registry partial blob {} changed while being resumed",
+                    path.display()
+                )));
+            }
+            hasher.update(&buffer[..read]);
+            remaining = remaining.saturating_sub(read as u64);
+        }
+        file.seek(std::io::SeekFrom::Start(bytes_written))
+            .await
+            .map_err(|error| blob_file_error(path, "seek", error))?;
+
+        Ok(Self {
+            file,
+            hasher,
+            bytes_written,
+        })
+    }
+
+    pub(super) fn bytes_written(&self) -> u64 {
         self.bytes_written
+    }
+
+    fn current_hex(&self) -> String {
+        use sha2::Digest as _;
+
+        format!("{:x}", self.hasher.clone().finalize())
     }
 
     pub(super) fn finalize_hex(self) -> String {
         use sha2::Digest as _;
 
         format!("{:x}", self.hasher.finalize())
+    }
+
+    pub(super) async fn reset(&mut self) -> std::io::Result<()> {
+        use sha2::Digest as _;
+
+        self.file.set_len(0).await?;
+        self.file.seek(std::io::SeekFrom::Start(0)).await?;
+        self.hasher = sha2::Sha256::new();
+        self.bytes_written = 0;
+        Ok(())
     }
 }
 
@@ -72,159 +163,204 @@ impl tokio::io::AsyncWrite for HashingFileWriter {
     }
 }
 
+#[derive(Clone, Copy)]
 pub(super) struct BlobPullTransport<'a> {
     pub(super) client: &'a Client,
+    pub(super) http: &'a oci_reqwest::Client,
     pub(super) oci_ref: &'a Reference,
-    pub(super) basic_client: Option<&'a BasicPullClient>,
+    pub(super) image_ref: &'a ImageReference,
     pub(super) force_basic: bool,
     pub(super) auth: &'a RegistryAuth,
     pub(super) registry: &'a str,
+    pub(super) protocol: RegistryProtocol,
+    pub(super) policy: &'a RegistryPullPolicy,
 }
 
-/// Stream a blob to `dest`, verifying its declared size and SHA-256 before
-/// atomically publishing it under its content-addressed name.
+/// Stream a blob to `dest`, resuming verified partial content and requiring
+/// declared-size and SHA-256 validation before atomic publication.
 pub(super) async fn stream_and_verify_blob(
     transport: &BlobPullTransport<'_>,
     descriptor: &OciDescriptor,
     dest: &Path,
     what: &str,
+    mut progress: Option<ProgressReporter>,
 ) -> Result<()> {
-    use tokio::io::AsyncWriteExt;
-
-    let tmp = dest.with_extension("partial");
-    let mut writer = create_blob_writer(&tmp, what, transport.registry).await?;
-
-    let first_result = if transport.force_basic {
-        match transport.basic_client {
-            Some(basic_client) => basic_client.pull_blob(descriptor, &mut writer).await,
-            None => Err(OciDistributionError::GenericError(Some(
-                "preemptive Basic blob pull requires non-empty credentials".to_string(),
-            ))),
-        }
-    } else {
-        transport
-            .client
-            .pull_blob(transport.oci_ref, descriptor, &mut writer)
-            .await
-    };
-
-    if let Err(first_error) = first_result {
-        if !transport.force_basic && is_unauthorized_registry_error(&first_error) {
-            if let Some(basic_client) = transport.basic_client {
-                tracing::warn!(
-                    error = %registry_error_summary(&first_error, transport.auth),
-                    "Registry rejected the default OCI blob auth flow; retrying with preemptive Basic auth"
-                );
-                drop(writer);
-                let _ = tokio::fs::remove_file(&tmp).await;
-                writer = create_blob_writer(&tmp, what, transport.registry).await?;
-                if let Err(fallback_error) = basic_client.pull_blob(descriptor, &mut writer).await {
-                    let _ = tokio::fs::remove_file(&tmp).await;
-                    return Err(BoxError::RegistryError {
-                        registry: transport.registry.to_string(),
-                        message: format!(
-                            "Failed to pull {what}: default auth failed: {}; preemptive Basic retry failed: {}",
-                            registry_error_summary(&first_error, transport.auth),
-                            registry_error_summary(&fallback_error, transport.auth)
-                        ),
-                    });
-                }
-            } else {
-                let _ = tokio::fs::remove_file(&tmp).await;
-                return Err(blob_pull_error(
-                    transport.registry,
-                    what,
-                    &first_error,
-                    transport.auth,
-                ));
-            }
-        } else {
-            let _ = tokio::fs::remove_file(&tmp).await;
-            return Err(blob_pull_error(
+    let expected_size = u64::try_from(descriptor.size).map_err(|_| blob_validation_error(
+        transport.registry,
+        format!("{what} has a negative declared size ({})", descriptor.size),
+    ))?;
+    let expected_hex = descriptor
+        .digest
+        .strip_prefix("sha256:")
+        .filter(|hex| {
+            hex.len() == 64
+                && hex
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        })
+        .ok_or_else(|| {
+            blob_validation_error(
                 transport.registry,
-                what,
-                &first_error,
-                transport.auth,
-            ));
-        }
-    }
-
-    if let Err(error) = writer.flush().await {
-        let _ = tokio::fs::remove_file(&tmp).await;
-        return Err(blob_io_error(transport.registry, what, "flush", error));
-    }
-    if let Err(error) = writer.shutdown().await {
-        let _ = tokio::fs::remove_file(&tmp).await;
-        return Err(blob_io_error(transport.registry, what, "close", error));
-    }
-    let actual_size = writer.bytes_written();
-    let actual_hex = writer.finalize_hex();
-
-    if descriptor.size < 0 || actual_size != descriptor.size as u64 {
-        let _ = tokio::fs::remove_file(&tmp).await;
-        return Err(BoxError::RegistryError {
-            registry: transport.registry.to_string(),
-            message: format!(
-                "{what} size mismatch: expected {} bytes, received {actual_size}",
-                descriptor.size
-            ),
-        });
-    }
-
-    match descriptor.digest.strip_prefix("sha256:") {
-        Some(expected_hex) if actual_hex.eq_ignore_ascii_case(expected_hex) => {}
-        Some(expected_hex) => {
-            let _ = tokio::fs::remove_file(&tmp).await;
-            return Err(BoxError::RegistryError {
-                registry: transport.registry.to_string(),
-                message: format!(
-                    "{what} digest mismatch: expected sha256:{expected_hex}, computed sha256:{actual_hex}"
-                ),
-            });
-        }
-        None => {
-            let _ = tokio::fs::remove_file(&tmp).await;
-            return Err(BoxError::RegistryError {
-                registry: transport.registry.to_string(),
-                message: format!(
-                    "{what} uses an unsupported digest algorithm ({}); refusing to store \
-                     unverifiable content (only sha256 is supported)",
+                format!(
+                    "{what} uses an unsupported or malformed digest {}; expected sha256:<64 lowercase hex>",
                     descriptor.digest
                 ),
-            });
-        }
+            )
+        })?;
+
+    let tmp = dest.with_extension("partial");
+    let mut writer = HashingFileWriter::open_resumable(&tmp, expected_size).await?;
+    if let Some(reporter) = progress.as_mut() {
+        reporter.downloading(writer.bytes_written(), 1, true);
     }
 
-    if let Err(error) = tokio::fs::rename(&tmp, dest).await {
-        let _ = tokio::fs::remove_file(&tmp).await;
-        return Err(BoxError::RegistryError {
-            registry: transport.registry.to_string(),
-            message: format!("Failed to store {what} blob: {error}"),
-        });
+    for attempt in 1..=transport.policy.max_attempts() {
+        if writer.bytes_written() == expected_size {
+            if writer.current_hex().eq_ignore_ascii_case(expected_hex) {
+                return publish_blob(
+                    transport.registry,
+                    what,
+                    &tmp,
+                    dest,
+                    writer,
+                    progress,
+                    attempt,
+                )
+                .await;
+            }
+            writer
+                .reset()
+                .await
+                .map_err(|error| blob_io_error(transport.registry, what, "reset", error))?;
+        }
+
+        let attempt_result = http::transfer_attempt(
+            transport,
+            descriptor,
+            &mut writer,
+            progress.as_mut(),
+            attempt,
+            expected_size,
+        )
+        .await;
+
+        let failure = match attempt_result {
+            Ok(()) if writer.bytes_written() < expected_size => Some(http::AttemptFailure::retryable(
+                format!(
+                    "response ended after {} of {expected_size} bytes",
+                    writer.bytes_written()
+                ),
+            )),
+            Ok(()) if writer.bytes_written() > expected_size => Some(http::AttemptFailure::fatal(
+                format!(
+                    "response exceeded declared size {expected_size} bytes (received {})",
+                    writer.bytes_written()
+                ),
+                true,
+            )),
+            Ok(()) if !writer.current_hex().eq_ignore_ascii_case(expected_hex) => {
+                Some(http::AttemptFailure::retryable_reset(format!(
+                    "digest mismatch after receiving {expected_size} bytes"
+                )))
+            }
+            Ok(()) => {
+                return publish_blob(
+                    transport.registry,
+                    what,
+                    &tmp,
+                    dest,
+                    writer,
+                    progress,
+                    attempt,
+                )
+                .await;
+            }
+            Err(failure) => Some(failure),
+        };
+
+        let Some(failure) = failure else {
+            return Err(blob_validation_error(
+                transport.registry,
+                format!("Failed to pull {what}: transfer ended without a terminal result"),
+            ));
+        };
+        if failure.reset_partial {
+            writer
+                .reset()
+                .await
+                .map_err(|error| blob_io_error(transport.registry, what, "reset", error))?;
+        }
+        if !failure.retryable || attempt == transport.policy.max_attempts() {
+            return Err(blob_validation_error(
+                transport.registry,
+                format!(
+                    "Failed to pull {what} after {attempt} attempt(s); downloaded {} of {expected_size} bytes: {}",
+                    writer.bytes_written(),
+                    failure.message
+                ),
+            ));
+        }
+
+        writer
+            .flush()
+            .await
+            .map_err(|error| blob_io_error(transport.registry, what, "flush", error))?;
+        let delay = transport.policy.retry_delay(attempt);
+        if let Some(reporter) = progress.as_mut() {
+            reporter.retrying(writer.bytes_written(), attempt + 1, delay);
+        }
+        tracing::warn!(
+            registry = transport.registry,
+            digest = %descriptor.digest,
+            attempt,
+            next_attempt = attempt + 1,
+            downloaded_bytes = writer.bytes_written(),
+            retry_delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+            error = %failure.message,
+            "Retrying registry blob transfer"
+        );
+        tokio::time::sleep(delay).await;
+    }
+
+    Err(blob_validation_error(
+        transport.registry,
+        format!("Failed to pull {what}: retry policy exhausted"),
+    ))
+}
+
+async fn publish_blob(
+    registry: &str,
+    what: &str,
+    tmp: &Path,
+    dest: &Path,
+    mut writer: HashingFileWriter,
+    mut progress: Option<ProgressReporter>,
+    attempt: usize,
+) -> Result<()> {
+    writer
+        .flush()
+        .await
+        .map_err(|error| blob_io_error(registry, what, "flush", error))?;
+    writer
+        .shutdown()
+        .await
+        .map_err(|error| blob_io_error(registry, what, "close", error))?;
+    let actual_size = writer.bytes_written();
+    let _ = writer.finalize_hex();
+    tokio::fs::rename(tmp, dest)
+        .await
+        .map_err(|error| blob_io_error(registry, what, "publish", error))?;
+    if let Some(reporter) = progress.as_mut() {
+        reporter.complete(actual_size, attempt);
     }
     Ok(())
 }
 
-fn blob_pull_error(
-    registry: &str,
-    what: &str,
-    error: &OciDistributionError,
-    auth: &RegistryAuth,
-) -> BoxError {
+fn blob_validation_error(registry: &str, message: String) -> BoxError {
     BoxError::RegistryError {
         registry: registry.to_string(),
-        message: format!(
-            "Failed to pull {what}: {}",
-            registry_error_summary(error, auth)
-        ),
+        message,
     }
-}
-
-async fn create_blob_writer(tmp: &Path, what: &str, registry: &str) -> Result<HashingFileWriter> {
-    tokio::fs::File::create(tmp)
-        .await
-        .map(HashingFileWriter::new)
-        .map_err(|error| blob_io_error(registry, what, "create", error))
 }
 
 fn blob_io_error(registry: &str, what: &str, operation: &str, error: std::io::Error) -> BoxError {
@@ -232,4 +368,11 @@ fn blob_io_error(registry: &str, what: &str, operation: &str, error: std::io::Er
         registry: registry.to_string(),
         message: format!("Failed to {operation} {what} file: {error}"),
     }
+}
+
+fn blob_file_error(path: &Path, operation: &str, error: std::io::Error) -> BoxError {
+    BoxError::OciImageError(format!(
+        "Failed to {operation} registry partial blob {}: {error}",
+        path.display()
+    ))
 }

--- a/src/runtime/src/oci/registry/blob_pull/http.rs
+++ b/src/runtime/src/oci/registry/blob_pull/http.rs
@@ -1,0 +1,311 @@
+use futures::StreamExt;
+use oci_distribution::manifest::OciDescriptor;
+use oci_distribution::RegistryOperation;
+use tokio::io::AsyncWriteExt;
+
+use super::{BlobPullTransport, HashingFileWriter};
+use crate::oci::registry::progress::ProgressReporter;
+use crate::oci::registry::{
+    registry_base_url, registry_blob_url, registry_error_summary,
+};
+
+pub(super) struct AttemptFailure {
+    pub(super) message: String,
+    pub(super) retryable: bool,
+    pub(super) reset_partial: bool,
+}
+
+impl AttemptFailure {
+    pub(super) fn retryable(message: String) -> Self {
+        Self {
+            message,
+            retryable: true,
+            reset_partial: false,
+        }
+    }
+
+    pub(super) fn retryable_reset(message: String) -> Self {
+        Self {
+            message,
+            retryable: true,
+            reset_partial: true,
+        }
+    }
+
+    pub(super) fn fatal(message: String, reset_partial: bool) -> Self {
+        Self {
+            message,
+            retryable: false,
+            reset_partial,
+        }
+    }
+}
+
+pub(super) async fn transfer_attempt(
+    transport: &BlobPullTransport<'_>,
+    descriptor: &OciDescriptor,
+    writer: &mut HashingFileWriter,
+    mut progress: Option<&mut ProgressReporter>,
+    attempt: usize,
+    expected_size: u64,
+) -> std::result::Result<(), AttemptFailure> {
+    let offset = writer.bytes_written();
+    let response = request_blob(transport, descriptor, offset).await?;
+    prepare_response(&response, writer, offset, expected_size).await?;
+
+    let mut stream = response.bytes_stream();
+    loop {
+        let next = tokio::time::timeout(
+            transport.policy.no_progress_timeout(),
+            stream.next(),
+        )
+        .await
+        .map_err(|_| {
+            AttemptFailure::retryable(format!(
+                "no byte progress for {:?}",
+                transport.policy.no_progress_timeout()
+            ))
+        })?;
+        let Some(chunk) = next else {
+            break;
+        };
+        let chunk = chunk.map_err(|error| {
+            AttemptFailure::retryable(format!("response body read failed: {error}"))
+        })?;
+        tokio::time::timeout(
+            transport.policy.no_progress_timeout(),
+            writer.write_all(&chunk),
+        )
+        .await
+        .map_err(|_| {
+            AttemptFailure::retryable(format!(
+                "no file-write progress for {:?}",
+                transport.policy.no_progress_timeout()
+            ))
+        })?
+        .map_err(|error| AttemptFailure::fatal(format!("blob file write failed: {error}"), false))?;
+
+        if writer.bytes_written() > expected_size {
+            return Err(AttemptFailure::fatal(
+                format!(
+                    "response exceeded declared size {expected_size} bytes (received {})",
+                    writer.bytes_written()
+                ),
+                true,
+            ));
+        }
+        if let Some(reporter) = progress.as_deref_mut() {
+            reporter.downloading(writer.bytes_written(), attempt, false);
+        }
+    }
+    Ok(())
+}
+
+async fn request_blob(
+    transport: &BlobPullTransport<'_>,
+    descriptor: &OciDescriptor,
+    offset: u64,
+) -> std::result::Result<oci_reqwest::Response, AttemptFailure> {
+    let base = registry_base_url(transport.protocol, transport.image_ref)
+        .map_err(|error| AttemptFailure::fatal(error.to_string(), false))?;
+    let url = registry_blob_url(&base, &transport.image_ref.repository, &descriptor.digest)
+        .map_err(|error| AttemptFailure::fatal(error.to_string(), false))?;
+
+    let token = if transport.force_basic {
+        None
+    } else {
+        let auth = transport.auth.to_oci_auth();
+        Some(
+            tokio::time::timeout(
+                transport.policy.no_progress_timeout(),
+                transport
+                    .client
+                    .auth(transport.oci_ref, &auth, RegistryOperation::Pull),
+            )
+            .await
+            .map_err(|_| AttemptFailure::retryable("registry authentication timed out".to_string()))?
+            .map_err(|error| {
+                AttemptFailure::retryable(format!(
+                    "registry authentication failed: {}",
+                    registry_error_summary(&error, transport.auth)
+                ))
+            })?,
+        )
+        .flatten()
+    };
+
+    let mut response = send_request(
+        transport,
+        url,
+        offset,
+        token.as_deref(),
+        transport.force_basic,
+    )
+    .await?;
+    if response.status() == oci_reqwest::StatusCode::UNAUTHORIZED
+        && !transport.force_basic
+        && transport.auth.basic_credentials().is_some()
+    {
+        let base = registry_base_url(transport.protocol, transport.image_ref)
+            .map_err(|error| AttemptFailure::fatal(error.to_string(), false))?;
+        let url = registry_blob_url(&base, &transport.image_ref.repository, &descriptor.digest)
+            .map_err(|error| AttemptFailure::fatal(error.to_string(), false))?;
+        response = send_request(transport, url, offset, None, true).await?;
+    }
+
+    if !response.status().is_success() {
+        if let Some(urls) = &descriptor.urls {
+            for candidate in urls {
+                let Ok(url) = oci_reqwest::Url::parse(candidate) else {
+                    continue;
+                };
+                if !matches!(url.scheme(), "http" | "https") {
+                    continue;
+                }
+                let external = send_request(transport, url, offset, None, false).await?;
+                if external.status().is_success() {
+                    return Ok(external);
+                }
+                response = external;
+            }
+        }
+    }
+
+    classify_response(response, offset)
+}
+
+async fn send_request(
+    transport: &BlobPullTransport<'_>,
+    url: oci_reqwest::Url,
+    offset: u64,
+    bearer_token: Option<&str>,
+    basic: bool,
+) -> std::result::Result<oci_reqwest::Response, AttemptFailure> {
+    let mut request = transport.http.get(url);
+    if offset > 0 {
+        request = request.header(oci_reqwest::header::RANGE, format!("bytes={offset}-"));
+    }
+    if let Some(token) = bearer_token {
+        request = request.bearer_auth(token);
+    } else if basic {
+        let (username, password) = transport.auth.basic_credentials().ok_or_else(|| {
+            AttemptFailure::fatal(
+                "preemptive Basic blob pull requires non-empty credentials".to_string(),
+                false,
+            )
+        })?;
+        request = request.basic_auth(username, Some(password));
+    }
+
+    tokio::time::timeout(transport.policy.no_progress_timeout(), request.send())
+        .await
+        .map_err(|_| AttemptFailure::retryable("registry response headers timed out".to_string()))?
+        .map_err(|error| AttemptFailure::retryable(format!("registry request failed: {error}")))
+}
+
+fn classify_response(
+    response: oci_reqwest::Response,
+    offset: u64,
+) -> std::result::Result<oci_reqwest::Response, AttemptFailure> {
+    let status = response.status();
+    if status == oci_reqwest::StatusCode::OK
+        || status == oci_reqwest::StatusCode::PARTIAL_CONTENT
+    {
+        return Ok(response);
+    }
+    if status == oci_reqwest::StatusCode::RANGE_NOT_SATISFIABLE && offset > 0 {
+        return Err(AttemptFailure::retryable_reset(
+            "registry rejected the requested resume offset".to_string(),
+        ));
+    }
+    let retryable = status == oci_reqwest::StatusCode::REQUEST_TIMEOUT
+        || status == oci_reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error();
+    let message = format!("registry returned HTTP {}", status.as_u16());
+    if retryable {
+        Err(AttemptFailure::retryable(message))
+    } else {
+        Err(AttemptFailure::fatal(message, false))
+    }
+}
+
+async fn prepare_response(
+    response: &oci_reqwest::Response,
+    writer: &mut HashingFileWriter,
+    requested_offset: u64,
+    expected_size: u64,
+) -> std::result::Result<(), AttemptFailure> {
+    if requested_offset > 0 && response.status() == oci_reqwest::StatusCode::OK {
+        writer
+            .reset()
+            .await
+            .map_err(|error| AttemptFailure::fatal(format!("failed to restart blob file: {error}"), true))?;
+    } else if response.status() == oci_reqwest::StatusCode::PARTIAL_CONTENT {
+        validate_content_range(response, requested_offset, expected_size)?;
+    }
+
+    if response.status() == oci_reqwest::StatusCode::OK {
+        if let Some(length) = response.content_length() {
+            if length != expected_size {
+                return Err(AttemptFailure::fatal(
+                    format!(
+                        "registry Content-Length mismatch: expected {expected_size}, received {length}"
+                    ),
+                    true,
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_content_range(
+    response: &oci_reqwest::Response,
+    requested_offset: u64,
+    expected_size: u64,
+) -> std::result::Result<(), AttemptFailure> {
+    let value = response
+        .headers()
+        .get(oci_reqwest::header::CONTENT_RANGE)
+        .ok_or_else(|| AttemptFailure::fatal("206 response omitted Content-Range".to_string(), false))?
+        .to_str()
+        .map_err(|error| AttemptFailure::fatal(format!("invalid Content-Range header: {error}"), false))?;
+    let value = value
+        .strip_prefix("bytes ")
+        .ok_or_else(|| AttemptFailure::fatal(format!("invalid Content-Range header: {value}"), false))?;
+    let (range, total) = value
+        .split_once('/')
+        .ok_or_else(|| AttemptFailure::fatal(format!("invalid Content-Range header: {value}"), false))?;
+    let (start, end) = range
+        .split_once('-')
+        .ok_or_else(|| AttemptFailure::fatal(format!("invalid Content-Range header: {value}"), false))?;
+    let start = start
+        .parse::<u64>()
+        .map_err(|_| AttemptFailure::fatal(format!("invalid Content-Range start: {value}"), false))?;
+    let end = end
+        .parse::<u64>()
+        .map_err(|_| AttemptFailure::fatal(format!("invalid Content-Range end: {value}"), false))?;
+    let total = total
+        .parse::<u64>()
+        .map_err(|_| AttemptFailure::fatal(format!("invalid Content-Range total: {value}"), false))?;
+    if start != requested_offset || end < start || total != expected_size || end >= total {
+        return Err(AttemptFailure::fatal(
+            format!(
+                "Content-Range {value} does not match requested offset {requested_offset} and declared size {expected_size}"
+            ),
+            false,
+        ));
+    }
+    if let Some(length) = response.content_length() {
+        let range_length = end.saturating_sub(start).saturating_add(1);
+        if length != range_length {
+            return Err(AttemptFailure::fatal(
+                format!(
+                    "partial Content-Length mismatch: range contains {range_length} bytes, header says {length}"
+                ),
+                false,
+            ));
+        }
+    }
+    Ok(())
+}

--- a/src/runtime/src/oci/registry/blob_pull/http.rs
+++ b/src/runtime/src/oci/registry/blob_pull/http.rs
@@ -5,9 +5,7 @@ use tokio::io::AsyncWriteExt;
 
 use super::{BlobPullTransport, HashingFileWriter};
 use crate::oci::registry::progress::ProgressReporter;
-use crate::oci::registry::{
-    registry_base_url, registry_blob_url, registry_error_summary,
-};
+use crate::oci::registry::{registry_base_url, registry_blob_url, registry_error_summary};
 
 pub(super) struct AttemptFailure {
     pub(super) message: String,
@@ -55,17 +53,14 @@ pub(super) async fn transfer_attempt(
 
     let mut stream = response.bytes_stream();
     loop {
-        let next = tokio::time::timeout(
-            transport.policy.no_progress_timeout(),
-            stream.next(),
-        )
-        .await
-        .map_err(|_| {
-            AttemptFailure::retryable(format!(
-                "no byte progress for {:?}",
-                transport.policy.no_progress_timeout()
-            ))
-        })?;
+        let next = tokio::time::timeout(transport.policy.no_progress_timeout(), stream.next())
+            .await
+            .map_err(|_| {
+                AttemptFailure::retryable(format!(
+                    "no byte progress for {:?}",
+                    transport.policy.no_progress_timeout()
+                ))
+            })?;
         let Some(chunk) = next else {
             break;
         };
@@ -83,7 +78,9 @@ pub(super) async fn transfer_attempt(
                 transport.policy.no_progress_timeout()
             ))
         })?
-        .map_err(|error| AttemptFailure::fatal(format!("blob file write failed: {error}"), false))?;
+        .map_err(|error| {
+            AttemptFailure::fatal(format!("blob file write failed: {error}"), false)
+        })?;
 
         if writer.bytes_written() > expected_size {
             return Err(AttemptFailure::fatal(
@@ -123,7 +120,9 @@ async fn request_blob(
                     .auth(transport.oci_ref, &auth, RegistryOperation::Pull),
             )
             .await
-            .map_err(|_| AttemptFailure::retryable("registry authentication timed out".to_string()))?
+            .map_err(|_| {
+                AttemptFailure::retryable("registry authentication timed out".to_string())
+            })?
             .map_err(|error| {
                 AttemptFailure::retryable(format!(
                     "registry authentication failed: {}",
@@ -208,9 +207,7 @@ fn classify_response(
     offset: u64,
 ) -> std::result::Result<oci_reqwest::Response, AttemptFailure> {
     let status = response.status();
-    if status == oci_reqwest::StatusCode::OK
-        || status == oci_reqwest::StatusCode::PARTIAL_CONTENT
-    {
+    if status == oci_reqwest::StatusCode::OK || status == oci_reqwest::StatusCode::PARTIAL_CONTENT {
         return Ok(response);
     }
     if status == oci_reqwest::StatusCode::RANGE_NOT_SATISFIABLE && offset > 0 {
@@ -236,10 +233,9 @@ async fn prepare_response(
     expected_size: u64,
 ) -> std::result::Result<(), AttemptFailure> {
     if requested_offset > 0 && response.status() == oci_reqwest::StatusCode::OK {
-        writer
-            .reset()
-            .await
-            .map_err(|error| AttemptFailure::fatal(format!("failed to restart blob file: {error}"), true))?;
+        writer.reset().await.map_err(|error| {
+            AttemptFailure::fatal(format!("failed to restart blob file: {error}"), true)
+        })?;
     } else if response.status() == oci_reqwest::StatusCode::PARTIAL_CONTENT {
         validate_content_range(response, requested_offset, expected_size)?;
     }
@@ -267,27 +263,31 @@ fn validate_content_range(
     let value = response
         .headers()
         .get(oci_reqwest::header::CONTENT_RANGE)
-        .ok_or_else(|| AttemptFailure::fatal("206 response omitted Content-Range".to_string(), false))?
+        .ok_or_else(|| {
+            AttemptFailure::fatal("206 response omitted Content-Range".to_string(), false)
+        })?
         .to_str()
-        .map_err(|error| AttemptFailure::fatal(format!("invalid Content-Range header: {error}"), false))?;
-    let value = value
-        .strip_prefix("bytes ")
-        .ok_or_else(|| AttemptFailure::fatal(format!("invalid Content-Range header: {value}"), false))?;
-    let (range, total) = value
-        .split_once('/')
-        .ok_or_else(|| AttemptFailure::fatal(format!("invalid Content-Range header: {value}"), false))?;
-    let (start, end) = range
-        .split_once('-')
-        .ok_or_else(|| AttemptFailure::fatal(format!("invalid Content-Range header: {value}"), false))?;
-    let start = start
-        .parse::<u64>()
-        .map_err(|_| AttemptFailure::fatal(format!("invalid Content-Range start: {value}"), false))?;
+        .map_err(|error| {
+            AttemptFailure::fatal(format!("invalid Content-Range header: {error}"), false)
+        })?;
+    let value = value.strip_prefix("bytes ").ok_or_else(|| {
+        AttemptFailure::fatal(format!("invalid Content-Range header: {value}"), false)
+    })?;
+    let (range, total) = value.split_once('/').ok_or_else(|| {
+        AttemptFailure::fatal(format!("invalid Content-Range header: {value}"), false)
+    })?;
+    let (start, end) = range.split_once('-').ok_or_else(|| {
+        AttemptFailure::fatal(format!("invalid Content-Range header: {value}"), false)
+    })?;
+    let start = start.parse::<u64>().map_err(|_| {
+        AttemptFailure::fatal(format!("invalid Content-Range start: {value}"), false)
+    })?;
     let end = end
         .parse::<u64>()
         .map_err(|_| AttemptFailure::fatal(format!("invalid Content-Range end: {value}"), false))?;
-    let total = total
-        .parse::<u64>()
-        .map_err(|_| AttemptFailure::fatal(format!("invalid Content-Range total: {value}"), false))?;
+    let total = total.parse::<u64>().map_err(|_| {
+        AttemptFailure::fatal(format!("invalid Content-Range total: {value}"), false)
+    })?;
     if start != requested_offset || end < start || total != expected_size || end >= total {
         return Err(AttemptFailure::fatal(
             format!(

--- a/src/runtime/src/oci/registry/content.rs
+++ b/src/runtime/src/oci/registry/content.rs
@@ -61,7 +61,6 @@ impl RegistryPuller {
 
         stream::iter(layers.into_iter().enumerate())
             .map(|(index, layer)| {
-                let transport = transport;
                 async move {
                     let expected_size =
                         u64::try_from(layer.size).map_err(|_| BoxError::RegistryError {

--- a/src/runtime/src/oci/registry/content.rs
+++ b/src/runtime/src/oci/registry/content.rs
@@ -1,0 +1,142 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use a3s_box_core::error::{BoxError, Result};
+use futures::{stream, StreamExt, TryStreamExt};
+use oci_distribution::manifest::{OciDescriptor, OciImageManifest};
+use oci_distribution::Reference;
+
+use super::blob_pull::{stream_and_verify_blob, BlobPullTransport};
+use super::progress::ProgressReporter;
+use super::{validated_digest_hex, ImageReference, ImageStore, RegistryPuller};
+
+impl RegistryPuller {
+    /// Pull config and unique layers with bounded concurrency, reusing verified
+    /// content from existing stored image layouts when available.
+    pub(super) async fn pull_image_content(
+        &self,
+        reference: &ImageReference,
+        oci_ref: &Reference,
+        manifest: &OciImageManifest,
+        blobs_dir: &Path,
+        force_basic: bool,
+        blob_store: Option<&ImageStore>,
+    ) -> Result<()> {
+        let transport = BlobPullTransport {
+            client: &self.client,
+            http: &self.blob_http,
+            oci_ref,
+            image_ref: reference,
+            force_basic,
+            auth: &self.auth,
+            registry: &reference.registry,
+            protocol: self.protocol,
+            policy: &self.pull_policy,
+        };
+
+        let config = &manifest.config;
+        let config_hex = validated_digest_hex(&config.digest)?;
+        self.materialize_blob(
+            &transport,
+            config,
+            &blobs_dir.join(config_hex),
+            "config blob",
+            blob_store,
+            None,
+        )
+        .await?;
+
+        let mut seen = HashSet::new();
+        let layers = manifest
+            .layers
+            .iter()
+            .filter(|layer| seen.insert(layer.digest.clone()))
+            .cloned()
+            .collect::<Vec<_>>();
+        let total = layers.len();
+        let concurrency = self.pull_policy.max_concurrent_downloads().min(total.max(1));
+
+        stream::iter(layers.into_iter().enumerate())
+            .map(|(index, layer)| {
+                let transport = transport;
+                async move {
+                    let expected_size = u64::try_from(layer.size).map_err(|_| {
+                        BoxError::RegistryError {
+                            registry: reference.registry.clone(),
+                            message: format!(
+                                "layer {} has a negative declared size ({})",
+                                layer.digest, layer.size
+                            ),
+                        }
+                    })?;
+                    let current = index + 1;
+                    tracing::debug!(
+                        digest = %layer.digest,
+                        size = layer.size,
+                        current,
+                        total,
+                        "Scheduling registry layer pull"
+                    );
+                    if let Some(callback) = &self.progress_fn {
+                        callback(current, total, &layer.digest, layer.size);
+                    }
+                    let reporter = ProgressReporter::new(
+                        self.progress_event_fn.clone(),
+                        current,
+                        total,
+                        layer.digest.clone(),
+                        expected_size,
+                        self.pull_policy.max_attempts(),
+                    );
+                    let digest_hex = validated_digest_hex(&layer.digest)?;
+                    self.materialize_blob(
+                        &transport,
+                        &layer,
+                        &blobs_dir.join(digest_hex),
+                        "layer",
+                        blob_store,
+                        Some(reporter),
+                    )
+                    .await?;
+                    if let Some(callback) = &self.progress_fn {
+                        callback(current, total, &layer.digest, -layer.size);
+                    }
+                    Ok::<(), BoxError>(())
+                }
+            })
+            .buffer_unordered(concurrency)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        Ok(())
+    }
+
+    async fn materialize_blob(
+        &self,
+        transport: &BlobPullTransport<'_>,
+        descriptor: &OciDescriptor,
+        dest: &Path,
+        what: &str,
+        blob_store: Option<&ImageStore>,
+        mut progress: Option<ProgressReporter>,
+    ) -> Result<()> {
+        if let Some(store) = blob_store {
+            if store
+                .reuse_verified_blob(&descriptor.digest, descriptor.size, dest)
+                .await?
+            {
+                tracing::info!(
+                    digest = %descriptor.digest,
+                    size = descriptor.size,
+                    "Reused verified registry blob from another stored image"
+                );
+                if let Some(reporter) = progress.as_mut() {
+                    reporter.reused();
+                }
+                return Ok(());
+            }
+        }
+
+        stream_and_verify_blob(transport, descriptor, dest, what, progress).await
+    }
+}

--- a/src/runtime/src/oci/registry/content.rs
+++ b/src/runtime/src/oci/registry/content.rs
@@ -54,21 +54,23 @@ impl RegistryPuller {
             .cloned()
             .collect::<Vec<_>>();
         let total = layers.len();
-        let concurrency = self.pull_policy.max_concurrent_downloads().min(total.max(1));
+        let concurrency = self
+            .pull_policy
+            .max_concurrent_downloads()
+            .min(total.max(1));
 
         stream::iter(layers.into_iter().enumerate())
             .map(|(index, layer)| {
                 let transport = transport;
                 async move {
-                    let expected_size = u64::try_from(layer.size).map_err(|_| {
-                        BoxError::RegistryError {
+                    let expected_size =
+                        u64::try_from(layer.size).map_err(|_| BoxError::RegistryError {
                             registry: reference.registry.clone(),
                             message: format!(
                                 "layer {} has a negative declared size ({})",
                                 layer.digest, layer.size
                             ),
-                        }
-                    })?;
+                        })?;
                     let current = index + 1;
                     tracing::debug!(
                         digest = %layer.digest,

--- a/src/runtime/src/oci/registry/content.rs
+++ b/src/runtime/src/oci/registry/content.rs
@@ -60,50 +60,48 @@ impl RegistryPuller {
             .min(total.max(1));
 
         stream::iter(layers.into_iter().enumerate())
-            .map(|(index, layer)| {
-                async move {
-                    let expected_size =
-                        u64::try_from(layer.size).map_err(|_| BoxError::RegistryError {
-                            registry: reference.registry.clone(),
-                            message: format!(
-                                "layer {} has a negative declared size ({})",
-                                layer.digest, layer.size
-                            ),
-                        })?;
-                    let current = index + 1;
-                    tracing::debug!(
-                        digest = %layer.digest,
-                        size = layer.size,
-                        current,
-                        total,
-                        "Scheduling registry layer pull"
-                    );
-                    if let Some(callback) = &self.progress_fn {
-                        callback(current, total, &layer.digest, layer.size);
-                    }
-                    let reporter = ProgressReporter::new(
-                        self.progress_event_fn.clone(),
-                        current,
-                        total,
-                        layer.digest.clone(),
-                        expected_size,
-                        self.pull_policy.max_attempts(),
-                    );
-                    let digest_hex = validated_digest_hex(&layer.digest)?;
-                    self.materialize_blob(
-                        &transport,
-                        &layer,
-                        &blobs_dir.join(digest_hex),
-                        "layer",
-                        blob_store,
-                        Some(reporter),
-                    )
-                    .await?;
-                    if let Some(callback) = &self.progress_fn {
-                        callback(current, total, &layer.digest, -layer.size);
-                    }
-                    Ok::<(), BoxError>(())
+            .map(|(index, layer)| async move {
+                let expected_size =
+                    u64::try_from(layer.size).map_err(|_| BoxError::RegistryError {
+                        registry: reference.registry.clone(),
+                        message: format!(
+                            "layer {} has a negative declared size ({})",
+                            layer.digest, layer.size
+                        ),
+                    })?;
+                let current = index + 1;
+                tracing::debug!(
+                    digest = %layer.digest,
+                    size = layer.size,
+                    current,
+                    total,
+                    "Scheduling registry layer pull"
+                );
+                if let Some(callback) = &self.progress_fn {
+                    callback(current, total, &layer.digest, layer.size);
                 }
+                let reporter = ProgressReporter::new(
+                    self.progress_event_fn.clone(),
+                    current,
+                    total,
+                    layer.digest.clone(),
+                    expected_size,
+                    self.pull_policy.max_attempts(),
+                );
+                let digest_hex = validated_digest_hex(&layer.digest)?;
+                self.materialize_blob(
+                    &transport,
+                    &layer,
+                    &blobs_dir.join(digest_hex),
+                    "layer",
+                    blob_store,
+                    Some(reporter),
+                )
+                .await?;
+                if let Some(callback) = &self.progress_fn {
+                    callback(current, total, &layer.digest, -layer.size);
+                }
+                Ok::<(), BoxError>(())
             })
             .buffer_unordered(concurrency)
             .try_collect::<Vec<_>>()

--- a/src/runtime/src/oci/registry/policy.rs
+++ b/src/runtime/src/oci/registry/policy.rs
@@ -134,7 +134,12 @@ fn positive_usize_env(name: &str, default: usize) -> usize {
         Ok(value) => match value.parse::<usize>() {
             Ok(parsed) if parsed > 0 => parsed,
             _ => {
-                tracing::warn!(variable = name, value, default, "Ignoring invalid registry pull setting");
+                tracing::warn!(
+                    variable = name,
+                    value,
+                    default,
+                    "Ignoring invalid registry pull setting"
+                );
                 default
             }
         },
@@ -147,7 +152,12 @@ fn positive_u64_env(name: &str, default: u64) -> u64 {
         Ok(value) => match value.parse::<u64>() {
             Ok(parsed) if parsed > 0 => parsed,
             _ => {
-                tracing::warn!(variable = name, value, default, "Ignoring invalid registry pull setting");
+                tracing::warn!(
+                    variable = name,
+                    value,
+                    default,
+                    "Ignoring invalid registry pull setting"
+                );
                 default
             }
         },

--- a/src/runtime/src/oci/registry/policy.rs
+++ b/src/runtime/src/oci/registry/policy.rs
@@ -1,0 +1,211 @@
+use std::time::Duration;
+
+const MAX_ATTEMPTS_ENV: &str = "A3S_REGISTRY_PULL_MAX_ATTEMPTS";
+const RETRY_INITIAL_MS_ENV: &str = "A3S_REGISTRY_PULL_RETRY_INITIAL_MS";
+const RETRY_MAX_MS_ENV: &str = "A3S_REGISTRY_PULL_RETRY_MAX_MS";
+const NO_PROGRESS_TIMEOUT_SECS_ENV: &str = "A3S_REGISTRY_PULL_NO_PROGRESS_TIMEOUT_SECS";
+const MAX_CONCURRENT_DOWNLOADS_ENV: &str = "A3S_REGISTRY_PULL_MAX_CONCURRENT";
+
+/// Bounded transfer settings for registry config and layer downloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryPullPolicy {
+    max_attempts: usize,
+    retry_initial: Duration,
+    retry_max: Duration,
+    no_progress_timeout: Duration,
+    max_concurrent_downloads: usize,
+}
+
+impl Default for RegistryPullPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 4,
+            retry_initial: Duration::from_millis(250),
+            retry_max: Duration::from_secs(4),
+            no_progress_timeout: Duration::from_secs(30),
+            max_concurrent_downloads: 4,
+        }
+    }
+}
+
+impl RegistryPullPolicy {
+    /// Construct a validated transfer policy.
+    pub fn try_new(
+        max_attempts: usize,
+        retry_initial: Duration,
+        retry_max: Duration,
+        no_progress_timeout: Duration,
+        max_concurrent_downloads: usize,
+    ) -> Result<Self, String> {
+        if max_attempts == 0 {
+            return Err("Registry pull max attempts must be at least 1".to_string());
+        }
+        if retry_initial.is_zero() {
+            return Err("Registry pull initial retry delay must be greater than zero".to_string());
+        }
+        if retry_max < retry_initial {
+            return Err(
+                "Registry pull maximum retry delay must not be less than the initial delay"
+                    .to_string(),
+            );
+        }
+        if no_progress_timeout.is_zero() {
+            return Err("Registry pull no-progress timeout must be greater than zero".to_string());
+        }
+        if max_concurrent_downloads == 0 {
+            return Err("Registry pull concurrency must be at least 1".to_string());
+        }
+        Ok(Self {
+            max_attempts,
+            retry_initial,
+            retry_max,
+            no_progress_timeout,
+            max_concurrent_downloads,
+        })
+    }
+
+    /// Load optional process-level overrides, retaining safe defaults for
+    /// absent or invalid values.
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        let max_attempts = positive_usize_env(MAX_ATTEMPTS_ENV, defaults.max_attempts);
+        let retry_initial = Duration::from_millis(positive_u64_env(
+            RETRY_INITIAL_MS_ENV,
+            duration_millis(defaults.retry_initial),
+        ));
+        let retry_max = Duration::from_millis(positive_u64_env(
+            RETRY_MAX_MS_ENV,
+            duration_millis(defaults.retry_max),
+        ));
+        let no_progress_timeout = Duration::from_secs(positive_u64_env(
+            NO_PROGRESS_TIMEOUT_SECS_ENV,
+            defaults.no_progress_timeout.as_secs(),
+        ));
+        let max_concurrent_downloads = positive_usize_env(
+            MAX_CONCURRENT_DOWNLOADS_ENV,
+            defaults.max_concurrent_downloads,
+        );
+
+        match Self::try_new(
+            max_attempts,
+            retry_initial,
+            retry_max,
+            no_progress_timeout,
+            max_concurrent_downloads,
+        ) {
+            Ok(policy) => policy,
+            Err(error) => {
+                tracing::warn!(%error, "Invalid registry pull policy override; using defaults");
+                defaults
+            }
+        }
+    }
+
+    pub fn max_attempts(&self) -> usize {
+        self.max_attempts
+    }
+
+    pub fn retry_initial(&self) -> Duration {
+        self.retry_initial
+    }
+
+    pub fn retry_max(&self) -> Duration {
+        self.retry_max
+    }
+
+    pub fn no_progress_timeout(&self) -> Duration {
+        self.no_progress_timeout
+    }
+
+    pub fn max_concurrent_downloads(&self) -> usize {
+        self.max_concurrent_downloads
+    }
+
+    pub(super) fn retry_delay(&self, failed_attempt: usize) -> Duration {
+        let exponent = failed_attempt.saturating_sub(1).min(31) as u32;
+        self.retry_initial
+            .saturating_mul(1_u32 << exponent)
+            .min(self.retry_max)
+    }
+}
+
+fn positive_usize_env(name: &str, default: usize) -> usize {
+    match std::env::var(name) {
+        Ok(value) => match value.parse::<usize>() {
+            Ok(parsed) if parsed > 0 => parsed,
+            _ => {
+                tracing::warn!(variable = name, value, default, "Ignoring invalid registry pull setting");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+fn positive_u64_env(name: &str, default: u64) -> u64 {
+    match std::env::var(name) {
+        Ok(value) => match value.parse::<u64>() {
+            Ok(parsed) if parsed > 0 => parsed,
+            _ => {
+                tracing::warn!(variable = name, value, default, "Ignoring invalid registry pull setting");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_rejects_unbounded_or_zero_values() {
+        let defaults = RegistryPullPolicy::default();
+        assert!(RegistryPullPolicy::try_new(
+            0,
+            defaults.retry_initial,
+            defaults.retry_max,
+            defaults.no_progress_timeout,
+            defaults.max_concurrent_downloads,
+        )
+        .is_err());
+        assert!(RegistryPullPolicy::try_new(
+            defaults.max_attempts,
+            defaults.retry_initial,
+            defaults.retry_max,
+            Duration::ZERO,
+            defaults.max_concurrent_downloads,
+        )
+        .is_err());
+        assert!(RegistryPullPolicy::try_new(
+            defaults.max_attempts,
+            defaults.retry_initial,
+            defaults.retry_max,
+            defaults.no_progress_timeout,
+            0,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn retry_delay_is_exponential_and_capped() {
+        let policy = RegistryPullPolicy::try_new(
+            8,
+            Duration::from_millis(10),
+            Duration::from_millis(40),
+            Duration::from_secs(1),
+            2,
+        )
+        .unwrap();
+
+        assert_eq!(policy.retry_delay(1), Duration::from_millis(10));
+        assert_eq!(policy.retry_delay(2), Duration::from_millis(20));
+        assert_eq!(policy.retry_delay(3), Duration::from_millis(40));
+        assert_eq!(policy.retry_delay(8), Duration::from_millis(40));
+    }
+}

--- a/src/runtime/src/oci/registry/progress.rs
+++ b/src/runtime/src/oci/registry/progress.rs
@@ -80,12 +80,7 @@ impl ProgressReporter {
         );
     }
 
-    pub(super) fn retrying(
-        &mut self,
-        downloaded_bytes: u64,
-        next_attempt: usize,
-        delay: Duration,
-    ) {
+    pub(super) fn retrying(&mut self, downloaded_bytes: u64, next_attempt: usize, delay: Duration) {
         self.emit(
             PullProgressState::Retrying,
             downloaded_bytes,
@@ -95,21 +90,11 @@ impl ProgressReporter {
     }
 
     pub(super) fn reused(&mut self) {
-        self.emit(
-            PullProgressState::Reused,
-            self.total_bytes,
-            0,
-            None,
-        );
+        self.emit(PullProgressState::Reused, self.total_bytes, 0, None);
     }
 
     pub(super) fn complete(&mut self, downloaded_bytes: u64, attempt: usize) {
-        self.emit(
-            PullProgressState::Complete,
-            downloaded_bytes,
-            attempt,
-            None,
-        );
+        self.emit(PullProgressState::Complete, downloaded_bytes, attempt, None);
     }
 
     fn emit(

--- a/src/runtime/src/oci/registry/progress.rs
+++ b/src/runtime/src/oci/registry/progress.rs
@@ -1,0 +1,151 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const REPORT_INTERVAL_BYTES: u64 = 1024 * 1024;
+const REPORT_INTERVAL_TIME: Duration = Duration::from_secs(5);
+
+/// Current phase of a registry layer transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PullProgressState {
+    Downloading,
+    Retrying,
+    Reused,
+    Complete,
+}
+
+/// Structured registry layer progress with actual transferred byte counts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PullProgress {
+    pub current_layer: usize,
+    pub total_layers: usize,
+    pub digest: String,
+    pub downloaded_bytes: u64,
+    pub total_bytes: u64,
+    pub attempt: usize,
+    pub max_attempts: usize,
+    pub retry_delay_ms: Option<u64>,
+    pub state: PullProgressState,
+}
+
+/// Callback for structured registry layer progress events.
+pub type PullProgressEventFn = Arc<dyn Fn(PullProgress) + Send + Sync>;
+
+pub(super) struct ProgressReporter {
+    callback: Option<PullProgressEventFn>,
+    current_layer: usize,
+    total_layers: usize,
+    digest: String,
+    total_bytes: u64,
+    max_attempts: usize,
+    last_bytes: u64,
+    last_report: Instant,
+}
+
+impl ProgressReporter {
+    pub(super) fn new(
+        callback: Option<PullProgressEventFn>,
+        current_layer: usize,
+        total_layers: usize,
+        digest: String,
+        total_bytes: u64,
+        max_attempts: usize,
+    ) -> Self {
+        Self {
+            callback,
+            current_layer,
+            total_layers,
+            digest,
+            total_bytes,
+            max_attempts,
+            last_bytes: 0,
+            last_report: Instant::now(),
+        }
+    }
+
+    pub(super) fn downloading(&mut self, downloaded_bytes: u64, attempt: usize, force: bool) {
+        let now = Instant::now();
+        if !force
+            && downloaded_bytes.saturating_sub(self.last_bytes) < REPORT_INTERVAL_BYTES
+            && now.duration_since(self.last_report) < REPORT_INTERVAL_TIME
+        {
+            return;
+        }
+        self.last_bytes = downloaded_bytes;
+        self.last_report = now;
+        self.emit(
+            PullProgressState::Downloading,
+            downloaded_bytes,
+            attempt,
+            None,
+        );
+    }
+
+    pub(super) fn retrying(
+        &mut self,
+        downloaded_bytes: u64,
+        next_attempt: usize,
+        delay: Duration,
+    ) {
+        self.emit(
+            PullProgressState::Retrying,
+            downloaded_bytes,
+            next_attempt,
+            Some(duration_millis(delay)),
+        );
+    }
+
+    pub(super) fn reused(&mut self) {
+        self.emit(
+            PullProgressState::Reused,
+            self.total_bytes,
+            0,
+            None,
+        );
+    }
+
+    pub(super) fn complete(&mut self, downloaded_bytes: u64, attempt: usize) {
+        self.emit(
+            PullProgressState::Complete,
+            downloaded_bytes,
+            attempt,
+            None,
+        );
+    }
+
+    fn emit(
+        &self,
+        state: PullProgressState,
+        downloaded_bytes: u64,
+        attempt: usize,
+        retry_delay_ms: Option<u64>,
+    ) {
+        tracing::info!(
+            layer = self.current_layer,
+            layers = self.total_layers,
+            digest = %self.digest,
+            downloaded_bytes,
+            total_bytes = self.total_bytes,
+            attempt,
+            max_attempts = self.max_attempts,
+            ?state,
+            "Registry layer transfer progress"
+        );
+        if let Some(callback) = &self.callback {
+            callback(PullProgress {
+                current_layer: self.current_layer,
+                total_layers: self.total_layers,
+                digest: self.digest.clone(),
+                downloaded_bytes,
+                total_bytes: self.total_bytes,
+                attempt,
+                max_attempts: self.max_attempts,
+                retry_delay_ms,
+                state,
+            });
+        }
+    }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}

--- a/src/runtime/src/oci/registry/resilient_pull_tests.rs
+++ b/src/runtime/src/oci/registry/resilient_pull_tests.rs
@@ -25,6 +25,7 @@ const REPOSITORY: &str = "a3s/resilient";
 enum LayerFault {
     Normal,
     DropFirst { prefix_bytes: usize },
+    IgnoreRange,
     Stall,
     ServiceUnavailable,
     Delay(Duration),
@@ -246,6 +247,9 @@ async fn registry_handler(
             state.active_layer_requests.fetch_sub(1, Ordering::SeqCst);
             ranged_response(layer, range.as_deref())
         }
+        LayerFault::IgnoreRange => {
+            complete_response(StatusCode::OK, "application/octet-stream", layer)
+        }
         LayerFault::Normal | LayerFault::DropFirst { .. } => {
             ranged_response(layer, range.as_deref())
         }
@@ -426,6 +430,32 @@ async fn interrupted_body_resumes_with_exact_range_and_reports_actual_bytes() {
     assert_eq!(complete.downloaded_bytes, layer_bytes.len() as u64);
     assert_eq!(complete.total_bytes, layer_bytes.len() as u64);
     assert_eq!(complete.attempt, 2);
+}
+
+#[tokio::test]
+async fn full_response_to_range_request_resets_partial_before_writing() {
+    let layer_bytes = b"registry-does-not-support-range".repeat(4096);
+    let prefix_bytes = 4096;
+    let fixture =
+        ResilientRegistryFixture::start(vec![layer_bytes.clone()], LayerFault::IgnoreRange).await;
+    let target = tempfile::tempdir().unwrap();
+    let partial = blob_path(target.path(), &fixture.layers[0].digest).with_extension("partial");
+    std::fs::create_dir_all(partial.parent().unwrap()).unwrap();
+    std::fs::write(&partial, &layer_bytes[..prefix_bytes]).unwrap();
+
+    puller(pull_policy(1, Duration::from_secs(1), 1))
+        .pull_with_store(&fixture.reference, target.path(), None)
+        .await
+        .unwrap();
+
+    let requests = fixture.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].range.as_deref(), Some("bytes=4096-"));
+    assert_eq!(
+        std::fs::read(blob_path(target.path(), &fixture.layers[0].digest)).unwrap(),
+        layer_bytes
+    );
+    assert!(!partial.exists());
 }
 
 #[tokio::test]

--- a/src/runtime/src/oci/registry/resilient_pull_tests.rs
+++ b/src/runtime/src/oci/registry/resilient_pull_tests.rs
@@ -220,11 +220,17 @@ async fn registry_handler(
     match state.fault {
         LayerFault::DropFirst { prefix_bytes } if request_number == 1 => {
             let prefix_bytes = prefix_bytes.min(layer.bytes.len());
+            let prefix = layer.bytes[..prefix_bytes].to_vec();
+            let (mut sender, body) = Body::channel();
+            tokio::spawn(async move {
+                let _ = sender.send_data(prefix.into()).await;
+                sender.abort();
+            });
             Response::builder()
                 .status(StatusCode::OK)
                 .header(CONTENT_TYPE, "application/octet-stream")
                 .header(CONTENT_LENGTH, layer.bytes.len().to_string())
-                .body(Body::from(layer.bytes[..prefix_bytes].to_vec()))
+                .body(body)
                 .unwrap()
         }
         LayerFault::Stall => stalled_response(layer.bytes.len()),

--- a/src/runtime/src/oci/registry/resilient_pull_tests.rs
+++ b/src/runtime/src/oci/registry/resilient_pull_tests.rs
@@ -223,7 +223,9 @@ async fn registry_handler(
             let prefix = layer.bytes[..prefix_bytes].to_vec();
             let (mut sender, body) = Body::channel();
             tokio::spawn(async move {
-                let _ = sender.send_data(prefix.into()).await;
+                if sender.send_data(prefix.into()).await.is_ok() {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
                 sender.abort();
             });
             Response::builder()

--- a/src/runtime/src/oci/registry/resilient_pull_tests.rs
+++ b/src/runtime/src/oci/registry/resilient_pull_tests.rs
@@ -1,0 +1,552 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::header::{CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, RANGE};
+use axum::http::{Method, Request, Response, StatusCode};
+use axum::routing::any;
+use axum::Router;
+use serde_json::json;
+use sha2::Digest as _;
+
+use super::super::store::ImageStore;
+use super::{
+    ImageReference, PullProgress, PullProgressState, RegistryAuth, RegistryProtocol,
+    RegistryPullPolicy, RegistryPuller,
+};
+
+const REPOSITORY: &str = "a3s/resilient";
+
+#[derive(Clone, Copy)]
+enum LayerFault {
+    Normal,
+    DropFirst { prefix_bytes: usize },
+    Stall,
+    ServiceUnavailable,
+    Delay(Duration),
+}
+
+#[derive(Clone)]
+struct BlobFixture {
+    digest: String,
+    bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+struct LayerRequest {
+    digest: String,
+    range: Option<String>,
+}
+
+#[derive(Clone)]
+struct RegistryState {
+    manifest: BlobFixture,
+    config: BlobFixture,
+    layers: Arc<HashMap<String, BlobFixture>>,
+    fault: LayerFault,
+    requests: Arc<Mutex<Vec<LayerRequest>>>,
+    active_layer_requests: Arc<AtomicUsize>,
+    max_active_layer_requests: Arc<AtomicUsize>,
+}
+
+struct ResilientRegistryFixture {
+    reference: ImageReference,
+    layers: Vec<BlobFixture>,
+    requests: Arc<Mutex<Vec<LayerRequest>>>,
+    active_layer_requests: Arc<AtomicUsize>,
+    max_active_layer_requests: Arc<AtomicUsize>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl ResilientRegistryFixture {
+    async fn start(layer_bytes: Vec<Vec<u8>>, fault: LayerFault) -> Self {
+        assert!(!layer_bytes.is_empty());
+        let config_bytes = serde_json::to_vec(&json!({
+            "architecture": "amd64",
+            "os": "linux",
+            "config": {},
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "history": []
+        }))
+        .unwrap();
+        let config = BlobFixture::new(config_bytes);
+        let layers = layer_bytes
+            .into_iter()
+            .map(BlobFixture::new)
+            .collect::<Vec<_>>();
+        let manifest_bytes = serde_json::to_vec(&json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": config.digest,
+                "size": config.bytes.len()
+            },
+            "layers": layers.iter().map(|layer| json!({
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "digest": layer.digest,
+                "size": layer.bytes.len()
+            })).collect::<Vec<_>>()
+        }))
+        .unwrap();
+        let manifest = BlobFixture::new(manifest_bytes);
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let active_layer_requests = Arc::new(AtomicUsize::new(0));
+        let max_active_layer_requests = Arc::new(AtomicUsize::new(0));
+        let state = RegistryState {
+            manifest,
+            config,
+            layers: Arc::new(
+                layers
+                    .iter()
+                    .cloned()
+                    .map(|layer| (layer.digest.clone(), layer))
+                    .collect(),
+            ),
+            fault,
+            requests: Arc::clone(&requests),
+            active_layer_requests: Arc::clone(&active_layer_requests),
+            max_active_layer_requests: Arc::clone(&max_active_layer_requests),
+        };
+        let app = Router::new()
+            .route("/*path", any(registry_handler))
+            .with_state(state);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .unwrap()
+                .serve(app.into_make_service())
+                .await
+                .unwrap();
+        });
+
+        Self {
+            reference: ImageReference {
+                registry: address.to_string(),
+                repository: REPOSITORY.to_string(),
+                tag: Some("latest".to_string()),
+                digest: None,
+            },
+            layers,
+            requests,
+            active_layer_requests,
+            max_active_layer_requests,
+            task,
+        }
+    }
+
+    fn requests(&self) -> Vec<LayerRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    fn max_active_layer_requests(&self) -> usize {
+        self.max_active_layer_requests.load(Ordering::SeqCst)
+    }
+
+    fn active_layer_requests(&self) -> usize {
+        self.active_layer_requests.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for ResilientRegistryFixture {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl BlobFixture {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            digest: digest(&bytes),
+            bytes,
+        }
+    }
+}
+
+async fn registry_handler(
+    State(state): State<RegistryState>,
+    request: Request<Body>,
+) -> Response<Body> {
+    if request.method() != Method::GET {
+        return empty_response(StatusCode::METHOD_NOT_ALLOWED);
+    }
+    let path = request.uri().path();
+    if path == "/v2/" {
+        return empty_response(StatusCode::OK);
+    }
+    if path == "/v2/a3s/resilient/manifests/latest" {
+        return complete_response(
+            StatusCode::OK,
+            "application/vnd.oci.image.manifest.v1+json",
+            &state.manifest,
+        );
+    }
+
+    let blob_prefix = format!("/v2/{REPOSITORY}/blobs/");
+    let Some(blob_digest) = path.strip_prefix(&blob_prefix) else {
+        return empty_response(StatusCode::NOT_FOUND);
+    };
+    if blob_digest == state.config.digest {
+        return complete_response(
+            StatusCode::OK,
+            "application/octet-stream",
+            &state.config,
+        );
+    }
+    let Some(layer) = state.layers.get(blob_digest) else {
+        return empty_response(StatusCode::NOT_FOUND);
+    };
+    let range = request
+        .headers()
+        .get(RANGE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let request_number = {
+        let mut requests = state.requests.lock().unwrap();
+        let number = requests
+            .iter()
+            .filter(|request| request.digest == blob_digest)
+            .count()
+            + 1;
+        requests.push(LayerRequest {
+            digest: blob_digest.to_string(),
+            range: range.clone(),
+        });
+        number
+    };
+
+    match state.fault {
+        LayerFault::DropFirst { prefix_bytes } if request_number == 1 => {
+            let prefix_bytes = prefix_bytes.min(layer.bytes.len());
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/octet-stream")
+                .header(CONTENT_LENGTH, layer.bytes.len().to_string())
+                .body(Body::from(layer.bytes[..prefix_bytes].to_vec()))
+                .unwrap()
+        }
+        LayerFault::Stall => stalled_response(layer.bytes.len()),
+        LayerFault::ServiceUnavailable => empty_response(StatusCode::SERVICE_UNAVAILABLE),
+        LayerFault::Delay(delay) => {
+            let active = state.active_layer_requests.fetch_add(1, Ordering::SeqCst) + 1;
+            state
+                .max_active_layer_requests
+                .fetch_max(active, Ordering::SeqCst);
+            tokio::time::sleep(delay).await;
+            state.active_layer_requests.fetch_sub(1, Ordering::SeqCst);
+            ranged_response(layer, range.as_deref())
+        }
+        LayerFault::Normal | LayerFault::DropFirst { .. } => {
+            ranged_response(layer, range.as_deref())
+        }
+    }
+}
+
+fn ranged_response(layer: &BlobFixture, range: Option<&str>) -> Response<Body> {
+    let Some(range) = range else {
+        return complete_response(
+            StatusCode::OK,
+            "application/octet-stream",
+            layer,
+        );
+    };
+    let Some(offset) = range
+        .strip_prefix("bytes=")
+        .and_then(|value| value.strip_suffix('-'))
+        .and_then(|value| value.parse::<usize>().ok())
+    else {
+        return empty_response(StatusCode::RANGE_NOT_SATISFIABLE);
+    };
+    if offset >= layer.bytes.len() {
+        return empty_response(StatusCode::RANGE_NOT_SATISFIABLE);
+    }
+    let end = layer.bytes.len() - 1;
+    Response::builder()
+        .status(StatusCode::PARTIAL_CONTENT)
+        .header(CONTENT_TYPE, "application/octet-stream")
+        .header(CONTENT_LENGTH, (layer.bytes.len() - offset).to_string())
+        .header(
+            CONTENT_RANGE,
+            format!("bytes {offset}-{end}/{}", layer.bytes.len()),
+        )
+        .body(Body::from(layer.bytes[offset..].to_vec()))
+        .unwrap()
+}
+
+fn stalled_response(content_length: usize) -> Response<Body> {
+    let (sender, body) = Body::channel();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        drop(sender);
+    });
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/octet-stream")
+        .header(CONTENT_LENGTH, content_length.to_string())
+        .body(body)
+        .unwrap()
+}
+
+fn complete_response(
+    status: StatusCode,
+    media_type: &'static str,
+    content: &BlobFixture,
+) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header(CONTENT_TYPE, media_type)
+        .header(CONTENT_LENGTH, content.bytes.len().to_string())
+        .header("docker-content-digest", &content.digest)
+        .body(Body::from(content.bytes.clone()))
+        .unwrap()
+}
+
+fn empty_response(status: StatusCode) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn pull_policy(
+    max_attempts: usize,
+    no_progress_timeout: Duration,
+    max_concurrent_downloads: usize,
+) -> RegistryPullPolicy {
+    RegistryPullPolicy::try_new(
+        max_attempts,
+        Duration::from_millis(1),
+        Duration::from_millis(2),
+        no_progress_timeout,
+        max_concurrent_downloads,
+    )
+    .unwrap()
+}
+
+fn puller(policy: RegistryPullPolicy) -> RegistryPuller {
+    RegistryPuller::with_auth_arch_and_protocol(
+        RegistryAuth::anonymous(),
+        "amd64".to_string(),
+        RegistryProtocol::Http,
+    )
+    .with_pull_policy(policy)
+}
+
+fn blob_path(root: &Path, digest: &str) -> PathBuf {
+    root.join("blobs/sha256")
+        .join(digest.strip_prefix("sha256:").unwrap())
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", sha2::Sha256::digest(bytes))
+}
+
+async fn seed_blob(store: &ImageStore, blob_digest: &str, bytes: &[u8]) -> PathBuf {
+    let source = tempfile::tempdir().unwrap();
+    let blobs = source.path().join("blobs/sha256");
+    std::fs::create_dir_all(&blobs).unwrap();
+    std::fs::write(
+        source.path().join("oci-layout"),
+        r#"{"imageLayoutVersion":"1.0.0"}"#,
+    )
+    .unwrap();
+    std::fs::write(source.path().join("index.json"), r#"{"manifests":[]}"#).unwrap();
+    std::fs::write(
+        blobs.join(blob_digest.strip_prefix("sha256:").unwrap()),
+        bytes,
+    )
+    .unwrap();
+    let stored = store
+        .put(
+            "seed.example/a3s/base:latest",
+            &digest(b"seed-image-layout"),
+            source.path(),
+        )
+        .await
+        .unwrap();
+    blob_path(&stored.path, blob_digest)
+}
+
+#[tokio::test]
+async fn interrupted_body_resumes_with_exact_range_and_reports_actual_bytes() {
+    let layer_bytes = (0..128 * 1024)
+        .map(|index| (index % 251) as u8)
+        .collect::<Vec<_>>();
+    let prefix_bytes = 8192;
+    let fixture = ResilientRegistryFixture::start(
+        vec![layer_bytes.clone()],
+        LayerFault::DropFirst { prefix_bytes },
+    )
+    .await;
+    let events = Arc::new(Mutex::new(Vec::<PullProgress>::new()));
+    let recorded_events = Arc::clone(&events);
+    let puller = puller(pull_policy(3, Duration::from_millis(100), 1))
+        .with_progress_event_fn(Arc::new(move |event| {
+            recorded_events.lock().unwrap().push(event);
+        }));
+    let target = tempfile::tempdir().unwrap();
+
+    puller
+        .pull_with_store(&fixture.reference, target.path(), None)
+        .await
+        .unwrap();
+
+    let layer = &fixture.layers[0];
+    assert_eq!(std::fs::read(blob_path(target.path(), &layer.digest)).unwrap(), layer_bytes);
+    assert!(!blob_path(target.path(), &layer.digest)
+        .with_extension("partial")
+        .exists());
+    let requests = fixture.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].range, None);
+    assert_eq!(requests[1].range.as_deref(), Some("bytes=8192-"));
+
+    let events = events.lock().unwrap();
+    let retry = events
+        .iter()
+        .find(|event| event.state == PullProgressState::Retrying)
+        .unwrap();
+    assert_eq!(retry.downloaded_bytes, prefix_bytes as u64);
+    assert_eq!(retry.attempt, 2);
+    assert_eq!(retry.retry_delay_ms, Some(1));
+    let complete = events
+        .iter()
+        .find(|event| event.state == PullProgressState::Complete)
+        .unwrap();
+    assert_eq!(complete.downloaded_bytes, layer_bytes.len() as u64);
+    assert_eq!(complete.total_bytes, layer_bytes.len() as u64);
+    assert_eq!(complete.attempt, 2);
+}
+
+#[tokio::test]
+async fn no_progress_timeout_stops_after_the_configured_attempt_bound() {
+    let fixture = ResilientRegistryFixture::start(
+        vec![b"stalled-layer".repeat(1024)],
+        LayerFault::Stall,
+    )
+    .await;
+    let target = tempfile::tempdir().unwrap();
+
+    let error = puller(pull_policy(3, Duration::from_millis(30), 1))
+        .pull_with_store(&fixture.reference, target.path(), None)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert_eq!(fixture.requests().len(), 3);
+    assert!(error.contains("after 3 attempt(s)"), "{error}");
+    assert!(error.contains("no byte progress"), "{error}");
+}
+
+#[tokio::test]
+async fn retryable_http_status_uses_exactly_the_configured_attempt_count() {
+    let fixture = ResilientRegistryFixture::start(
+        vec![b"temporarily-unavailable-layer".repeat(512)],
+        LayerFault::ServiceUnavailable,
+    )
+    .await;
+    let target = tempfile::tempdir().unwrap();
+
+    let error = puller(pull_policy(4, Duration::from_millis(100), 1))
+        .pull_with_store(&fixture.reference, target.path(), None)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert_eq!(fixture.requests().len(), 4);
+    assert!(error.contains("after 4 attempt(s)"), "{error}");
+    assert!(error.contains("HTTP 503"), "{error}");
+}
+
+#[tokio::test]
+async fn layer_downloads_reach_but_never_exceed_the_concurrency_bound() {
+    let layers = (0..5)
+        .map(|index| vec![b'a' + index as u8; 16 * 1024 + index])
+        .collect::<Vec<_>>();
+    let fixture = ResilientRegistryFixture::start(
+        layers,
+        LayerFault::Delay(Duration::from_millis(60)),
+    )
+    .await;
+    let target = tempfile::tempdir().unwrap();
+
+    puller(pull_policy(1, Duration::from_secs(1), 2))
+        .pull_with_store(&fixture.reference, target.path(), None)
+        .await
+        .unwrap();
+
+    assert_eq!(fixture.requests().len(), 5);
+    assert_eq!(fixture.max_active_layer_requests(), 2);
+    assert_eq!(fixture.active_layer_requests(), 0);
+    for layer in &fixture.layers {
+        assert_eq!(
+            std::fs::read(blob_path(target.path(), &layer.digest)).unwrap(),
+            layer.bytes
+        );
+    }
+}
+
+#[tokio::test]
+async fn verified_cross_image_layer_reuse_avoids_network_and_is_copy_safe() {
+    let layer_bytes = b"verified-shared-layer".repeat(1024);
+    let fixture = ResilientRegistryFixture::start(
+        vec![layer_bytes.clone()],
+        LayerFault::Normal,
+    )
+    .await;
+    let root = tempfile::tempdir().unwrap();
+    let store = ImageStore::new(&root.path().join("images"), u64::MAX).unwrap();
+    let source_blob = seed_blob(&store, &fixture.layers[0].digest, &layer_bytes).await;
+    let target = root.path().join("pull-target");
+
+    puller(pull_policy(1, Duration::from_secs(1), 1))
+        .pull_with_store(&fixture.reference, &target, Some(&store))
+        .await
+        .unwrap();
+
+    assert!(fixture.requests().is_empty());
+    let target_blob = blob_path(&target, &fixture.layers[0].digest);
+    assert_eq!(std::fs::read(&target_blob).unwrap(), layer_bytes);
+    std::fs::write(source_blob, vec![b'x'; layer_bytes.len()]).unwrap();
+    assert_eq!(std::fs::read(target_blob).unwrap(), layer_bytes);
+}
+
+#[tokio::test]
+async fn same_size_corrupt_cross_image_layer_is_rejected_and_downloaded() {
+    let layer_bytes = b"network-fallback-layer".repeat(1024);
+    let fixture = ResilientRegistryFixture::start(
+        vec![layer_bytes.clone()],
+        LayerFault::Normal,
+    )
+    .await;
+    let mut corrupt_bytes = layer_bytes.clone();
+    corrupt_bytes[0] ^= 0xff;
+    let root = tempfile::tempdir().unwrap();
+    let store = ImageStore::new(&root.path().join("images"), u64::MAX).unwrap();
+    seed_blob(&store, &fixture.layers[0].digest, &corrupt_bytes).await;
+    let target = root.path().join("pull-target");
+
+    puller(pull_policy(1, Duration::from_secs(1), 1))
+        .pull_with_store(&fixture.reference, &target, Some(&store))
+        .await
+        .unwrap();
+
+    assert_eq!(fixture.requests().len(), 1);
+    assert_eq!(
+        std::fs::read(blob_path(&target, &fixture.layers[0].digest)).unwrap(),
+        layer_bytes
+    );
+    assert!(std::fs::read_dir(target.join("blobs/sha256"))
+        .unwrap()
+        .all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".blob-reuse-")));
+}

--- a/src/runtime/src/oci/registry/resilient_pull_tests.rs
+++ b/src/runtime/src/oci/registry/resilient_pull_tests.rs
@@ -193,11 +193,7 @@ async fn registry_handler(
         return empty_response(StatusCode::NOT_FOUND);
     };
     if blob_digest == state.config.digest {
-        return complete_response(
-            StatusCode::OK,
-            "application/octet-stream",
-            &state.config,
-        );
+        return complete_response(StatusCode::OK, "application/octet-stream", &state.config);
     }
     let Some(layer) = state.layers.get(blob_digest) else {
         return empty_response(StatusCode::NOT_FOUND);
@@ -250,11 +246,7 @@ async fn registry_handler(
 
 fn ranged_response(layer: &BlobFixture, range: Option<&str>) -> Response<Body> {
     let Some(range) = range else {
-        return complete_response(
-            StatusCode::OK,
-            "application/octet-stream",
-            layer,
-        );
+        return complete_response(StatusCode::OK, "application/octet-stream", layer);
     };
     let Some(offset) = range
         .strip_prefix("bytes=")
@@ -386,10 +378,11 @@ async fn interrupted_body_resumes_with_exact_range_and_reports_actual_bytes() {
     .await;
     let events = Arc::new(Mutex::new(Vec::<PullProgress>::new()));
     let recorded_events = Arc::clone(&events);
-    let puller = puller(pull_policy(3, Duration::from_millis(100), 1))
-        .with_progress_event_fn(Arc::new(move |event| {
+    let puller = puller(pull_policy(3, Duration::from_millis(100), 1)).with_progress_event_fn(
+        Arc::new(move |event| {
             recorded_events.lock().unwrap().push(event);
-        }));
+        }),
+    );
     let target = tempfile::tempdir().unwrap();
 
     puller
@@ -398,7 +391,10 @@ async fn interrupted_body_resumes_with_exact_range_and_reports_actual_bytes() {
         .unwrap();
 
     let layer = &fixture.layers[0];
-    assert_eq!(std::fs::read(blob_path(target.path(), &layer.digest)).unwrap(), layer_bytes);
+    assert_eq!(
+        std::fs::read(blob_path(target.path(), &layer.digest)).unwrap(),
+        layer_bytes
+    );
     assert!(!blob_path(target.path(), &layer.digest)
         .with_extension("partial")
         .exists());
@@ -426,11 +422,9 @@ async fn interrupted_body_resumes_with_exact_range_and_reports_actual_bytes() {
 
 #[tokio::test]
 async fn no_progress_timeout_stops_after_the_configured_attempt_bound() {
-    let fixture = ResilientRegistryFixture::start(
-        vec![b"stalled-layer".repeat(1024)],
-        LayerFault::Stall,
-    )
-    .await;
+    let fixture =
+        ResilientRegistryFixture::start(vec![b"stalled-layer".repeat(1024)], LayerFault::Stall)
+            .await;
     let target = tempfile::tempdir().unwrap();
 
     let error = puller(pull_policy(3, Duration::from_millis(30), 1))
@@ -469,11 +463,8 @@ async fn layer_downloads_reach_but_never_exceed_the_concurrency_bound() {
     let layers = (0..5)
         .map(|index| vec![b'a' + index as u8; 16 * 1024 + index])
         .collect::<Vec<_>>();
-    let fixture = ResilientRegistryFixture::start(
-        layers,
-        LayerFault::Delay(Duration::from_millis(60)),
-    )
-    .await;
+    let fixture =
+        ResilientRegistryFixture::start(layers, LayerFault::Delay(Duration::from_millis(60))).await;
     let target = tempfile::tempdir().unwrap();
 
     puller(pull_policy(1, Duration::from_secs(1), 2))
@@ -495,11 +486,8 @@ async fn layer_downloads_reach_but_never_exceed_the_concurrency_bound() {
 #[tokio::test]
 async fn verified_cross_image_layer_reuse_avoids_network_and_is_copy_safe() {
     let layer_bytes = b"verified-shared-layer".repeat(1024);
-    let fixture = ResilientRegistryFixture::start(
-        vec![layer_bytes.clone()],
-        LayerFault::Normal,
-    )
-    .await;
+    let fixture =
+        ResilientRegistryFixture::start(vec![layer_bytes.clone()], LayerFault::Normal).await;
     let root = tempfile::tempdir().unwrap();
     let store = ImageStore::new(&root.path().join("images"), u64::MAX).unwrap();
     let source_blob = seed_blob(&store, &fixture.layers[0].digest, &layer_bytes).await;
@@ -520,11 +508,8 @@ async fn verified_cross_image_layer_reuse_avoids_network_and_is_copy_safe() {
 #[tokio::test]
 async fn same_size_corrupt_cross_image_layer_is_rejected_and_downloaded() {
     let layer_bytes = b"network-fallback-layer".repeat(1024);
-    let fixture = ResilientRegistryFixture::start(
-        vec![layer_bytes.clone()],
-        LayerFault::Normal,
-    )
-    .await;
+    let fixture =
+        ResilientRegistryFixture::start(vec![layer_bytes.clone()], LayerFault::Normal).await;
     let mut corrupt_bytes = layer_bytes.clone();
     corrupt_bytes[0] ^= 0xff;
     let root = tempfile::tempdir().unwrap();

--- a/src/runtime/src/oci/store.rs
+++ b/src/runtime/src/oci/store.rs
@@ -15,6 +15,8 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
+mod blob_reuse;
+
 /// Per-process counter for unique staging-dir names in `put`.
 static PUT_SEQ: AtomicU64 = AtomicU64::new(0);
 

--- a/src/runtime/src/oci/store/blob_reuse.rs
+++ b/src/runtime/src/oci/store/blob_reuse.rs
@@ -1,0 +1,350 @@
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use a3s_box_core::error::{BoxError, Result};
+use sha2::{Digest, Sha256};
+
+use super::ImageStore;
+
+static REUSE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+impl ImageStore {
+    /// Reuse a content-addressed blob from any indexed image layout.
+    ///
+    /// Candidates are selected only by canonical digest path, cloned or copied
+    /// into a private staging file, and then revalidated by declared size and
+    /// SHA-256 before an atomic no-clobber publication.
+    pub(crate) async fn reuse_verified_blob(
+        &self,
+        digest: &str,
+        declared_size: i64,
+        dest: &Path,
+    ) -> Result<bool> {
+        let expected_hex = validate_digest(digest)?;
+        let expected_size = u64::try_from(declared_size).map_err(|_| {
+            BoxError::OciImageError(format!(
+                "Cannot reuse blob {digest} with negative declared size {declared_size}"
+            ))
+        })?;
+        let candidates = {
+            let index = self.index.read().await;
+            index
+                .values()
+                .map(|image| {
+                    image
+                        .path
+                        .join("blobs")
+                        .join("sha256")
+                        .join(&expected_hex)
+                })
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>()
+        };
+        if candidates.is_empty() {
+            return Ok(false);
+        }
+
+        let dest = dest.to_path_buf();
+        let digest = digest.to_string();
+        tokio::task::spawn_blocking(move || {
+            reuse_from_candidates(&candidates, &dest, &digest, expected_size)
+        })
+        .await
+        .map_err(|error| {
+            BoxError::OciImageError(format!("Verified blob reuse worker failed: {error}"))
+        })?
+    }
+}
+
+fn reuse_from_candidates(
+    candidates: &[PathBuf],
+    dest: &Path,
+    digest: &str,
+    expected_size: u64,
+) -> Result<bool> {
+    if dest.exists() {
+        return verify_path(dest, digest, expected_size).map_err(|error| {
+            BoxError::OciImageError(format!(
+                "Failed to verify existing destination blob {}: {error}",
+                dest.display()
+            ))
+        });
+    }
+    let parent = dest.parent().ok_or_else(|| {
+        BoxError::OciImageError(format!("Blob destination has no parent: {}", dest.display()))
+    })?;
+    std::fs::create_dir_all(parent).map_err(|error| {
+        BoxError::OciImageError(format!(
+            "Failed to create blob destination directory {}: {error}",
+            parent.display()
+        ))
+    })?;
+
+    for candidate in candidates {
+        let metadata = match std::fs::symlink_metadata(candidate) {
+            Ok(metadata)
+                if metadata.file_type().is_file()
+                    && !metadata.file_type().is_symlink()
+                    && metadata.len() == expected_size =>
+            {
+                metadata
+            }
+            _ => continue,
+        };
+        if !metadata.file_type().is_file() {
+            continue;
+        }
+
+        let seq = REUSE_SEQ.fetch_add(1, Ordering::Relaxed);
+        let staging = parent.join(format!(
+            ".blob-reuse-{}-{}-{seq}",
+            std::process::id(),
+            digest.strip_prefix("sha256:").unwrap_or("invalid")
+        ));
+        match clone_or_copy_verified(candidate, &staging, digest, expected_size) {
+            Ok(method) => {
+                let published = match std::fs::hard_link(&staging, dest) {
+                    Ok(()) => true,
+                    Err(error) if dest.exists() => match verify_path(dest, digest, expected_size) {
+                        Ok(valid) => valid,
+                        Err(verify_error) => {
+                            let _ = std::fs::remove_file(&staging);
+                            return Err(BoxError::OciImageError(format!(
+                                "Concurrent blob publication failed verification after {error}: {verify_error}"
+                            )));
+                        }
+                    },
+                    Err(error) => {
+                        let _ = std::fs::remove_file(&staging);
+                        return Err(BoxError::OciImageError(format!(
+                            "Failed to publish reused blob {}: {error}",
+                            dest.display()
+                        )));
+                    }
+                };
+                let _ = std::fs::remove_file(&staging);
+                if published {
+                    tracing::debug!(
+                        source = %candidate.display(),
+                        destination = %dest.display(),
+                        ?method,
+                        "Published verified shared blob"
+                    );
+                    return Ok(true);
+                }
+            }
+            Err(error) => {
+                let _ = std::fs::remove_file(&staging);
+                tracing::warn!(
+                    source = %candidate.display(),
+                    %digest,
+                    %error,
+                    "Ignoring invalid shared blob candidate"
+                );
+            }
+        }
+    }
+    Ok(false)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ReuseMethod {
+    Reflink,
+    Copy,
+}
+
+fn clone_or_copy_verified(
+    source_path: &Path,
+    staging: &Path,
+    digest: &str,
+    expected_size: u64,
+) -> std::io::Result<ReuseMethod> {
+    let mut source = open_source(source_path)?;
+    let source_metadata = source.metadata()?;
+    if !source_metadata.file_type().is_file() || source_metadata.len() != expected_size {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "shared blob candidate changed before reuse",
+        ));
+    }
+    let mut destination = OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(staging)?;
+
+    let method = if try_reflink(&source, &destination)? {
+        ReuseMethod::Reflink
+    } else {
+        source.seek(std::io::SeekFrom::Start(0))?;
+        destination.set_len(0)?;
+        destination.seek(std::io::SeekFrom::Start(0))?;
+        std::io::copy(&mut source, &mut destination)?;
+        ReuseMethod::Copy
+    };
+    destination.flush()?;
+    destination.sync_all()?;
+    if !verify_file(&mut destination, digest, expected_size)? {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "shared blob candidate failed digest or size verification",
+        ));
+    }
+    Ok(method)
+}
+
+fn open_source(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    }
+    options.open(path)
+}
+
+#[cfg(target_os = "linux")]
+fn try_reflink(source: &File, destination: &File) -> std::io::Result<bool> {
+    use std::os::fd::AsRawFd;
+
+    let result = unsafe {
+        libc::ioctl(
+            destination.as_raw_fd(),
+            libc::FICLONE as _,
+            source.as_raw_fd(),
+        )
+    };
+    if result == 0 {
+        Ok(true)
+    } else {
+        let error = std::io::Error::last_os_error();
+        match error.raw_os_error() {
+            Some(code)
+                if matches!(
+                    code,
+                    libc::EOPNOTSUPP | libc::ENOTTY | libc::EXDEV | libc::EINVAL
+                ) =>
+            {
+                Ok(false)
+            }
+            _ => Err(error),
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn try_reflink(_source: &File, _destination: &File) -> std::io::Result<bool> {
+    Ok(false)
+}
+
+fn verify_path(path: &Path, digest: &str, expected_size: u64) -> std::io::Result<bool> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink()
+        || !metadata.file_type().is_file()
+        || metadata.len() != expected_size
+    {
+        return Ok(false);
+    }
+    let mut file = open_source(path)?;
+    verify_file(&mut file, digest, expected_size)
+}
+
+fn verify_file(file: &mut File, digest: &str, expected_size: u64) -> std::io::Result<bool> {
+    if file.metadata()?.len() != expected_size {
+        return Ok(false);
+    }
+    file.seek(std::io::SeekFrom::Start(0))?;
+    let mut hasher = Sha256::new();
+    let mut actual_size = 0_u64;
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        actual_size = actual_size.saturating_add(read as u64);
+    }
+    let actual = format!("sha256:{:x}", hasher.finalize());
+    Ok(actual_size == expected_size && actual == digest)
+}
+
+fn validate_digest(digest: &str) -> Result<String> {
+    digest
+        .strip_prefix("sha256:")
+        .filter(|hex| {
+            hex.len() == 64
+                && hex
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        })
+        .map(str::to_string)
+        .ok_or_else(|| {
+            BoxError::OciImageError(format!(
+                "Cannot reuse malformed blob digest {digest:?}; expected sha256:<64 lowercase hex>"
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(bytes: &[u8]) -> String {
+        format!("sha256:{:x}", Sha256::digest(bytes))
+    }
+
+    async fn seeded_store(bytes: &[u8]) -> (tempfile::TempDir, ImageStore, String) {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let blob_digest = digest(bytes);
+        let blob_hex = blob_digest.strip_prefix("sha256:").unwrap();
+        std::fs::create_dir_all(source.join("blobs/sha256")).unwrap();
+        std::fs::write(source.join("oci-layout"), r#"{"imageLayoutVersion":"1.0.0"}"#)
+            .unwrap();
+        std::fs::write(source.join("index.json"), r#"{"manifests":[]}"#).unwrap();
+        std::fs::write(source.join("blobs/sha256").join(blob_hex), bytes).unwrap();
+        let store = ImageStore::new(&root.path().join("images"), u64::MAX).unwrap();
+        store
+            .put(
+                "seed:latest",
+                &format!("sha256:{}", "a".repeat(64)),
+                &source,
+            )
+            .await
+            .unwrap();
+        (root, store, blob_digest)
+    }
+
+    #[tokio::test]
+    async fn reuses_only_size_and_digest_verified_content() {
+        let (root, store, blob_digest) = seeded_store(b"shared-layer").await;
+        let dest = root.path().join("target/blobs/sha256/blob");
+
+        assert!(store
+            .reuse_verified_blob(&blob_digest, 12, &dest)
+            .await
+            .unwrap());
+        assert_eq!(std::fs::read(dest).unwrap(), b"shared-layer");
+    }
+
+    #[tokio::test]
+    async fn corrupt_shared_candidate_is_not_reused() {
+        let (root, store, blob_digest) = seeded_store(b"shared-layer").await;
+        let blob_hex = blob_digest.strip_prefix("sha256:").unwrap();
+        let stored = store.get("seed:latest").await.unwrap();
+        std::fs::write(stored.path.join("blobs/sha256").join(blob_hex), b"corrupt-data").unwrap();
+        let dest = root.path().join("target/blobs/sha256/blob");
+
+        assert!(!store
+            .reuse_verified_blob(&blob_digest, 12, &dest)
+            .await
+            .unwrap());
+        assert!(!dest.exists());
+    }
+}

--- a/src/runtime/src/oci/store/blob_reuse.rs
+++ b/src/runtime/src/oci/store/blob_reuse.rs
@@ -221,14 +221,7 @@ fn try_reflink(source: &File, destination: &File) -> std::io::Result<bool> {
     } else {
         let error = std::io::Error::last_os_error();
         match error.raw_os_error() {
-            Some(code)
-                if matches!(
-                    code,
-                    libc::EOPNOTSUPP | libc::ENOTTY | libc::EXDEV | libc::EINVAL
-                ) =>
-            {
-                Ok(false)
-            }
+            Some(libc::EOPNOTSUPP | libc::ENOTTY | libc::EXDEV | libc::EINVAL) => Ok(false),
             _ => Err(error),
         }
     }

--- a/src/runtime/src/oci/store/blob_reuse.rs
+++ b/src/runtime/src/oci/store/blob_reuse.rs
@@ -33,13 +33,7 @@ impl ImageStore {
             let index = self.index.read().await;
             index
                 .values()
-                .map(|image| {
-                    image
-                        .path
-                        .join("blobs")
-                        .join("sha256")
-                        .join(&expected_hex)
-                })
+                .map(|image| image.path.join("blobs").join("sha256").join(&expected_hex))
                 .collect::<HashSet<_>>()
                 .into_iter()
                 .collect::<Vec<_>>()
@@ -75,7 +69,10 @@ fn reuse_from_candidates(
         });
     }
     let parent = dest.parent().ok_or_else(|| {
-        BoxError::OciImageError(format!("Blob destination has no parent: {}", dest.display()))
+        BoxError::OciImageError(format!(
+            "Blob destination has no parent: {}",
+            dest.display()
+        ))
     })?;
     std::fs::create_dir_all(parent).map_err(|error| {
         BoxError::OciImageError(format!(
@@ -305,8 +302,11 @@ mod tests {
         let blob_digest = digest(bytes);
         let blob_hex = blob_digest.strip_prefix("sha256:").unwrap();
         std::fs::create_dir_all(source.join("blobs/sha256")).unwrap();
-        std::fs::write(source.join("oci-layout"), r#"{"imageLayoutVersion":"1.0.0"}"#)
-            .unwrap();
+        std::fs::write(
+            source.join("oci-layout"),
+            r#"{"imageLayoutVersion":"1.0.0"}"#,
+        )
+        .unwrap();
         std::fs::write(source.join("index.json"), r#"{"manifests":[]}"#).unwrap();
         std::fs::write(source.join("blobs/sha256").join(blob_hex), bytes).unwrap();
         let store = ImageStore::new(&root.path().join("images"), u64::MAX).unwrap();
@@ -338,7 +338,11 @@ mod tests {
         let (root, store, blob_digest) = seeded_store(b"shared-layer").await;
         let blob_hex = blob_digest.strip_prefix("sha256:").unwrap();
         let stored = store.get("seed:latest").await.unwrap();
-        std::fs::write(stored.path.join("blobs/sha256").join(blob_hex), b"corrupt-data").unwrap();
+        std::fs::write(
+            stored.path.join("blobs/sha256").join(blob_hex),
+            b"corrupt-data",
+        )
+        .unwrap();
         let dest = root.path().join("target/blobs/sha256/blob");
 
         assert!(!store


### PR DESCRIPTION
## Summary

- add validated bounded retry/backoff and configurable no-progress deadlines for registry config and layer transfers
- resume interrupted bodies with exact HTTP Range requests, safely restart when a registry ignores Range, and cap concurrent layer downloads
- report actual downloaded bytes, retry attempts, delays, reuse, and completion through structured progress events and the pull CLI
- reuse size-and-digest-verified blobs across indexed image layouts through private reflink/copy staging and atomic no-clobber publication
- retain mandatory declared-size and SHA-256 verification, rejecting corrupt partials and same-size corrupt reuse candidates
- document policy defaults, environment overrides, and production validation

## A3S OS validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p a3s-box-runtime -p a3s-box-cli --all-targets -- -D warnings`
- resilient registry fault injection: **7 passed**
- CLI unit tests: **742 passed**
- runtime unit tests: **1341 passed, 1 ignored**
- live GHCR cold-pull evidence: four simultaneous layers plus a no-progress retry retaining an exact 796,370-byte partial offset

Closes #105
