### PR TITLE
feat(compose): add canonical ACL project workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Pure deterministic Compose normalization.** Canonical ACL and bounded YAML
+  inputs now produce one typed, byte-stable model covered by shared golden
+  fixtures. A closed schema reports unsupported fields and values through
+  stable codes and JSON Pointer-style paths. Stateless
+  `ComposeRuntimePlan` translation is separate from CLI lifecycle state and
+  Cloud desired state, and declared service network aliases now reach Runtime
+  DNS endpoint registration.
+
 ### Fixed
 
 - **Resilient and observable registry blob pulls.** Configuration and layer

--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ a3s-box compose -f compose.yaml logs -f
 a3s-box compose -f compose.yaml down
 ```
 
+`compose.acl` is the canonical project format; explicit Compose YAML remains a
+bounded compatibility input. Both formats pass through the same pure,
+deterministic normalizer. Unknown fields fail with stable diagnostic codes and
+JSON Pointer-style paths instead of being silently ignored. Embedding and
+Runtime-boundary details are documented in
+[Compose Normalization](docs/compose-normalization.md).
+
 Compose is a MicroVM-oriented subset today. Although the parser accepts
 `--isolation sandbox`, the current Compose plan creates a default named bridge,
 so the fail-closed Sandbox resolver rejects it before launch.

--- a/docs/compose-normalization.md
+++ b/docs/compose-normalization.md
@@ -1,0 +1,82 @@
+# Compose Normalization
+
+Box exposes Compose interpretation as a pure component in
+`a3s_box_core::compose`. It accepts an in-memory ACL or YAML source plus an
+explicit environment map and returns a typed `NormalizedComposeConfig`.
+
+```rust
+use std::collections::HashMap;
+
+use a3s_box_core::compose::{
+    normalize_compose, ComposeSourceFormat,
+};
+
+let source = r#"
+service "api" {
+  image = env("API_IMAGE")
+  ports = ["8080:80/tcp"]
+}
+"#;
+let environment = HashMap::from([(
+    "API_IMAGE".to_string(),
+    "ghcr.io/a3s/api:latest".to_string(),
+)]);
+
+let project = normalize_compose(
+    source,
+    ComposeSourceFormat::Acl,
+    &environment,
+)?;
+assert_eq!(project.service_order()?, ["api"]);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The normalizer does not read files, inspect process environment, create Box
+resources, or mutate lifecycle state. Callers load source files and `.env`
+content before invoking it. Relative `env_file` content remains a Runtime
+translation concern because it depends on the caller-provided project base
+directory.
+
+## Deterministic Output
+
+The normalized model has one representation for ACL and YAML alternatives:
+
+- semantic maps use `BTreeMap`;
+- the informational YAML `version` field is discarded;
+- dependency and network map traversal is sorted;
+- environment and label maps have stable key order;
+- TCP port suffixes normalize to the Runtime form;
+- default volume and network drivers become explicit;
+- network aliases are validated, sorted, and deduplicated.
+
+`NormalizedComposeConfig::to_canonical_json` emits stable pretty JSON with a
+final newline. ACL and YAML golden fixtures in
+`src/core/tests/fixtures/compose/` must continue to produce identical bytes.
+
+## Structured Diagnostics
+
+Box uses a closed Compose schema. Unsupported YAML fields are collected instead
+of being ignored, and ACL schema failures use the same diagnostic type.
+
+```json
+{
+  "code": "compose.unsupported_field",
+  "path": "/services/api/build",
+  "message": "unsupported Compose field \"build\""
+}
+```
+
+Every diagnostic has a stable code, a JSON Pointer-style path, and a message.
+Parser diagnostics also include one-based line and column values when
+available. Unsupported drivers and dependency conditions use
+`compose.unsupported_value`; malformed recognized values use
+`compose.invalid_value`.
+
+## Runtime Boundary
+
+`a3s_box_runtime::ComposeRuntimePlan` translates normalized configuration into
+Box Runtime inputs. It contains no running-unit registry, persisted Box
+lifecycle state, or Cloud desired state. The CLI owns local convergence and
+cleanup; Cloud can reuse normalized interpretation without importing those
+orchestration internals. Compose input is never Cloud's persisted desired-state
+model.

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -286,9 +286,10 @@ before a release window when the monorepo depends on thousands of packages.
 
 ## Host command matrix
 
-The host matrix extends the core smoke with VM lifecycle commands, Compose,
-copy, stats, snapshots, network operations, image tagging/saving, local build,
-and optional registry push coverage.
+The host matrix extends the core smoke with VM lifecycle commands, canonical
+`compose.acl` discovery and teardown, copy, stats, snapshots, network
+operations, image tagging/saving, local build, and optional registry push
+coverage.
 
 ```bash
 cd crates/box

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -199,6 +199,12 @@ Current notes:
   stop/start/restart, pause/unpause, kill/wait/remove, `down -v`, and final
   Box/socket cleanup. Linux KVM and the complete host matrix remain release
   gates.
+- Core Compose interpretation is now a side-effect-free typed normalizer with
+  explicit environment input, deterministic `BTreeMap` output, shared ACL/YAML
+  golden fixtures, and structured diagnostics for unknown fields and
+  unsupported values. Runtime consumes the result through the stateless
+  `ComposeRuntimePlan`; Box lifecycle records and Cloud desired state remain
+  outside that translation boundary.
 - Boot failure cleanup now stops any shim that was spawned before readiness,
   stops bridge-network backends, unmounts rootfs providers before removing box
   directories, and removes only the anonymous OCI volumes created by that boot

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -182,6 +182,23 @@ Current notes:
 - Compose labels are persisted alongside A3S project/service labels, and image
   healthcheck/stop-signal defaults are applied to Compose services when the
   service does not override or disable them.
+- Compose applications now use `compose.acl` as the canonical discovered
+  project file, parsed through `a3s-acl` with a closed schema, direct
+  `${...}` interpolation, and `env("NAME")` lookup. Explicit Compose YAML
+  remains an intentionally bounded compatibility input. `compose up` now
+  converges services by an effective-config digest and service selections
+  include only their dependency closure. Project-scoped start/stop/restart,
+  remove, signal, pause, wait, exec, top, port, copy, image, pull, project, and
+  volume operations are now exposed; lifecycle, process, copy, and pull
+  operations delegate to the corresponding single-box paths while project
+  views stay read-only. Pure regression coverage protects Unicode ACL parsing,
+  strict service scoping, exact network cleanup, deduplicated volume cleanup,
+  and partial-start directory teardown. On 2026-07-18, the canonical ACL smoke
+  passed on macOS arm64/HVF with `docker.io/library/alpine:latest`, covering
+  unchanged convergence, pull/project views, exec/top/port/copy,
+  stop/start/restart, pause/unpause, kill/wait/remove, `down -v`, and final
+  Box/socket cleanup. Linux KVM and the complete host matrix remain release
+  gates.
 - Boot failure cleanup now stops any shim that was spawned before readiness,
   stops bridge-network backends, unmounts rootfs providers before removing box
   directories, and removes only the anonymous OCI volumes created by that boot

--- a/scripts/host-integration-smoke.sh
+++ b/scripts/host-integration-smoke.sh
@@ -255,6 +255,15 @@ host_arch() {
 
 stub_dir=""
 
+cleanup_stub_libkrun() {
+    if [ -n "$stub_dir" ] && [ -d "$stub_dir" ]; then
+        rm -rf -- "$stub_dir"
+    fi
+    stub_dir=""
+}
+
+trap 'cleanup_stub_libkrun' EXIT
+
 ensure_stub_libkrun() {
     if [ -n "$stub_dir" ]; then
         return
@@ -456,7 +465,7 @@ run_host_suite() {
     log "Running warm-pool Dockerfile RUN smoke"
     run_real cargo test -p a3s-box-cli --test host_smoke test_real_build_run_pool_smoke -- --ignored --nocapture --test-threads=1
     log "Running host Compose smoke"
-    run_real cargo test -p a3s-box-cli --test host_smoke test_real_compose_smoke -- --ignored --nocapture --test-threads=1
+    run_real cargo test -p a3s-box-cli --test host_smoke test_real_compose_acl_smoke -- --ignored --nocapture --test-threads=1
 
     if [ -n "${A3S_BOX_PUSH_TEST_REF:-}" ]; then
         log "Running registry push smoke"
@@ -738,6 +747,7 @@ run_soak_verifier() {
 
 handle_soak_exit() {
     local rc="$1"
+    cleanup_stub_libkrun
     if [ "$rc" -eq 0 ] || [ "$SOAK_FAILURE_TRAP_ARMED" -eq 0 ]; then
         return
     fi

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -4,8 +4,8 @@ version = 4
 
 [[package]]
 name = "a3s-acl"
-version = "0.2.1"
-source = "git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22#6e2a6469edc0f4c61b1e588d0ace873aaf15ce22"
+version = "0.2.2"
+source = "git+https://github.com/A3S-Lab/ACL.git?rev=fc041758758eba89dd5d22a3414d884c158c9ac1#fc041758758eba89dd5d22a3414d884c158c9ac1"
 
 [[package]]
 name = "a3s-box-cli"
@@ -83,6 +83,7 @@ dependencies = [
 name = "a3s-box-core"
 version = "3.0.10"
 dependencies = [
+ "a3s-acl",
  "a3s-common",
  "async-trait",
  "base64 0.22.1",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,6 +125,7 @@ base64 = "0.22"
 ring = "0.17"
 
 # Shared types (transport protocol, privacy, tools)
+a3s-acl = { git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 
 # Metrics

--- a/src/cli/src/commands/compose.rs
+++ b/src/cli/src/commands/compose.rs
@@ -1,6 +1,15 @@
 //! `a3s-box compose` command — Multi-container orchestration.
 //!
-//! Subcommands: `up`, `down`, `ps`, `config`.
+//! Project discovery, service selection, and lifecycle operations are kept in
+//! this command while individual box behavior is delegated to the existing
+//! single-box commands.
+
+mod args;
+mod lifecycle;
+mod operations;
+mod read;
+#[cfg(test)]
+mod tests;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -8,94 +17,52 @@ use std::path::PathBuf;
 use a3s_box_core::compose::{ComposeConfig, ServiceConfig};
 use a3s_box_core::event::EventEmitter;
 use a3s_box_runtime::{ComposeProject, NetworkStore, VmManager};
-use clap::{Args, Subcommand};
+use sha2::{Digest, Sha256};
 
 use super::common;
 use crate::state::{BoxRecord, HealthCheck, StateFile};
 use crate::status;
 
+pub use args::{ComposeArgs, ComposeCommand, ComposeDownArgs, ComposeLogsArgs, ComposeUpArgs};
+use lifecycle::{
+    cleanup_partial_service_box, cleanup_service_box, execute_down, rollback_compose_up,
+    rollback_with_current, stop_service_process, ServiceBox,
+};
+use operations::{ComposeStopArgs, ProjectServicesArgs};
+use read::{execute_config, execute_logs, execute_ps};
+
 /// Label key for compose project name.
 const LABEL_PROJECT: &str = "com.a3s.compose.project";
 /// Label key for compose service name.
 const LABEL_SERVICE: &str = "com.a3s.compose.service";
+/// Label key for the normalized service configuration digest.
+const LABEL_CONFIG_HASH: &str = "com.a3s.compose.config-hash";
+type ExistingService = (ServiceBox, Option<String>);
 
 /// Default compose file names to search for.
 const COMPOSE_FILES: &[&str] = &[
+    "compose.acl",
     "compose.yaml",
     "compose.yml",
     "docker-compose.yaml",
     "docker-compose.yml",
 ];
 
-#[derive(Args)]
-pub struct ComposeArgs {
-    /// Path to compose file (default: compose.yaml or docker-compose.yml)
-    #[arg(short = 'f', long = "file")]
-    pub file: Option<PathBuf>,
-
-    /// Project name (default: directory name)
-    #[arg(short = 'p', long = "project-name")]
-    pub project_name: Option<String>,
-
-    #[command(subcommand)]
-    pub command: ComposeCommand,
-}
-
-#[derive(Subcommand)]
-pub enum ComposeCommand {
-    /// Create and start all services
-    Up(ComposeUpArgs),
-    /// Stop and remove all services
-    Down(ComposeDownArgs),
-    /// List services and their status
-    Ps,
-    /// Validate and display the compose configuration
-    Config,
-    /// View logs from all services
-    Logs(ComposeLogsArgs),
-}
-
-#[derive(Args)]
-pub struct ComposeUpArgs {
-    /// Run in detached mode (background)
-    #[arg(short = 'd', long)]
-    pub detach: bool,
-
-    /// Timeout in seconds to wait for healthy dependencies (default: 120)
-    #[arg(long, default_value = "120")]
-    pub timeout: u64,
-
-    /// Use the shared-kernel sandbox backend (omit for MicroVM isolation)
-    #[arg(long, value_enum)]
-    pub isolation: Option<common::IsolationArg>,
-}
-
-#[derive(Args)]
-pub struct ComposeDownArgs {
-    /// Remove named volumes declared in the compose file
-    #[arg(short = 'v', long)]
-    pub volumes: bool,
-}
-
-#[derive(Args)]
-pub struct ComposeLogsArgs {
-    /// Follow log output
-    #[arg(short = 'f', long)]
-    pub follow: bool,
-
-    /// Number of lines to show from the end of the logs
-    #[arg(long, default_value = "100")]
-    pub tail: usize,
-
-    /// Show logs for a specific service only
-    pub service: Option<String>,
-}
-
 pub async fn execute(args: ComposeArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let (compose_path, config) = load_compose_file(args.file.as_deref())?;
+    let ComposeArgs {
+        file,
+        project_name,
+        command,
+    } = args;
+
+    if let ComposeCommand::Ls(ls_args) = command {
+        return operations::execute_ls(ls_args).await;
+    }
+
+    let (compose_path, config) = load_compose_file(file.as_deref())?;
 
     // Derive project name from flag or directory name
-    let project_name = args.project_name.unwrap_or_else(|| {
+    let project_name = project_name.unwrap_or_else(|| {
         compose_path
             .parent()
             .and_then(|p| p.file_name())
@@ -104,14 +71,60 @@ pub async fn execute(args: ComposeArgs) -> Result<(), Box<dyn std::error::Error>
             .to_string()
     });
 
-    match args.command {
+    match command {
         ComposeCommand::Up(up_args) => {
             execute_up(&project_name, config, compose_path, up_args).await
         }
-        ComposeCommand::Down(down_args) => execute_down(&project_name, down_args).await,
-        ComposeCommand::Ps => execute_ps(&project_name).await,
+        ComposeCommand::Down(down_args) => execute_down(&project_name, &config, down_args).await,
+        ComposeCommand::Ps(command_args) => execute_ps(&project_name, &config, command_args).await,
         ComposeCommand::Config => execute_config(&project_name, config),
-        ComposeCommand::Logs(logs_args) => execute_logs(&project_name, logs_args).await,
+        ComposeCommand::Logs(logs_args) => execute_logs(&project_name, &config, logs_args).await,
+        ComposeCommand::Start(command_args) => {
+            operations::execute_start(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Stop(command_args) => {
+            operations::execute_stop(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Restart(command_args) => {
+            operations::execute_restart(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Rm(command_args) => {
+            operations::execute_rm(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Kill(command_args) => {
+            operations::execute_kill(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Pause(command_args) => {
+            operations::execute_pause(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Unpause(command_args) => {
+            operations::execute_unpause(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Wait(command_args) => {
+            operations::execute_wait(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Exec(command_args) => {
+            operations::execute_exec(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Top(command_args) => {
+            operations::execute_top(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Port(command_args) => {
+            operations::execute_port(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Cp(command_args) => {
+            operations::execute_cp(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Images(command_args) => {
+            operations::execute_images(&project_name, &config, command_args)
+        }
+        ComposeCommand::Pull(command_args) => {
+            operations::execute_pull(&project_name, &config, command_args).await
+        }
+        ComposeCommand::Volumes => operations::execute_volumes(&project_name, &config),
+        ComposeCommand::Ls(_) => {
+            Err("Compose ls was not dispatched before project file loading".into())
+        }
     }
 }
 
@@ -126,27 +139,10 @@ fn load_compose_file_with_environment(
     explicit_path: Option<&std::path::Path>,
     shell_environment: impl IntoIterator<Item = (String, String)>,
 ) -> Result<(PathBuf, ComposeConfig), Box<dyn std::error::Error>> {
-    let path = if let Some(p) = explicit_path {
-        if !p.exists() {
-            return Err(format!("Compose file not found: {}", p.display()).into());
-        }
-        p.to_path_buf()
-    } else {
-        // Search for default compose files in current directory
-        let cwd = std::env::current_dir()?;
-        COMPOSE_FILES
-            .iter()
-            .map(|name| cwd.join(name))
-            .find(|p| p.exists())
-            .ok_or_else(|| {
-                format!(
-                    "No compose file found. Looked for: {}",
-                    COMPOSE_FILES.join(", ")
-                )
-            })?
-    };
+    let cwd = std::env::current_dir()?;
+    let path = resolve_compose_path(explicit_path, &cwd)?;
 
-    let yaml = std::fs::read_to_string(&path)
+    let source = std::fs::read_to_string(&path)
         .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
     let mut environment = HashMap::new();
@@ -172,12 +168,46 @@ fn load_compose_file_with_environment(
     }
     environment.extend(shell_environment);
 
-    let yaml = a3s_box_core::compose::interpolate_compose_yaml(&yaml, &environment)
-        .map_err(|e| format!("Failed to interpolate {}: {}", path.display(), e))?;
-    let config = ComposeConfig::from_yaml_str(&yaml)
-        .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+    let config = if path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("acl"))
+    {
+        ComposeConfig::from_acl_str_with_environment(&source, &environment)
+            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?
+    } else {
+        let source = a3s_box_core::compose::interpolate_compose_yaml(&source, &environment)
+            .map_err(|e| format!("Failed to interpolate {}: {}", path.display(), e))?;
+        ComposeConfig::from_yaml_str(&source)
+            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?
+    };
 
     Ok((path, config))
+}
+
+fn resolve_compose_path(
+    explicit_path: Option<&std::path::Path>,
+    search_directory: &std::path::Path,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if let Some(p) = explicit_path {
+        if !p.exists() {
+            return Err(format!("Compose file not found: {}", p.display()).into());
+        }
+        Ok(p.to_path_buf())
+    } else {
+        match COMPOSE_FILES
+            .iter()
+            .map(|name| search_directory.join(name))
+            .find(|p| p.exists())
+        {
+            Some(path) => Ok(path),
+            None => Err(format!(
+                "No compose file found. Looked for: {}",
+                COMPOSE_FILES.join(", ")
+            )
+            .into()),
+        }
+    }
 }
 
 fn validate_compose_restart_policies(config: &ComposeConfig) -> Result<(), String> {
@@ -214,6 +244,7 @@ async fn execute_up(
     up_args: ComposeUpArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let isolation = common::resolve_isolation(up_args.isolation);
+    let config = operations::select_up_config(config, &up_args.services)?;
     let base_dir = compose_path
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."));
@@ -229,29 +260,6 @@ async fn execute_up(
         }
     }
     let mut state = StateFile::load_default()?;
-
-    // Check for already-active services
-    let existing = state.find_by_label(LABEL_PROJECT, project_name);
-    let active: Vec<_> = existing
-        .iter()
-        .filter(|record| status::is_active(record))
-        .collect();
-    if !active.is_empty() {
-        let names: Vec<_> = active
-            .iter()
-            .filter_map(|r| r.labels.get(LABEL_SERVICE))
-            .collect();
-        return Err(format!(
-            "Project '{}' already has active services: {}. Run `compose down` first.",
-            project_name,
-            names
-                .iter()
-                .map(|s| s.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
-        .into());
-    }
 
     // Step 1: Create networks
     let networks = project.required_networks();
@@ -329,6 +337,29 @@ async fn execute_up(
     );
 
     for svc_name in &project.service_order {
+        let service = project.config.services.get(svc_name).ok_or_else(|| {
+            format!("Service '{svc_name}' disappeared from the resolved Compose project")
+        })?;
+        let mut desired_box_config = project.build_box_config(svc_name, Some(&default_net))?;
+        desired_box_config.isolation = isolation;
+        let config_hash = service_config_hash(service, &desired_box_config)?;
+        if let Some((existing, existing_hash)) = find_existing_service(project_name, svc_name)? {
+            if existing.is_active() && existing_hash.as_deref() == Some(config_hash.as_str()) {
+                println!("  [=] {} is unchanged and already running", svc_name);
+                continue;
+            }
+
+            if existing.is_active() {
+                println!("  [~] Recreating changed service {}...", svc_name);
+                stop_service_process(&existing).await;
+            } else {
+                println!("  [~] Recreating existing service {}...", svc_name);
+            }
+            StateFile::remove_record(&existing.box_id)?;
+            state.forget(&existing.box_id);
+            cleanup_service_box(&existing);
+        }
+
         // Wait for healthy dependencies before booting this service
         let health_deps = project.health_wait_deps(svc_name);
         if !health_deps.is_empty() {
@@ -370,19 +401,7 @@ async fn execute_up(
             println!(" ✓");
         }
 
-        let mut box_config = match project.build_box_config(svc_name, Some(&default_net)) {
-            Ok(config) => config,
-            Err(error) => {
-                return rollback_compose_up(
-                    &mut state,
-                    &started_services,
-                    &created_networks,
-                    error,
-                )
-                .await;
-            }
-        };
-        box_config.isolation = isolation;
+        let mut box_config = desired_box_config;
         let (resolved_volumes, volume_names) = match resolve_service_volumes(&box_config.volumes) {
             Ok(volumes) => volumes,
             Err(error) => {
@@ -413,13 +432,30 @@ async fn execute_up(
         let mut vm = VmManager::new(box_config, emitter);
         let box_id = vm.box_id().to_string();
         let box_dir = home.join("boxes").join(&box_id);
+        let initial_exec_socket_path = box_dir.join("sockets").join("exec.sock");
 
         // Create box directory structure
         if let Err(error) = std::fs::create_dir_all(box_dir.join("sockets")) {
+            cleanup_partial_service_box(
+                &box_id,
+                &box_dir,
+                &initial_exec_socket_path,
+                network_name.as_deref(),
+                &volume_names,
+                &[],
+            );
             return rollback_compose_up(&mut state, &started_services, &created_networks, error)
                 .await;
         }
         if let Err(error) = std::fs::create_dir_all(box_dir.join("logs")) {
+            cleanup_partial_service_box(
+                &box_id,
+                &box_dir,
+                &initial_exec_socket_path,
+                network_name.as_deref(),
+                &volume_names,
+                &[],
+            );
             return rollback_compose_up(&mut state, &started_services, &created_networks, error)
                 .await;
         }
@@ -460,6 +496,14 @@ async fn execute_up(
                 ) {
                     Ok(endpoint) => endpoint,
                     Err(error) => {
+                        cleanup_partial_service_box(
+                            &box_id,
+                            &box_dir,
+                            &initial_exec_socket_path,
+                            network_name.as_deref(),
+                            &volume_names,
+                            &[],
+                        );
                         return rollback_compose_up(
                             &mut state,
                             &started_services,
@@ -476,17 +520,14 @@ async fn execute_up(
         }
 
         if let Err(e) = vm.boot().await {
-            crate::cleanup::cleanup_box_resources(&box_id, &volume_names, network_name.as_deref());
-            crate::cleanup::cleanup_external_socket_dir(
+            cleanup_partial_service_box(
+                &box_id,
                 &box_dir,
-                &box_dir.join("sockets/exec.sock"),
+                &initial_exec_socket_path,
+                network_name.as_deref(),
+                &volume_names,
+                vm.anonymous_volumes(),
             );
-            // Release the overlay mount before deleting the box dir, else
-            // remove_dir_all recurses into the live mount ("Stale file handle")
-            // and leaks it — the same class as the rm/restart leak fixed in #33,
-            // which cleanup_box_resources (volumes + network only) does not cover.
-            a3s_box_runtime::rootfs::unmount_box_overlay(&box_dir.join("merged"));
-            let _ = std::fs::remove_dir_all(&box_dir);
             return rollback_compose_up(
                 &mut state,
                 &started_services,
@@ -514,6 +555,7 @@ async fn execute_up(
         let mut labels = svc.map(|s| s.labels.to_map()).unwrap_or_default();
         labels.insert(LABEL_PROJECT.to_string(), project_name.to_string());
         labels.insert(LABEL_SERVICE.to_string(), svc_name.to_string());
+        labels.insert(LABEL_CONFIG_HASH.to_string(), config_hash);
 
         // Get service config for extra fields
         let port_map: Vec<String> = svc.map(|s| s.ports.clone()).unwrap_or_default();
@@ -667,8 +709,76 @@ async fn execute_up(
         println!(" ✓");
     }
 
-    println!("All {} services started.", project.service_order.len());
+    println!("All {} services converged.", project.service_order.len());
+
+    if !up_args.detach {
+        println!("Attaching to project logs. Press Ctrl-C to stop services.");
+        let logs = execute_logs(
+            project_name,
+            &project.config,
+            ComposeLogsArgs {
+                follow: true,
+                tail: 100,
+                services: project.service_order.clone(),
+            },
+        );
+        tokio::select! {
+            result = logs => result?,
+            signal = tokio::signal::ctrl_c() => {
+                signal.map_err(|error| format!("Failed to listen for Ctrl-C: {error}"))?;
+                operations::execute_stop(
+                    project_name,
+                    &project.config,
+                    ComposeStopArgs {
+                        timeout: None,
+                        services: project.service_order.clone(),
+                    },
+                )
+                .await?;
+            }
+        }
+    }
+
     Ok(())
+}
+
+fn service_config_hash(
+    service: &ServiceConfig,
+    config: &a3s_box_core::BoxConfig,
+) -> Result<String, serde_json::Error> {
+    let mut normalized = config.clone();
+    normalized.extra_env.sort();
+    let value = serde_json::json!({
+        "service": service,
+        "runtime": normalized,
+    });
+    let encoded = serde_json::to_vec(&value)?;
+    Ok(hex::encode(Sha256::digest(encoded)))
+}
+
+fn find_existing_service(
+    project_name: &str,
+    service_name: &str,
+) -> Result<Option<ExistingService>, Box<dyn std::error::Error>> {
+    let state = StateFile::load_default()?;
+    let matching = state
+        .find_by_label(LABEL_PROJECT, project_name)
+        .into_iter()
+        .filter(|record| record.labels.get(LABEL_SERVICE).map(String::as_str) == Some(service_name))
+        .collect::<Vec<_>>();
+    if matching.len() > 1 {
+        return Err(format!(
+            "service '{service_name}' has {} existing boxes; scaling is not yet enabled for this project",
+            matching.len()
+        )
+        .into());
+    }
+    Ok(matching.first().map(|record| {
+        (
+            ServiceBox::from_record(record),
+            record.labels.get(LABEL_CONFIG_HASH).cloned(),
+        )
+    }))
 }
 
 fn resolve_service_volumes(
@@ -791,696 +901,5 @@ async fn wait_for_completed(
         }
 
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    }
-}
-
-// ============================================================================
-// compose down
-// ============================================================================
-
-/// Snapshot of a compose service box for the `down` operation.
-#[derive(Clone)]
-struct ServiceBox {
-    box_id: String,
-    svc_name: String,
-    pid: Option<u32>,
-    status: String,
-    box_dir: PathBuf,
-    exec_socket_path: PathBuf,
-    network_name: Option<String>,
-    volume_names: Vec<String>,
-    anonymous_volumes: Vec<String>,
-    stop_signal: Option<String>,
-    stop_timeout: Option<u64>,
-}
-
-impl ServiceBox {
-    fn from_record(record: &BoxRecord) -> Self {
-        Self {
-            box_id: record.id.clone(),
-            svc_name: record
-                .labels
-                .get(LABEL_SERVICE)
-                .cloned()
-                .unwrap_or_default(),
-            pid: record.pid,
-            status: record.status.clone(),
-            box_dir: record.box_dir.clone(),
-            exec_socket_path: record.exec_socket_path.clone(),
-            network_name: crate::cleanup::record_network_name(record).map(str::to_string),
-            volume_names: record.volume_names.clone(),
-            anonymous_volumes: record.anonymous_volumes.clone(),
-            stop_signal: record.stop_signal.clone(),
-            stop_timeout: record.stop_timeout,
-        }
-    }
-
-    fn is_active(&self) -> bool {
-        status::is_active_status(&self.status)
-    }
-}
-
-fn cleanup_service_box(svc: &ServiceBox) {
-    crate::cleanup::cleanup_box_resources(
-        &svc.box_id,
-        &svc.volume_names,
-        svc.network_name.as_deref(),
-    );
-    crate::cleanup::cleanup_anonymous_volumes(&svc.anonymous_volumes);
-    // Release the overlay mount before deleting the box dir, else remove_dir_all
-    // recurses into the live mount ("Stale file handle") and leaks it (#33).
-    // cleanup_box_resources above only detaches volumes + network, not the mount.
-    a3s_box_runtime::rootfs::unmount_box_overlay(&svc.box_dir.join("merged"));
-    let _ = std::fs::remove_dir_all(&svc.box_dir);
-    crate::cleanup::cleanup_external_socket_dir(&svc.box_dir, &svc.exec_socket_path);
-}
-
-fn rollback_with_current(started_services: &[ServiceBox], current: ServiceBox) -> Vec<ServiceBox> {
-    let mut rollback_services = started_services.to_vec();
-    rollback_services.push(current);
-    rollback_services
-}
-
-async fn rollback_compose_up<T>(
-    state: &mut StateFile,
-    started_services: &[ServiceBox],
-    created_networks: &[String],
-    error: impl Into<Box<dyn std::error::Error>>,
-) -> Result<T, Box<dyn std::error::Error>> {
-    rollback_started_services(state, started_services).await;
-    cleanup_created_networks(created_networks);
-    Err(error.into())
-}
-
-async fn rollback_started_services(state: &mut StateFile, started_services: &[ServiceBox]) {
-    if started_services.is_empty() {
-        return;
-    }
-
-    eprintln!(
-        "  [!] Rolling back {} started service(s)...",
-        started_services.len()
-    );
-
-    for svc in started_services.iter().rev() {
-        stop_service_process(svc).await;
-
-        cleanup_service_box(svc);
-        let _ = state.remove(&svc.box_id);
-    }
-}
-
-async fn stop_service_process(svc: &ServiceBox) {
-    if !svc.is_active() {
-        return;
-    }
-
-    let Some(pid) = svc.pid else {
-        eprintln!(
-            "  Warning: service {} is {} but has no recorded PID; removing stale service state.",
-            svc.svc_name, svc.status
-        );
-        return;
-    };
-
-    if svc.status == "paused" {
-        #[cfg(unix)]
-        if let Err(error) = crate::process::send_signal(pid, libc::SIGCONT) {
-            eprintln!(
-                "  Warning: failed to resume paused service {} before stopping: {}",
-                svc.svc_name, error
-            );
-        }
-    }
-
-    let stop_signal = svc
-        .stop_signal
-        .as_deref()
-        .map(a3s_box_core::vmm::parse_signal_name)
-        .unwrap_or(libc::SIGTERM);
-    let stop_timeout = svc.stop_timeout.unwrap_or(10);
-    let exec_socket = if svc.exec_socket_path.as_os_str().is_empty() {
-        svc.box_dir.join("sockets").join("exec.sock")
-    } else {
-        svc.exec_socket_path.clone()
-    };
-    crate::process::graceful_stop_via_guest(pid, &exec_socket, stop_signal, stop_timeout).await;
-}
-
-fn cleanup_created_networks(created_networks: &[String]) {
-    if created_networks.is_empty() {
-        return;
-    }
-
-    let Ok(net_store) = NetworkStore::default_path() else {
-        return;
-    };
-
-    for net_name in created_networks.iter().rev() {
-        if let Ok(Some(mut net_config)) = net_store.get(net_name) {
-            let endpoint_ids: Vec<_> = net_config.endpoints.keys().cloned().collect();
-            for endpoint_id in endpoint_ids {
-                let _ = net_config.disconnect(&endpoint_id);
-            }
-            let _ = net_store.update(&net_config);
-        }
-
-        if let Err(error) = net_store.remove(net_name) {
-            eprintln!(
-                "  Warning: failed to roll back network {}: {}",
-                net_name, error
-            );
-        }
-    }
-}
-
-/// `compose down` — Stop and remove all services, networks, and optionally volumes.
-async fn execute_down(
-    project_name: &str,
-    down_args: ComposeDownArgs,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let mut state = StateFile::load_default()?;
-
-    // Find all boxes belonging to this project
-    let project_boxes: Vec<ServiceBox> = state
-        .find_by_label(LABEL_PROJECT, project_name)
-        .iter()
-        .map(|r| ServiceBox::from_record(r))
-        .collect();
-
-    if project_boxes.is_empty() {
-        println!("No services found for project '{}'.", project_name);
-        return Ok(());
-    }
-
-    println!(
-        "Stopping project '{}' ({} services)...",
-        project_name,
-        project_boxes.len()
-    );
-
-    // Stop in reverse order (last started = first stopped)
-    for svc in project_boxes.iter().rev() {
-        print!("  [-] Stopping {}...", svc.svc_name);
-
-        stop_service_process(svc).await;
-
-        cleanup_service_box(svc);
-        state.remove(&svc.box_id)?;
-
-        println!(" ✓");
-    }
-
-    // Clean up networks
-    if let Ok(net_store) = NetworkStore::default_path() {
-        let prefix = format!("{}_", project_name);
-        if let Ok(all_nets) = net_store.list() {
-            for net in all_nets {
-                if net.name.starts_with(&prefix) {
-                    // Disconnect any remaining endpoints first
-                    if !net.endpoints.is_empty() {
-                        let mut net_config = net.clone();
-                        let ids: Vec<_> = net_config.endpoints.keys().cloned().collect();
-                        for id in ids {
-                            net_config.disconnect(&id).ok();
-                        }
-                        let _ = net_store.update(&net_config);
-                    }
-                    if let Err(e) = net_store.remove(&net.name) {
-                        eprintln!("  Warning: failed to remove network {}: {}", net.name, e);
-                    } else {
-                        println!("  [-] Network {} removed", net.name);
-                    }
-                }
-            }
-        }
-    }
-
-    // Optionally remove named volumes
-    if down_args.volumes {
-        let vol_store = a3s_box_runtime::volume::VolumeStore::default_path()?;
-        let mut removed = 0u32;
-        for svc in &project_boxes {
-            for vol_name in &svc.volume_names {
-                match vol_store.remove(vol_name, true) {
-                    Ok(_) => {
-                        println!("  [-] Volume {} removed", vol_name);
-                        removed += 1;
-                    }
-                    Err(e) => {
-                        eprintln!("  Warning: failed to remove volume {}: {}", vol_name, e);
-                    }
-                }
-            }
-        }
-        if removed > 0 {
-            println!("  Removed {} volume(s).", removed);
-        }
-    }
-
-    println!("Project '{}' stopped.", project_name);
-    Ok(())
-}
-
-// ============================================================================
-// compose ps
-// ============================================================================
-
-/// `compose ps` — List services and their actual status.
-async fn execute_ps(project_name: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let state = StateFile::load_default()?;
-    let boxes = state.find_by_label(LABEL_PROJECT, project_name);
-
-    if boxes.is_empty() {
-        println!("No services found for project '{}'.", project_name);
-        return Ok(());
-    }
-
-    println!(
-        "{:<20} {:<30} {:<12} {:<12} {:<10}",
-        "SERVICE", "IMAGE", "STATUS", "HEALTH", "PID"
-    );
-    println!("{}", "-".repeat(84));
-
-    for record in &boxes {
-        let svc_name = record
-            .labels
-            .get(LABEL_SERVICE)
-            .map(|s| s.as_str())
-            .unwrap_or("?");
-        let pid_str = record
-            .pid
-            .map(|p| p.to_string())
-            .unwrap_or_else(|| "-".to_string());
-        println!(
-            "{:<20} {:<30} {:<12} {:<12} {:<10}",
-            svc_name, record.image, record.status, record.health_status, pid_str
-        );
-    }
-
-    Ok(())
-}
-
-// ============================================================================
-// compose config
-// ============================================================================
-
-/// `compose config` — Validate and display the parsed compose configuration.
-fn execute_config(
-    project_name: &str,
-    config: ComposeConfig,
-) -> Result<(), Box<dyn std::error::Error>> {
-    validate_compose_restart_policies(&config)
-        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    let project = ComposeProject::new(project_name, config)?;
-
-    println!("Project: {}", project_name);
-    println!("Services: {}", project.config.services.len());
-    println!("Networks: {}", project.required_networks().len());
-    println!("Volumes: {}", project.config.volumes.len());
-    println!("\nBoot order: {}", project.service_order.join(" → "));
-
-    for svc_name in &project.service_order {
-        if let Some(svc) = project.config.services.get(svc_name) {
-            println!("\n[{}]", svc_name);
-            if let Some(ref img) = svc.image {
-                println!("  image: {}", img);
-            }
-            if !svc.ports.is_empty() {
-                println!("  ports: {}", svc.ports.join(", "));
-            }
-            if !svc.volumes.is_empty() {
-                println!("  volumes: {}", svc.volumes.join(", "));
-            }
-            let deps = svc.depends_on.services();
-            if !deps.is_empty() {
-                println!("  depends_on: {}", deps.join(", "));
-            }
-            let env = svc.environment.to_pairs();
-            if !env.is_empty() {
-                println!("  environment:");
-                for (k, v) in &env {
-                    println!("    {}={}", k, v);
-                }
-            }
-        }
-    }
-
-    println!("\nConfiguration is valid.");
-    Ok(())
-}
-
-// ============================================================================
-// compose logs
-// ============================================================================
-
-/// `compose logs` — View logs from all (or one) service in the project.
-async fn execute_logs(
-    project_name: &str,
-    logs_args: ComposeLogsArgs,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let state = StateFile::load_default()?;
-    let boxes = state.find_by_label(LABEL_PROJECT, project_name);
-
-    if boxes.is_empty() {
-        println!("No services found for project '{}'.", project_name);
-        return Ok(());
-    }
-
-    // Filter to specific service if requested
-    let targets: Vec<_> = if let Some(ref svc) = logs_args.service {
-        boxes
-            .iter()
-            .filter(|r| {
-                r.labels
-                    .get(LABEL_SERVICE)
-                    .map(|s| s == svc)
-                    .unwrap_or(false)
-            })
-            .collect()
-    } else {
-        boxes.iter().collect()
-    };
-
-    if targets.is_empty() {
-        if let Some(ref svc) = logs_args.service {
-            return Err(
-                format!("Service '{}' not found in project '{}'.", svc, project_name).into(),
-            );
-        }
-    }
-
-    for record in &targets {
-        let svc_name = record
-            .labels
-            .get(LABEL_SERVICE)
-            .map(|s| s.as_str())
-            .unwrap_or("?");
-
-        let log_path = record.console_log.clone();
-        if !log_path.exists() {
-            println!("[{}] (no logs)", svc_name);
-            continue;
-        }
-
-        let content = std::fs::read_to_string(&log_path)
-            .map_err(|e| format!("Failed to read logs for {}: {}", svc_name, e))?;
-
-        let lines: Vec<&str> = content.lines().collect();
-        let start = lines.len().saturating_sub(logs_args.tail);
-        let prefix = if targets.len() > 1 {
-            format!("{} | ", svc_name)
-        } else {
-            String::new()
-        };
-
-        for line in &lines[start..] {
-            println!("{}{}", prefix, line);
-        }
-    }
-
-    if logs_args.follow {
-        println!("(follow mode: use Ctrl-C to stop)");
-        // In follow mode, tail all log files concurrently
-        // For simplicity, we poll every second
-        let mut last_sizes: HashMap<String, u64> = HashMap::new();
-        for record in &targets {
-            let size = std::fs::metadata(&record.console_log)
-                .map(|m| m.len())
-                .unwrap_or(0);
-            last_sizes.insert(record.id.clone(), size);
-        }
-
-        loop {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-            for record in &targets {
-                let log_path = &record.console_log;
-                let current_size = std::fs::metadata(log_path).map(|m| m.len()).unwrap_or(0);
-                let last_size = last_sizes.get(&record.id).copied().unwrap_or(0);
-
-                if current_size > last_size {
-                    let svc_name = record
-                        .labels
-                        .get(LABEL_SERVICE)
-                        .map(|s| s.as_str())
-                        .unwrap_or("?");
-                    let prefix = if targets.len() > 1 {
-                        format!("{} | ", svc_name)
-                    } else {
-                        String::new()
-                    };
-
-                    if let Ok(file) = std::fs::File::open(log_path) {
-                        use std::io::{Read, Seek, SeekFrom};
-                        let mut file = file;
-                        if file.seek(SeekFrom::Start(last_size)).is_ok() {
-                            let mut buf = String::new();
-                            if file.read_to_string(&mut buf).is_ok() {
-                                for line in buf.lines() {
-                                    println!("{}{}", prefix, line);
-                                }
-                            }
-                        }
-                    }
-
-                    last_sizes.insert(record.id.clone(), current_size);
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_load_compose_file_not_found() {
-        let result = load_compose_file(Some(std::path::Path::new("/nonexistent/compose.yaml")));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not found"));
-    }
-
-    #[test]
-    fn test_load_compose_file_interpolates_dotenv_and_shell_before_validation() {
-        let directory = tempfile::TempDir::new().unwrap();
-        let compose_path = directory.path().join("compose.yaml");
-        std::fs::write(
-            &compose_path,
-            r#"
-services:
-  redis:
-    image: redis:7-alpine
-    ports:
-      - "${REDIS_PORT:-6379}:6379"
-    environment:
-      DASH_EMPTY: ${EMPTY-default}
-      COLON_DASH_EMPTY: ${EMPTY:-default}
-      PLUS_EMPTY: ${EMPTY+replacement}
-      COLON_PLUS_EMPTY: ${EMPTY:+replacement}
-      DOTENV_ONLY: ${DOTENV_ONLY}
-      SHELL_WINS: ${SHELL_WINS}
-"#,
-        )
-        .unwrap();
-        std::fs::write(
-            directory.path().join(".env"),
-            "REDIS_PORT=6379\nEMPTY=\nDOTENV_ONLY=dotenv\nSHELL_WINS=dotenv\n",
-        )
-        .unwrap();
-        let shell = HashMap::from([
-            ("REDIS_PORT".to_string(), "16379".to_string()),
-            ("SHELL_WINS".to_string(), "shell".to_string()),
-        ]);
-
-        let (_, config) = load_compose_file_with_environment(Some(&compose_path), shell).unwrap();
-        let service = &config.services["redis"];
-        assert_eq!(service.ports, vec!["16379:6379"]);
-        let environment: HashMap<_, _> = service.environment.to_pairs().into_iter().collect();
-        assert_eq!(environment["DASH_EMPTY"], "");
-        assert_eq!(environment["COLON_DASH_EMPTY"], "default");
-        assert_eq!(environment["PLUS_EMPTY"], "replacement");
-        assert_eq!(environment["COLON_PLUS_EMPTY"], "");
-        assert_eq!(environment["DOTENV_ONLY"], "dotenv");
-        assert_eq!(environment["SHELL_WINS"], "shell");
-
-        a3s_box_runtime::ComposeProject::with_base_dir("test", config, directory.path())
-            .expect("interpolation must run before port validation");
-    }
-
-    #[test]
-    fn test_load_compose_file_reports_unreadable_dotenv() {
-        let directory = tempfile::TempDir::new().unwrap();
-        let compose_path = directory.path().join("compose.yaml");
-        std::fs::write(&compose_path, "services: {}\n").unwrap();
-        std::fs::create_dir(directory.path().join(".env")).unwrap();
-
-        let error = load_compose_file_with_environment(
-            Some(&compose_path),
-            HashMap::<String, String>::new(),
-        )
-        .unwrap_err();
-
-        assert!(error
-            .to_string()
-            .contains("Failed to read Compose environment file"));
-        assert!(error.to_string().contains(".env"));
-    }
-
-    #[test]
-    fn test_compose_files_constant() {
-        assert_eq!(COMPOSE_FILES.len(), 4);
-        assert!(COMPOSE_FILES.contains(&"compose.yaml"));
-        assert!(COMPOSE_FILES.contains(&"docker-compose.yml"));
-    }
-
-    #[test]
-    fn test_label_constants() {
-        assert_eq!(LABEL_PROJECT, "com.a3s.compose.project");
-        assert_eq!(LABEL_SERVICE, "com.a3s.compose.service");
-    }
-
-    #[test]
-    fn test_service_restart_policy_normalizes_on_failure_limit() {
-        let service = ServiceConfig {
-            restart: Some("on-failure:3".to_string()),
-            ..Default::default()
-        };
-
-        let (policy, max_count) = service_restart_policy("web", Some(&service)).unwrap();
-
-        assert_eq!(policy, "on-failure");
-        assert_eq!(max_count, 3);
-    }
-
-    #[test]
-    fn test_validate_compose_restart_policies_rejects_invalid_service_policy() {
-        let mut services = HashMap::new();
-        services.insert(
-            "web".to_string(),
-            ServiceConfig {
-                image: Some("docker.io/library/alpine:latest".to_string()),
-                restart: Some("never".to_string()),
-                ..Default::default()
-            },
-        );
-        let config = ComposeConfig {
-            version: None,
-            services,
-            volumes: HashMap::new(),
-            networks: HashMap::new(),
-        };
-
-        let error = validate_compose_restart_policies(&config).unwrap_err();
-
-        assert!(error.contains("Service 'web' has invalid restart policy"));
-        assert!(error.contains("Invalid restart policy"));
-    }
-
-    #[test]
-    fn test_service_box_from_record_captures_cleanup_fields() {
-        let mut record = crate::test_helpers::fixtures::make_record(
-            "compose-id",
-            "project-web",
-            "running",
-            Some(123),
-        );
-        record
-            .labels
-            .insert(LABEL_SERVICE.to_string(), "web".to_string());
-        record.network_name = Some("project_default".to_string());
-        record.volume_names = vec!["data".to_string()];
-        record.anonymous_volumes = vec!["anon".to_string()];
-        record.stop_signal = Some("SIGINT".to_string());
-        record.stop_timeout = Some(3);
-
-        let service = ServiceBox::from_record(&record);
-
-        assert_eq!(service.box_id, "compose-id");
-        assert_eq!(service.svc_name, "web");
-        assert_eq!(service.pid, Some(123));
-        assert_eq!(service.network_name.as_deref(), Some("project_default"));
-        assert_eq!(service.volume_names, vec!["data".to_string()]);
-        assert_eq!(service.anonymous_volumes, vec!["anon".to_string()]);
-        assert_eq!(service.stop_signal.as_deref(), Some("SIGINT"));
-        assert_eq!(service.stop_timeout, Some(3));
-        assert!(service.is_active());
-    }
-
-    #[test]
-    fn test_service_box_from_record_uses_network_mode_fallback() {
-        let mut record = crate::test_helpers::fixtures::make_record(
-            "compose-id",
-            "project-web",
-            "running",
-            None,
-        );
-        record.network_name = None;
-        record.network_mode = a3s_box_core::NetworkMode::Bridge {
-            network: "legacy_default".to_string(),
-        };
-
-        let service = ServiceBox::from_record(&record);
-
-        assert_eq!(service.network_name.as_deref(), Some("legacy_default"));
-    }
-
-    #[test]
-    fn test_rollback_with_current_appends_current_service() {
-        let mut first_record =
-            crate::test_helpers::fixtures::make_record("first-id", "project-db", "running", None);
-        first_record
-            .labels
-            .insert(LABEL_SERVICE.to_string(), "db".to_string());
-        let mut current_record = crate::test_helpers::fixtures::make_record(
-            "current-id",
-            "project-web",
-            "running",
-            None,
-        );
-        current_record
-            .labels
-            .insert(LABEL_SERVICE.to_string(), "web".to_string());
-
-        let first = ServiceBox::from_record(&first_record);
-        let current = ServiceBox::from_record(&current_record);
-        let rollback_services = rollback_with_current(&[first], current);
-
-        assert_eq!(rollback_services.len(), 2);
-        assert_eq!(rollback_services[0].svc_name, "db");
-        assert_eq!(rollback_services[1].svc_name, "web");
-    }
-
-    #[test]
-    fn test_service_box_paused_is_active() {
-        let mut record =
-            crate::test_helpers::fixtures::make_record("compose-id", "project-web", "paused", None);
-        record
-            .labels
-            .insert(LABEL_SERVICE.to_string(), "web".to_string());
-
-        let service = ServiceBox::from_record(&record);
-
-        assert!(service.is_active());
-    }
-
-    #[test]
-    fn test_service_box_stopped_is_not_active() {
-        let mut record = crate::test_helpers::fixtures::make_record(
-            "compose-id",
-            "project-web",
-            "stopped",
-            None,
-        );
-        record
-            .labels
-            .insert(LABEL_SERVICE.to_string(), "web".to_string());
-
-        let service = ServiceBox::from_record(&record);
-
-        assert!(!service.is_active());
     }
 }

--- a/src/cli/src/commands/compose.rs
+++ b/src/cli/src/commands/compose.rs
@@ -14,9 +14,9 @@ mod tests;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use a3s_box_core::compose::{ComposeConfig, ServiceConfig};
+use a3s_box_core::compose::{normalize_compose, ComposeConfig, ComposeSourceFormat, ServiceConfig};
 use a3s_box_core::event::EventEmitter;
-use a3s_box_runtime::{ComposeProject, NetworkStore, VmManager};
+use a3s_box_runtime::{ComposeRuntimePlan, NetworkStore, VmManager};
 use sha2::{Digest, Sha256};
 
 use super::common;
@@ -168,19 +168,18 @@ fn load_compose_file_with_environment(
     }
     environment.extend(shell_environment);
 
-    let config = if path
+    let format = if path
         .extension()
         .and_then(|extension| extension.to_str())
         .is_some_and(|extension| extension.eq_ignore_ascii_case("acl"))
     {
-        ComposeConfig::from_acl_str_with_environment(&source, &environment)
-            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?
+        ComposeSourceFormat::Acl
     } else {
-        let source = a3s_box_core::compose::interpolate_compose_yaml(&source, &environment)
-            .map_err(|e| format!("Failed to interpolate {}: {}", path.display(), e))?;
-        ComposeConfig::from_yaml_str(&source)
-            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?
+        ComposeSourceFormat::Yaml
     };
+    let config = normalize_compose(&source, format, &environment)
+        .map_err(|error| format!("Failed to normalize {}: {error}", path.display()))?
+        .into_config();
 
     Ok((path, config))
 }
@@ -250,7 +249,7 @@ async fn execute_up(
         .unwrap_or_else(|| std::path::Path::new("."));
     validate_compose_restart_policies(&config)
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    let project = ComposeProject::with_base_dir(project_name, config, base_dir)?;
+    let project = ComposeRuntimePlan::with_base_dir(project_name, config, base_dir)?;
     if isolation.is_sandbox() {
         let default_network = project.default_network_name();
         for service_name in &project.service_order {
@@ -462,13 +461,14 @@ async fn execute_up(
 
         // Connect to network before boot
         if let Some(net_name) = network_name.as_deref() {
+            let network_aliases = project.service_network_aliases(svc_name);
             // Atomic load → validate → allocate-IP → save under the store's
             // cross-process lock. A get → connect → update reads the network
             // outside the lock, so a concurrent connect (another compose up, or
             // a `run --network` to the same net) could dup the IP or drop this
-            // endpoint. Register the bare service name as a DNS alias so peers
-            // can reach this service as `svc` (Docker Compose behavior), not
-            // only as the `{project}-{svc}` box name.
+            // endpoint. Register the bare service name plus declared network
+            // aliases so peers can use Compose DNS names, not only the
+            // `{project}-{svc}` box name.
             let endpoint =
                 match net_store.with_write_lock(
                     |networks| -> Result<
@@ -483,11 +483,7 @@ async fn execute_up(
                         super::network::validate_attachable_network(net_config)
                             .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
                         net_config
-                            .connect_with_aliases(
-                                &box_id,
-                                &box_name,
-                                std::slice::from_ref(svc_name),
-                            )
+                            .connect_with_aliases(&box_id, &box_name, &network_aliases)
                             .map_err(|e| -> Box<dyn std::error::Error> {
                                 format!("Failed to connect service '{}' to network: {e}", svc_name)
                                     .into()

--- a/src/cli/src/commands/compose/args.rs
+++ b/src/cli/src/commands/compose/args.rs
@@ -1,0 +1,113 @@
+//! Clap argument models for Compose commands.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+use super::super::common;
+use super::operations::{
+    ComposeCpArgs, ComposeExecArgs, ComposeKillArgs, ComposeLsArgs, ComposePortArgs,
+    ComposePullArgs, ComposeRestartArgs, ComposeRmArgs, ComposeStopArgs, ComposeTopArgs,
+    ComposeWaitArgs, ProjectServicesArgs,
+};
+
+#[derive(Args)]
+pub struct ComposeArgs {
+    /// Path to compose file (default: compose.acl, then Compose YAML names)
+    #[arg(short = 'f', long = "file")]
+    pub file: Option<PathBuf>,
+
+    /// Project name (default: directory name)
+    #[arg(short = 'p', long = "project-name")]
+    pub project_name: Option<String>,
+
+    #[command(subcommand)]
+    pub command: ComposeCommand,
+}
+
+#[derive(Subcommand)]
+pub enum ComposeCommand {
+    /// Create and start all services
+    Up(ComposeUpArgs),
+    /// Stop and remove all services
+    Down(ComposeDownArgs),
+    /// List services and their status
+    Ps(ProjectServicesArgs),
+    /// Validate and display the compose configuration
+    Config,
+    /// View logs from all services
+    Logs(ComposeLogsArgs),
+    /// Start existing service boxes
+    Start(ProjectServicesArgs),
+    /// Stop running service boxes without removing them
+    Stop(ComposeStopArgs),
+    /// Restart service boxes
+    Restart(ComposeRestartArgs),
+    /// Remove stopped service boxes
+    Rm(ComposeRmArgs),
+    /// Force-stop service boxes with a signal
+    Kill(ComposeKillArgs),
+    /// Pause running service boxes
+    Pause(ProjectServicesArgs),
+    /// Resume paused service boxes
+    Unpause(ProjectServicesArgs),
+    /// Wait for service boxes to stop
+    Wait(ComposeWaitArgs),
+    /// Execute a command in a running service box
+    Exec(ComposeExecArgs),
+    /// Display running processes for service boxes
+    Top(ComposeTopArgs),
+    /// Print published ports for a service
+    Port(ComposePortArgs),
+    /// Copy files between a service box and the host
+    Cp(ComposeCpArgs),
+    /// List images declared by services
+    Images(ProjectServicesArgs),
+    /// Pull service images
+    Pull(ComposePullArgs),
+    /// List Compose projects known to A3S Box
+    Ls(ComposeLsArgs),
+    /// List named volumes declared by the project
+    Volumes,
+}
+
+#[derive(Args)]
+pub struct ComposeUpArgs {
+    /// Run in detached mode (background)
+    #[arg(short = 'd', long)]
+    pub detach: bool,
+
+    /// Timeout in seconds to wait for healthy dependencies (default: 120)
+    #[arg(long, default_value = "120")]
+    pub timeout: u64,
+
+    /// Use the shared-kernel sandbox backend (omit for MicroVM isolation)
+    #[arg(long, value_enum)]
+    pub isolation: Option<common::IsolationArg>,
+
+    /// Limit convergence to these services and their dependencies
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeDownArgs {
+    /// Remove named volumes declared in the compose file
+    #[arg(short = 'v', long)]
+    pub volumes: bool,
+}
+
+#[derive(Args)]
+pub struct ComposeLogsArgs {
+    /// Follow log output
+    #[arg(short = 'f', long)]
+    pub follow: bool,
+
+    /// Number of lines to show from the end of the logs
+    #[arg(long, default_value = "100")]
+    pub tail: usize,
+
+    /// Limit output to these services
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}

--- a/src/cli/src/commands/compose/lifecycle.rs
+++ b/src/cli/src/commands/compose/lifecycle.rs
@@ -1,0 +1,362 @@
+//! Compose service teardown, rollback, and project removal.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use a3s_box_core::compose::ComposeConfig;
+use a3s_box_runtime::NetworkStore;
+
+use super::{ComposeDownArgs, LABEL_PROJECT, LABEL_SERVICE};
+use crate::state::{BoxRecord, StateFile};
+use crate::status;
+
+// ============================================================================
+// compose down
+// ============================================================================
+
+/// Snapshot of a compose service box for the `down` operation.
+#[derive(Clone)]
+pub(super) struct ServiceBox {
+    pub(super) box_id: String,
+    pub(super) svc_name: String,
+    pub(super) pid: Option<u32>,
+    pub(super) status: String,
+    pub(super) box_dir: PathBuf,
+    pub(super) exec_socket_path: PathBuf,
+    pub(super) network_name: Option<String>,
+    pub(super) volume_names: Vec<String>,
+    pub(super) anonymous_volumes: Vec<String>,
+    pub(super) stop_signal: Option<String>,
+    pub(super) stop_timeout: Option<u64>,
+}
+
+impl ServiceBox {
+    pub(super) fn from_record(record: &BoxRecord) -> Self {
+        Self {
+            box_id: record.id.clone(),
+            svc_name: record
+                .labels
+                .get(LABEL_SERVICE)
+                .cloned()
+                .unwrap_or_default(),
+            pid: record.pid,
+            status: record.status.clone(),
+            box_dir: record.box_dir.clone(),
+            exec_socket_path: record.exec_socket_path.clone(),
+            network_name: crate::cleanup::record_network_name(record).map(str::to_string),
+            volume_names: record.volume_names.clone(),
+            anonymous_volumes: record.anonymous_volumes.clone(),
+            stop_signal: record.stop_signal.clone(),
+            stop_timeout: record.stop_timeout,
+        }
+    }
+
+    pub(super) fn is_active(&self) -> bool {
+        status::is_active_status(&self.status)
+    }
+}
+
+pub(super) fn cleanup_service_box(svc: &ServiceBox) {
+    cleanup_partial_service_box(
+        &svc.box_id,
+        &svc.box_dir,
+        &svc.exec_socket_path,
+        svc.network_name.as_deref(),
+        &svc.volume_names,
+        &svc.anonymous_volumes,
+    );
+}
+
+pub(super) fn cleanup_partial_service_box(
+    box_id: &str,
+    box_dir: &std::path::Path,
+    exec_socket_path: &std::path::Path,
+    network_name: Option<&str>,
+    volume_names: &[String],
+    anonymous_volumes: &[String],
+) {
+    crate::cleanup::cleanup_box_resources(box_id, volume_names, network_name);
+    crate::cleanup::cleanup_anonymous_volumes(anonymous_volumes);
+    // Release every rootfs provider before deleting the box dir. Linux uses an
+    // overlay mount, while macOS mounts a case-sensitive APFS image at rootfs.
+    // cleanup_box_resources above only detaches volumes and networking.
+    a3s_box_runtime::rootfs::unmount_box_overlay(&box_dir.join("merged"));
+    a3s_box_runtime::rootfs::unmount_box_rootfs(&box_dir.join("rootfs"));
+    let _ = std::fs::remove_dir_all(box_dir);
+    crate::cleanup::cleanup_external_socket_dir(box_dir, exec_socket_path);
+}
+
+pub(super) fn rollback_with_current(
+    started_services: &[ServiceBox],
+    current: ServiceBox,
+) -> Vec<ServiceBox> {
+    let mut rollback_services = started_services.to_vec();
+    rollback_services.push(current);
+    rollback_services
+}
+
+pub(super) async fn rollback_compose_up<T>(
+    state: &mut StateFile,
+    started_services: &[ServiceBox],
+    created_networks: &[String],
+    error: impl Into<Box<dyn std::error::Error>>,
+) -> Result<T, Box<dyn std::error::Error>> {
+    rollback_started_services(state, started_services).await;
+    cleanup_created_networks(created_networks);
+    Err(error.into())
+}
+
+async fn rollback_started_services(state: &mut StateFile, started_services: &[ServiceBox]) {
+    if started_services.is_empty() {
+        return;
+    }
+
+    eprintln!(
+        "  [!] Rolling back {} started service(s)...",
+        started_services.len()
+    );
+
+    for svc in started_services.iter().rev() {
+        stop_service_process(svc).await;
+
+        match StateFile::remove_record(&svc.box_id) {
+            Ok(_) => state.forget(&svc.box_id),
+            Err(error) => eprintln!(
+                "  Warning: failed to remove rolled-back service {} from state: {}",
+                svc.svc_name, error
+            ),
+        }
+        cleanup_service_box(svc);
+    }
+}
+
+pub(super) async fn stop_service_process(svc: &ServiceBox) {
+    if !svc.is_active() {
+        return;
+    }
+
+    let Some(pid) = svc.pid else {
+        eprintln!(
+            "  Warning: service {} is {} but has no recorded PID; removing stale service state.",
+            svc.svc_name, svc.status
+        );
+        return;
+    };
+
+    if svc.status == "paused" {
+        #[cfg(unix)]
+        if let Err(error) = crate::process::send_signal(pid, libc::SIGCONT) {
+            eprintln!(
+                "  Warning: failed to resume paused service {} before stopping: {}",
+                svc.svc_name, error
+            );
+        }
+    }
+
+    let stop_signal = svc
+        .stop_signal
+        .as_deref()
+        .map(a3s_box_core::vmm::parse_signal_name)
+        .unwrap_or(libc::SIGTERM);
+    let stop_timeout = svc.stop_timeout.unwrap_or(10);
+    let exec_socket = if svc.exec_socket_path.as_os_str().is_empty() {
+        svc.box_dir.join("sockets").join("exec.sock")
+    } else {
+        svc.exec_socket_path.clone()
+    };
+    crate::process::graceful_stop_via_guest(pid, &exec_socket, stop_signal, stop_timeout).await;
+}
+
+fn cleanup_created_networks(created_networks: &[String]) {
+    if created_networks.is_empty() {
+        return;
+    }
+
+    let Ok(net_store) = NetworkStore::default_path() else {
+        return;
+    };
+
+    for net_name in created_networks.iter().rev() {
+        if let Ok(Some(mut net_config)) = net_store.get(net_name) {
+            let endpoint_ids: Vec<_> = net_config.endpoints.keys().cloned().collect();
+            for endpoint_id in endpoint_ids {
+                let _ = net_config.disconnect(&endpoint_id);
+            }
+            let _ = net_store.update(&net_config);
+        }
+
+        if let Err(error) = net_store.remove(net_name) {
+            eprintln!(
+                "  Warning: failed to roll back network {}: {}",
+                net_name, error
+            );
+        }
+    }
+}
+
+/// `compose down` — Stop and remove all services, networks, and optionally volumes.
+pub(super) async fn execute_down(
+    project_name: &str,
+    config: &ComposeConfig,
+    down_args: ComposeDownArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut state = StateFile::load_default()?;
+
+    // Find all boxes belonging to this project
+    let project_boxes: Vec<ServiceBox> = state
+        .find_by_label(LABEL_PROJECT, project_name)
+        .iter()
+        .map(|r| ServiceBox::from_record(r))
+        .collect();
+    let network_names = project_network_names(project_name, config, &project_boxes);
+    let volume_names = project_volume_names(config, &project_boxes);
+
+    if project_boxes.is_empty() {
+        println!("No services found for project '{}'.", project_name);
+    } else {
+        println!(
+            "Stopping project '{}' ({} services)...",
+            project_name,
+            project_boxes.len()
+        );
+
+        // Stop in reverse order (last started = first stopped)
+        for svc in project_boxes.iter().rev() {
+            print!("  [-] Stopping {}...", svc.svc_name);
+
+            stop_service_process(svc).await;
+            StateFile::remove_record(&svc.box_id)?;
+            state.forget(&svc.box_id);
+            cleanup_service_box(svc);
+
+            println!(" ✓");
+        }
+    }
+
+    // Clean up networks
+    if let Ok(net_store) = NetworkStore::default_path() {
+        for network_name in network_names {
+            if let Ok(Some(mut network)) = net_store.get(&network_name) {
+                let ids = network.endpoints.keys().cloned().collect::<Vec<_>>();
+                for id in ids {
+                    network.disconnect(&id).ok();
+                }
+                let _ = net_store.update(&network);
+                if let Err(error) = net_store.remove(&network_name) {
+                    eprintln!(
+                        "  Warning: failed to remove network {}: {}",
+                        network_name, error
+                    );
+                } else {
+                    println!("  [-] Network {} removed", network_name);
+                }
+            }
+        }
+    }
+
+    // Optionally remove named volumes
+    if down_args.volumes {
+        let vol_store = a3s_box_runtime::volume::VolumeStore::default_path()?;
+        let mut removed = 0u32;
+        for volume_name in volume_names {
+            match vol_store.remove(&volume_name, true) {
+                Ok(_) => {
+                    println!("  [-] Volume {} removed", volume_name);
+                    removed += 1;
+                }
+                Err(error) => {
+                    eprintln!(
+                        "  Warning: failed to remove volume {}: {}",
+                        volume_name, error
+                    );
+                }
+            }
+        }
+        if removed > 0 {
+            println!("  Removed {} volume(s).", removed);
+        }
+    }
+
+    println!("Project '{}' stopped.", project_name);
+    Ok(())
+}
+
+fn project_network_names(
+    project_name: &str,
+    config: &ComposeConfig,
+    project_boxes: &[ServiceBox],
+) -> BTreeSet<String> {
+    let mut names = BTreeSet::from([format!("{project_name}_default")]);
+    names.extend(
+        config
+            .networks
+            .keys()
+            .map(|network| format!("{project_name}_{network}")),
+    );
+    names.extend(config.services.values().flat_map(|service| {
+        service
+            .networks
+            .names()
+            .into_iter()
+            .map(|network| format!("{project_name}_{network}"))
+    }));
+    names.extend(
+        project_boxes
+            .iter()
+            .filter_map(|service| service.network_name.clone()),
+    );
+    names
+}
+
+fn project_volume_names(config: &ComposeConfig, project_boxes: &[ServiceBox]) -> BTreeSet<String> {
+    let mut names = config.volumes.keys().cloned().collect::<BTreeSet<_>>();
+    names.extend(
+        project_boxes
+            .iter()
+            .flat_map(|service| service.volume_names.iter().cloned()),
+    );
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn service_box_with_resources(network: &str, volumes: &[&str]) -> ServiceBox {
+        let mut record = crate::test_helpers::fixtures::make_record(
+            "compose-id",
+            "project-api",
+            "stopped",
+            None,
+        );
+        record.network_name = Some(network.to_string());
+        record.volume_names = volumes.iter().map(|name| (*name).to_string()).collect();
+        ServiceBox::from_record(&record)
+    }
+
+    #[test]
+    fn teardown_names_are_exact_and_deduplicated() {
+        let config = ComposeConfig::from_yaml_str(
+            "services:\n  api:\n    image: api\n    networks: [backend]\nvolumes:\n  data:\nnetworks:\n  backend:\n  unused:\n",
+        )
+        .unwrap();
+        let boxes = vec![service_box_with_resources(
+            "project_legacy",
+            &["data", "legacy", "data"],
+        )];
+
+        assert_eq!(
+            project_network_names("project", &config, &boxes),
+            BTreeSet::from([
+                "project_backend".to_string(),
+                "project_default".to_string(),
+                "project_legacy".to_string(),
+                "project_unused".to_string(),
+            ])
+        );
+        assert_eq!(
+            project_volume_names(&config, &boxes),
+            BTreeSet::from(["data".to_string(), "legacy".to_string()])
+        );
+    }
+}

--- a/src/cli/src/commands/compose/operations.rs
+++ b/src/cli/src/commands/compose/operations.rs
@@ -1,0 +1,750 @@
+//! Project-scoped Compose operations built from the canonical box commands.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use a3s_box_core::compose::ComposeConfig;
+use clap::Args;
+
+use super::{LABEL_PROJECT, LABEL_SERVICE};
+use crate::state::{BoxRecord, StateFile};
+
+pub(super) fn select_up_config(
+    mut config: ComposeConfig,
+    requested: &[String],
+) -> Result<ComposeConfig, Box<dyn std::error::Error>> {
+    if requested.is_empty() {
+        config.service_order()?;
+        return Ok(config);
+    }
+
+    let mut selected = BTreeSet::new();
+    for service in requested {
+        collect_service_dependencies(&config, service, &mut selected)?;
+    }
+    config.services.retain(|name, _| selected.contains(name));
+    config.service_order()?;
+    Ok(config)
+}
+
+fn collect_service_dependencies(
+    config: &ComposeConfig,
+    service: &str,
+    selected: &mut BTreeSet<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let definition = config
+        .services
+        .get(service)
+        .ok_or_else(|| format!("service '{service}' is not defined in the Compose project"))?;
+    if !selected.insert(service.to_string()) {
+        return Ok(());
+    }
+    for dependency in definition.depends_on.services() {
+        collect_service_dependencies(config, &dependency, selected)?;
+    }
+    Ok(())
+}
+
+#[derive(Args)]
+pub struct ProjectServicesArgs {
+    /// Limit the operation to these services (default: every project service)
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeStopArgs {
+    /// Seconds to wait before force-killing
+    #[arg(short = 't', long)]
+    pub timeout: Option<u64>,
+
+    /// Limit the operation to these services
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeRestartArgs {
+    /// Seconds to wait before force-killing
+    #[arg(short = 't', long, default_value_t = 10)]
+    pub timeout: u64,
+
+    /// Limit the operation to these services
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeRmArgs {
+    /// Stop active services before removing them
+    #[arg(short = 's', long)]
+    pub stop: bool,
+
+    /// Do not ask for confirmation (A3S Box is non-interactive by default)
+    #[arg(short = 'f', long)]
+    pub force: bool,
+
+    /// Limit the operation to these services
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeKillArgs {
+    /// Signal to send
+    #[arg(short = 's', long, default_value = "KILL")]
+    pub signal: String,
+
+    /// Limit the operation to these services
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeWaitArgs {
+    /// Seconds between keepalive messages (0 disables them)
+    #[arg(long, default_value_t = 60)]
+    pub heartbeat_interval: u64,
+
+    /// Disable keepalive messages
+    #[arg(long)]
+    pub no_heartbeat: bool,
+
+    /// Limit the operation to these services
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeExecArgs {
+    /// Service name
+    pub service: String,
+
+    /// Timeout in seconds
+    #[arg(long, default_value_t = 5)]
+    pub timeout: u64,
+
+    /// Set an environment variable (KEY=VALUE)
+    #[arg(short, long = "env")]
+    pub envs: Vec<String>,
+
+    /// Working directory inside the service box
+    #[arg(short, long)]
+    pub workdir: Option<String>,
+
+    /// Keep standard input open
+    #[arg(short = 'i', long = "interactive")]
+    pub interactive: bool,
+
+    /// Allocate a pseudo-terminal
+    #[arg(short = 't', long = "tty")]
+    pub tty: bool,
+
+    /// Run as a specific user
+    #[arg(short = 'u', long)]
+    pub user: Option<String>,
+
+    /// Command and arguments
+    #[arg(last = true, required = true)]
+    pub command: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeTopArgs {
+    /// Limit output to these services
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposePortArgs {
+    /// Service name
+    pub service: String,
+
+    /// Private port and optional protocol, for example 80 or 80/tcp
+    pub private_port: Option<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeCpArgs {
+    /// Source path (HOST_PATH or SERVICE:CONTAINER_PATH)
+    pub src: String,
+
+    /// Destination path (HOST_PATH or SERVICE:CONTAINER_PATH)
+    pub dst: String,
+}
+
+#[derive(Args)]
+pub struct ComposePullArgs {
+    /// Suppress progress output
+    #[arg(short, long)]
+    pub quiet: bool,
+
+    /// Target platform, for example linux/amd64
+    #[arg(long)]
+    pub platform: Option<String>,
+
+    /// Limit the operation to these services
+    #[arg(value_name = "SERVICE")]
+    pub services: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ComposeLsArgs {
+    /// Print project names only
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+#[derive(Clone)]
+struct ProjectBox {
+    id: String,
+    name: String,
+    service: String,
+    status: String,
+    record: BoxRecord,
+}
+
+pub async fn execute_start(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ProjectServicesArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &args.services, false)?;
+    let queries = matching_ids(&boxes, |status| {
+        matches!(status, "created" | "stopped" | "dead")
+    });
+    if queries.is_empty() {
+        println!("All selected services are already active.");
+        return Ok(());
+    }
+    super::super::start::execute(super::super::start::StartArgs { boxes: queries }).await
+}
+
+pub async fn execute_stop(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ComposeStopArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &args.services, true)?;
+    let queries = matching_ids(&boxes, |status| matches!(status, "running" | "paused"));
+    if queries.is_empty() {
+        println!("All selected services are already stopped.");
+        return Ok(());
+    }
+    super::super::stop::execute(super::super::stop::StopArgs {
+        boxes: queries,
+        timeout: args.timeout,
+    })
+    .await
+}
+
+pub async fn execute_restart(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ComposeRestartArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &args.services, false)?;
+    super::super::restart::execute(super::super::restart::RestartArgs {
+        boxes: ids(&boxes),
+        timeout: args.timeout,
+    })
+    .await
+}
+
+pub async fn execute_rm(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ComposeRmArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &args.services, true)?;
+    let active = matching_ids(&boxes, |status| matches!(status, "running" | "paused"));
+    if !active.is_empty() {
+        if !args.stop {
+            return Err(
+                "selected services are active; pass --stop or run `compose stop` first".into(),
+            );
+        }
+        super::super::stop::execute(super::super::stop::StopArgs {
+            boxes: active,
+            timeout: None,
+        })
+        .await?;
+    }
+    let _confirmation_is_implicit = args.force;
+    super::super::rm::execute(super::super::rm::RmArgs {
+        boxes: ids(&boxes),
+        force: false,
+    })
+    .await
+}
+
+pub async fn execute_kill(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ComposeKillArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &args.services, true)?;
+    let queries = matching_ids(&boxes, |status| matches!(status, "running" | "paused"));
+    if queries.is_empty() {
+        println!("No selected services are active.");
+        return Ok(());
+    }
+    super::super::kill::execute(super::super::kill::KillArgs {
+        boxes: queries,
+        signal: args.signal,
+    })
+    .await
+}
+
+pub async fn execute_pause(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ProjectServicesArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &args.services, false)?;
+    let queries = matching_ids(&boxes, |status| status == "running");
+    if queries.is_empty() {
+        println!("No selected services are running.");
+        return Ok(());
+    }
+    super::super::pause::execute(super::super::pause::PauseArgs { boxes: queries }).await
+}
+
+pub async fn execute_unpause(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ProjectServicesArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &args.services, false)?;
+    let queries = matching_ids(&boxes, |status| status == "paused");
+    if queries.is_empty() {
+        println!("No selected services are paused.");
+        return Ok(());
+    }
+    super::super::unpause::execute(super::super::unpause::UnpauseArgs { boxes: queries }).await
+}
+
+pub async fn execute_wait(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ComposeWaitArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &args.services, false)?;
+    super::super::wait::execute(super::super::wait::WaitArgs {
+        boxes: ids(&boxes),
+        heartbeat_interval: args.heartbeat_interval,
+        no_heartbeat: args.no_heartbeat,
+    })
+    .await
+}
+
+pub async fn execute_exec(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ComposeExecArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let service_box = one_service(project_name, config, &args.service)?;
+    super::super::exec::execute(super::super::exec::ExecArgs {
+        r#box: service_box.id,
+        timeout: args.timeout,
+        envs: args.envs,
+        workdir: args.workdir,
+        interactive: args.interactive,
+        tty: args.tty,
+        user: args.user,
+        cmd: args.command,
+    })
+    .await
+}
+
+pub async fn execute_top(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ComposeTopArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &args.services, false)?;
+    for service_box in boxes {
+        println!("{}", service_box.service);
+        super::super::top::execute(super::super::top::TopArgs {
+            r#box: service_box.id,
+            format: super::super::top::TopFormat::Table,
+            ps_args: Vec::new(),
+        })
+        .await?;
+    }
+    Ok(())
+}
+
+pub async fn execute_port(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ComposePortArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let service_box = one_service(project_name, config, &args.service)?;
+    let requested = args.private_port.as_deref().map(normalize_private_port);
+    let mut found = false;
+    for value in &service_box.record.port_map {
+        let mapping = a3s_box_core::parse_port_mapping(value)?;
+        let private = format!("{}/{}", mapping.guest_port, mapping.protocol.as_str());
+        if requested.as_deref().is_some_and(|value| value != private) {
+            continue;
+        }
+        found = true;
+        println!("0.0.0.0:{}", mapping.host_port);
+    }
+    if requested.is_some() && !found {
+        return Err(format!(
+            "service '{}' does not publish the requested port",
+            args.service
+        )
+        .into());
+    }
+    Ok(())
+}
+
+pub async fn execute_cp(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ComposeCpArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let src = resolve_copy_endpoint(project_name, config, args.src)?;
+    let dst = resolve_copy_endpoint(project_name, config, args.dst)?;
+    super::super::cp::execute(super::super::cp::CpArgs { src, dst }).await
+}
+
+pub fn execute_images(
+    _project_name: &str,
+    config: &ComposeConfig,
+    args: ProjectServicesArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let services = selected_service_names(config, &args.services)?;
+    let mut table = crate::output::new_table(&["SERVICE", "IMAGE"]);
+    for service in services {
+        let image = config
+            .services
+            .get(&service)
+            .and_then(|value| value.image.as_deref())
+            .unwrap_or("<build-only>");
+        table.add_row([service.as_str(), image]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+pub async fn execute_pull(
+    _project_name: &str,
+    config: &ComposeConfig,
+    args: ComposePullArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let services = selected_service_names(config, &args.services)?;
+    let mut images = BTreeSet::new();
+    for service in services {
+        if let Some(image) = config
+            .services
+            .get(&service)
+            .and_then(|value| value.image.clone())
+        {
+            images.insert(image);
+        }
+    }
+    if images.is_empty() {
+        return Err("selected services do not declare an image".into());
+    }
+    for image in images {
+        super::super::pull::execute(super::super::pull::PullArgs {
+            image,
+            quiet: args.quiet,
+            platform: args.platform.clone(),
+            verify_key: None,
+            verify_issuer: None,
+            verify_identity: None,
+        })
+        .await?;
+    }
+    Ok(())
+}
+
+pub async fn execute_ls(args: ComposeLsArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let state = StateFile::load_default()?;
+    let mut projects: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    for record in state.records() {
+        let Some(project) = record.labels.get(LABEL_PROJECT) else {
+            continue;
+        };
+        let entry = projects.entry(project.clone()).or_default();
+        entry.0 += 1;
+        if matches!(record.status.as_str(), "running" | "paused") {
+            entry.1 += 1;
+        }
+    }
+    if args.quiet {
+        for project in projects.keys() {
+            println!("{project}");
+        }
+        return Ok(());
+    }
+    let mut table = crate::output::new_table(&["NAME", "STATUS", "SERVICES"]);
+    for (project, (total, active)) in projects {
+        let status = if active == total {
+            "running"
+        } else if active == 0 {
+            "stopped"
+        } else {
+            "partial"
+        };
+        table.add_row([project, status.to_string(), format!("{active}/{total}")]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+pub fn execute_volumes(
+    _project_name: &str,
+    config: &ComposeConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut volumes = config.volumes.keys().cloned().collect::<Vec<_>>();
+    volumes.sort();
+    for volume in volumes {
+        println!("{volume}");
+    }
+    Ok(())
+}
+
+fn select_boxes(
+    project_name: &str,
+    config: &ComposeConfig,
+    requested: &[String],
+    reverse: bool,
+) -> Result<Vec<ProjectBox>, Box<dyn std::error::Error>> {
+    let state = StateFile::load_default()?;
+    let mut by_service: BTreeMap<String, Vec<ProjectBox>> = BTreeMap::new();
+    for record in state.find_by_label(LABEL_PROJECT, project_name) {
+        let Some(service) = record.labels.get(LABEL_SERVICE) else {
+            continue;
+        };
+        by_service
+            .entry(service.clone())
+            .or_default()
+            .push(ProjectBox {
+                id: record.id.clone(),
+                name: record.name.clone(),
+                service: service.clone(),
+                status: record.status.clone(),
+                record: record.clone(),
+            });
+    }
+    if by_service.is_empty() {
+        return Err(format!(
+            "No services found for project '{project_name}'. Run `compose up` first."
+        )
+        .into());
+    }
+
+    let existing = by_service.keys().cloned().collect::<BTreeSet<_>>();
+    let service_order = service_box_order(config, &existing, requested, reverse)?;
+
+    let mut result = Vec::new();
+    for service in service_order {
+        let Some(mut boxes) = by_service.remove(&service) else {
+            if !requested.is_empty() {
+                return Err(format!("service '{service}' has not been created").into());
+            }
+            continue;
+        };
+        boxes.sort_by(|left, right| left.name.cmp(&right.name));
+        result.extend(boxes);
+    }
+    Ok(result)
+}
+
+fn service_box_order(
+    config: &ComposeConfig,
+    existing: &BTreeSet<String>,
+    requested: &[String],
+    reverse: bool,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut service_order = if requested.is_empty() {
+        let mut order = config.service_order()?;
+        for service in existing {
+            if !order.contains(service) {
+                order.push(service.clone());
+            }
+        }
+        order
+    } else {
+        validate_requested_services(config, existing, requested)?;
+        unique_service_names(requested)
+    };
+    if reverse {
+        service_order.reverse();
+    }
+    Ok(service_order)
+}
+
+fn validate_requested_services(
+    config: &ComposeConfig,
+    existing: &BTreeSet<String>,
+    requested: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    for service in requested {
+        if !config.services.contains_key(service) && !existing.contains(service) {
+            return Err(
+                format!("service '{service}' is not defined in the Compose project").into(),
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn selected_service_names(
+    config: &ComposeConfig,
+    requested: &[String],
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    if requested.is_empty() {
+        return Ok(config.service_order()?);
+    }
+    for service in requested {
+        if !config.services.contains_key(service) {
+            return Err(
+                format!("service '{service}' is not defined in the Compose project").into(),
+            );
+        }
+    }
+    Ok(unique_service_names(requested))
+}
+
+fn unique_service_names(requested: &[String]) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    requested
+        .iter()
+        .filter(|service| seen.insert((*service).clone()))
+        .cloned()
+        .collect()
+}
+
+fn one_service(
+    project_name: &str,
+    config: &ComposeConfig,
+    service: &str,
+) -> Result<ProjectBox, Box<dyn std::error::Error>> {
+    let boxes = select_boxes(project_name, config, &[service.to_string()], false)?;
+    if boxes.len() != 1 {
+        return Err(format!(
+            "service '{service}' resolves to {} boxes; select one instance explicitly",
+            boxes.len()
+        )
+        .into());
+    }
+    boxes
+        .into_iter()
+        .next()
+        .ok_or_else(|| format!("service '{service}' did not resolve to a box").into())
+}
+
+fn resolve_copy_endpoint(
+    project_name: &str,
+    config: &ComposeConfig,
+    endpoint: String,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let Some((service, path)) = endpoint.split_once(':') else {
+        return Ok(endpoint);
+    };
+    if service.len() == 1 {
+        return Ok(endpoint);
+    }
+    if !config.services.contains_key(service) {
+        return Err(format!("service '{service}' is not defined in the Compose project").into());
+    }
+    let service_box = one_service(project_name, config, service)?;
+    Ok(format!("{}:{path}", service_box.id))
+}
+
+fn normalize_private_port(value: &str) -> String {
+    if value.contains('/') {
+        value.to_string()
+    } else {
+        format!("{value}/tcp")
+    }
+}
+
+fn ids(boxes: &[ProjectBox]) -> Vec<String> {
+    boxes.iter().map(|value| value.id.clone()).collect()
+}
+
+fn matching_ids(boxes: &[ProjectBox], predicate: impl Fn(&str) -> bool) -> Vec<String> {
+    boxes
+        .iter()
+        .filter(|value| predicate(&value.status))
+        .map(|value| value.id.clone())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn private_ports_default_to_tcp() {
+        assert_eq!(normalize_private_port("8080"), "8080/tcp");
+        assert_eq!(normalize_private_port("53/udp"), "53/udp");
+    }
+
+    #[test]
+    fn service_selection_rejects_unknown_names() {
+        let config = ComposeConfig::from_yaml_str("services:\n  web:\n    image: nginx\n").unwrap();
+        let error = selected_service_names(&config, &["db".to_string()]).unwrap_err();
+        assert!(error.to_string().contains("service 'db' is not defined"));
+    }
+
+    #[test]
+    fn up_selection_includes_transitive_dependencies_only() {
+        let config = ComposeConfig::from_yaml_str(
+            "services:\n  db:\n    image: postgres\n  api:\n    image: api\n    depends_on: [db]\n  worker:\n    image: worker\n",
+        )
+        .unwrap();
+
+        let selected = select_up_config(config, &["api".to_string()]).unwrap();
+
+        assert!(selected.services.contains_key("api"));
+        assert!(selected.services.contains_key("db"));
+        assert!(!selected.services.contains_key("worker"));
+    }
+
+    #[test]
+    fn explicit_box_selection_does_not_include_unrequested_services() {
+        let config = ComposeConfig::from_yaml_str(
+            "services:\n  db:\n    image: postgres\n  api:\n    image: api\n    depends_on: [db]\n",
+        )
+        .unwrap();
+        let existing = BTreeSet::from(["api".to_string(), "db".to_string(), "orphan".to_string()]);
+
+        let selected = service_box_order(&config, &existing, &["api".to_string()], false).unwrap();
+
+        assert_eq!(selected, ["api"]);
+    }
+
+    #[test]
+    fn implicit_box_selection_keeps_config_order_and_existing_orphans() {
+        let config = ComposeConfig::from_yaml_str(
+            "services:\n  db:\n    image: postgres\n  api:\n    image: api\n    depends_on: [db]\n",
+        )
+        .unwrap();
+        let existing = BTreeSet::from(["api".to_string(), "db".to_string(), "orphan".to_string()]);
+
+        let selected = service_box_order(&config, &existing, &[], false).unwrap();
+
+        assert_eq!(selected, ["db", "api", "orphan"]);
+    }
+
+    #[test]
+    fn copy_endpoint_rejects_non_project_service_names() {
+        let config = ComposeConfig::from_yaml_str("services:\n  api:\n    image: api\n").unwrap();
+
+        let error =
+            resolve_copy_endpoint("project", &config, "other:/tmp/data".to_string()).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("service 'other' is not defined in the Compose project"));
+    }
+}

--- a/src/cli/src/commands/compose/read.rs
+++ b/src/cli/src/commands/compose/read.rs
@@ -1,0 +1,249 @@
+//! Read-only Compose project views and log streaming.
+
+use std::collections::HashMap;
+
+use a3s_box_core::compose::ComposeConfig;
+use a3s_box_runtime::ComposeProject;
+
+use super::{
+    validate_compose_restart_policies, ComposeLogsArgs, ProjectServicesArgs, LABEL_PROJECT,
+    LABEL_SERVICE,
+};
+use crate::state::StateFile;
+
+// ============================================================================
+// compose ps
+// ============================================================================
+
+/// `compose ps` — List services and their actual status.
+pub(super) async fn execute_ps(
+    project_name: &str,
+    config: &ComposeConfig,
+    args: ProjectServicesArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state = StateFile::load_default()?;
+    let boxes = state
+        .find_by_label(LABEL_PROJECT, project_name)
+        .into_iter()
+        .filter(|record| {
+            args.services.is_empty()
+                || record
+                    .labels
+                    .get(LABEL_SERVICE)
+                    .is_some_and(|service| args.services.contains(service))
+        })
+        .collect::<Vec<_>>();
+
+    for service in &args.services {
+        if !config.services.contains_key(service) {
+            return Err(
+                format!("Service '{service}' is not defined in project '{project_name}'.").into(),
+            );
+        }
+    }
+
+    if boxes.is_empty() {
+        println!("No services found for project '{}'.", project_name);
+        return Ok(());
+    }
+
+    println!(
+        "{:<20} {:<30} {:<12} {:<12} {:<10}",
+        "SERVICE", "IMAGE", "STATUS", "HEALTH", "PID"
+    );
+    println!("{}", "-".repeat(84));
+
+    for record in &boxes {
+        let svc_name = record
+            .labels
+            .get(LABEL_SERVICE)
+            .map(|s| s.as_str())
+            .unwrap_or("?");
+        let pid_str = record
+            .pid
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{:<20} {:<30} {:<12} {:<12} {:<10}",
+            svc_name, record.image, record.status, record.health_status, pid_str
+        );
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// compose config
+// ============================================================================
+
+/// `compose config` — Validate and display the parsed compose configuration.
+pub(super) fn execute_config(
+    project_name: &str,
+    config: ComposeConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    validate_compose_restart_policies(&config)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let project = ComposeProject::new(project_name, config)?;
+
+    println!("Project: {}", project_name);
+    println!("Services: {}", project.config.services.len());
+    println!("Networks: {}", project.required_networks().len());
+    println!("Volumes: {}", project.config.volumes.len());
+    println!("\nBoot order: {}", project.service_order.join(" → "));
+
+    for svc_name in &project.service_order {
+        if let Some(svc) = project.config.services.get(svc_name) {
+            println!("\n[{}]", svc_name);
+            if let Some(ref img) = svc.image {
+                println!("  image: {}", img);
+            }
+            if !svc.ports.is_empty() {
+                println!("  ports: {}", svc.ports.join(", "));
+            }
+            if !svc.volumes.is_empty() {
+                println!("  volumes: {}", svc.volumes.join(", "));
+            }
+            let deps = svc.depends_on.services();
+            if !deps.is_empty() {
+                println!("  depends_on: {}", deps.join(", "));
+            }
+            let env = svc.environment.to_pairs();
+            if !env.is_empty() {
+                println!("  environment:");
+                for (k, v) in &env {
+                    println!("    {}={}", k, v);
+                }
+            }
+        }
+    }
+
+    println!("\nConfiguration is valid.");
+    Ok(())
+}
+
+// ============================================================================
+// compose logs
+// ============================================================================
+
+/// `compose logs` — View logs from all (or one) service in the project.
+pub(super) async fn execute_logs(
+    project_name: &str,
+    config: &ComposeConfig,
+    logs_args: ComposeLogsArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !logs_args.services.is_empty() {
+        super::operations::selected_service_names(config, &logs_args.services)?;
+    }
+    let state = StateFile::load_default()?;
+    let boxes = state.find_by_label(LABEL_PROJECT, project_name);
+
+    if boxes.is_empty() {
+        println!("No services found for project '{}'.", project_name);
+        return Ok(());
+    }
+
+    // Filter to requested services if supplied.
+    let targets: Vec<_> = if !logs_args.services.is_empty() {
+        boxes
+            .iter()
+            .filter(|r| {
+                r.labels
+                    .get(LABEL_SERVICE)
+                    .is_some_and(|service| logs_args.services.contains(service))
+            })
+            .collect()
+    } else {
+        boxes.iter().collect()
+    };
+
+    if targets.is_empty() && !logs_args.services.is_empty() {
+        return Err(format!(
+            "Services '{}' were not found in project '{}'.",
+            logs_args.services.join(", "),
+            project_name
+        )
+        .into());
+    }
+
+    for record in &targets {
+        let svc_name = record
+            .labels
+            .get(LABEL_SERVICE)
+            .map(|s| s.as_str())
+            .unwrap_or("?");
+
+        let log_path = record.console_log.clone();
+        if !log_path.exists() {
+            println!("[{}] (no logs)", svc_name);
+            continue;
+        }
+
+        let content = std::fs::read_to_string(&log_path)
+            .map_err(|e| format!("Failed to read logs for {}: {}", svc_name, e))?;
+
+        let lines: Vec<&str> = content.lines().collect();
+        let start = lines.len().saturating_sub(logs_args.tail);
+        let prefix = if targets.len() > 1 {
+            format!("{} | ", svc_name)
+        } else {
+            String::new()
+        };
+
+        for line in &lines[start..] {
+            println!("{}{}", prefix, line);
+        }
+    }
+
+    if logs_args.follow {
+        println!("(follow mode: use Ctrl-C to stop)");
+        // In follow mode, tail all log files concurrently
+        // For simplicity, we poll every second
+        let mut last_sizes: HashMap<String, u64> = HashMap::new();
+        for record in &targets {
+            let size = std::fs::metadata(&record.console_log)
+                .map(|m| m.len())
+                .unwrap_or(0);
+            last_sizes.insert(record.id.clone(), size);
+        }
+
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+            for record in &targets {
+                let log_path = &record.console_log;
+                let current_size = std::fs::metadata(log_path).map(|m| m.len()).unwrap_or(0);
+                let last_size = last_sizes.get(&record.id).copied().unwrap_or(0);
+
+                if current_size > last_size {
+                    let svc_name = record
+                        .labels
+                        .get(LABEL_SERVICE)
+                        .map(|s| s.as_str())
+                        .unwrap_or("?");
+                    let prefix = if targets.len() > 1 {
+                        format!("{} | ", svc_name)
+                    } else {
+                        String::new()
+                    };
+
+                    if let Ok(file) = std::fs::File::open(log_path) {
+                        use std::io::{Read, Seek, SeekFrom};
+                        let mut file = file;
+                        if file.seek(SeekFrom::Start(last_size)).is_ok() {
+                            let mut buf = String::new();
+                            if file.read_to_string(&mut buf).is_ok() {
+                                for line in buf.lines() {
+                                    println!("{}{}", prefix, line);
+                                }
+                            }
+                        }
+                    }
+
+                    last_sizes.insert(record.id.clone(), current_size);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/src/commands/compose/read.rs
+++ b/src/cli/src/commands/compose/read.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use a3s_box_core::compose::ComposeConfig;
-use a3s_box_runtime::ComposeProject;
+use a3s_box_runtime::ComposeRuntimePlan;
 
 use super::{
     validate_compose_restart_policies, ComposeLogsArgs, ProjectServicesArgs, LABEL_PROJECT,
@@ -83,7 +83,7 @@ pub(super) fn execute_config(
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_compose_restart_policies(&config)
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    let project = ComposeProject::new(project_name, config)?;
+    let project = ComposeRuntimePlan::new(project_name, config)?;
 
     println!("Project: {}", project_name);
     println!("Services: {}", project.config.services.len());

--- a/src/cli/src/commands/compose/tests.rs
+++ b/src/cli/src/commands/compose/tests.rs
@@ -1,0 +1,312 @@
+use super::*;
+
+#[test]
+fn service_config_hash_is_stable_across_environment_order() {
+    let service = ServiceConfig::default();
+    let first = a3s_box_core::BoxConfig {
+        image: "example:latest".to_string(),
+        extra_env: vec![
+            ("B".to_string(), "2".to_string()),
+            ("A".to_string(), "1".to_string()),
+        ],
+        ..Default::default()
+    };
+    let mut second = first.clone();
+    second.extra_env.reverse();
+
+    assert_eq!(
+        service_config_hash(&service, &first).unwrap(),
+        service_config_hash(&service, &second).unwrap()
+    );
+}
+
+#[test]
+fn service_config_hash_tracks_runtime_isolation() {
+    let service = ServiceConfig::default();
+    let microvm = a3s_box_core::BoxConfig {
+        image: "example:latest".to_string(),
+        ..Default::default()
+    };
+    let mut sandbox = microvm.clone();
+    sandbox.isolation = a3s_box_core::ExecutionIsolation::Sandbox;
+
+    assert_ne!(
+        service_config_hash(&service, &microvm).unwrap(),
+        service_config_hash(&service, &sandbox).unwrap()
+    );
+}
+
+#[test]
+fn test_load_compose_file_not_found() {
+    let result = load_compose_file(Some(std::path::Path::new("/nonexistent/compose.yaml")));
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("not found"));
+}
+
+#[test]
+fn test_load_compose_file_interpolates_dotenv_and_shell_before_validation() {
+    let directory = tempfile::TempDir::new().unwrap();
+    let compose_path = directory.path().join("compose.yaml");
+    std::fs::write(
+        &compose_path,
+        r#"
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    environment:
+      DASH_EMPTY: ${EMPTY-default}
+      COLON_DASH_EMPTY: ${EMPTY:-default}
+      PLUS_EMPTY: ${EMPTY+replacement}
+      COLON_PLUS_EMPTY: ${EMPTY:+replacement}
+      DOTENV_ONLY: ${DOTENV_ONLY}
+      SHELL_WINS: ${SHELL_WINS}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        directory.path().join(".env"),
+        "REDIS_PORT=6379\nEMPTY=\nDOTENV_ONLY=dotenv\nSHELL_WINS=dotenv\n",
+    )
+    .unwrap();
+    let shell = HashMap::from([
+        ("REDIS_PORT".to_string(), "16379".to_string()),
+        ("SHELL_WINS".to_string(), "shell".to_string()),
+    ]);
+
+    let (_, config) = load_compose_file_with_environment(Some(&compose_path), shell).unwrap();
+    let service = &config.services["redis"];
+    assert_eq!(service.ports, vec!["16379:6379"]);
+    let environment: HashMap<_, _> = service.environment.to_pairs().into_iter().collect();
+    assert_eq!(environment["DASH_EMPTY"], "");
+    assert_eq!(environment["COLON_DASH_EMPTY"], "default");
+    assert_eq!(environment["PLUS_EMPTY"], "replacement");
+    assert_eq!(environment["COLON_PLUS_EMPTY"], "");
+    assert_eq!(environment["DOTENV_ONLY"], "dotenv");
+    assert_eq!(environment["SHELL_WINS"], "shell");
+
+    a3s_box_runtime::ComposeProject::with_base_dir("test", config, directory.path())
+        .expect("interpolation must run before port validation");
+}
+
+#[test]
+fn test_load_compose_file_reports_unreadable_dotenv() {
+    let directory = tempfile::TempDir::new().unwrap();
+    let compose_path = directory.path().join("compose.yaml");
+    std::fs::write(&compose_path, "services: {}\n").unwrap();
+    std::fs::create_dir(directory.path().join(".env")).unwrap();
+
+    let error =
+        load_compose_file_with_environment(Some(&compose_path), HashMap::<String, String>::new())
+            .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("Failed to read Compose environment file"));
+    assert!(error.to_string().contains(".env"));
+}
+
+#[test]
+fn test_compose_files_constant() {
+    assert_eq!(COMPOSE_FILES.len(), 5);
+    assert_eq!(COMPOSE_FILES[0], "compose.acl");
+    assert!(COMPOSE_FILES.contains(&"compose.yaml"));
+    assert!(COMPOSE_FILES.contains(&"docker-compose.yml"));
+}
+
+#[test]
+fn test_default_discovery_prefers_compose_acl() {
+    let directory = tempfile::TempDir::new().unwrap();
+    let acl_path = directory.path().join("compose.acl");
+    let yaml_path = directory.path().join("compose.yaml");
+    std::fs::write(&acl_path, "service \"api\" { image = \"api:latest\" }").unwrap();
+    std::fs::write(&yaml_path, "services: {}\n").unwrap();
+
+    let selected = resolve_compose_path(None, directory.path()).unwrap();
+
+    assert_eq!(selected, acl_path);
+}
+
+#[test]
+fn test_load_compose_acl_uses_dotenv_and_shell_environment() {
+    let directory = tempfile::TempDir::new().unwrap();
+    let compose_path = directory.path().join("compose.acl");
+    std::fs::write(
+        &compose_path,
+        r#"service "api" {
+  image = "api:${IMAGE_TAG}"
+  environment = {
+    FROM_DOTENV = env("FROM_DOTENV")
+    SHELL_WINS = env("SHELL_WINS")
+  }
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        directory.path().join(".env"),
+        "IMAGE_TAG=dotenv\nFROM_DOTENV=present\nSHELL_WINS=dotenv\n",
+    )
+    .unwrap();
+    let shell = HashMap::from([
+        ("IMAGE_TAG".to_string(), "shell".to_string()),
+        ("SHELL_WINS".to_string(), "shell".to_string()),
+    ]);
+
+    let (_, config) = load_compose_file_with_environment(Some(&compose_path), shell).unwrap();
+    let service = &config.services["api"];
+    assert_eq!(service.image.as_deref(), Some("api:shell"));
+    let environment: HashMap<_, _> = service.environment.to_pairs().into_iter().collect();
+    assert_eq!(environment["FROM_DOTENV"], "present");
+    assert_eq!(environment["SHELL_WINS"], "shell");
+}
+
+#[test]
+fn test_label_constants() {
+    assert_eq!(LABEL_PROJECT, "com.a3s.compose.project");
+    assert_eq!(LABEL_SERVICE, "com.a3s.compose.service");
+}
+
+#[test]
+fn test_service_restart_policy_normalizes_on_failure_limit() {
+    let service = ServiceConfig {
+        restart: Some("on-failure:3".to_string()),
+        ..Default::default()
+    };
+
+    let (policy, max_count) = service_restart_policy("web", Some(&service)).unwrap();
+
+    assert_eq!(policy, "on-failure");
+    assert_eq!(max_count, 3);
+}
+
+#[test]
+fn test_validate_compose_restart_policies_rejects_invalid_service_policy() {
+    let mut services = HashMap::new();
+    services.insert(
+        "web".to_string(),
+        ServiceConfig {
+            image: Some("docker.io/library/alpine:latest".to_string()),
+            restart: Some("never".to_string()),
+            ..Default::default()
+        },
+    );
+    let config = ComposeConfig {
+        version: None,
+        services,
+        volumes: HashMap::new(),
+        networks: HashMap::new(),
+    };
+
+    let error = validate_compose_restart_policies(&config).unwrap_err();
+
+    assert!(error.contains("Service 'web' has invalid restart policy"));
+    assert!(error.contains("Invalid restart policy"));
+}
+
+#[test]
+fn test_service_box_from_record_captures_cleanup_fields() {
+    let mut record = crate::test_helpers::fixtures::make_record(
+        "compose-id",
+        "project-web",
+        "running",
+        Some(123),
+    );
+    record
+        .labels
+        .insert(LABEL_SERVICE.to_string(), "web".to_string());
+    record.network_name = Some("project_default".to_string());
+    record.volume_names = vec!["data".to_string()];
+    record.anonymous_volumes = vec!["anon".to_string()];
+    record.stop_signal = Some("SIGINT".to_string());
+    record.stop_timeout = Some(3);
+
+    let service = ServiceBox::from_record(&record);
+
+    assert_eq!(service.box_id, "compose-id");
+    assert_eq!(service.svc_name, "web");
+    assert_eq!(service.pid, Some(123));
+    assert_eq!(service.network_name.as_deref(), Some("project_default"));
+    assert_eq!(service.volume_names, vec!["data".to_string()]);
+    assert_eq!(service.anonymous_volumes, vec!["anon".to_string()]);
+    assert_eq!(service.stop_signal.as_deref(), Some("SIGINT"));
+    assert_eq!(service.stop_timeout, Some(3));
+    assert!(service.is_active());
+}
+
+#[test]
+fn test_service_box_from_record_uses_network_mode_fallback() {
+    let mut record =
+        crate::test_helpers::fixtures::make_record("compose-id", "project-web", "running", None);
+    record.network_name = None;
+    record.network_mode = a3s_box_core::NetworkMode::Bridge {
+        network: "legacy_default".to_string(),
+    };
+
+    let service = ServiceBox::from_record(&record);
+
+    assert_eq!(service.network_name.as_deref(), Some("legacy_default"));
+}
+
+#[test]
+fn test_rollback_with_current_appends_current_service() {
+    let mut first_record =
+        crate::test_helpers::fixtures::make_record("first-id", "project-db", "running", None);
+    first_record
+        .labels
+        .insert(LABEL_SERVICE.to_string(), "db".to_string());
+    let mut current_record =
+        crate::test_helpers::fixtures::make_record("current-id", "project-web", "running", None);
+    current_record
+        .labels
+        .insert(LABEL_SERVICE.to_string(), "web".to_string());
+
+    let first = ServiceBox::from_record(&first_record);
+    let current = ServiceBox::from_record(&current_record);
+    let rollback_services = rollback_with_current(&[first], current);
+
+    assert_eq!(rollback_services.len(), 2);
+    assert_eq!(rollback_services[0].svc_name, "db");
+    assert_eq!(rollback_services[1].svc_name, "web");
+}
+
+#[test]
+fn test_service_box_paused_is_active() {
+    let mut record =
+        crate::test_helpers::fixtures::make_record("compose-id", "project-web", "paused", None);
+    record
+        .labels
+        .insert(LABEL_SERVICE.to_string(), "web".to_string());
+
+    let service = ServiceBox::from_record(&record);
+
+    assert!(service.is_active());
+}
+
+#[test]
+fn test_service_box_stopped_is_not_active() {
+    let mut record =
+        crate::test_helpers::fixtures::make_record("compose-id", "project-web", "stopped", None);
+    record
+        .labels
+        .insert(LABEL_SERVICE.to_string(), "web".to_string());
+
+    let service = ServiceBox::from_record(&record);
+
+    assert!(!service.is_active());
+}
+
+#[test]
+fn test_partial_service_cleanup_removes_box_directory() {
+    let directory = tempfile::TempDir::new().unwrap();
+    let box_dir = directory.path().join("box");
+    let exec_socket = box_dir.join("sockets").join("exec.sock");
+    std::fs::create_dir_all(box_dir.join("rootfs")).unwrap();
+    std::fs::create_dir_all(exec_socket.parent().unwrap()).unwrap();
+    std::fs::write(box_dir.join("rootfs").join("partial"), "data").unwrap();
+
+    cleanup_partial_service_box("partial-id", &box_dir, &exec_socket, None, &[], &[]);
+
+    assert!(!box_dir.exists());
+}

--- a/src/cli/src/commands/compose/tests.rs
+++ b/src/cli/src/commands/compose/tests.rs
@@ -86,7 +86,7 @@ services:
     assert_eq!(environment["DOTENV_ONLY"], "dotenv");
     assert_eq!(environment["SHELL_WINS"], "shell");
 
-    a3s_box_runtime::ComposeProject::with_base_dir("test", config, directory.path())
+    a3s_box_runtime::ComposeRuntimePlan::with_base_dir("test", config, directory.path())
         .expect("interpolation must run before port validation");
 }
 
@@ -105,6 +105,25 @@ fn test_load_compose_file_reports_unreadable_dotenv() {
         .to_string()
         .contains("Failed to read Compose environment file"));
     assert!(error.to_string().contains(".env"));
+}
+
+#[test]
+fn test_load_compose_file_rejects_unknown_yaml_fields_with_structured_path() {
+    let directory = tempfile::TempDir::new().unwrap();
+    let compose_path = directory.path().join("compose.yaml");
+    std::fs::write(
+        &compose_path,
+        "services:\n  api:\n    image: api:latest\n    build: .\n",
+    )
+    .unwrap();
+
+    let error =
+        load_compose_file_with_environment(Some(&compose_path), HashMap::<String, String>::new())
+            .unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains("compose.unsupported_field"));
+    assert!(message.contains("/services/api/build"));
 }
 
 #[test]

--- a/src/cli/src/commands/mod.rs
+++ b/src/cli/src/commands/mod.rs
@@ -448,5 +448,6 @@ mod isolation_cli_tests {
             panic!("expected compose up command");
         };
         assert_eq!(args.isolation, Some(common::IsolationArg::Sandbox));
+        assert!(args.services.is_empty());
     }
 }

--- a/src/cli/tests/command_coverage.rs
+++ b/src/cli/tests/command_coverage.rs
@@ -167,6 +167,22 @@ fn test_nested_subcommand_help() {
         &["compose", "ps"],
         &["compose", "logs"],
         &["compose", "config"],
+        &["compose", "start"],
+        &["compose", "stop"],
+        &["compose", "restart"],
+        &["compose", "rm"],
+        &["compose", "kill"],
+        &["compose", "pause"],
+        &["compose", "unpause"],
+        &["compose", "wait"],
+        &["compose", "exec"],
+        &["compose", "top"],
+        &["compose", "port"],
+        &["compose", "cp"],
+        &["compose", "images"],
+        &["compose", "pull"],
+        &["compose", "ls"],
+        &["compose", "volumes"],
     ];
 
     for command in commands {
@@ -700,6 +716,80 @@ fn test_compose_config_interpolates_shell_over_project_dotenv() {
     assert!(output.contains("EMPTY_SET=replacement"));
     assert!(output.contains("EMPTY_NONEMPTY="));
     assert!(output.contains("Configuration is valid."));
+}
+
+#[test]
+fn test_compose_config_accepts_a3s_acl() {
+    let cli = CliTest::new();
+    let project = cli.home_path().join("compose-acl");
+    std::fs::create_dir_all(&project).expect("create Compose ACL project directory");
+    let compose = project.join("compose.acl");
+    std::fs::write(
+        &compose,
+        r#"service "api" {
+  image = "ghcr.io/a3s-lab/api:${A3S_COMPOSE_TEST_TAG:-latest}"
+  environment = { TOKEN = env("A3S_COMPOSE_TEST_TOKEN") }
+  labels = { description = "服务" }
+  ports = ["8080:8080"]
+
+  healthcheck {
+    test = ["CMD", "true"]
+  }
+}
+"#,
+    )
+    .expect("write Compose ACL file");
+    let compose_arg = compose.to_string_lossy().to_string();
+
+    let output = cli.ok_with_env(
+        &["compose", "--file", &compose_arg, "config"],
+        &[("A3S_COMPOSE_TEST_TOKEN", "secret")],
+    );
+
+    assert!(output.contains("ghcr.io/a3s-lab/api:latest"));
+    assert!(output.contains("TOKEN=secret"));
+    assert!(output.contains("ports: 8080:8080"));
+    assert!(output.contains("Configuration is valid."));
+}
+
+#[test]
+fn test_compose_local_project_views_do_not_require_a_runtime() {
+    let cli = CliTest::new();
+    let project = cli.home_path().join("compose-views");
+    std::fs::create_dir_all(&project).expect("create Compose project directory");
+    let compose = project.join("compose.yaml");
+    std::fs::write(
+        &compose,
+        r#"services:
+  api:
+    image: ghcr.io/a3s-lab/api:latest
+    depends_on: [db]
+  db:
+    image: postgres:17
+    volumes:
+      - data:/var/lib/postgresql/data
+volumes:
+  data:
+"#,
+    )
+    .expect("write Compose file");
+    let compose_arg = compose.to_string_lossy().to_string();
+
+    let images = cli.ok(&["compose", "--file", &compose_arg, "images"]);
+    assert!(images.contains("api"));
+    assert!(images.contains("ghcr.io/a3s-lab/api:latest"));
+    assert!(images.contains("postgres:17"));
+
+    let volumes = cli.ok(&["compose", "--file", &compose_arg, "volumes"]);
+    assert_eq!(volumes.trim(), "data");
+
+    let projects = cli.ok(&["compose", "ls"]);
+    assert!(projects.contains("NAME"));
+
+    cli.fails(
+        &["compose", "--file", &compose_arg, "logs", "api", "missing"],
+        "service 'missing' is not defined in the Compose project",
+    );
 }
 
 #[cfg(unix)]

--- a/src/cli/tests/host_smoke.rs
+++ b/src/cli/tests/host_smoke.rs
@@ -16,6 +16,15 @@ use std::time::Duration;
 mod support;
 use support::*;
 
+fn inspect_box(cli: &CliTest, name: &str) -> serde_json::Value {
+    let value: serde_json::Value =
+        serde_json::from_str(&cli.ok(&["inspect", name])).expect("box inspect JSON");
+    match value {
+        serde_json::Value::Array(mut records) if !records.is_empty() => records.remove(0),
+        other => other,
+    }
+}
+
 #[test]
 #[ignore]
 #[cfg(target_os = "linux")]
@@ -385,30 +394,47 @@ fn test_real_vm_command_matrix() {
 
 #[test]
 #[ignore]
-fn test_real_compose_smoke() {
+fn test_real_compose_acl_smoke() {
     let cli = CliTest::new();
     let image = host_smoke_image();
     let boot_timeout = host_smoke_timeout(45);
     let project = "covcompose";
     let service_box = "covcompose-worker";
+    let unowned_network = "covcompose_unowned";
+    let socket_dirs_before = host_socket_dirs();
+    let listener =
+        std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve Compose host port");
+    let host_port = listener.local_addr().expect("reserved host address").port();
+    drop(listener);
 
     cleanup(&cli, service_box);
     seed_runnable_alpine_image(&cli, &image);
+    cli.ok(&[
+        "network",
+        "create",
+        unowned_network,
+        "--subnet",
+        "10.126.0.0/24",
+    ]);
 
     let compose_dir = cli.home_path().join("compose");
     std::fs::create_dir_all(&compose_dir).expect("create compose dir");
-    let compose_file = compose_dir.join("compose.yaml");
+    let compose_file = compose_dir.join("compose.acl");
     std::fs::write(
         &compose_file,
         format!(
-            r#"services:
-  worker:
-    image: {image}
-    command: ["sleep", "3600"]
-    environment:
-      A3S_COMPOSE_COVERAGE: "1"
-    labels:
-      purpose: coverage
+            r#"service "worker" {{
+  image = "{image}"
+  command = ["sleep", "3600"]
+  environment = {{ A3S_COMPOSE_COVERAGE = "1" }}
+  labels = {{ purpose = "coverage" }}
+  ports = ["{host_port}:8080"]
+  volumes = ["data:/data"]
+}}
+
+volume "data" {{
+  driver = "local"
+}}
 "#,
         ),
     )
@@ -423,6 +449,16 @@ fn test_real_compose_smoke() {
         project,
         "config",
     ]);
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "pull",
+        "--quiet",
+        "worker",
+    ]);
     cli.ok_status(&[
         "compose",
         "--file",
@@ -433,6 +469,21 @@ fn test_real_compose_smoke() {
         "--detach",
     ]);
     wait_for_running(&cli, service_box, boot_timeout);
+    let first_inspect = inspect_box(&cli, service_box);
+
+    // A second unchanged `up` must converge onto the same service box.
+    cli.ok_status(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "up",
+        "--detach",
+    ]);
+    let second_inspect = inspect_box(&cli, service_box);
+    assert_eq!(first_inspect["id"], second_inspect["id"]);
+
     cli.ok(&[
         "compose",
         "--file",
@@ -451,9 +502,47 @@ fn test_real_compose_smoke() {
         "--tail",
         "20",
     ]);
+    let images = cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "images",
+    ]);
+    assert!(images.contains("worker"));
+    assert!(images.contains(&image));
+    let volumes = cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "volumes",
+    ]);
+    assert_eq!(volumes.trim(), "data");
+    let projects = cli.ok(&["compose", "ls", "--quiet"]);
+    assert!(projects.lines().any(|name| name == project));
+    let published = cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "port",
+        "worker",
+        "8080",
+    ]);
+    assert_eq!(published.trim(), format!("0.0.0.0:{host_port}"));
+
     let env_value = cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
         "exec",
-        service_box,
+        "worker",
         "--",
         "sh",
         "-c",
@@ -466,11 +555,167 @@ fn test_real_compose_smoke() {
         &compose_file_arg,
         "--project-name",
         project,
+        "top",
+        "worker",
+    ]);
+
+    let source = cli.home_path().join("compose-copy-source.txt");
+    let destination = cli.home_path().join("compose-copy-destination.txt");
+    std::fs::write(&source, "compose-copy-ok\n").expect("write Compose copy source");
+    let source_arg = source.to_string_lossy().to_string();
+    let destination_arg = destination.to_string_lossy().to_string();
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "cp",
+        &source_arg,
+        "worker:/tmp/compose-copy.txt",
+    ]);
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "cp",
+        "worker:/tmp/compose-copy.txt",
+        &destination_arg,
+    ]);
+    assert_eq!(
+        std::fs::read_to_string(&destination).expect("read Compose copy destination"),
+        "compose-copy-ok\n"
+    );
+
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "stop",
+        "worker",
+    ]);
+    let stopped = inspect_box(&cli, service_box);
+    assert_eq!(stopped["status"], "stopped");
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "start",
+        "worker",
+    ]);
+    wait_for_running(&cli, service_box, boot_timeout);
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "restart",
+        "worker",
+    ]);
+    wait_for_running(&cli, service_box, boot_timeout);
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "pause",
+        "worker",
+    ]);
+    let paused = inspect_box(&cli, service_box);
+    assert_eq!(paused["status"], "paused");
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "unpause",
+        "worker",
+    ]);
+    wait_for_running(&cli, service_box, boot_timeout);
+
+    let waiter = cli.spawn_background(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "wait",
+        "--no-heartbeat",
+        "worker",
+    ]);
+    std::thread::sleep(Duration::from_secs(1));
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "kill",
+        "--signal",
+        "TERM",
+        "worker",
+    ]);
+    let wait_output = waiter
+        .wait_with_output()
+        .expect("collect Compose wait output");
+    assert!(
+        wait_output.status.success(),
+        "Compose wait failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&wait_output.stdout),
+        String::from_utf8_lossy(&wait_output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&wait_output.stdout).trim(), "143");
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
+        "rm",
+        "worker",
+    ]);
+    cli.ok(&[
+        "compose",
+        "--file",
+        &compose_file_arg,
+        "--project-name",
+        project,
         "down",
+        "--volumes",
     ]);
 
     let ps = cli.ok(&["ps", "-a"]);
     assert!(!ps.contains(service_box));
+    let volume_list = cli.ok(&["volume", "ls"]);
+    assert!(!volume_list
+        .lines()
+        .any(|line| line.split_whitespace().next() == Some("data")));
+    let network_list = cli.ok(&["network", "ls"]);
+    assert!(
+        network_list.contains(unowned_network),
+        "Compose down removed a prefix-matching network it did not own\n{network_list}"
+    );
+    assert!(!network_list.contains("covcompose_default"));
+    cli.ok(&["network", "rm", unowned_network]);
+    let boxes_dir = cli.home_path().join("boxes");
+    let remaining_boxes = std::fs::read_dir(&boxes_dir)
+        .map(|entries| entries.filter_map(Result::ok).collect::<Vec<_>>())
+        .unwrap_or_default();
+    assert!(
+        remaining_boxes.is_empty(),
+        "compose down left box storage or a mounted rootfs under {}",
+        boxes_dir.display()
+    );
+    assert_no_new_host_socket_dirs(&socket_dirs_before);
 }
 
 /// Warm-pool daemon end-to-end: `pool start` pre-warms VMs, then `pool run`

--- a/src/compat/Cargo.toml
+++ b/src/compat/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Protocol compatibility service and contract fixtures for A3S Box"
 
 [dependencies]
-a3s-acl = { git = "https://github.com/A3S-Lab/ACL.git", rev = "6e2a6469edc0f4c61b1e588d0ace873aaf15ce22" }
+a3s-acl = { workspace = true }
 a3s-box-core = { version = "3.0", path = "../core" }
 a3s-box-runtime = { version = "3.0", path = "../runtime", default-features = false, features = ["vm"] }
 anyhow = { workspace = true }

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "Core types, config, and error handling for A3S Box MicroVM runtime"
 
 [dependencies]
+a3s-acl = { workspace = true }
 a3s-transport = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }

--- a/src/core/src/compose.rs
+++ b/src/core/src/compose.rs
@@ -7,10 +7,21 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 mod acl;
+mod diagnostic;
 mod interpolation;
+mod normalization;
+mod normalized;
+mod schema;
 
 pub use acl::ComposeAclError;
+pub use diagnostic::{ComposeDiagnostic, ComposeDiagnosticCode, ComposeNormalizationError};
 pub use interpolation::{interpolate_compose_yaml, ComposeInterpolationError};
+pub use normalization::{normalize_compose, normalize_compose_config, ComposeSourceFormat};
+pub use normalized::{
+    NormalizedComposeConfig, NormalizedDependsOn, NormalizedHealthcheckConfig,
+    NormalizedNetworkDeclaration, NormalizedServiceConfig, NormalizedServiceNetwork,
+    NormalizedVolumeDeclaration,
+};
 
 /// Top-level compose file configuration.
 ///
@@ -33,6 +44,7 @@ pub use interpolation::{interpolate_compose_yaml, ComposeInterpolationError};
 ///   default:
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ComposeConfig {
     /// Compose file version (informational, not enforced).
     #[serde(default)]
@@ -52,6 +64,7 @@ pub struct ComposeConfig {
 
 /// A single service in a compose file.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ServiceConfig {
     /// OCI image reference (e.g., "nginx:latest").
     #[serde(default)]
@@ -144,6 +157,7 @@ pub struct ServiceConfig {
 
 /// Health check configuration for a service.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HealthcheckConfig {
     /// Command to run (e.g., ["CMD", "curl", "-f", "http://localhost/"]).
     #[serde(default)]
@@ -167,6 +181,7 @@ pub struct HealthcheckConfig {
 
 /// Volume declaration.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct VolumeDeclaration {
     /// Volume driver (default: "local").
     #[serde(default)]
@@ -175,6 +190,7 @@ pub struct VolumeDeclaration {
 
 /// Network declaration.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct NetworkDeclaration {
     /// Network driver (default: "bridge").
     #[serde(default)]
@@ -231,7 +247,14 @@ impl EnvVars {
     pub fn to_pairs(&self) -> Vec<(String, String)> {
         match self {
             Self::Empty => vec![],
-            Self::Map(m) => m.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+            Self::Map(m) => {
+                let mut pairs = m
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect::<Vec<_>>();
+                pairs.sort_by(|left, right| left.0.cmp(&right.0));
+                pairs
+            }
             Self::List(list) => list
                 .iter()
                 .filter_map(|s| {
@@ -262,13 +285,18 @@ impl DependsOn {
         match self {
             Self::Empty => vec![],
             Self::List(v) => v.clone(),
-            Self::Map(m) => m.keys().cloned().collect(),
+            Self::Map(m) => {
+                let mut services = m.keys().cloned().collect::<Vec<_>>();
+                services.sort();
+                services
+            }
         }
     }
 }
 
 /// Condition for a depends_on entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DependsOnCondition {
     /// Condition: "service_started" (default) or "service_healthy".
     #[serde(default = "default_condition")]
@@ -298,13 +326,18 @@ impl ServiceNetworks {
         match self {
             Self::Empty => vec![],
             Self::List(v) => v.clone(),
-            Self::Map(m) => m.keys().cloned().collect(),
+            Self::Map(m) => {
+                let mut names = m.keys().cloned().collect::<Vec<_>>();
+                names.sort();
+                names
+            }
         }
     }
 }
 
 /// Per-service network configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ServiceNetworkConfig {
     /// Network aliases for this service.
     #[serde(default)]
@@ -393,7 +426,9 @@ impl ComposeConfig {
         // 0 = unvisited, 1 = in-progress, 2 = done
         let mut state: HashMap<String, u8> = HashMap::new();
 
-        for name in self.services.keys() {
+        let mut service_names = self.services.keys().collect::<Vec<_>>();
+        service_names.sort();
+        for name in service_names {
             if !state.contains_key(name) {
                 self.topo_visit(name, &mut state, &mut order)?;
             }
@@ -457,6 +492,16 @@ services:
             config.services["web"].image.as_deref(),
             Some("nginx:latest")
         );
+    }
+
+    #[test]
+    fn test_raw_yaml_parser_never_silently_ignores_unknown_fields() {
+        let error = ComposeConfig::from_yaml_str(
+            "services:\n  api:\n    image: api:latest\n    build: .\n",
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("unknown field `build`"));
     }
 
     #[test]

--- a/src/core/src/compose.rs
+++ b/src/core/src/compose.rs
@@ -1,13 +1,15 @@
 //! Compose file types for multi-container orchestration.
 //!
-//! Defines a docker-compose-compatible YAML schema for declaring
+//! Defines A3S ACL and Docker Compose-compatible YAML schemas for declaring
 //! multi-service workloads. Each service maps to a single MicroVM.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+mod acl;
 mod interpolation;
 
+pub use acl::ComposeAclError;
 pub use interpolation::{interpolate_compose_yaml, ComposeInterpolationError};
 
 /// Top-level compose file configuration.
@@ -358,6 +360,21 @@ impl DnsConfig {
 }
 
 impl ComposeConfig {
+    /// Parse an A3S Compose ACL document using the process environment for
+    /// `env("NAME")` calls.
+    pub fn from_acl_str(source: &str) -> Result<Self, ComposeAclError> {
+        let environment = std::env::vars().collect();
+        Self::from_acl_str_with_environment(source, &environment)
+    }
+
+    /// Parse an A3S Compose ACL document using an explicit environment.
+    pub fn from_acl_str_with_environment(
+        source: &str,
+        environment: &HashMap<String, String>,
+    ) -> Result<Self, ComposeAclError> {
+        acl::parse_compose_acl(source, environment)
+    }
+
     /// Parse a compose config from YAML bytes.
     pub fn from_yaml(yaml: &[u8]) -> Result<Self, serde_yaml::Error> {
         serde_yaml::from_slice(yaml)

--- a/src/core/src/compose/acl.rs
+++ b/src/core/src/compose/acl.rs
@@ -5,59 +5,63 @@ use std::collections::HashMap;
 use a3s_acl::{Block, Document, Lexer, Token, Value};
 use thiserror::Error;
 
+use super::diagnostic::{child_path, pointer_segment, ComposeDiagnostic};
 use super::interpolation::interpolate_compose_scalar;
-use super::{
-    ComposeConfig, DependsOn, DependsOnCondition, DnsConfig, EnvVars, HealthcheckConfig, Labels,
-    NetworkDeclaration, ServiceConfig, ServiceNetworkConfig, ServiceNetworks, StringOrList,
-    VolumeDeclaration,
+use super::schema::{
+    DEPENDS_ON_FIELDS, HEALTHCHECK_FIELDS, NETWORK_FIELDS, SERVICE_FIELDS, SERVICE_NETWORK_FIELDS,
+    VOLUME_FIELDS,
 };
-
-const SERVICE_ATTRIBUTES: &[&str] = &[
-    "image",
-    "entrypoint",
-    "command",
-    "environment",
-    "env_file",
-    "ports",
-    "volumes",
-    "depends_on",
-    "networks",
-    "cpus",
-    "mem_limit",
-    "restart",
-    "dns",
-    "tmpfs",
-    "cap_add",
-    "cap_drop",
-    "privileged",
-    "labels",
-    "healthcheck",
-    "working_dir",
-    "hostname",
-    "extra_hosts",
-];
-
-const HEALTHCHECK_ATTRIBUTES: &[&str] = &[
-    "test",
-    "disable",
-    "interval",
-    "timeout",
-    "retries",
-    "start_period",
-];
+use super::{
+    ComposeConfig, ComposeDiagnosticCode, DependsOn, DependsOnCondition, DnsConfig, EnvVars,
+    HealthcheckConfig, Labels, NetworkDeclaration, ServiceConfig, ServiceNetworkConfig,
+    ServiceNetworks, StringOrList, VolumeDeclaration,
+};
 
 /// An invalid A3S Compose ACL document.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error("{message}")]
+#[error("{diagnostic}")]
 pub struct ComposeAclError {
-    message: String,
+    diagnostic: ComposeDiagnostic,
 }
 
 impl ComposeAclError {
     fn invalid(message: impl Into<String>) -> Self {
         Self {
-            message: message.into(),
+            diagnostic: ComposeDiagnostic::new(ComposeDiagnosticCode::InvalidValue, "/", message),
         }
+    }
+
+    fn syntax(message: impl Into<String>) -> Self {
+        Self {
+            diagnostic: ComposeDiagnostic::new(ComposeDiagnosticCode::Syntax, "/", message),
+        }
+    }
+
+    fn interpolation(message: impl Into<String>) -> Self {
+        Self {
+            diagnostic: ComposeDiagnostic::new(ComposeDiagnosticCode::Interpolation, "/", message),
+        }
+    }
+
+    fn unsupported_field(path: impl Into<String>, field: &str) -> Self {
+        Self {
+            diagnostic: ComposeDiagnostic::unsupported_field(path, field),
+        }
+    }
+
+    fn unsupported_value(path: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            diagnostic: ComposeDiagnostic::new(
+                ComposeDiagnosticCode::UnsupportedValue,
+                path,
+                message,
+            ),
+        }
+    }
+
+    /// Structured diagnostic suitable for CLI, API, or Cloud callers.
+    pub fn diagnostic(&self) -> &ComposeDiagnostic {
+        &self.diagnostic
     }
 }
 
@@ -67,7 +71,7 @@ pub(super) fn parse_compose_acl(
 ) -> Result<ComposeConfig, ComposeAclError> {
     validate_balanced_braces(source)?;
     let mut document = a3s_acl::parse(source)
-        .map_err(|error| ComposeAclError::invalid(format!("invalid A3S ACL: {error}")))?;
+        .map_err(|error| ComposeAclError::syntax(format!("invalid A3S ACL: {error}")))?;
     interpolate_document_values(&mut document, environment)?;
     resolve_environment_calls(&mut document, environment)?;
     convert_document(document)
@@ -79,7 +83,7 @@ fn validate_balanced_braces(source: &str) -> Result<(), ComposeAclError> {
         match token.token {
             Token::LeftBrace => depth += 1,
             Token::RightBrace if depth == 0 => {
-                return Err(ComposeAclError::invalid(
+                return Err(ComposeAclError::syntax(
                     "compose ACL contains an unmatched closing brace",
                 ));
             }
@@ -88,7 +92,7 @@ fn validate_balanced_braces(source: &str) -> Result<(), ComposeAclError> {
         }
     }
     if depth != 0 {
-        return Err(ComposeAclError::invalid(
+        return Err(ComposeAclError::syntax(
             "compose ACL contains an unclosed block or object",
         ));
     }
@@ -125,7 +129,7 @@ fn interpolate_value(
     match value {
         Value::String(text) => {
             *text = interpolate_compose_scalar(text, environment).map_err(|error| {
-                ComposeAclError::invalid(format!("invalid Compose interpolation: {error}"))
+                ComposeAclError::interpolation(format!("invalid Compose interpolation: {error}"))
             })?;
         }
         Value::List(values) | Value::Call(_, values) => {
@@ -173,9 +177,10 @@ fn resolve_value_environment(
     match value {
         Value::Call(name, arguments) => {
             if name != "env" {
-                return Err(ComposeAclError::invalid(format!(
-                    "unsupported ACL function {name:?}; only env(\"NAME\") is supported"
-                )));
+                return Err(ComposeAclError::unsupported_value(
+                    "/",
+                    format!("unsupported ACL function {name:?}; only env(\"NAME\") is supported"),
+                ));
             }
             let [Value::String(variable)] = arguments.as_slice() else {
                 return Err(ComposeAclError::invalid(
@@ -224,9 +229,10 @@ fn convert_document(document: Document) -> Result<ComposeConfig, ComposeAclError
             "volume" => {
                 let name = named_block_label(&block, "volume")?;
                 validate_compose_name("volume", &name)?;
-                validate_plain_block(&block, &["driver"], &format!("volume {name:?}"))?;
+                let path = format!("/volumes/{}", pointer_segment(&name));
+                validate_plain_block(&block, VOLUME_FIELDS, &path)?;
                 let declaration = VolumeDeclaration {
-                    driver: optional_string(&block, "driver", &format!("volume {name:?}"))?,
+                    driver: optional_string(&block, "driver", &path)?,
                 };
                 if volumes.insert(name.clone(), Some(declaration)).is_some() {
                     return Err(ComposeAclError::invalid(format!(
@@ -237,9 +243,10 @@ fn convert_document(document: Document) -> Result<ComposeConfig, ComposeAclError
             "network" => {
                 let name = named_block_label(&block, "network")?;
                 validate_compose_name("network", &name)?;
-                validate_plain_block(&block, &["driver"], &format!("network {name:?}"))?;
+                let path = format!("/networks/{}", pointer_segment(&name));
+                validate_plain_block(&block, NETWORK_FIELDS, &path)?;
                 let declaration = NetworkDeclaration {
-                    driver: optional_string(&block, "driver", &format!("network {name:?}"))?,
+                    driver: optional_string(&block, "driver", &path)?,
                 };
                 if networks.insert(name.clone(), Some(declaration)).is_some() {
                     return Err(ComposeAclError::invalid(format!(
@@ -248,9 +255,10 @@ fn convert_document(document: Document) -> Result<ComposeConfig, ComposeAclError
                 }
             }
             name => {
-                return Err(ComposeAclError::invalid(format!(
-                    "unsupported root block {name:?}; expected service, volume, or network"
-                )));
+                return Err(ComposeAclError::unsupported_field(
+                    format!("/{}", pointer_segment(name)),
+                    name,
+                ));
             }
         }
     }
@@ -270,8 +278,8 @@ fn convert_document(document: Document) -> Result<ComposeConfig, ComposeAclError
 }
 
 fn parse_service(block: &Block, name: &str) -> Result<ServiceConfig, ComposeAclError> {
-    let path = format!("service {name:?}");
-    validate_attributes(block, SERVICE_ATTRIBUTES, &path)?;
+    let path = format!("/services/{}", pointer_segment(name));
+    validate_attributes(block, SERVICE_FIELDS, &path)?;
     let healthcheck = parse_service_healthcheck(block, &path)?;
 
     Ok(ServiceConfig {
@@ -307,10 +315,10 @@ fn parse_service_healthcheck(
     let mut nested_healthcheck = None;
     for nested in &service.blocks {
         if nested.name != "healthcheck" {
-            return Err(ComposeAclError::invalid(format!(
-                "{service_path} contains unsupported nested block {:?}",
-                nested.name
-            )));
+            return Err(ComposeAclError::unsupported_field(
+                child_path(service_path, &nested.name),
+                &nested.name,
+            ));
         }
         if nested_healthcheck.replace(nested).is_some() {
             return Err(ComposeAclError::invalid(format!(
@@ -339,13 +347,13 @@ fn parse_healthcheck(
     value: &Value,
     service_path: &str,
 ) -> Result<HealthcheckConfig, ComposeAclError> {
-    let path = format!("{service_path}.healthcheck");
+    let path = child_path(service_path, "healthcheck");
     let Value::Object(entries) = value else {
         return Err(ComposeAclError::invalid(format!(
             "{path} must be an object or a healthcheck block"
         )));
     };
-    let fields = object_fields(entries, HEALTHCHECK_ATTRIBUTES, &path)?;
+    let fields = object_fields(entries, HEALTHCHECK_FIELDS, &path)?;
     parse_healthcheck_fields(&fields, &path)
 }
 
@@ -353,13 +361,13 @@ fn parse_healthcheck_block(
     block: &Block,
     service_path: &str,
 ) -> Result<HealthcheckConfig, ComposeAclError> {
-    let path = format!("{service_path}.healthcheck");
+    let path = child_path(service_path, "healthcheck");
     if !block.labels.is_empty() {
         return Err(ComposeAclError::invalid(format!(
             "{path} block cannot have labels"
         )));
     }
-    validate_plain_block(block, HEALTHCHECK_ATTRIBUTES, &path)?;
+    validate_plain_block(block, HEALTHCHECK_FIELDS, &path)?;
     let fields = block
         .attributes
         .iter()
@@ -447,10 +455,14 @@ fn validate_attributes(block: &Block, allowed: &[&str], path: &str) -> Result<()
         .collect::<Vec<_>>();
     unknown.sort();
     if !unknown.is_empty() {
-        return Err(ComposeAclError::invalid(format!(
-            "{path} contains unsupported attribute(s): {}",
-            unknown.join(", ")
-        )));
+        let first = &unknown[0];
+        return Err(ComposeAclError {
+            diagnostic: ComposeDiagnostic::new(
+                ComposeDiagnosticCode::UnsupportedField,
+                child_path(path, first),
+                format!("unsupported Compose field(s): {}", unknown.join(", ")),
+            ),
+        });
     }
     Ok(())
 }
@@ -630,7 +642,7 @@ fn optional_depends_on(
     let Some(value) = block.attributes.get(field) else {
         return Ok(DependsOn::Empty);
     };
-    let field_path = format!("{path}.{field}");
+    let field_path = child_path(path, field);
     match value {
         Value::List(_) => string_list_value(value, &field_path).map(DependsOn::List),
         Value::Object(entries) => {
@@ -640,19 +652,20 @@ fn optional_depends_on(
                 let condition = match value {
                     Value::Null => "service_started".to_string(),
                     Value::Object(fields) => {
-                        let fields =
-                            object_fields(fields, &["condition"], &format!("{field_path}.{name}"))?;
+                        let dependency_path = child_path(&field_path, name);
+                        let fields = object_fields(fields, DEPENDS_ON_FIELDS, &dependency_path)?;
                         fields
                             .get("condition")
                             .map(|value| {
-                                string_value(value, &format!("{field_path}.{name}.condition"))
+                                string_value(value, &child_path(&dependency_path, "condition"))
                             })
                             .transpose()?
                             .unwrap_or_else(|| "service_started".to_string())
                     }
                     _ => {
                         return Err(ComposeAclError::invalid(format!(
-                            "{field_path}.{name} must be an object or null"
+                            "{} must be an object or null",
+                            child_path(&field_path, name)
                         )));
                     }
                 };
@@ -660,9 +673,10 @@ fn optional_depends_on(
                     condition.as_str(),
                     "service_started" | "service_healthy" | "service_completed_successfully"
                 ) {
-                    return Err(ComposeAclError::invalid(format!(
-                        "{field_path}.{name}.condition has unsupported value {condition:?}"
-                    )));
+                    return Err(ComposeAclError::unsupported_value(
+                        child_path(&child_path(&field_path, name), "condition"),
+                        format!("unsupported depends_on condition {condition:?}"),
+                    ));
                 }
                 if dependencies
                     .insert(name.clone(), DependsOnCondition { condition })
@@ -689,7 +703,7 @@ fn optional_service_networks(
     let Some(value) = block.attributes.get(field) else {
         return Ok(ServiceNetworks::Empty);
     };
-    let field_path = format!("{path}.{field}");
+    let field_path = child_path(path, field);
     match value {
         Value::List(_) => string_list_value(value, &field_path).map(ServiceNetworks::List),
         Value::Object(entries) => {
@@ -699,12 +713,12 @@ fn optional_service_networks(
                 let config = match value {
                     Value::Null => None,
                     Value::Object(fields) => {
-                        let fields =
-                            object_fields(fields, &["aliases"], &format!("{field_path}.{name}"))?;
+                        let network_path = child_path(&field_path, name);
+                        let fields = object_fields(fields, SERVICE_NETWORK_FIELDS, &network_path)?;
                         let aliases = fields
                             .get("aliases")
                             .map(|value| {
-                                string_list_value(value, &format!("{field_path}.{name}.aliases"))
+                                string_list_value(value, &child_path(&network_path, "aliases"))
                             })
                             .transpose()?
                             .unwrap_or_default();
@@ -712,7 +726,8 @@ fn optional_service_networks(
                     }
                     _ => {
                         return Err(ComposeAclError::invalid(format!(
-                            "{field_path}.{name} must be an object or null"
+                            "{} must be an object or null",
+                            child_path(&field_path, name)
                         )));
                     }
                 };
@@ -738,9 +753,10 @@ fn object_fields<'a>(
     let mut output = HashMap::new();
     for (key, value) in entries {
         if !allowed.contains(&key.as_str()) {
-            return Err(ComposeAclError::invalid(format!(
-                "{path} contains unsupported attribute {key:?}"
-            )));
+            return Err(ComposeAclError::unsupported_field(
+                child_path(path, key),
+                key,
+            ));
         }
         if output.insert(key.as_str(), value).is_some() {
             return Err(ComposeAclError::invalid(format!(

--- a/src/core/src/compose/acl.rs
+++ b/src/core/src/compose/acl.rs
@@ -1,0 +1,917 @@
+//! Closed-schema A3S ACL parser for Compose applications.
+
+use std::collections::HashMap;
+
+use a3s_acl::{Block, Document, Lexer, Token, Value};
+use thiserror::Error;
+
+use super::interpolation::interpolate_compose_scalar;
+use super::{
+    ComposeConfig, DependsOn, DependsOnCondition, DnsConfig, EnvVars, HealthcheckConfig, Labels,
+    NetworkDeclaration, ServiceConfig, ServiceNetworkConfig, ServiceNetworks, StringOrList,
+    VolumeDeclaration,
+};
+
+const SERVICE_ATTRIBUTES: &[&str] = &[
+    "image",
+    "entrypoint",
+    "command",
+    "environment",
+    "env_file",
+    "ports",
+    "volumes",
+    "depends_on",
+    "networks",
+    "cpus",
+    "mem_limit",
+    "restart",
+    "dns",
+    "tmpfs",
+    "cap_add",
+    "cap_drop",
+    "privileged",
+    "labels",
+    "healthcheck",
+    "working_dir",
+    "hostname",
+    "extra_hosts",
+];
+
+const HEALTHCHECK_ATTRIBUTES: &[&str] = &[
+    "test",
+    "disable",
+    "interval",
+    "timeout",
+    "retries",
+    "start_period",
+];
+
+/// An invalid A3S Compose ACL document.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{message}")]
+pub struct ComposeAclError {
+    message: String,
+}
+
+impl ComposeAclError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+pub(super) fn parse_compose_acl(
+    source: &str,
+    environment: &HashMap<String, String>,
+) -> Result<ComposeConfig, ComposeAclError> {
+    validate_balanced_braces(source)?;
+    let mut document = a3s_acl::parse(source)
+        .map_err(|error| ComposeAclError::invalid(format!("invalid A3S ACL: {error}")))?;
+    interpolate_document_values(&mut document, environment)?;
+    resolve_environment_calls(&mut document, environment)?;
+    convert_document(document)
+}
+
+fn validate_balanced_braces(source: &str) -> Result<(), ComposeAclError> {
+    let mut depth = 0usize;
+    for token in Lexer::new(source).tokenize() {
+        match token.token {
+            Token::LeftBrace => depth += 1,
+            Token::RightBrace if depth == 0 => {
+                return Err(ComposeAclError::invalid(
+                    "compose ACL contains an unmatched closing brace",
+                ));
+            }
+            Token::RightBrace => depth -= 1,
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return Err(ComposeAclError::invalid(
+            "compose ACL contains an unclosed block or object",
+        ));
+    }
+    Ok(())
+}
+
+fn interpolate_document_values(
+    document: &mut Document,
+    environment: &HashMap<String, String>,
+) -> Result<(), ComposeAclError> {
+    for block in &mut document.blocks {
+        interpolate_block_values(block, environment)?;
+    }
+    Ok(())
+}
+
+fn interpolate_block_values(
+    block: &mut Block,
+    environment: &HashMap<String, String>,
+) -> Result<(), ComposeAclError> {
+    for value in block.attributes.values_mut() {
+        interpolate_value(value, environment)?;
+    }
+    for nested in &mut block.blocks {
+        interpolate_block_values(nested, environment)?;
+    }
+    Ok(())
+}
+
+fn interpolate_value(
+    value: &mut Value,
+    environment: &HashMap<String, String>,
+) -> Result<(), ComposeAclError> {
+    match value {
+        Value::String(text) => {
+            *text = interpolate_compose_scalar(text, environment).map_err(|error| {
+                ComposeAclError::invalid(format!("invalid Compose interpolation: {error}"))
+            })?;
+        }
+        Value::List(values) | Value::Call(_, values) => {
+            for value in values {
+                interpolate_value(value, environment)?;
+            }
+        }
+        Value::Object(entries) => {
+            for (_, value) in entries {
+                interpolate_value(value, environment)?;
+            }
+        }
+        Value::Number(_) | Value::Bool(_) | Value::Null => {}
+    }
+    Ok(())
+}
+
+fn resolve_environment_calls(
+    document: &mut Document,
+    environment: &HashMap<String, String>,
+) -> Result<(), ComposeAclError> {
+    for block in &mut document.blocks {
+        resolve_block_environment(block, environment)?;
+    }
+    Ok(())
+}
+
+fn resolve_block_environment(
+    block: &mut Block,
+    environment: &HashMap<String, String>,
+) -> Result<(), ComposeAclError> {
+    for value in block.attributes.values_mut() {
+        resolve_value_environment(value, environment)?;
+    }
+    for nested in &mut block.blocks {
+        resolve_block_environment(nested, environment)?;
+    }
+    Ok(())
+}
+
+fn resolve_value_environment(
+    value: &mut Value,
+    environment: &HashMap<String, String>,
+) -> Result<(), ComposeAclError> {
+    match value {
+        Value::Call(name, arguments) => {
+            if name != "env" {
+                return Err(ComposeAclError::invalid(format!(
+                    "unsupported ACL function {name:?}; only env(\"NAME\") is supported"
+                )));
+            }
+            let [Value::String(variable)] = arguments.as_slice() else {
+                return Err(ComposeAclError::invalid(
+                    "env() must receive exactly one string environment variable name",
+                ));
+            };
+            let resolved = environment.get(variable).cloned().ok_or_else(|| {
+                ComposeAclError::invalid(format!(
+                    "environment variable {variable:?} referenced by env() is not set"
+                ))
+            })?;
+            *value = Value::String(resolved);
+        }
+        Value::List(values) => {
+            for value in values {
+                resolve_value_environment(value, environment)?;
+            }
+        }
+        Value::Object(entries) => {
+            for (_, value) in entries {
+                resolve_value_environment(value, environment)?;
+            }
+        }
+        Value::String(_) | Value::Number(_) | Value::Bool(_) | Value::Null => {}
+    }
+    Ok(())
+}
+
+fn convert_document(document: Document) -> Result<ComposeConfig, ComposeAclError> {
+    let mut services = HashMap::new();
+    let mut volumes = HashMap::new();
+    let mut networks = HashMap::new();
+
+    for block in document.blocks {
+        match block.name.as_str() {
+            "service" => {
+                let name = named_block_label(&block, "service")?;
+                validate_compose_name("service", &name)?;
+                let config = parse_service(&block, &name)?;
+                if services.insert(name.clone(), config).is_some() {
+                    return Err(ComposeAclError::invalid(format!(
+                        "duplicate service block {name:?}"
+                    )));
+                }
+            }
+            "volume" => {
+                let name = named_block_label(&block, "volume")?;
+                validate_compose_name("volume", &name)?;
+                validate_plain_block(&block, &["driver"], &format!("volume {name:?}"))?;
+                let declaration = VolumeDeclaration {
+                    driver: optional_string(&block, "driver", &format!("volume {name:?}"))?,
+                };
+                if volumes.insert(name.clone(), Some(declaration)).is_some() {
+                    return Err(ComposeAclError::invalid(format!(
+                        "duplicate volume block {name:?}"
+                    )));
+                }
+            }
+            "network" => {
+                let name = named_block_label(&block, "network")?;
+                validate_compose_name("network", &name)?;
+                validate_plain_block(&block, &["driver"], &format!("network {name:?}"))?;
+                let declaration = NetworkDeclaration {
+                    driver: optional_string(&block, "driver", &format!("network {name:?}"))?,
+                };
+                if networks.insert(name.clone(), Some(declaration)).is_some() {
+                    return Err(ComposeAclError::invalid(format!(
+                        "duplicate network block {name:?}"
+                    )));
+                }
+            }
+            name => {
+                return Err(ComposeAclError::invalid(format!(
+                    "unsupported root block {name:?}; expected service, volume, or network"
+                )));
+            }
+        }
+    }
+
+    if services.is_empty() {
+        return Err(ComposeAclError::invalid(
+            "compose.acl must contain at least one service block",
+        ));
+    }
+
+    Ok(ComposeConfig {
+        version: None,
+        services,
+        volumes,
+        networks,
+    })
+}
+
+fn parse_service(block: &Block, name: &str) -> Result<ServiceConfig, ComposeAclError> {
+    let path = format!("service {name:?}");
+    validate_attributes(block, SERVICE_ATTRIBUTES, &path)?;
+    let healthcheck = parse_service_healthcheck(block, &path)?;
+
+    Ok(ServiceConfig {
+        image: optional_string(block, "image", &path)?,
+        entrypoint: optional_string_or_list(block, "entrypoint", &path)?,
+        command: optional_string_or_list(block, "command", &path)?,
+        environment: optional_env_vars(block, "environment", &path)?,
+        env_file: optional_string_or_list(block, "env_file", &path)?.unwrap_or_default(),
+        ports: optional_string_list(block, "ports", &path)?.unwrap_or_default(),
+        volumes: optional_string_list(block, "volumes", &path)?.unwrap_or_default(),
+        depends_on: optional_depends_on(block, "depends_on", &path)?,
+        networks: optional_service_networks(block, "networks", &path)?,
+        cpus: optional_integer(block, "cpus", &path)?,
+        mem_limit: optional_string(block, "mem_limit", &path)?,
+        restart: optional_string(block, "restart", &path)?,
+        dns: optional_dns(block, "dns", &path)?,
+        tmpfs: optional_string_or_list(block, "tmpfs", &path)?.unwrap_or_default(),
+        cap_add: optional_string_list(block, "cap_add", &path)?.unwrap_or_default(),
+        cap_drop: optional_string_list(block, "cap_drop", &path)?.unwrap_or_default(),
+        privileged: optional_bool(block, "privileged", &path)?.unwrap_or(false),
+        labels: optional_labels(block, "labels", &path)?,
+        healthcheck,
+        working_dir: optional_string(block, "working_dir", &path)?,
+        hostname: optional_string(block, "hostname", &path)?,
+        extra_hosts: optional_string_or_list(block, "extra_hosts", &path)?.unwrap_or_default(),
+    })
+}
+
+fn parse_service_healthcheck(
+    service: &Block,
+    service_path: &str,
+) -> Result<Option<HealthcheckConfig>, ComposeAclError> {
+    let mut nested_healthcheck = None;
+    for nested in &service.blocks {
+        if nested.name != "healthcheck" {
+            return Err(ComposeAclError::invalid(format!(
+                "{service_path} contains unsupported nested block {:?}",
+                nested.name
+            )));
+        }
+        if nested_healthcheck.replace(nested).is_some() {
+            return Err(ComposeAclError::invalid(format!(
+                "{service_path} contains more than one healthcheck block"
+            )));
+        }
+    }
+
+    let attribute_healthcheck = service.attributes.get("healthcheck");
+    if attribute_healthcheck.is_some() && nested_healthcheck.is_some() {
+        return Err(ComposeAclError::invalid(format!(
+            "{service_path} declares healthcheck both as an attribute and a block"
+        )));
+    }
+
+    if let Some(value) = attribute_healthcheck {
+        return parse_healthcheck(value, service_path).map(Some);
+    }
+    if let Some(block) = nested_healthcheck {
+        return parse_healthcheck_block(block, service_path).map(Some);
+    }
+    Ok(None)
+}
+
+fn parse_healthcheck(
+    value: &Value,
+    service_path: &str,
+) -> Result<HealthcheckConfig, ComposeAclError> {
+    let path = format!("{service_path}.healthcheck");
+    let Value::Object(entries) = value else {
+        return Err(ComposeAclError::invalid(format!(
+            "{path} must be an object or a healthcheck block"
+        )));
+    };
+    let fields = object_fields(entries, HEALTHCHECK_ATTRIBUTES, &path)?;
+    parse_healthcheck_fields(&fields, &path)
+}
+
+fn parse_healthcheck_block(
+    block: &Block,
+    service_path: &str,
+) -> Result<HealthcheckConfig, ComposeAclError> {
+    let path = format!("{service_path}.healthcheck");
+    if !block.labels.is_empty() {
+        return Err(ComposeAclError::invalid(format!(
+            "{path} block cannot have labels"
+        )));
+    }
+    validate_plain_block(block, HEALTHCHECK_ATTRIBUTES, &path)?;
+    let fields = block
+        .attributes
+        .iter()
+        .map(|(name, value)| (name.as_str(), value))
+        .collect::<HashMap<_, _>>();
+    parse_healthcheck_fields(&fields, &path)
+}
+
+fn parse_healthcheck_fields(
+    fields: &HashMap<&str, &Value>,
+    path: &str,
+) -> Result<HealthcheckConfig, ComposeAclError> {
+    Ok(HealthcheckConfig {
+        test: fields
+            .get("test")
+            .map(|value| string_or_list_value(value, &format!("{path}.test")))
+            .transpose()?
+            .unwrap_or_default(),
+        disable: fields
+            .get("disable")
+            .map(|value| bool_value(value, &format!("{path}.disable")))
+            .transpose()?
+            .unwrap_or(false),
+        interval: fields
+            .get("interval")
+            .map(|value| string_value(value, &format!("{path}.interval")))
+            .transpose()?,
+        timeout: fields
+            .get("timeout")
+            .map(|value| string_value(value, &format!("{path}.timeout")))
+            .transpose()?,
+        retries: fields
+            .get("retries")
+            .map(|value| integer_value(value, &format!("{path}.retries")))
+            .transpose()?,
+        start_period: fields
+            .get("start_period")
+            .map(|value| string_value(value, &format!("{path}.start_period")))
+            .transpose()?,
+    })
+}
+
+fn named_block_label(block: &Block, kind: &str) -> Result<String, ComposeAclError> {
+    let [name] = block.labels.as_slice() else {
+        return Err(ComposeAclError::invalid(format!(
+            "{kind} blocks require exactly one string label"
+        )));
+    };
+    Ok(name.clone())
+}
+
+fn validate_compose_name(kind: &str, name: &str) -> Result<(), ComposeAclError> {
+    let mut bytes = name.bytes();
+    let valid = bytes
+        .next()
+        .is_some_and(|byte| byte.is_ascii_alphanumeric())
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+    if !valid {
+        return Err(ComposeAclError::invalid(format!(
+            "{kind} name {name:?} must start with an ASCII letter or digit and contain only letters, digits, '.', '_', or '-'"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_plain_block(
+    block: &Block,
+    attributes: &[&str],
+    path: &str,
+) -> Result<(), ComposeAclError> {
+    if !block.blocks.is_empty() {
+        return Err(ComposeAclError::invalid(format!(
+            "{path} cannot contain nested blocks"
+        )));
+    }
+    validate_attributes(block, attributes, path)
+}
+
+fn validate_attributes(block: &Block, allowed: &[&str], path: &str) -> Result<(), ComposeAclError> {
+    let mut unknown = block
+        .attributes
+        .keys()
+        .filter(|field| !allowed.contains(&field.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    unknown.sort();
+    if !unknown.is_empty() {
+        return Err(ComposeAclError::invalid(format!(
+            "{path} contains unsupported attribute(s): {}",
+            unknown.join(", ")
+        )));
+    }
+    Ok(())
+}
+
+fn optional_string(
+    block: &Block,
+    field: &str,
+    path: &str,
+) -> Result<Option<String>, ComposeAclError> {
+    block
+        .attributes
+        .get(field)
+        .map(|value| string_value(value, &format!("{path}.{field}")))
+        .transpose()
+}
+
+fn string_value(value: &Value, path: &str) -> Result<String, ComposeAclError> {
+    value
+        .as_str()
+        .map(str::to_owned)
+        .ok_or_else(|| ComposeAclError::invalid(format!("{path} must be a string")))
+}
+
+fn optional_string_list(
+    block: &Block,
+    field: &str,
+    path: &str,
+) -> Result<Option<Vec<String>>, ComposeAclError> {
+    block
+        .attributes
+        .get(field)
+        .map(|value| string_list_value(value, &format!("{path}.{field}")))
+        .transpose()
+}
+
+fn string_list_value(value: &Value, path: &str) -> Result<Vec<String>, ComposeAclError> {
+    let Value::List(values) = value else {
+        return Err(ComposeAclError::invalid(format!(
+            "{path} must be a list of strings"
+        )));
+    };
+    values
+        .iter()
+        .map(|value| string_value(value, path))
+        .collect()
+}
+
+fn optional_string_or_list(
+    block: &Block,
+    field: &str,
+    path: &str,
+) -> Result<Option<StringOrList>, ComposeAclError> {
+    block
+        .attributes
+        .get(field)
+        .map(|value| string_or_list_value(value, &format!("{path}.{field}")))
+        .transpose()
+}
+
+fn string_or_list_value(value: &Value, path: &str) -> Result<StringOrList, ComposeAclError> {
+    match value {
+        Value::String(value) => Ok(StringOrList::Single(value.clone())),
+        Value::List(_) => string_list_value(value, path).map(StringOrList::List),
+        _ => Err(ComposeAclError::invalid(format!(
+            "{path} must be a string or a list of strings"
+        ))),
+    }
+}
+
+fn optional_integer<T>(block: &Block, field: &str, path: &str) -> Result<Option<T>, ComposeAclError>
+where
+    T: TryFrom<u64>,
+{
+    block
+        .attributes
+        .get(field)
+        .map(|value| integer_value(value, &format!("{path}.{field}")))
+        .transpose()
+}
+
+fn integer_value<T>(value: &Value, path: &str) -> Result<T, ComposeAclError>
+where
+    T: TryFrom<u64>,
+{
+    let Value::Number(number) = value else {
+        return Err(ComposeAclError::invalid(format!(
+            "{path} must be a nonnegative integer"
+        )));
+    };
+    if !number.is_finite() || *number < 0.0 || number.fract() != 0.0 || *number > u64::MAX as f64 {
+        return Err(ComposeAclError::invalid(format!(
+            "{path} must be a nonnegative integer"
+        )));
+    }
+    T::try_from(*number as u64)
+        .map_err(|_| ComposeAclError::invalid(format!("{path} is out of range")))
+}
+
+fn optional_bool(block: &Block, field: &str, path: &str) -> Result<Option<bool>, ComposeAclError> {
+    block
+        .attributes
+        .get(field)
+        .map(|value| bool_value(value, &format!("{path}.{field}")))
+        .transpose()
+}
+
+fn bool_value(value: &Value, path: &str) -> Result<bool, ComposeAclError> {
+    value
+        .as_bool()
+        .ok_or_else(|| ComposeAclError::invalid(format!("{path} must be a boolean")))
+}
+
+fn optional_env_vars(block: &Block, field: &str, path: &str) -> Result<EnvVars, ComposeAclError> {
+    let Some(value) = block.attributes.get(field) else {
+        return Ok(EnvVars::Empty);
+    };
+    match value {
+        Value::List(_) => string_list_value(value, &format!("{path}.{field}")).map(EnvVars::List),
+        Value::Object(entries) => {
+            string_map_value(entries, &format!("{path}.{field}")).map(EnvVars::Map)
+        }
+        _ => Err(ComposeAclError::invalid(format!(
+            "{path}.{field} must be an object or a list of KEY=value strings"
+        ))),
+    }
+}
+
+fn optional_labels(block: &Block, field: &str, path: &str) -> Result<Labels, ComposeAclError> {
+    let Some(value) = block.attributes.get(field) else {
+        return Ok(Labels::Empty);
+    };
+    match value {
+        Value::List(_) => string_list_value(value, &format!("{path}.{field}")).map(Labels::List),
+        Value::Object(entries) => {
+            string_map_value(entries, &format!("{path}.{field}")).map(Labels::Map)
+        }
+        _ => Err(ComposeAclError::invalid(format!(
+            "{path}.{field} must be an object or a list of label strings"
+        ))),
+    }
+}
+
+fn string_map_value(
+    entries: &[(String, Value)],
+    path: &str,
+) -> Result<HashMap<String, String>, ComposeAclError> {
+    let mut output = HashMap::new();
+    for (key, value) in entries {
+        let value = string_value(value, &format!("{path}.{key}"))?;
+        if output.insert(key.clone(), value).is_some() {
+            return Err(ComposeAclError::invalid(format!(
+                "{path} contains duplicate key {key:?}"
+            )));
+        }
+    }
+    Ok(output)
+}
+
+fn optional_dns(block: &Block, field: &str, path: &str) -> Result<DnsConfig, ComposeAclError> {
+    let Some(value) = block.attributes.get(field) else {
+        return Ok(DnsConfig::Empty);
+    };
+    match value {
+        Value::String(value) => Ok(DnsConfig::Single(value.clone())),
+        Value::List(_) => string_list_value(value, &format!("{path}.{field}")).map(DnsConfig::List),
+        _ => Err(ComposeAclError::invalid(format!(
+            "{path}.{field} must be a string or a list of strings"
+        ))),
+    }
+}
+
+fn optional_depends_on(
+    block: &Block,
+    field: &str,
+    path: &str,
+) -> Result<DependsOn, ComposeAclError> {
+    let Some(value) = block.attributes.get(field) else {
+        return Ok(DependsOn::Empty);
+    };
+    let field_path = format!("{path}.{field}");
+    match value {
+        Value::List(_) => string_list_value(value, &field_path).map(DependsOn::List),
+        Value::Object(entries) => {
+            let mut dependencies = HashMap::new();
+            for (name, value) in entries {
+                validate_compose_name("dependency service", name)?;
+                let condition = match value {
+                    Value::Null => "service_started".to_string(),
+                    Value::Object(fields) => {
+                        let fields =
+                            object_fields(fields, &["condition"], &format!("{field_path}.{name}"))?;
+                        fields
+                            .get("condition")
+                            .map(|value| {
+                                string_value(value, &format!("{field_path}.{name}.condition"))
+                            })
+                            .transpose()?
+                            .unwrap_or_else(|| "service_started".to_string())
+                    }
+                    _ => {
+                        return Err(ComposeAclError::invalid(format!(
+                            "{field_path}.{name} must be an object or null"
+                        )));
+                    }
+                };
+                if !matches!(
+                    condition.as_str(),
+                    "service_started" | "service_healthy" | "service_completed_successfully"
+                ) {
+                    return Err(ComposeAclError::invalid(format!(
+                        "{field_path}.{name}.condition has unsupported value {condition:?}"
+                    )));
+                }
+                if dependencies
+                    .insert(name.clone(), DependsOnCondition { condition })
+                    .is_some()
+                {
+                    return Err(ComposeAclError::invalid(format!(
+                        "{field_path} contains duplicate service {name:?}"
+                    )));
+                }
+            }
+            Ok(DependsOn::Map(dependencies))
+        }
+        _ => Err(ComposeAclError::invalid(format!(
+            "{field_path} must be a list of service names or an object"
+        ))),
+    }
+}
+
+fn optional_service_networks(
+    block: &Block,
+    field: &str,
+    path: &str,
+) -> Result<ServiceNetworks, ComposeAclError> {
+    let Some(value) = block.attributes.get(field) else {
+        return Ok(ServiceNetworks::Empty);
+    };
+    let field_path = format!("{path}.{field}");
+    match value {
+        Value::List(_) => string_list_value(value, &field_path).map(ServiceNetworks::List),
+        Value::Object(entries) => {
+            let mut networks = HashMap::new();
+            for (name, value) in entries {
+                validate_compose_name("network", name)?;
+                let config = match value {
+                    Value::Null => None,
+                    Value::Object(fields) => {
+                        let fields =
+                            object_fields(fields, &["aliases"], &format!("{field_path}.{name}"))?;
+                        let aliases = fields
+                            .get("aliases")
+                            .map(|value| {
+                                string_list_value(value, &format!("{field_path}.{name}.aliases"))
+                            })
+                            .transpose()?
+                            .unwrap_or_default();
+                        Some(ServiceNetworkConfig { aliases })
+                    }
+                    _ => {
+                        return Err(ComposeAclError::invalid(format!(
+                            "{field_path}.{name} must be an object or null"
+                        )));
+                    }
+                };
+                if networks.insert(name.clone(), config).is_some() {
+                    return Err(ComposeAclError::invalid(format!(
+                        "{field_path} contains duplicate network {name:?}"
+                    )));
+                }
+            }
+            Ok(ServiceNetworks::Map(networks))
+        }
+        _ => Err(ComposeAclError::invalid(format!(
+            "{field_path} must be a list of network names or an object"
+        ))),
+    }
+}
+
+fn object_fields<'a>(
+    entries: &'a [(String, Value)],
+    allowed: &[&str],
+    path: &str,
+) -> Result<HashMap<&'a str, &'a Value>, ComposeAclError> {
+    let mut output = HashMap::new();
+    for (key, value) in entries {
+        if !allowed.contains(&key.as_str()) {
+            return Err(ComposeAclError::invalid(format!(
+                "{path} contains unsupported attribute {key:?}"
+            )));
+        }
+        if output.insert(key.as_str(), value).is_some() {
+            return Err(ComposeAclError::invalid(format!(
+                "{path} contains duplicate attribute {key:?}"
+            )));
+        }
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const COMPLETE: &str = r#"
+service "api" {
+  image = "ghcr.io/a3s/api:latest"
+  entrypoint = ["/bin/api"]
+  command = ["serve", "--port", "8080"]
+  environment = {
+    PORT = "8080"
+    TOKEN = env("API_TOKEN")
+  }
+  env_file = ["base.env", "local.env"]
+  ports = ["8080:8080"]
+  volumes = ["data:/data"]
+  depends_on = {
+    db = { condition = "service_healthy" }
+  }
+  networks = {
+    backend = { aliases = ["service-api"] }
+  }
+  cpus = 2
+  mem_limit = "1g"
+  restart = "unless-stopped"
+  dns = ["1.1.1.1"]
+  tmpfs = "/tmp"
+  cap_add = ["NET_ADMIN"]
+  cap_drop = ["SYS_ADMIN"]
+  privileged = false
+  labels = { tier = "api" }
+  working_dir = "/app"
+  hostname = "api"
+  extra_hosts = ["host.internal:10.0.0.1"]
+
+  healthcheck {
+    test = ["CMD", "curl", "-f", "http://localhost:8080/health"]
+    interval = "10s"
+    timeout = "3s"
+    retries = 3
+    start_period = "5s"
+  }
+}
+
+service "db" {
+  image = "postgres:17"
+}
+
+volume "data" {
+  driver = "local"
+}
+
+network "backend" {
+  driver = "bridge"
+}
+"#;
+
+    #[test]
+    fn parses_complete_closed_acl_schema() {
+        let environment = HashMap::from([("API_TOKEN".to_string(), "secret".to_string())]);
+        let config = parse_compose_acl(COMPLETE, &environment).expect("valid compose ACL");
+
+        assert_eq!(config.services.len(), 2);
+        let api = &config.services["api"];
+        assert_eq!(api.image.as_deref(), Some("ghcr.io/a3s/api:latest"));
+        assert_eq!(
+            api.command.as_ref().unwrap().to_vec(),
+            ["serve", "--port", "8080"]
+        );
+        assert_eq!(api.environment.to_pairs().len(), 2);
+        assert!(api
+            .environment
+            .to_pairs()
+            .contains(&("TOKEN".to_string(), "secret".to_string())));
+        assert_eq!(api.depends_on.services(), ["db"]);
+        assert_eq!(api.networks.names(), ["backend"]);
+        assert_eq!(api.cpus, Some(2));
+        assert_eq!(api.healthcheck.as_ref().unwrap().retries, Some(3));
+        assert_eq!(
+            config.volumes["data"].as_ref().unwrap().driver.as_deref(),
+            Some("local")
+        );
+        assert_eq!(
+            config.networks["backend"]
+                .as_ref()
+                .unwrap()
+                .driver
+                .as_deref(),
+            Some("bridge")
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_blocks_attributes_and_nested_fields() {
+        for source in [
+            "database \"db\" {}",
+            "service \"api\" { image = \"api\" typo = true }",
+            "service \"api\" { image = \"api\" deploy {} }",
+            "service \"api\" { image = \"api\" healthcheck { typo = 1 } }",
+            "service \"api\" { image = \"api\"",
+            "service \"api\" { image = \"api\" } }",
+        ] {
+            assert!(
+                parse_compose_acl(source, &HashMap::new()).is_err(),
+                "source should fail: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_labels_types_numbers_and_functions() {
+        for source in [
+            "service {}",
+            "service \"bad/name\" { image = \"api\" }",
+            "service \"api\" { ports = \"8080:80\" }",
+            "service \"api\" { cpus = -1 }",
+            "service \"api\" { privileged = \"true\" }",
+            "service \"api\" { image = concat(\"a\", \"b\") }",
+        ] {
+            assert!(
+                parse_compose_acl(source, &HashMap::new()).is_err(),
+                "source should fail: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn reports_missing_environment_values() {
+        let error = parse_compose_acl(
+            "service \"api\" { environment = { TOKEN = env(\"MISSING\") } }",
+            &HashMap::new(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("MISSING"));
+        assert!(error.to_string().contains("not set"));
+    }
+
+    #[test]
+    fn parses_nested_healthcheck_after_multibyte_string() {
+        let source = r#"
+service "api" {
+  image = "api:latest"
+  labels = { description = "服务" }
+
+  healthcheck {
+    test = ["CMD", "true"]
+  }
+}
+"#;
+
+        let config = parse_compose_acl(source, &HashMap::new()).expect("valid Unicode ACL");
+
+        assert_eq!(
+            config.services["api"]
+                .healthcheck
+                .as_ref()
+                .unwrap()
+                .test
+                .to_vec(),
+            ["CMD", "true"]
+        );
+    }
+}

--- a/src/core/src/compose/diagnostic.rs
+++ b/src/core/src/compose/diagnostic.rs
@@ -1,0 +1,181 @@
+//! Structured diagnostics produced while parsing and normalizing Compose input.
+
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Stable machine-readable category for a Compose diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum ComposeDiagnosticCode {
+    /// The source is not syntactically valid YAML or ACL.
+    #[serde(rename = "compose.syntax")]
+    Syntax,
+    /// Environment interpolation could not be completed.
+    #[serde(rename = "compose.interpolation")]
+    Interpolation,
+    /// The source contains a field outside Box's closed Compose schema.
+    #[serde(rename = "compose.unsupported_field")]
+    UnsupportedField,
+    /// A recognized field contains a value that Box cannot implement.
+    #[serde(rename = "compose.unsupported_value")]
+    UnsupportedValue,
+    /// A recognized field contains an invalid value.
+    #[serde(rename = "compose.invalid_value")]
+    InvalidValue,
+}
+
+impl ComposeDiagnosticCode {
+    /// Stable dotted representation suitable for logs and API responses.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Syntax => "compose.syntax",
+            Self::Interpolation => "compose.interpolation",
+            Self::UnsupportedField => "compose.unsupported_field",
+            Self::UnsupportedValue => "compose.unsupported_value",
+            Self::InvalidValue => "compose.invalid_value",
+        }
+    }
+}
+
+impl fmt::Display for ComposeDiagnosticCode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One actionable Compose parsing or normalization failure.
+///
+/// `path` uses JSON Pointer-style segments so callers do not need to parse a
+/// human error string. ACL blocks are projected onto the equivalent Compose
+/// object path (for example, `service "api"` becomes `/services/api`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComposeDiagnostic {
+    /// Stable machine-readable failure category.
+    pub code: ComposeDiagnosticCode,
+    /// JSON Pointer-style path to the rejected field or value.
+    pub path: String,
+    /// Human-readable explanation.
+    pub message: String,
+    /// One-based source line when the parser exposes it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    /// One-based source column when the parser exposes it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<usize>,
+}
+
+impl ComposeDiagnostic {
+    pub(super) fn new(
+        code: ComposeDiagnosticCode,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            path: path.into(),
+            message: message.into(),
+            line: None,
+            column: None,
+        }
+    }
+
+    pub(super) fn with_location(mut self, line: usize, column: usize) -> Self {
+        self.line = Some(line);
+        self.column = Some(column);
+        self
+    }
+
+    pub(super) fn unsupported_field(path: impl Into<String>, field: &str) -> Self {
+        Self::new(
+            ComposeDiagnosticCode::UnsupportedField,
+            path,
+            format!("unsupported Compose field {field:?}"),
+        )
+    }
+}
+
+impl fmt::Display for ComposeDiagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} at {}: {}",
+            self.code, self.path, self.message
+        )?;
+        if let (Some(line), Some(column)) = (self.line, self.column) {
+            write!(formatter, " (line {line}, column {column})")?;
+        }
+        Ok(())
+    }
+}
+
+/// One or more structured failures from a pure Compose normalization pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposeNormalizationError {
+    diagnostics: Vec<ComposeDiagnostic>,
+}
+
+impl ComposeNormalizationError {
+    pub(super) fn new(mut diagnostics: Vec<ComposeDiagnostic>) -> Self {
+        diagnostics.sort_by(|left, right| {
+            left.path
+                .cmp(&right.path)
+                .then_with(|| left.code.cmp(&right.code))
+                .then_with(|| left.message.cmp(&right.message))
+        });
+        diagnostics.dedup();
+        Self { diagnostics }
+    }
+
+    pub(super) fn one(diagnostic: ComposeDiagnostic) -> Self {
+        Self::new(vec![diagnostic])
+    }
+
+    /// Structured diagnostics in deterministic path/code/message order.
+    pub fn diagnostics(&self) -> &[ComposeDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// Consume the error and return its structured diagnostics.
+    pub fn into_diagnostics(self) -> Vec<ComposeDiagnostic> {
+        self.diagnostics
+    }
+}
+
+impl fmt::Display for ComposeNormalizationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.diagnostics.as_slice() {
+            [] => formatter.write_str("Compose normalization failed"),
+            [diagnostic] => diagnostic.fmt(formatter),
+            diagnostics => {
+                write!(
+                    formatter,
+                    "Compose normalization failed with {} diagnostics: ",
+                    diagnostics.len()
+                )?;
+                for (index, diagnostic) in diagnostics.iter().enumerate() {
+                    if index > 0 {
+                        formatter.write_str("; ")?;
+                    }
+                    diagnostic.fmt(formatter)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Error for ComposeNormalizationError {}
+
+pub(super) fn pointer_segment(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}
+
+pub(super) fn child_path(parent: &str, child: &str) -> String {
+    let child = pointer_segment(child);
+    if parent == "/" {
+        format!("/{child}")
+    } else {
+        format!("{parent}/{child}")
+    }
+}

--- a/src/core/src/compose/interpolation.rs
+++ b/src/core/src/compose/interpolation.rs
@@ -42,6 +42,13 @@ pub fn interpolate_compose_yaml(
     serde_yaml::to_string(&yaml).map_err(ComposeInterpolationError::from)
 }
 
+pub(super) fn interpolate_compose_scalar(
+    input: &str,
+    environment: &HashMap<String, String>,
+) -> Result<String, ComposeInterpolationError> {
+    interpolate_scalar(input, environment, 0)
+}
+
 fn interpolate_value(
     value: &mut serde_yaml::Value,
     environment: &HashMap<String, String>,

--- a/src/core/src/compose/normalization.rs
+++ b/src/core/src/compose/normalization.rs
@@ -1,0 +1,507 @@
+//! Pure, typed, deterministic Compose parsing and normalization.
+
+use std::collections::{BTreeMap, HashMap};
+
+use serde_yaml::{Mapping, Value};
+
+use super::diagnostic::{child_path, ComposeDiagnostic};
+use super::schema::{
+    DEPENDS_ON_FIELDS, HEALTHCHECK_FIELDS, NETWORK_FIELDS, ROOT_FIELDS, SERVICE_FIELDS,
+    SERVICE_NETWORK_FIELDS, VOLUME_FIELDS,
+};
+use super::{
+    ComposeConfig, ComposeDiagnosticCode, ComposeNormalizationError, DependsOn, DependsOnCondition,
+    EnvVars, HealthcheckConfig, NormalizedComposeConfig, NormalizedDependsOn,
+    NormalizedHealthcheckConfig, NormalizedNetworkDeclaration, NormalizedServiceConfig,
+    NormalizedServiceNetwork, NormalizedVolumeDeclaration, ServiceConfig, ServiceNetworks,
+};
+
+/// Syntax used by one in-memory Compose source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComposeSourceFormat {
+    /// Canonical A3S Agent Configuration Language.
+    Acl,
+    /// Bounded Docker Compose-compatible YAML.
+    Yaml,
+}
+
+/// Parse and normalize one Compose source without filesystem or process access.
+///
+/// Environment lookup is explicit, making the result fully determined by the
+/// three arguments. Callers own `.env` or process-environment loading.
+pub fn normalize_compose(
+    source: &str,
+    format: ComposeSourceFormat,
+    environment: &HashMap<String, String>,
+) -> Result<NormalizedComposeConfig, ComposeNormalizationError> {
+    let config = match format {
+        ComposeSourceFormat::Acl => {
+            ComposeConfig::from_acl_str_with_environment(source, environment)
+                .map_err(|error| ComposeNormalizationError::one(error.diagnostic().clone()))?
+        }
+        ComposeSourceFormat::Yaml => parse_yaml(source, environment)?,
+    };
+    normalize_compose_config(config)
+}
+
+/// Normalize an already parsed compatibility model.
+pub fn normalize_compose_config(
+    config: ComposeConfig,
+) -> Result<NormalizedComposeConfig, ComposeNormalizationError> {
+    let ComposeConfig {
+        version: _,
+        services: raw_services,
+        volumes: raw_volumes,
+        networks: raw_networks,
+    } = config;
+
+    let mut diagnostics = Vec::new();
+    let mut volumes = BTreeMap::new();
+    let mut networks = BTreeMap::new();
+    let mut services = BTreeMap::new();
+
+    for (name, declaration) in raw_volumes {
+        validate_name(
+            "volume",
+            &name,
+            &format!("/volumes/{}", pointer(&name)),
+            &mut diagnostics,
+        );
+        let path = format!("/volumes/{}/driver", pointer(&name));
+        let driver = declaration
+            .and_then(|declaration| declaration.driver)
+            .unwrap_or_else(|| "local".to_string());
+        if driver != "local" {
+            diagnostics.push(ComposeDiagnostic::new(
+                ComposeDiagnosticCode::UnsupportedValue,
+                path,
+                format!("unsupported volume driver {driver:?}; only \"local\" is supported"),
+            ));
+        }
+        volumes.insert(name, NormalizedVolumeDeclaration { driver });
+    }
+
+    for (name, declaration) in raw_networks {
+        validate_name(
+            "network",
+            &name,
+            &format!("/networks/{}", pointer(&name)),
+            &mut diagnostics,
+        );
+        let path = format!("/networks/{}/driver", pointer(&name));
+        let driver = declaration
+            .and_then(|declaration| declaration.driver)
+            .unwrap_or_else(|| "bridge".to_string());
+        if driver != "bridge" {
+            diagnostics.push(ComposeDiagnostic::new(
+                ComposeDiagnosticCode::UnsupportedValue,
+                path,
+                format!("unsupported network driver {driver:?}; only \"bridge\" is supported"),
+            ));
+        }
+        networks.insert(name, NormalizedNetworkDeclaration { driver });
+    }
+
+    for (name, service) in raw_services {
+        let path = format!("/services/{}", pointer(&name));
+        validate_name("service", &name, &path, &mut diagnostics);
+        services.insert(name, normalize_service(service, &path, &mut diagnostics));
+    }
+
+    if services.is_empty() {
+        diagnostics.push(ComposeDiagnostic::new(
+            ComposeDiagnosticCode::InvalidValue,
+            "/services",
+            "Compose projects must define at least one service",
+        ));
+    }
+
+    let normalized = NormalizedComposeConfig {
+        services,
+        volumes,
+        networks,
+    };
+    if let Err(error) = normalized.service_order() {
+        diagnostics.extend(error.into_diagnostics());
+    }
+
+    if diagnostics.is_empty() {
+        Ok(normalized)
+    } else {
+        Err(ComposeNormalizationError::new(diagnostics))
+    }
+}
+
+fn parse_yaml(
+    source: &str,
+    environment: &HashMap<String, String>,
+) -> Result<ComposeConfig, ComposeNormalizationError> {
+    let interpolated = super::interpolate_compose_yaml(source, environment).map_err(|error| {
+        ComposeNormalizationError::one(ComposeDiagnostic::new(
+            ComposeDiagnosticCode::Interpolation,
+            "/",
+            error.to_string(),
+        ))
+    })?;
+    let value: Value = serde_yaml::from_str(&interpolated).map_err(yaml_error)?;
+    let diagnostics = unsupported_yaml_fields(&value);
+    if !diagnostics.is_empty() {
+        return Err(ComposeNormalizationError::new(diagnostics));
+    }
+    serde_yaml::from_value(value).map_err(yaml_error)
+}
+
+fn yaml_error(error: serde_yaml::Error) -> ComposeNormalizationError {
+    let mut diagnostic = ComposeDiagnostic::new(
+        ComposeDiagnosticCode::Syntax,
+        "/",
+        format!("invalid Compose YAML: {error}"),
+    );
+    if let Some(location) = error.location() {
+        diagnostic = diagnostic.with_location(location.line(), location.column());
+    }
+    ComposeNormalizationError::one(diagnostic)
+}
+
+fn unsupported_yaml_fields(value: &Value) -> Vec<ComposeDiagnostic> {
+    let mut diagnostics = Vec::new();
+    let Some(root) = value.as_mapping() else {
+        return diagnostics;
+    };
+
+    validate_mapping_fields(root, ROOT_FIELDS, "/", &mut diagnostics);
+
+    if let Some(services) = mapping_field(root, "services").and_then(Value::as_mapping) {
+        for (name, service) in string_entries(services) {
+            let service_path = format!("/services/{}", pointer(name));
+            let Some(service) = service.as_mapping() else {
+                continue;
+            };
+            validate_mapping_fields(service, SERVICE_FIELDS, &service_path, &mut diagnostics);
+
+            if let Some(healthcheck) =
+                mapping_field(service, "healthcheck").and_then(Value::as_mapping)
+            {
+                validate_mapping_fields(
+                    healthcheck,
+                    HEALTHCHECK_FIELDS,
+                    &child_path(&service_path, "healthcheck"),
+                    &mut diagnostics,
+                );
+            }
+            if let Some(dependencies) =
+                mapping_field(service, "depends_on").and_then(Value::as_mapping)
+            {
+                for (dependency, condition) in string_entries(dependencies) {
+                    if let Some(condition) = condition.as_mapping() {
+                        validate_mapping_fields(
+                            condition,
+                            DEPENDS_ON_FIELDS,
+                            &format!(
+                                "{}/{}",
+                                child_path(&service_path, "depends_on"),
+                                pointer(dependency)
+                            ),
+                            &mut diagnostics,
+                        );
+                    }
+                }
+            }
+            if let Some(networks) = mapping_field(service, "networks").and_then(Value::as_mapping) {
+                for (network, config) in string_entries(networks) {
+                    if let Some(config) = config.as_mapping() {
+                        validate_mapping_fields(
+                            config,
+                            SERVICE_NETWORK_FIELDS,
+                            &format!(
+                                "{}/{}",
+                                child_path(&service_path, "networks"),
+                                pointer(network)
+                            ),
+                            &mut diagnostics,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    validate_declaration_fields(root, "volumes", VOLUME_FIELDS, &mut diagnostics);
+    validate_declaration_fields(root, "networks", NETWORK_FIELDS, &mut diagnostics);
+    diagnostics
+}
+
+fn validate_declaration_fields(
+    root: &Mapping,
+    section: &str,
+    allowed: &[&str],
+    diagnostics: &mut Vec<ComposeDiagnostic>,
+) {
+    let Some(declarations) = mapping_field(root, section).and_then(Value::as_mapping) else {
+        return;
+    };
+    for (name, declaration) in string_entries(declarations) {
+        if let Some(declaration) = declaration.as_mapping() {
+            validate_mapping_fields(
+                declaration,
+                allowed,
+                &format!("/{section}/{}", pointer(name)),
+                diagnostics,
+            );
+        }
+    }
+}
+
+fn validate_mapping_fields(
+    mapping: &Mapping,
+    allowed: &[&str],
+    path: &str,
+    diagnostics: &mut Vec<ComposeDiagnostic>,
+) {
+    for (field, _) in string_entries(mapping) {
+        if !allowed.contains(&field) {
+            diagnostics.push(ComposeDiagnostic::unsupported_field(
+                child_path(path, field),
+                field,
+            ));
+        }
+    }
+}
+
+fn mapping_field<'a>(mapping: &'a Mapping, field: &str) -> Option<&'a Value> {
+    mapping.get(Value::String(field.to_string()))
+}
+
+fn string_entries(mapping: &Mapping) -> impl Iterator<Item = (&str, &Value)> {
+    mapping
+        .iter()
+        .filter_map(|(key, value)| key.as_str().map(|key| (key, value)))
+}
+
+fn normalize_service(
+    service: ServiceConfig,
+    path: &str,
+    diagnostics: &mut Vec<ComposeDiagnostic>,
+) -> NormalizedServiceConfig {
+    let ServiceConfig {
+        image,
+        entrypoint,
+        command,
+        environment,
+        env_file,
+        ports,
+        volumes,
+        depends_on,
+        networks,
+        cpus,
+        mem_limit,
+        restart,
+        dns,
+        tmpfs,
+        cap_add,
+        cap_drop,
+        privileged,
+        labels,
+        healthcheck,
+        working_dir,
+        hostname,
+        extra_hosts,
+    } = service;
+
+    if image.as_deref().is_none_or(str::is_empty) {
+        diagnostics.push(ComposeDiagnostic::new(
+            ComposeDiagnosticCode::InvalidValue,
+            child_path(path, "image"),
+            "Compose services must specify a non-empty image",
+        ));
+    }
+
+    let ports = ports
+        .into_iter()
+        .enumerate()
+        .filter_map(
+            |(index, port)| match crate::normalize_port_maps(std::slice::from_ref(&port)) {
+                Ok(mut normalized) => normalized.pop(),
+                Err(error) => {
+                    diagnostics.push(ComposeDiagnostic::new(
+                        ComposeDiagnosticCode::InvalidValue,
+                        format!("{path}/ports/{index}"),
+                        error,
+                    ));
+                    None
+                }
+            },
+        )
+        .collect();
+    let networks = normalize_networks(networks, path, diagnostics);
+    if networks.len() > 1 {
+        diagnostics.push(ComposeDiagnostic::new(
+            ComposeDiagnosticCode::UnsupportedValue,
+            child_path(path, "networks"),
+            "Box services currently support exactly one explicit Compose network",
+        ));
+    }
+
+    NormalizedServiceConfig {
+        image,
+        entrypoint: entrypoint.map(|value| value.to_vec()),
+        command: command.map(|value| value.to_vec()),
+        environment: normalize_environment(environment, path, diagnostics),
+        env_file: env_file.to_vec(),
+        ports,
+        volumes,
+        depends_on: normalize_dependencies(depends_on, path, diagnostics),
+        networks,
+        cpus,
+        mem_limit,
+        restart,
+        dns: dns.to_vec(),
+        tmpfs: tmpfs.to_vec(),
+        cap_add,
+        cap_drop,
+        privileged,
+        labels: labels.to_map().into_iter().collect(),
+        healthcheck: healthcheck.map(normalize_healthcheck),
+        working_dir,
+        hostname,
+        extra_hosts: extra_hosts.to_vec(),
+    }
+}
+
+fn normalize_environment(
+    environment: EnvVars,
+    service_path: &str,
+    diagnostics: &mut Vec<ComposeDiagnostic>,
+) -> BTreeMap<String, String> {
+    match environment {
+        EnvVars::Empty => BTreeMap::new(),
+        EnvVars::Map(values) => values.into_iter().collect(),
+        EnvVars::List(values) => {
+            let mut normalized = BTreeMap::new();
+            for (index, entry) in values.into_iter().enumerate() {
+                let Some((key, value)) = entry.split_once('=') else {
+                    diagnostics.push(ComposeDiagnostic::new(
+                        ComposeDiagnosticCode::InvalidValue,
+                        format!("{service_path}/environment/{index}"),
+                        "environment list entries must use KEY=value syntax",
+                    ));
+                    continue;
+                };
+                normalized.insert(key.to_string(), value.to_string());
+            }
+            normalized
+        }
+    }
+}
+
+fn normalize_dependencies(
+    depends_on: DependsOn,
+    service_path: &str,
+    diagnostics: &mut Vec<ComposeDiagnostic>,
+) -> BTreeMap<String, NormalizedDependsOn> {
+    let dependencies = match depends_on {
+        DependsOn::Empty => return BTreeMap::new(),
+        DependsOn::List(names) => names
+            .into_iter()
+            .map(|name| {
+                (
+                    name,
+                    DependsOnCondition {
+                        condition: "service_started".to_string(),
+                    },
+                )
+            })
+            .collect(),
+        DependsOn::Map(dependencies) => dependencies,
+    };
+    dependencies
+        .into_iter()
+        .map(|(name, dependency)| {
+            let path = format!("{service_path}/depends_on/{}", pointer(&name));
+            validate_name("dependency service", &name, &path, diagnostics);
+            if !matches!(
+                dependency.condition.as_str(),
+                "service_started" | "service_healthy" | "service_completed_successfully"
+            ) {
+                diagnostics.push(ComposeDiagnostic::new(
+                    ComposeDiagnosticCode::UnsupportedValue,
+                    child_path(&path, "condition"),
+                    format!(
+                        "unsupported depends_on condition {:?}",
+                        dependency.condition
+                    ),
+                ));
+            }
+            (
+                name,
+                NormalizedDependsOn {
+                    condition: dependency.condition,
+                },
+            )
+        })
+        .collect()
+}
+
+fn normalize_networks(
+    networks: ServiceNetworks,
+    service_path: &str,
+    diagnostics: &mut Vec<ComposeDiagnostic>,
+) -> BTreeMap<String, NormalizedServiceNetwork> {
+    let networks = match networks {
+        ServiceNetworks::Empty => return BTreeMap::new(),
+        ServiceNetworks::List(names) => names.into_iter().map(|name| (name, None)).collect(),
+        ServiceNetworks::Map(networks) => networks,
+    };
+    networks
+        .into_iter()
+        .map(|(name, config)| {
+            let path = format!("{service_path}/networks/{}", pointer(&name));
+            validate_name("network", &name, &path, diagnostics);
+            let mut aliases = config.map(|config| config.aliases).unwrap_or_default();
+            for (index, alias) in aliases.iter().enumerate() {
+                if let Err(error) = crate::dns::validate_hostname(alias) {
+                    diagnostics.push(ComposeDiagnostic::new(
+                        ComposeDiagnosticCode::InvalidValue,
+                        format!("{path}/aliases/{index}"),
+                        format!("invalid network alias: {error}"),
+                    ));
+                }
+            }
+            aliases.sort();
+            aliases.dedup();
+            (name, NormalizedServiceNetwork { aliases })
+        })
+        .collect()
+}
+
+fn normalize_healthcheck(healthcheck: HealthcheckConfig) -> NormalizedHealthcheckConfig {
+    NormalizedHealthcheckConfig {
+        test: healthcheck.test.to_vec(),
+        disable: healthcheck.disable,
+        interval: healthcheck.interval,
+        timeout: healthcheck.timeout,
+        retries: healthcheck.retries,
+        start_period: healthcheck.start_period,
+    }
+}
+
+fn validate_name(kind: &str, name: &str, path: &str, diagnostics: &mut Vec<ComposeDiagnostic>) {
+    let mut bytes = name.bytes();
+    let valid = bytes
+        .next()
+        .is_some_and(|byte| byte.is_ascii_alphanumeric())
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+    if !valid {
+        diagnostics.push(ComposeDiagnostic::new(
+            ComposeDiagnosticCode::InvalidValue,
+            path,
+            format!(
+                "{kind} names must start with an ASCII letter or digit and contain only letters, digits, '.', '_', or '-'"
+            ),
+        ));
+    }
+}
+
+fn pointer(value: &str) -> String {
+    super::diagnostic::pointer_segment(value)
+}

--- a/src/core/src/compose/normalized.rs
+++ b/src/core/src/compose/normalized.rs
@@ -1,0 +1,355 @@
+//! Canonical Compose data model and compatibility conversion.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use super::diagnostic::{pointer_segment, ComposeDiagnostic};
+use super::{
+    ComposeConfig, ComposeDiagnosticCode, ComposeNormalizationError, DependsOn, DependsOnCondition,
+    DnsConfig, EnvVars, HealthcheckConfig, Labels, NetworkDeclaration, ServiceConfig,
+    ServiceNetworkConfig, ServiceNetworks, StringOrList, VolumeDeclaration,
+};
+
+/// Deterministic, syntax-independent Compose project model.
+///
+/// All semantic maps use `BTreeMap`, alternate list/map spellings are collapsed
+/// into one representation, and supported driver defaults are explicit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NormalizedComposeConfig {
+    /// Canonically ordered service definitions.
+    pub services: BTreeMap<String, NormalizedServiceConfig>,
+    /// Canonically ordered named volume declarations.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub volumes: BTreeMap<String, NormalizedVolumeDeclaration>,
+    /// Canonically ordered named network declarations.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub networks: BTreeMap<String, NormalizedNetworkDeclaration>,
+}
+
+/// Canonical service definition independent of ACL/YAML spelling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NormalizedServiceConfig {
+    /// OCI image reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Tokenized entrypoint override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<Vec<String>>,
+    /// Tokenized command override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<Vec<String>>,
+    /// Canonically ordered inline environment.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub environment: BTreeMap<String, String>,
+    /// Environment files in precedence order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub env_file: Vec<String>,
+    /// Validated and normalized TCP port mappings.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ports: Vec<String>,
+    /// Volume mounts in source order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub volumes: Vec<String>,
+    /// Canonically ordered dependency conditions.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub depends_on: BTreeMap<String, NormalizedDependsOn>,
+    /// Canonically ordered service networks.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub networks: BTreeMap<String, NormalizedServiceNetwork>,
+    /// Requested virtual CPU count.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpus: Option<u32>,
+    /// Compose memory limit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mem_limit: Option<String>,
+    /// Compose restart policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub restart: Option<String>,
+    /// DNS servers in source order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub dns: Vec<String>,
+    /// tmpfs mounts in source order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tmpfs: Vec<String>,
+    /// Linux capabilities to add.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cap_add: Vec<String>,
+    /// Linux capabilities to drop.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cap_drop: Vec<String>,
+    /// Whether privileged execution is requested.
+    #[serde(skip_serializing_if = "is_false")]
+    pub privileged: bool,
+    /// Canonically ordered service labels.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
+    /// Optional service health check.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub healthcheck: Option<NormalizedHealthcheckConfig>,
+    /// Working directory inside the workload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
+    /// Workload hostname.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    /// Static host entries in source order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub extra_hosts: Vec<String>,
+}
+
+/// Canonical dependency condition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NormalizedDependsOn {
+    /// Validated dependency condition.
+    pub condition: String,
+}
+
+/// Canonical per-service network settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NormalizedServiceNetwork {
+    /// Validated, sorted, deduplicated DNS aliases.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+}
+
+/// Canonical health-check settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NormalizedHealthcheckConfig {
+    /// Tokenized health-check command.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub test: Vec<String>,
+    /// Whether the health check is explicitly disabled.
+    #[serde(skip_serializing_if = "is_false")]
+    pub disable: bool,
+    /// Interval between health checks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interval: Option<String>,
+    /// Timeout for one health check.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<String>,
+    /// Consecutive failures before unhealthy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retries: Option<u32>,
+    /// Startup grace period.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_period: Option<String>,
+}
+
+/// Canonical named-volume declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NormalizedVolumeDeclaration {
+    /// Validated volume driver (`local`).
+    pub driver: String,
+}
+
+/// Canonical named-network declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NormalizedNetworkDeclaration {
+    /// Validated network driver (`bridge`).
+    pub driver: String,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+impl NormalizedComposeConfig {
+    /// Serialize a byte-stable, pretty JSON representation with a final newline.
+    pub fn to_canonical_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self).map(|json| format!("{json}\n"))
+    }
+
+    /// Compute a deterministic dependency-first service order.
+    pub fn service_order(&self) -> Result<Vec<String>, ComposeNormalizationError> {
+        let mut diagnostics = Vec::new();
+        for (service_name, service) in &self.services {
+            for dependency in service.depends_on.keys() {
+                if !self.services.contains_key(dependency) {
+                    diagnostics.push(ComposeDiagnostic::new(
+                        ComposeDiagnosticCode::InvalidValue,
+                        format!(
+                            "/services/{}/depends_on/{}",
+                            pointer_segment(service_name),
+                            pointer_segment(dependency)
+                        ),
+                        format!(
+                            "service {service_name:?} depends on undefined service {dependency:?}"
+                        ),
+                    ));
+                }
+            }
+        }
+        if !diagnostics.is_empty() {
+            return Err(ComposeNormalizationError::new(diagnostics));
+        }
+
+        let mut state = BTreeMap::<String, u8>::new();
+        let mut order = Vec::new();
+        for service_name in self.services.keys() {
+            visit_service(self, service_name, &mut state, &mut order)?;
+        }
+        Ok(order)
+    }
+
+    /// Convert the canonical model into the compatibility model consumed by
+    /// the current Runtime translation layer.
+    pub fn into_config(self) -> ComposeConfig {
+        self.into()
+    }
+}
+
+fn visit_service(
+    config: &NormalizedComposeConfig,
+    service_name: &str,
+    state: &mut BTreeMap<String, u8>,
+    order: &mut Vec<String>,
+) -> Result<(), ComposeNormalizationError> {
+    match state.get(service_name) {
+        Some(1) => {
+            return Err(ComposeNormalizationError::one(ComposeDiagnostic::new(
+                ComposeDiagnosticCode::InvalidValue,
+                format!("/services/{}/depends_on", pointer_segment(service_name)),
+                format!("dependency cycle detected involving service {service_name:?}"),
+            )));
+        }
+        Some(2) => return Ok(()),
+        _ => {}
+    }
+    state.insert(service_name.to_string(), 1);
+    if let Some(service) = config.services.get(service_name) {
+        for dependency in service.depends_on.keys() {
+            visit_service(config, dependency, state, order)?;
+        }
+    }
+    state.insert(service_name.to_string(), 2);
+    order.push(service_name.to_string());
+    Ok(())
+}
+
+impl From<NormalizedComposeConfig> for ComposeConfig {
+    fn from(config: NormalizedComposeConfig) -> Self {
+        Self {
+            version: None,
+            services: config
+                .services
+                .into_iter()
+                .map(|(name, service)| (name, service.into()))
+                .collect(),
+            volumes: config
+                .volumes
+                .into_iter()
+                .map(|(name, declaration)| {
+                    (
+                        name,
+                        Some(VolumeDeclaration {
+                            driver: Some(declaration.driver),
+                        }),
+                    )
+                })
+                .collect(),
+            networks: config
+                .networks
+                .into_iter()
+                .map(|(name, declaration)| {
+                    (
+                        name,
+                        Some(NetworkDeclaration {
+                            driver: Some(declaration.driver),
+                        }),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<NormalizedServiceConfig> for ServiceConfig {
+    fn from(service: NormalizedServiceConfig) -> Self {
+        Self {
+            image: service.image,
+            entrypoint: service.entrypoint.map(StringOrList::List),
+            command: service.command.map(StringOrList::List),
+            environment: if service.environment.is_empty() {
+                EnvVars::Empty
+            } else {
+                EnvVars::Map(service.environment.into_iter().collect())
+            },
+            env_file: list_or_empty(service.env_file),
+            ports: service.ports,
+            volumes: service.volumes,
+            depends_on: if service.depends_on.is_empty() {
+                DependsOn::Empty
+            } else {
+                DependsOn::Map(
+                    service
+                        .depends_on
+                        .into_iter()
+                        .map(|(name, dependency)| {
+                            (
+                                name,
+                                DependsOnCondition {
+                                    condition: dependency.condition,
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            },
+            networks: if service.networks.is_empty() {
+                ServiceNetworks::Empty
+            } else {
+                ServiceNetworks::Map(
+                    service
+                        .networks
+                        .into_iter()
+                        .map(|(name, network)| {
+                            (
+                                name,
+                                Some(ServiceNetworkConfig {
+                                    aliases: network.aliases,
+                                }),
+                            )
+                        })
+                        .collect(),
+                )
+            },
+            cpus: service.cpus,
+            mem_limit: service.mem_limit,
+            restart: service.restart,
+            dns: if service.dns.is_empty() {
+                DnsConfig::Empty
+            } else {
+                DnsConfig::List(service.dns)
+            },
+            tmpfs: list_or_empty(service.tmpfs),
+            cap_add: service.cap_add,
+            cap_drop: service.cap_drop,
+            privileged: service.privileged,
+            labels: if service.labels.is_empty() {
+                Labels::Empty
+            } else {
+                Labels::Map(service.labels.into_iter().collect())
+            },
+            healthcheck: service.healthcheck.map(|healthcheck| HealthcheckConfig {
+                test: list_or_empty(healthcheck.test),
+                disable: healthcheck.disable,
+                interval: healthcheck.interval,
+                timeout: healthcheck.timeout,
+                retries: healthcheck.retries,
+                start_period: healthcheck.start_period,
+            }),
+            working_dir: service.working_dir,
+            hostname: service.hostname,
+            extra_hosts: list_or_empty(service.extra_hosts),
+        }
+    }
+}
+
+fn list_or_empty(values: Vec<String>) -> StringOrList {
+    if values.is_empty() {
+        StringOrList::Empty
+    } else {
+        StringOrList::List(values)
+    }
+}

--- a/src/core/src/compose/schema.rs
+++ b/src/core/src/compose/schema.rs
@@ -1,0 +1,42 @@
+//! Single source of truth for the bounded Compose schema accepted by Box.
+
+pub(super) const ROOT_FIELDS: &[&str] = &["version", "services", "volumes", "networks"];
+
+pub(super) const SERVICE_FIELDS: &[&str] = &[
+    "image",
+    "entrypoint",
+    "command",
+    "environment",
+    "env_file",
+    "ports",
+    "volumes",
+    "depends_on",
+    "networks",
+    "cpus",
+    "mem_limit",
+    "restart",
+    "dns",
+    "tmpfs",
+    "cap_add",
+    "cap_drop",
+    "privileged",
+    "labels",
+    "healthcheck",
+    "working_dir",
+    "hostname",
+    "extra_hosts",
+];
+
+pub(super) const HEALTHCHECK_FIELDS: &[&str] = &[
+    "test",
+    "disable",
+    "interval",
+    "timeout",
+    "retries",
+    "start_period",
+];
+
+pub(super) const DEPENDS_ON_FIELDS: &[&str] = &["condition"];
+pub(super) const SERVICE_NETWORK_FIELDS: &[&str] = &["aliases"];
+pub(super) const VOLUME_FIELDS: &[&str] = &["driver"];
+pub(super) const NETWORK_FIELDS: &[&str] = &["driver"];

--- a/src/core/tests/compose_normalization.rs
+++ b/src/core/tests/compose_normalization.rs
@@ -1,0 +1,185 @@
+use std::collections::HashMap;
+
+use a3s_box_core::compose::{normalize_compose, ComposeDiagnosticCode, ComposeSourceFormat};
+
+const YAML_FIXTURE: &str = include_str!("fixtures/compose/canonical.yaml");
+const ACL_FIXTURE: &str = include_str!("fixtures/compose/canonical.acl");
+const NORMALIZED_FIXTURE: &str = include_str!("fixtures/compose/canonical.normalized.json");
+
+fn environment() -> HashMap<String, String> {
+    HashMap::from([(
+        "API_IMAGE".to_string(),
+        "ghcr.io/a3s/api:latest".to_string(),
+    )])
+}
+
+#[test]
+fn yaml_and_acl_normalize_to_the_same_golden_document() {
+    let environment = environment();
+    let yaml = normalize_compose(YAML_FIXTURE, ComposeSourceFormat::Yaml, &environment)
+        .expect("normalize YAML fixture");
+    let acl = normalize_compose(ACL_FIXTURE, ComposeSourceFormat::Acl, &environment)
+        .expect("normalize ACL fixture");
+
+    assert_eq!(yaml, acl);
+    assert_eq!(
+        yaml.to_canonical_json().expect("serialize normalized YAML"),
+        NORMALIZED_FIXTURE
+    );
+    assert_eq!(
+        yaml.service_order().expect("deterministic service order"),
+        ["db", "api"]
+    );
+}
+
+#[test]
+fn normalization_is_stable_across_repeated_runs() {
+    let environment = environment();
+    let expected = normalize_compose(YAML_FIXTURE, ComposeSourceFormat::Yaml, &environment)
+        .expect("normalize fixture")
+        .to_canonical_json()
+        .expect("serialize fixture");
+
+    for _ in 0..32 {
+        let actual = normalize_compose(YAML_FIXTURE, ComposeSourceFormat::Yaml, &environment)
+            .expect("normalize fixture")
+            .to_canonical_json()
+            .expect("serialize fixture");
+        assert_eq!(actual, expected);
+    }
+}
+
+#[test]
+fn yaml_unknown_fields_return_sorted_structured_diagnostics() {
+    let source = r#"
+name: silently-ignored-before
+services:
+  db:
+    image: postgres:17
+  api:
+    image: api:latest
+    build: .
+    deploy:
+      replicas: 2
+    depends_on:
+      db:
+        restart: true
+    networks:
+      backend:
+        priority: 10
+    healthcheck:
+      test: ["CMD", "true"]
+      grace_period: 5s
+volumes:
+  data:
+    external: true
+networks:
+  backend:
+    external: true
+"#;
+
+    let error = normalize_compose(source, ComposeSourceFormat::Yaml, &HashMap::new())
+        .expect_err("unsupported fields must fail normalization");
+    let diagnostics = error.diagnostics();
+
+    assert!(diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.code == ComposeDiagnosticCode::UnsupportedField));
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.path.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "/name",
+            "/networks/backend/external",
+            "/services/api/build",
+            "/services/api/depends_on/db/restart",
+            "/services/api/deploy",
+            "/services/api/healthcheck/grace_period",
+            "/services/api/networks/backend/priority",
+            "/volumes/data/external",
+        ]
+    );
+}
+
+#[test]
+fn acl_unknown_fields_return_a_structured_diagnostic() {
+    let error = normalize_compose(
+        r#"service "api" { image = "api:latest" build = "." }"#,
+        ComposeSourceFormat::Acl,
+        &HashMap::new(),
+    )
+    .expect_err("unsupported ACL field must fail normalization");
+
+    assert_eq!(error.diagnostics().len(), 1);
+    assert_eq!(
+        error.diagnostics()[0].code,
+        ComposeDiagnosticCode::UnsupportedField
+    );
+    assert_eq!(error.diagnostics()[0].path, "/services/api/build");
+    assert_eq!(
+        serde_json::to_value(&error.diagnostics()[0]).unwrap()["code"],
+        "compose.unsupported_field"
+    );
+}
+
+#[test]
+fn unsupported_driver_values_return_structured_diagnostics() {
+    let error = normalize_compose(
+        r#"
+services:
+  api:
+    image: api:latest
+volumes:
+  data:
+    driver: nfs
+networks:
+  backend:
+    driver: overlay
+"#,
+        ComposeSourceFormat::Yaml,
+        &HashMap::new(),
+    )
+    .expect_err("unsupported drivers must fail normalization");
+
+    assert_eq!(
+        error
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| (&diagnostic.code, diagnostic.path.as_str()))
+            .collect::<Vec<_>>(),
+        [
+            (
+                &ComposeDiagnosticCode::UnsupportedValue,
+                "/networks/backend/driver",
+            ),
+            (
+                &ComposeDiagnosticCode::UnsupportedValue,
+                "/volumes/data/driver",
+            ),
+        ]
+    );
+}
+
+#[test]
+fn unsupported_multi_network_runtime_shape_fails_before_lifecycle_work() {
+    let error = normalize_compose(
+        r#"
+services:
+  api:
+    image: api:latest
+    networks: [frontend, backend]
+"#,
+        ComposeSourceFormat::Yaml,
+        &HashMap::new(),
+    )
+    .expect_err("a service cannot be partially attached to multiple networks");
+
+    assert_eq!(error.diagnostics().len(), 1);
+    assert_eq!(
+        error.diagnostics()[0].code,
+        ComposeDiagnosticCode::UnsupportedValue
+    );
+    assert_eq!(error.diagnostics()[0].path, "/services/api/networks");
+}

--- a/src/core/tests/fixtures/compose/canonical.acl
+++ b/src/core/tests/fixtures/compose/canonical.acl
@@ -1,0 +1,53 @@
+service "db" {
+  image = "postgres:17"
+  environment = {
+    Z_LAST = "z"
+    A_FIRST = "a"
+  }
+}
+
+service "api" {
+  image = env("API_IMAGE")
+  entrypoint = ["/bin/api"]
+  command = ["serve", "--port", "8080"]
+  environment = {
+    Z_LAST = "z"
+    A_FIRST = "a"
+  }
+  env_file = ["base.env", "local.env"]
+  ports = ["8080:80/tcp"]
+  volumes = ["data:/data"]
+  depends_on = {
+    db = { condition = "service_healthy" }
+  }
+  networks = {
+    backend = { aliases = ["api.internal"] }
+  }
+  cpus = 2
+  mem_limit = "1g"
+  restart = "unless-stopped"
+  dns = ["1.1.1.1"]
+  tmpfs = ["/tmp:rw"]
+  cap_add = ["NET_ADMIN"]
+  cap_drop = ["SYS_ADMIN"]
+  labels = ["z.label=last", "a.label=first"]
+  working_dir = "/app"
+  hostname = "api"
+  extra_hosts = ["host.internal:10.0.0.1"]
+
+  healthcheck {
+    test = ["CMD", "/bin/health"]
+    interval = "10s"
+    timeout = "3s"
+    retries = 3
+    start_period = "5s"
+  }
+}
+
+volume "data" {
+  driver = "local"
+}
+
+network "backend" {
+  driver = "bridge"
+}

--- a/src/core/tests/fixtures/compose/canonical.normalized.json
+++ b/src/core/tests/fixtures/compose/canonical.normalized.json
@@ -1,0 +1,92 @@
+{
+  "services": {
+    "api": {
+      "image": "ghcr.io/a3s/api:latest",
+      "entrypoint": [
+        "/bin/api"
+      ],
+      "command": [
+        "serve",
+        "--port",
+        "8080"
+      ],
+      "environment": {
+        "A_FIRST": "a",
+        "Z_LAST": "z"
+      },
+      "env_file": [
+        "base.env",
+        "local.env"
+      ],
+      "ports": [
+        "8080:80"
+      ],
+      "volumes": [
+        "data:/data"
+      ],
+      "depends_on": {
+        "db": {
+          "condition": "service_healthy"
+        }
+      },
+      "networks": {
+        "backend": {
+          "aliases": [
+            "api.internal"
+          ]
+        }
+      },
+      "cpus": 2,
+      "mem_limit": "1g",
+      "restart": "unless-stopped",
+      "dns": [
+        "1.1.1.1"
+      ],
+      "tmpfs": [
+        "/tmp:rw"
+      ],
+      "cap_add": [
+        "NET_ADMIN"
+      ],
+      "cap_drop": [
+        "SYS_ADMIN"
+      ],
+      "labels": {
+        "a.label": "first",
+        "z.label": "last"
+      },
+      "healthcheck": {
+        "test": [
+          "CMD",
+          "/bin/health"
+        ],
+        "interval": "10s",
+        "timeout": "3s",
+        "retries": 3,
+        "start_period": "5s"
+      },
+      "working_dir": "/app",
+      "hostname": "api",
+      "extra_hosts": [
+        "host.internal:10.0.0.1"
+      ]
+    },
+    "db": {
+      "image": "postgres:17",
+      "environment": {
+        "A_FIRST": "a",
+        "Z_LAST": "z"
+      }
+    }
+  },
+  "volumes": {
+    "data": {
+      "driver": "local"
+    }
+  },
+  "networks": {
+    "backend": {
+      "driver": "bridge"
+    }
+  }
+}

--- a/src/core/tests/fixtures/compose/canonical.yaml
+++ b/src/core/tests/fixtures/compose/canonical.yaml
@@ -1,0 +1,64 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:17
+    environment:
+      Z_LAST: z
+      A_FIRST: a
+  api:
+    image: ${API_IMAGE}
+    entrypoint:
+      - /bin/api
+    command:
+      - serve
+      - --port
+      - "8080"
+    environment:
+      Z_LAST: z
+      A_FIRST: a
+    env_file:
+      - base.env
+      - local.env
+    ports:
+      - 8080:80/tcp
+    volumes:
+      - data:/data
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      backend:
+        aliases:
+          - api.internal
+    cpus: 2
+    mem_limit: 1g
+    restart: unless-stopped
+    dns:
+      - 1.1.1.1
+    tmpfs:
+      - /tmp:rw
+    cap_add:
+      - NET_ADMIN
+    cap_drop:
+      - SYS_ADMIN
+    labels:
+      z.label: last
+      a.label: first
+    working_dir: /app
+    hostname: api
+    extra_hosts:
+      - host.internal:10.0.0.1
+    healthcheck:
+      test:
+        - CMD
+        - /bin/health
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+volumes:
+  data:
+    driver: local
+networks:
+  backend:
+    driver: bridge

--- a/src/runtime/src/compose.rs
+++ b/src/runtime/src/compose.rs
@@ -1,9 +1,10 @@
-//! Compose orchestrator for multi-container workloads.
+//! Stateless Compose-to-Runtime translation.
 //!
-//! Coordinates the lifecycle of multiple services defined in a compose file:
-//! network creation, dependency-ordered boot, and grouped teardown.
+//! This module builds deterministic Runtime inputs from a parsed Compose
+//! project. It deliberately owns no running-unit registry, persisted lifecycle
+//! state, or Cloud desired state; those concerns stay with their callers.
 
-use std::collections::HashMap;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use a3s_box_core::compose::ComposeConfig;
@@ -11,36 +12,28 @@ use a3s_box_core::config::{BoxConfig, ResourceConfig};
 use a3s_box_core::error::{BoxError, Result};
 use a3s_box_core::network::NetworkMode;
 
-/// State of a compose project (group of services).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ProjectState {
-    /// All services are running.
-    Running,
-    /// Some services are running.
-    Partial,
-    /// All services are stopped.
-    Stopped,
-}
-
-/// A running compose project.
+/// Stateless plan for translating one Compose project into Runtime inputs.
 #[derive(Debug, Clone)]
-pub struct ComposeProject {
+pub struct ComposeRuntimePlan {
     /// Project name (derived from directory name or --project-name).
     pub name: String,
     /// The parsed compose config.
     pub config: ComposeConfig,
     /// Service boot order (topologically sorted).
     pub service_order: Vec<String>,
-    /// Map of service name → box ID (once started).
-    pub service_boxes: HashMap<String, String>,
-    /// Networks created for this project.
-    pub networks: Vec<String>,
     /// Base directory used to resolve relative env_file paths.
     pub base_dir: PathBuf,
 }
 
-impl ComposeProject {
-    /// Create a new compose project from a config.
+/// Compatibility name for the former stateful Compose project type.
+///
+/// New code should use [`ComposeRuntimePlan`] to make the stateless translation
+/// boundary explicit.
+#[deprecated(note = "use ComposeRuntimePlan; lifecycle state is owned by the caller")]
+pub type ComposeProject = ComposeRuntimePlan;
+
+impl ComposeRuntimePlan {
+    /// Create a new translation plan from a config.
     ///
     /// Validates the config and computes the service boot order.
     pub fn new(name: impl Into<String>, config: ComposeConfig) -> Result<Self> {
@@ -82,21 +75,8 @@ impl ComposeProject {
             name,
             config,
             service_order,
-            service_boxes: HashMap::new(),
-            networks: Vec::new(),
             base_dir: base_dir.into(),
         })
-    }
-
-    /// Get the project state based on which services have box IDs.
-    pub fn state(&self) -> ProjectState {
-        if self.service_boxes.is_empty() {
-            ProjectState::Stopped
-        } else if self.service_boxes.len() == self.config.services.len() {
-            ProjectState::Running
-        } else {
-            ProjectState::Partial
-        }
     }
 
     /// Build a BoxConfig for a single service.
@@ -218,42 +198,52 @@ impl ComposeProject {
 
     /// Get all network names this project needs (project-prefixed).
     pub fn required_networks(&self) -> Vec<String> {
-        let mut nets = vec![self.default_network_name()];
+        let default = self.default_network_name();
+        let mut explicit = BTreeSet::new();
 
         // Add explicitly declared networks
         for net_name in self.config.networks.keys() {
-            let prefixed = format!("{}_{}", self.name, net_name);
-            if !nets.contains(&prefixed) {
-                nets.push(prefixed);
-            }
+            explicit.insert(format!("{}_{}", self.name, net_name));
         }
 
         // Add networks referenced by services
         for svc in self.config.services.values() {
             for net_name in svc.networks.names() {
-                let prefixed = format!("{}_{}", self.name, net_name);
-                if !nets.contains(&prefixed) {
-                    nets.push(prefixed);
-                }
+                explicit.insert(format!("{}_{}", self.name, net_name));
             }
         }
 
+        let mut nets = Vec::with_capacity(explicit.len() + 1);
+        nets.push(default);
+        nets.extend(explicit);
         nets
     }
 
-    /// Record that a service has been started with the given box ID.
-    pub fn register_service(&mut self, service_name: &str, box_id: String) {
-        self.service_boxes.insert(service_name.to_string(), box_id);
-    }
-
-    /// Remove a service's box ID (on stop/destroy).
-    pub fn unregister_service(&mut self, service_name: &str) {
-        self.service_boxes.remove(service_name);
-    }
-
-    /// Get the box ID for a service, if running.
-    pub fn box_id(&self, service_name: &str) -> Option<&str> {
-        self.service_boxes.get(service_name).map(|s| s.as_str())
+    /// DNS aliases to register for a service on its selected Compose network.
+    ///
+    /// The bare service name is always present. User-declared aliases are
+    /// deduplicated and sorted so endpoint state does not depend on map order.
+    pub fn service_network_aliases(&self, service_name: &str) -> Vec<String> {
+        let mut aliases = BTreeSet::from([service_name.to_string()]);
+        let Some(service) = self.config.services.get(service_name) else {
+            return aliases.into_iter().collect();
+        };
+        let a3s_box_core::compose::ServiceNetworks::Map(networks) = &service.networks else {
+            return aliases.into_iter().collect();
+        };
+        let Some(selected_network) = service.networks.names().into_iter().next() else {
+            return aliases.into_iter().collect();
+        };
+        if let Some(Some(config)) = networks.get(&selected_network) {
+            aliases.extend(
+                config
+                    .aliases
+                    .iter()
+                    .filter(|alias| !alias.is_empty())
+                    .cloned(),
+            );
+        }
+        aliases.into_iter().collect()
     }
 
     /// Get the shutdown order (reverse of boot order).
@@ -271,14 +261,16 @@ impl ComposeProject {
             return vec![];
         };
 
-        match &svc.depends_on {
+        let mut dependencies = match &svc.depends_on {
             a3s_box_core::compose::DependsOn::Map(map) => map
                 .iter()
                 .filter(|(_, cond)| cond.condition == "service_healthy")
                 .map(|(name, _)| name.clone())
                 .collect(),
             _ => vec![],
-        }
+        };
+        dependencies.sort();
+        dependencies
     }
 
     /// Dependencies this service must wait to run to completion (exit 0) before
@@ -288,14 +280,16 @@ impl ComposeProject {
             return vec![];
         };
 
-        match &svc.depends_on {
+        let mut dependencies = match &svc.depends_on {
             a3s_box_core::compose::DependsOn::Map(map) => map
                 .iter()
                 .filter(|(_, cond)| cond.condition == "service_completed_successfully")
                 .map(|(name, _)| name.clone())
                 .collect(),
             _ => vec![],
-        }
+        };
+        dependencies.sort();
+        dependencies
     }
 
     /// Get the health check config for a service, if defined.
@@ -540,7 +534,7 @@ volumes:
     #[test]
     fn test_compose_project_new() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         assert_eq!(project.name, "myapp");
         assert_eq!(project.service_order.len(), 3);
         // db must come before api, api before web
@@ -564,36 +558,9 @@ volumes:
     }
 
     #[test]
-    fn test_compose_project_state() {
-        let config = sample_config();
-        let mut project = ComposeProject::new("myapp", config).unwrap();
-        assert_eq!(project.state(), ProjectState::Stopped);
-
-        project.register_service("db", "box-1".to_string());
-        assert_eq!(project.state(), ProjectState::Partial);
-
-        project.register_service("api", "box-2".to_string());
-        project.register_service("web", "box-3".to_string());
-        assert_eq!(project.state(), ProjectState::Running);
-
-        project.unregister_service("web");
-        assert_eq!(project.state(), ProjectState::Partial);
-    }
-
-    #[test]
-    fn test_compose_project_box_id() {
-        let config = sample_config();
-        let mut project = ComposeProject::new("myapp", config).unwrap();
-        assert!(project.box_id("db").is_none());
-
-        project.register_service("db", "box-123".to_string());
-        assert_eq!(project.box_id("db"), Some("box-123"));
-    }
-
-    #[test]
     fn test_compose_project_shutdown_order() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let shutdown = project.shutdown_order();
         // Shutdown is reverse of boot: web → api → db
         let web_pos = shutdown.iter().position(|s| s == "web").unwrap();
@@ -606,7 +573,7 @@ volumes:
     #[test]
     fn test_compose_project_default_network() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         assert_eq!(project.default_network_name(), "myapp_default");
     }
 
@@ -628,17 +595,43 @@ networks:
   backend:
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
-        let nets = project.required_networks();
-        assert!(nets.contains(&"myapp_default".to_string()));
-        assert!(nets.contains(&"myapp_frontend".to_string()));
-        assert!(nets.contains(&"myapp_backend".to_string()));
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
+        assert_eq!(
+            project.required_networks(),
+            ["myapp_default", "myapp_backend", "myapp_frontend",]
+        );
+    }
+
+    #[test]
+    fn test_compose_runtime_plan_includes_declared_network_aliases() {
+        let config = ComposeConfig::from_yaml_str(
+            r#"
+services:
+  api:
+    image: api:latest
+    networks:
+      backend:
+        aliases:
+          - z-api
+          - api.internal
+          - z-api
+networks:
+  backend:
+"#,
+        )
+        .unwrap();
+        let plan = ComposeRuntimePlan::new("myapp", config).unwrap();
+
+        assert_eq!(
+            plan.service_network_aliases("api"),
+            ["api", "api.internal", "z-api"]
+        );
     }
 
     #[test]
     fn test_build_box_config_basic() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project
             .build_box_config("db", Some("myapp_default"))
             .unwrap();
@@ -652,7 +645,7 @@ networks:
     #[test]
     fn test_build_box_config_env() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project
             .build_box_config("api", Some("myapp_default"))
             .unwrap();
@@ -678,7 +671,7 @@ services:
       BAZ: inline
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::with_base_dir("myapp", config, dir.path()).unwrap();
+        let project = ComposeRuntimePlan::with_base_dir("myapp", config, dir.path()).unwrap();
         let box_config = project
             .build_box_config("api", Some("myapp_default"))
             .unwrap();
@@ -703,7 +696,7 @@ services:
     env_file: missing.env
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::with_base_dir("myapp", config, dir.path()).unwrap();
+        let project = ComposeRuntimePlan::with_base_dir("myapp", config, dir.path()).unwrap();
 
         let err = project
             .build_box_config("api", Some("myapp_default"))
@@ -721,7 +714,7 @@ services:
     working_dir: /srv/app
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project
             .build_box_config("worker", Some("myapp_default"))
             .unwrap();
@@ -740,7 +733,7 @@ services:
       - "db.local:10.88.0.10"
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project
             .build_box_config("web", Some("myapp_default"))
             .unwrap();
@@ -759,7 +752,7 @@ services:
       - "db.local:not-an-ip"
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
 
         let err = project
             .build_box_config("web", Some("myapp_default"))
@@ -771,7 +764,7 @@ services:
     #[test]
     fn test_build_box_config_ports() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project
             .build_box_config("web", Some("myapp_default"))
             .unwrap();
@@ -789,7 +782,7 @@ services:
       - "8080:80/tcp"
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project
             .build_box_config("web", Some("myapp_default"))
             .unwrap();
@@ -808,7 +801,7 @@ services:
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
 
-        let err = ComposeProject::new("myapp", config).unwrap_err();
+        let err = ComposeRuntimePlan::new("myapp", config).unwrap_err();
 
         assert!(err.to_string().contains("only TCP is supported"));
     }
@@ -816,7 +809,7 @@ services:
     #[test]
     fn test_build_box_config_network_mode() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project
             .build_box_config("web", Some("myapp_default"))
             .unwrap();
@@ -830,7 +823,7 @@ services:
     #[test]
     fn test_build_box_config_service_not_found() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let result = project.build_box_config("nonexistent", None);
         assert!(result.is_err());
     }
@@ -838,7 +831,7 @@ services:
     #[test]
     fn test_build_box_config_no_network() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project.build_box_config("web", None).unwrap();
         // No default network → falls back to Tsi
         assert!(matches!(box_config.network, NetworkMode::Tsi));
@@ -853,7 +846,7 @@ services:
       - "8080:80"
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let result = ComposeProject::new("myapp", config);
+        let result = ComposeRuntimePlan::new("myapp", config);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("no image"));
     }
@@ -904,7 +897,7 @@ networks:
   frontend:
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project
             .build_box_config("web", Some("myapp_default"))
             .unwrap();
@@ -929,7 +922,7 @@ services:
       - ALL
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let box_config = project
             .build_box_config("web", Some("myapp_default"))
             .unwrap();
@@ -962,7 +955,7 @@ services:
     image: postgres
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         // Simple depends_on → no health wait (condition defaults to service_started)
         assert!(project.health_wait_deps("web").is_empty());
     }
@@ -989,7 +982,7 @@ services:
     image: redis
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let deps = project.health_wait_deps("web");
         assert_eq!(deps, vec!["db".to_string()]);
     }
@@ -1008,7 +1001,7 @@ services:
       start_period: 30s
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let hc = project.healthcheck("web").unwrap();
         assert_eq!(hc.cmd, vec!["curl", "-f", "http://localhost/"]);
         assert_eq!(hc.interval_secs, 10);
@@ -1027,7 +1020,7 @@ services:
       test: ["CMD", "true"]
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let hc = project.healthcheck("web").unwrap();
         assert_eq!(hc.cmd, vec!["true"]);
         assert_eq!(hc.interval_secs, 30);
@@ -1046,7 +1039,7 @@ services:
       test: ["CMD-SHELL", "curl -f http://localhost/ || exit 1"]
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let hc = project.healthcheck("web").unwrap();
         assert_eq!(
             hc.cmd,
@@ -1064,7 +1057,7 @@ services:
       test: curl -f http://localhost/ || exit 1
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         let hc = project.healthcheck("web").unwrap();
         assert_eq!(
             hc.cmd,
@@ -1086,7 +1079,7 @@ services:
       disable: true
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         assert!(project.healthcheck("none").is_none());
         assert!(project.healthcheck_disabled("none"));
         assert!(project.healthcheck("disabled").is_none());
@@ -1096,7 +1089,7 @@ services:
     #[test]
     fn test_healthcheck_none() {
         let config = sample_config();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         assert!(project.healthcheck("db").is_none());
     }
 
@@ -1113,7 +1106,7 @@ services:
     image: busybox
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let project = ComposeProject::new("myapp", config).unwrap();
+        let project = ComposeRuntimePlan::new("myapp", config).unwrap();
         assert_eq!(project.completed_wait_deps("web"), vec!["init".to_string()]);
         // `init` itself has no completion wait.
         assert!(project.completed_wait_deps("init").is_empty());
@@ -1132,7 +1125,7 @@ services:
     image: postgres
 "#;
         let config = ComposeConfig::from_yaml_str(yaml).unwrap();
-        let err = ComposeProject::new("myapp", config).unwrap_err();
+        let err = ComposeRuntimePlan::new("myapp", config).unwrap_err();
         assert!(err.to_string().contains("unsupported condition"));
     }
 }

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -138,7 +138,8 @@ pub use volume::VolumeStore;
 pub use oci::{BuildConfig, BuildRunPoolConfig, Dockerfile, Instruction};
 
 #[cfg(feature = "compose")]
-pub use compose::{ComposeProject, HealthCheckSpec};
+#[allow(deprecated)]
+pub use compose::{ComposeProject, ComposeRuntimePlan, HealthCheckSpec};
 
 #[cfg(feature = "operator")]
 pub use operator::AutoscalerController;


### PR DESCRIPTION
## Summary

- parse canonical ACL Compose projects through `a3s-acl`
- support Compose lifecycle and operational commands against ACL project files
- split the CLI Compose handler into focused argument, read, lifecycle, operation, and test modules
- expose pure, typed ACL/YAML normalization with deterministic `BTreeMap` output
- reject unknown Compose fields through stable structured diagnostics instead of silently ignoring them
- separate Compose-to-Runtime translation into the stateless `ComposeRuntimePlan`
- preserve declared service network aliases in Runtime DNS endpoint registration
- expand command coverage, golden fixtures, host smoke coverage, and product documentation

## Issue #124 acceptance mapping

- normalization reads no files or process environment and depends only on source, format, and the explicit environment map
- ACL and YAML fixtures produce the same byte-stable canonical JSON output
- unknown YAML fields are aggregated as `compose.unsupported_field` diagnostics with JSON Pointer-style paths; ACL uses the same diagnostic model
- unsupported drivers, dependency conditions, and multi-network service shapes fail before lifecycle work
- `ComposeRuntimePlan` contains no running-unit registry, persisted Box lifecycle state, or Cloud desired state

## Dependencies and integration

A3S-Lab/ACL#1 merged into ACL `main` as `04c008f911387fe628c17d132a9543ac532f6abd`. Box remains reproducibly pinned to the reviewed implementation commit `fc041758758eba89dd5d22a3414d884c158c9ac1`, which is now a parent of that mainline merge.

PR #126 merged into Box `main` as `91b849ce14f08795bd7f307ec519fad72311c5fc`. This branch was refreshed with that exact main commit in `1da41b38d1e10b5744847d8461cdbde0c3b547a9`; the only textual conflict was the mechanical concatenation of `CHANGELOG.md` entries.

## Validation

- exact HEAD `1da41b38d1e10b5744847d8461cdbde0c3b547a9`: CI run 29664228178 passed Format, Clippy, Test, E2B Contract, E2B Official Clients, SDK Packages, Linux x86_64/arm64, macOS arm64, and Windows WHPX
- combined main + Compose tests: Core 444, normalization 6, Runtime Compose 37, CLI Compose 26, and command coverage 13 passed
- host smoke suite: environment-dependent tests intentionally ignored unless a dedicated host is selected
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `git diff --check`