### PR TITLE
feat(runtime): certify Box as an A3S Runtime provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- **A3S Runtime recovery fault fixtures.** The real-provider R17 Recovery
+  profile now cancels a Task apply after its Sandbox is running and seeds a
+  provider reservation without starting it. Exact retries must reattach to
+  those original identities, finish the pending work, and leave one resource
+  before complete removal.
 - **A3S Runtime tmpfs conformance.** The Sandbox-backed Runtime provider now
   advertises bounded tmpfs mounts, preserves `ro`/`rw` intent through guest and
   OCI paths, rejects protected destinations and unsupported mount kinds before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to A3S Box will be documented in this file.
   profile now cancels a Task apply after its Sandbox is running and seeds a
   provider reservation without starting it. Exact retries must reattach to
   those original identities, finish the pending work, and leave one resource
-  before complete removal.
+  before complete removal. The opt-in test provisions bounded runner and Tokio
+  worker stacks instead of depending on an external `RUST_MIN_STACK`.
 - **A3S Runtime tmpfs conformance.** The Sandbox-backed Runtime provider now
   advertises bounded tmpfs mounts, preserves `ro`/`rw` intent through guest and
   OCI paths, rejects protected destinations and unsupported mount kinds before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,23 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **A3S Runtime tmpfs conformance.** The Sandbox-backed Runtime provider now
+  advertises bounded tmpfs mounts, preserves `ro`/`rw` intent through guest and
+  OCI paths, rejects protected destinations and unsupported mount kinds before
+  mutation, and passes the real-provider R17 Mounts profile for read-only
+  enforcement, restart isolation, and complete removal.
+
 ### Fixed
 
+- **A3S Runtime recovery and certification stability.** Terminal Sandbox
+  owners and recovered log workers are reaped with PID identity fencing,
+  naturally exited in-process owners are reclaimed, exec reserves time to
+  return replayable timeout results, and structured log timestamps remain
+  ordered across concurrent writers and host clock regression. The R17 suite
+  now reports case-level exec failures and validates the exact bootstrap versus
+  workload capability boundary.
 - **Resilient and observable registry blob pulls.** Configuration and layer
   transfers now use bounded capped-exponential retries, exact HTTP Range resume,
   configurable no-progress deadlines, and bounded concurrent layer downloads.

--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ stated under [SDKs and Compatibility](#sdks-and-compatibility).
   resource and syscall controls, audit records, AMD SEV-SNP-oriented
   attestation, RA-TLS, sealing, and secret injection
 - **Typed SDKs and protocols**: Direct runtime-backed Rust management APIs,
-  an optional programmable pipeline runner, and a production-tested E2B
-  protocol subset with Python and TypeScript packages
+  a provider-neutral A3S Runtime adapter, an optional programmable pipeline
+  runner, and a production-tested E2B protocol subset with Python and
+  TypeScript packages
 - **Operations and cluster integration**: Structured logs, stats, events,
   Prometheus endpoints, health monitoring, CRI, and containerd RuntimeClass
 
@@ -162,6 +163,7 @@ stated under [SDKs and Compatibility](#sdks-and-compatibility).
 | --- | --- | --- |
 | MicroVM runtime | libkrun-backed OCI execution on Linux/KVM and Apple Silicon/HVF | Primary local runtime. Each box has its own guest kernel. Host-backed validation is required for releases. |
 | OCI Sandbox | Explicit `--isolation sandbox` execution through certified `crun 1.28` on Linux | Preview. Shares the host kernel, never replaces or emulates MicroVM isolation, and still has open security-negative and performance release gates. |
+| A3S Runtime provider | Sandbox-backed Task and Service lifecycle, recovery, `none` networking, bounded tmpfs mounts, CPU/memory/PID controls, structured logs, idempotent exec, and security fencing | The real-provider R17 suite passes Base, Recovery, Networking, Mounts, Resources, Logs, Exec, and Security profiles. Artifacts must be digest-pinned; the provider advertises only `tmpfs` mounts and `none` networking. |
 | Lifecycle and exec | Foreground/detached runs, managed create/start/restart/kill, exec, PTY, logs, health, wait, and cleanup | Implemented for MicroVM. The managed Sandbox path and its structured logs are implemented, while complete parity and adversarial validation remain in progress. |
 | OCI images | Resumable bounded registry pulls, concurrent layers, verified cross-image blob reuse, push, credentials, digest verification, optional cosign verification/signing, indexed archive selection, and tag operations | Implemented. `pull` validates declared size and SHA-256 before atomic blob publication; `load` selects one Linux platform from direct or nested OCI indexes and verifies the selected manifest, config, and layers before publishing it. Registry throughput and redirect behavior still require validation against each production registry. |
 | Dockerfile builds | Built-in Dockerfile subset, layer cache, BuildKit-in-MicroVM, and warm-pool `RUN` execution | Implemented subset, not a full Buildx replacement. One target platform is recorded per build. |
@@ -349,6 +351,22 @@ Some controls are platform- or backend-specific. `--device` and GPU
 passthrough are not implemented, custom seccomp profiles are not accepted by
 the local CLI, and the Sandbox resolver rejects every VM-only feature before
 pulling an image or allocating runtime state.
+
+### A3S Runtime provider
+
+The `a3s-box-runtime` crate includes a provider-neutral A3S Runtime driver
+backed by the certified shared-kernel Sandbox. It maps digest-pinned Tasks and
+Services onto durable Box executions with generation fencing, recovery,
+structured logs, bounded idempotent exec, CPU/memory/PID controls, and tmpfs
+mounts. Tmpfs requests preserve byte limits and `ro`/`rw` intent, reject
+protected destinations, start empty for each Sandbox generation, and are
+removed with their owner process and provider record.
+
+The driver advertises only capabilities it maps losslessly: Sandbox isolation,
+`none` networking, and tmpfs mounts. Bind, volume, and artifact mounts remain
+unadvertised, and unsupported input fails before provider mutation. The
+opt-in R17 gate runs every activated profile against real `crun`, including
+restart recovery and cleanup inventory equality.
 
 ### OCI images and builds
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,9 @@ The driver advertises only capabilities it maps losslessly: Sandbox isolation,
 `none` networking, and tmpfs mounts. Bind, volume, and artifact mounts remain
 unadvertised, and unsupported input fails before provider mutation. The
 opt-in R17 gate runs every activated profile against real `crun`, including
-restart recovery and cleanup inventory equality.
+provider-effect cancellation replay, partial-creation adoption, client and
+provider restart recovery, external deletion, duplicate detection, and cleanup
+inventory equality.
 
 ### OCI images and builds
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
  "a3s-common",
+ "a3s-runtime",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -228,6 +229,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
+ "url",
  "uuid",
  "windows-sys 0.48.0",
  "x509-cert",
@@ -297,6 +299,22 @@ dependencies = [
  "pkg-config",
  "tempfile",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "a3s-runtime"
+version = "0.2.0"
+source = "git+https://github.com/A3S-Lab/Runtime.git?rev=f1161b2e8a14c73b22af6c6fc10ebc8814631f41#f1161b2e8a14c73b22af6c6fc10ebc8814631f41"
+dependencies = [
+ "async-trait",
+ "fs2",
+ "libc",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -1276,6 +1294,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "a3s-runtime"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/Runtime.git?rev=f1161b2e8a14c73b22af6c6fc10ebc8814631f41#f1161b2e8a14c73b22af6c6fc10ebc8814631f41"
+source = "git+https://github.com/A3S-Lab/Runtime.git?rev=e68054612a1d488e1bcc295f92467fdc655f68c2#e68054612a1d488e1bcc295f92467fdc655f68c2"
 dependencies = [
  "async-trait",
  "fs2",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "a3s-runtime"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/Runtime.git?rev=e68054612a1d488e1bcc295f92467fdc655f68c2#e68054612a1d488e1bcc295f92467fdc655f68c2"
+source = "git+https://github.com/A3S-Lab/Runtime.git?rev=91a1b4c67ef2691915f2409a8cf835f7534020ff#91a1b4c67ef2691915f2409a8cf835f7534020ff"
 dependencies = [
  "async-trait",
  "fs2",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 
 # Shared types (transport protocol, privacy, tools)
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
-a3s-runtime = { git = "https://github.com/A3S-Lab/Runtime.git", rev = "e68054612a1d488e1bcc295f92467fdc655f68c2" }
+a3s-runtime = { git = "https://github.com/A3S-Lab/Runtime.git", rev = "91a1b4c67ef2691915f2409a8cf835f7534020ff" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,6 +126,7 @@ ring = "0.17"
 
 # Shared types (transport protocol, privacy, tools)
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
+a3s-runtime = { git = "https://github.com/A3S-Lab/Runtime.git", rev = "f1161b2e8a14c73b22af6c6fc10ebc8814631f41" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 
 # Shared types (transport protocol, privacy, tools)
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
-a3s-runtime = { git = "https://github.com/A3S-Lab/Runtime.git", rev = "f1161b2e8a14c73b22af6c6fc10ebc8814631f41" }
+a3s-runtime = { git = "https://github.com/A3S-Lab/Runtime.git", rev = "e68054612a1d488e1bcc295f92467fdc655f68c2" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/cli/src/commands/common.rs
+++ b/src/cli/src/commands/common.rs
@@ -655,6 +655,7 @@ pub(crate) fn build_resource_limits(
         cpu_period: args.cpu_period,
         memory_reservation,
         memory_swap,
+        sandbox_memory_limit_bytes: None,
     })
 }
 

--- a/src/cli/src/commands/common.rs
+++ b/src/cli/src/commands/common.rs
@@ -112,7 +112,7 @@ pub struct CommonBoxArgs {
     #[arg(short = 'l', long = "label")]
     pub labels: Vec<String>,
 
-    /// Mount a tmpfs (e.g., "/tmp" or "/tmp:size=100m"), can be repeated
+    /// Mount a tmpfs (PATH[:size=SIZE][,ro|rw]), can be repeated
     #[arg(long)]
     pub tmpfs: Vec<String>,
 

--- a/src/cli/src/commands/container_update.rs
+++ b/src/cli/src/commands/container_update.rs
@@ -195,6 +195,7 @@ pub async fn execute(args: ContainerUpdateArgs) -> Result<(), Box<dyn std::error
 
                     for cmd_str in &commands {
                         let request = ExecRequest {
+                            request_id: None,
                             cmd: vec!["sh".to_string(), "-c".to_string(), cmd_str.clone()],
                             timeout_ns: 5_000_000_000,
                             env: vec![],

--- a/src/cli/src/commands/cp.rs
+++ b/src/cli/src/commands/cp.rs
@@ -131,6 +131,7 @@ async fn is_directory_in_box(
     box_path: &str,
 ) -> Result<bool, Box<dyn std::error::Error>> {
     let request = ExecRequest {
+        request_id: None,
         cmd: vec!["test".to_string(), "-d".to_string(), box_path.to_string()],
         timeout_ns: DEFAULT_EXEC_TIMEOUT_NS,
         env: vec![],
@@ -159,6 +160,7 @@ async fn copy_file_from_box(
     host_path: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let request = ExecRequest {
+        request_id: None,
         cmd: vec![
             "sh".to_string(),
             "-c".to_string(),
@@ -216,6 +218,7 @@ async fn copy_file_to_box(
     // (Docker `cp` preserves permissions).
     let dst = shell_escape(box_path);
     let request = ExecRequest {
+        request_id: None,
         cmd: vec![
             "sh".to_string(),
             "-c".to_string(),
@@ -273,6 +276,7 @@ async fn copy_dir_from_box(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Archive the directory inside the box and base64-encode it
     let request = ExecRequest {
+        request_id: None,
         cmd: vec![
             "sh".to_string(),
             "-c".to_string(),
@@ -339,6 +343,7 @@ async fn copy_dir_to_box(
 
     // Create destination directory and extract inside the box
     let request = ExecRequest {
+        request_id: None,
         cmd: vec![
             "sh".to_string(),
             "-c".to_string(),

--- a/src/cli/src/commands/exec.rs
+++ b/src/cli/src/commands/exec.rs
@@ -135,6 +135,7 @@ pub async fn execute(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let request = ExecRequest {
+        request_id: None,
         cmd: args.cmd,
         timeout_ns,
         env: args.envs,

--- a/src/cli/src/commands/pool.rs
+++ b/src/cli/src/commands/pool.rs
@@ -700,6 +700,7 @@ impl PoolRegistry {
             .lock()
             .await
             .exec_request(&a3s_box_core::exec::ExecRequest {
+                request_id: None,
                 cmd: req.cmd,
                 timeout_ns: req.timeout_ns.unwrap_or(60_000_000_000),
                 env: req.env,
@@ -1158,6 +1159,7 @@ async fn handle_conn(
                             .await
                         } else {
                             vm.exec_request(&a3s_box_core::exec::ExecRequest {
+                                request_id: None,
                                 cmd: run.cmd,
                                 timeout_ns: run.timeout_ns.unwrap_or(EXEC_TIMEOUT_NS),
                                 env: run.env,

--- a/src/cli/src/commands/stats.rs
+++ b/src/cli/src/commands/stats.rs
@@ -247,6 +247,7 @@ async fn collect_guest_process_count(record: &BoxRecord) -> Option<u64> {
         crate::socket_paths::runtime_socket(record, crate::socket_paths::RuntimeSocket::Exec);
     let client = ExecClient::connect(&exec_socket_path).await.ok()?;
     let request = ExecRequest {
+        request_id: None,
         cmd: vec!["ps".to_string(), "-eo".to_string(), "pid,args".to_string()],
         timeout_ns: DEFAULT_EXEC_TIMEOUT_NS,
         env: vec![],

--- a/src/cli/src/commands/top.rs
+++ b/src/cli/src/commands/top.rs
@@ -84,6 +84,7 @@ pub async fn execute(args: TopArgs) -> Result<(), Box<dyn std::error::Error>> {
     cmd.extend(ps_args);
 
     let request = ExecRequest {
+        request_id: None,
         cmd,
         timeout_ns: DEFAULT_EXEC_TIMEOUT_NS,
         env: vec![],

--- a/src/cli/src/health.rs
+++ b/src/cli/src/health.rs
@@ -273,6 +273,7 @@ pub(crate) async fn run_probe(
     };
 
     let request = ExecRequest {
+        request_id: None,
         cmd: cmd.to_vec(),
         timeout_ns,
         env: vec![],

--- a/src/compat/src/envd/process.rs
+++ b/src/compat/src/envd/process.rs
@@ -131,6 +131,7 @@ impl ProcessBroker {
                     &key.execution_id,
                     key.generation(),
                     ExecRequest {
+                        request_id: None,
                         cmd: config.argv(),
                         timeout_ns,
                         env: config.environment(),

--- a/src/core/src/config.rs
+++ b/src/core/src/config.rs
@@ -276,6 +276,14 @@ pub struct ResourceLimits {
     /// Applied via cgroup v2 memory.swap.max (Linux only).
     #[serde(default)]
     pub memory_swap: Option<i64>,
+
+    /// Exact hard memory limit for the shared-kernel Sandbox backend.
+    ///
+    /// `None` preserves the CLI's historical MiB-based `resources.memory_mb`
+    /// value. Provider adapters use this field when their public contract is
+    /// byte-granular and must not silently round the requested limit.
+    #[serde(default)]
+    pub sandbox_memory_limit_bytes: Option<u64>,
 }
 
 /// Box configuration
@@ -1080,6 +1088,7 @@ mod tests {
         assert!(limits.cpu_period.is_none());
         assert!(limits.memory_reservation.is_none());
         assert!(limits.memory_swap.is_none());
+        assert!(limits.sandbox_memory_limit_bytes.is_none());
     }
 
     #[test]
@@ -1093,6 +1102,7 @@ mod tests {
             cpu_period: Some(100000),
             memory_reservation: Some(256 * 1024 * 1024),
             memory_swap: Some(1024 * 1024 * 1024),
+            sandbox_memory_limit_bytes: Some(256 * 1024 * 1024),
         };
 
         let json = serde_json::to_string(&limits).unwrap();
@@ -1106,6 +1116,10 @@ mod tests {
         assert_eq!(parsed.cpu_period, Some(100000));
         assert_eq!(parsed.memory_reservation, Some(256 * 1024 * 1024));
         assert_eq!(parsed.memory_swap, Some(1024 * 1024 * 1024));
+        assert_eq!(
+            parsed.sandbox_memory_limit_bytes,
+            Some(256 * 1024 * 1024)
+        );
     }
 
     #[test]

--- a/src/core/src/config.rs
+++ b/src/core/src/config.rs
@@ -1116,10 +1116,7 @@ mod tests {
         assert_eq!(parsed.cpu_period, Some(100000));
         assert_eq!(parsed.memory_reservation, Some(256 * 1024 * 1024));
         assert_eq!(parsed.memory_swap, Some(1024 * 1024 * 1024));
-        assert_eq!(
-            parsed.sandbox_memory_limit_bytes,
-            Some(256 * 1024 * 1024)
-        );
+        assert_eq!(parsed.sandbox_memory_limit_bytes, Some(256 * 1024 * 1024));
     }
 
     #[test]

--- a/src/core/src/exec.rs
+++ b/src/core/src/exec.rs
@@ -24,8 +24,17 @@ pub const FRAME_EXEC_CHUNK: u8 = 0x01;
 pub const FRAME_EXEC_EXIT: u8 = 0x02;
 
 /// Request to execute a command in the guest.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecRequest {
+    /// Optional idempotency key for one-shot execution.
+    ///
+    /// A guest that supports replay must execute the same keyed request at
+    /// most once while the result remains in its bounded replay cache. The key
+    /// is deliberately optional for wire compatibility with older clients.
+    /// Streaming execution cannot provide an exact one-shot result replay and
+    /// therefore must not set this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
     /// Command and arguments (e.g., ["ls", "-la"]).
     pub cmd: Vec<String>,
     /// Timeout in nanoseconds. 0 means use the default.
@@ -54,7 +63,7 @@ pub struct ExecRequest {
 }
 
 /// Output from an executed command.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecOutput {
     /// Captured stdout bytes.
     pub stdout: Vec<u8>,
@@ -62,6 +71,10 @@ pub struct ExecOutput {
     pub stderr: Vec<u8>,
     /// Process exit code.
     pub exit_code: i32,
+    /// Whether either captured stream exceeded its bound and was truncated.
+    /// Defaults to `false` when reading responses from older guest binaries.
+    #[serde(default)]
+    pub truncated: bool,
 }
 
 /// Which output stream a chunk belongs to.
@@ -176,6 +189,7 @@ mod tests {
     #[test]
     fn test_exec_request_serialization_roundtrip() {
         let req = ExecRequest {
+            request_id: Some("exec-1".to_string()),
             cmd: vec!["ls".to_string(), "-la".to_string()],
             timeout_ns: 3_000_000_000,
             env: vec!["FOO=bar".to_string()],
@@ -189,6 +203,7 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
         let parsed: ExecRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.cmd, vec!["ls", "-la"]);
+        assert_eq!(parsed.request_id.as_deref(), Some("exec-1"));
         assert_eq!(parsed.timeout_ns, 3_000_000_000);
         assert_eq!(parsed.env, vec!["FOO=bar"]);
         assert_eq!(parsed.working_dir, Some("/tmp".to_string()));
@@ -205,6 +220,7 @@ mod tests {
     #[test]
     fn test_exec_request_streaming_flag() {
         let req = ExecRequest {
+            request_id: None,
             cmd: vec!["tail".to_string(), "-f".to_string()],
             timeout_ns: 0,
             env: vec![],
@@ -224,6 +240,7 @@ mod tests {
     #[test]
     fn test_exec_request_stdin_streaming_flag() {
         let req = ExecRequest {
+            request_id: None,
             cmd: vec!["cat".to_string()],
             timeout_ns: 0,
             env: vec![],
@@ -245,12 +262,14 @@ mod tests {
             stdout: b"hello\n".to_vec(),
             stderr: b"warning\n".to_vec(),
             exit_code: 0,
+            truncated: true,
         };
         let json = serde_json::to_string(&output).unwrap();
         let parsed: ExecOutput = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.stdout, b"hello\n");
         assert_eq!(parsed.stderr, b"warning\n");
         assert_eq!(parsed.exit_code, 0);
+        assert!(parsed.truncated);
     }
 
     #[test]
@@ -259,6 +278,7 @@ mod tests {
             stdout: vec![],
             stderr: b"not found\n".to_vec(),
             exit_code: 127,
+            truncated: false,
         };
         let json = serde_json::to_string(&output).unwrap();
         let parsed: ExecOutput = serde_json::from_str(&json).unwrap();
@@ -279,6 +299,7 @@ mod tests {
     #[test]
     fn test_exec_request_empty_cmd() {
         let req = ExecRequest {
+            request_id: None,
             cmd: vec![],
             timeout_ns: 0,
             env: vec![],
@@ -292,6 +313,7 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
         let parsed: ExecRequest = serde_json::from_str(&json).unwrap();
         assert!(parsed.cmd.is_empty());
+        assert!(parsed.request_id.is_none());
         assert_eq!(parsed.timeout_ns, 0);
         assert!(parsed.env.is_empty());
         assert!(parsed.working_dir.is_none());
@@ -306,6 +328,7 @@ mod tests {
         let json = r#"{"cmd":["ls"],"timeout_ns":0}"#;
         let parsed: ExecRequest = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.cmd, vec!["ls"]);
+        assert!(parsed.request_id.is_none());
         assert!(parsed.env.is_empty());
         assert!(parsed.working_dir.is_none());
         assert!(parsed.rootfs.is_none());
@@ -318,6 +341,7 @@ mod tests {
     #[test]
     fn test_exec_request_with_stdin() {
         let req = ExecRequest {
+            request_id: None,
             cmd: vec!["sh".to_string()],
             timeout_ns: 0,
             env: vec![],
@@ -337,6 +361,7 @@ mod tests {
     #[test]
     fn test_exec_request_with_user() {
         let req = ExecRequest {
+            request_id: None,
             cmd: vec!["whoami".to_string()],
             timeout_ns: 0,
             env: vec![],
@@ -355,6 +380,7 @@ mod tests {
     #[test]
     fn test_exec_request_with_user_uid_gid() {
         let req = ExecRequest {
+            request_id: None,
             cmd: vec!["id".to_string()],
             timeout_ns: 0,
             env: vec![],
@@ -376,10 +402,19 @@ mod tests {
             stdout: vec![],
             stderr: vec![],
             exit_code: 0,
+            truncated: false,
         };
         assert!(output.stdout.is_empty());
         assert!(output.stderr.is_empty());
         assert_eq!(output.exit_code, 0);
+        assert!(!output.truncated);
+    }
+
+    #[test]
+    fn test_exec_output_backward_compatible_deserialization() {
+        let parsed: ExecOutput =
+            serde_json::from_str(r#"{"stdout":[],"stderr":[],"exit_code":0}"#).unwrap();
+        assert!(!parsed.truncated);
     }
 
     // --- Streaming types ---

--- a/src/core/src/exec.rs
+++ b/src/core/src/exec.rs
@@ -14,8 +14,16 @@ pub const PORT_FWD_VSOCK_PORT: u32 = 4093;
 /// Default exec timeout: 5 seconds.
 pub const DEFAULT_EXEC_TIMEOUT_NS: u64 = 5_000_000_000;
 
-/// Maximum output size per stream (stdout/stderr): 16 MiB.
+/// Maximum buffered streaming output size per stream (stdout/stderr): 16 MiB.
 pub const MAX_OUTPUT_BYTES: usize = 16 * 1024 * 1024;
+
+/// Maximum captured one-shot output size per stream: 1 MiB.
+///
+/// One-shot responses retain the legacy JSON `Vec<u8>` representation, whose
+/// worst-case encoding uses four bytes per input byte. Bounding both streams
+/// at 1 MiB guarantees the complete response fits the transport's 16 MiB
+/// frame without breaking older host or guest binaries.
+pub const MAX_ONE_SHOT_OUTPUT_BYTES: usize = 1024 * 1024;
 
 /// Frame type byte for streaming exec chunks.
 pub const FRAME_EXEC_CHUNK: u8 = 0x01;
@@ -294,6 +302,19 @@ mod tests {
     #[test]
     fn test_max_output_bytes_constant() {
         assert_eq!(MAX_OUTPUT_BYTES, 16 * 1024 * 1024);
+        assert_eq!(MAX_ONE_SHOT_OUTPUT_BYTES, 1024 * 1024);
+    }
+
+    #[test]
+    fn maximum_one_shot_output_fits_one_transport_frame() {
+        let output = ExecOutput {
+            stdout: vec![u8::MAX; MAX_ONE_SHOT_OUTPUT_BYTES],
+            stderr: vec![u8::MAX; MAX_ONE_SHOT_OUTPUT_BYTES],
+            exit_code: i32::MIN,
+            truncated: true,
+        };
+        let encoded = serde_json::to_vec(&output).unwrap();
+        assert!(encoded.len() <= a3s_transport::MAX_PAYLOAD_SIZE as usize);
     }
 
     #[test]

--- a/src/core/src/log.rs
+++ b/src/core/src/log.rs
@@ -499,24 +499,20 @@ fn run_json_file_processor(
     eof_policy: ConsoleEofPolicy,
 ) {
     let json_path = json_log_path(log_dir);
-    let writer = std::sync::Mutex::new(match RotatingWriter::new(&json_path, max_size, max_file) {
-        Ok(w) => w,
-        Err(_) => return,
-    });
+    let writer = std::sync::Mutex::new(
+        match OrderedJsonWriter::new(&json_path, max_size, max_file) {
+            Ok(writer) => writer,
+            Err(_) => return,
+        },
+    );
     let err_log = stderr_console_path(console_log);
 
     // Write one tagged JSON record per line; shared by the stdout and stderr
-    // tail threads (the Mutex serializes their interleave into container.json).
+    // tail threads. Timestamp assignment is inside the same critical section
+    // as the append, so file order cannot invert timestamps across streams.
     let emit = |line: &str, stream: &str| {
-        let entry = LogEntry {
-            log: format!("{line}\n"),
-            stream: stream.to_string(),
-            time: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
-        };
-        if let Ok(json) = serde_json::to_string(&entry) {
-            if let Ok(mut w) = writer.lock() {
-                let _ = w.write_line(&json);
-            }
+        if let Ok(mut writer) = writer.lock() {
+            writer.write_entry(line, stream, chrono::Utc::now());
         }
     };
     let emit: &(dyn Fn(&str, &str) + Sync) = &emit;
@@ -554,6 +550,36 @@ fn run_json_file_processor(
             )
         });
     });
+}
+
+struct OrderedJsonWriter {
+    output: RotatingWriter,
+    last_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl OrderedJsonWriter {
+    fn new(path: &Path, max_size: u64, max_file: u32) -> std::io::Result<Self> {
+        Ok(Self {
+            output: RotatingWriter::new(path, max_size, max_file)?,
+            last_timestamp: None,
+        })
+    }
+
+    fn write_entry(&mut self, line: &str, stream: &str, timestamp: chrono::DateTime<chrono::Utc>) {
+        let timestamp = match &self.last_timestamp {
+            Some(previous) if previous > &timestamp => previous.to_owned(),
+            _ => timestamp,
+        };
+        let entry = LogEntry {
+            log: format!("{line}\n"),
+            stream: stream.to_string(),
+            time: timestamp.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
+        };
+        self.last_timestamp = Some(timestamp);
+        if let Ok(json) = serde_json::to_string(&entry) {
+            let _ = self.output.write_line(&json);
+        }
+    }
 }
 
 /// Forward both console streams (stdout + stderr) to a syslog endpoint.
@@ -1153,6 +1179,31 @@ mod tests {
             !json.contains("init.krun"),
             "runtime noise must be filtered: {json}"
         );
+    }
+
+    #[test]
+    fn ordered_json_writer_clamps_a_regressed_clock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("container.json");
+        let mut writer = OrderedJsonWriter::new(&path, 10 * 1024 * 1024, 3).unwrap();
+        let newer = chrono::DateTime::parse_from_rfc3339("2026-07-19T12:00:01Z")
+            .unwrap()
+            .to_utc();
+        let older = chrono::DateTime::parse_from_rfc3339("2026-07-19T12:00:00Z")
+            .unwrap()
+            .to_utc();
+
+        writer.write_entry("first", "stdout", newer);
+        writer.write_entry("second", "stderr", older);
+        drop(writer);
+
+        let entries = std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<LogEntry>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].time, entries[1].time);
     }
 
     #[test]

--- a/src/cri/src/container.rs
+++ b/src/cri/src/container.rs
@@ -139,6 +139,7 @@ impl Container {
             .collect();
 
         Ok(ExecRequest {
+            request_id: None,
             cmd,
             timeout_ns,
             env,

--- a/src/cri/src/runtime_service/mod.rs
+++ b/src/cri/src/runtime_service/mod.rs
@@ -2280,6 +2280,7 @@ impl RuntimeService for BoxRuntimeService {
         };
 
         let exec_request = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: req.cmd,
             timeout_ns,
             // Inherit the container's security envelope (A3S_SEC_*, e.g.

--- a/src/cri/src/spdy.rs
+++ b/src/cri/src/spdy.rs
@@ -320,6 +320,7 @@ pub async fn serve_exec(mut stream: TcpStream, session: &StreamingSession) -> Re
     let error_id = ids.get(&Channel::Error).copied();
 
     let request = a3s_box_core::exec::ExecRequest {
+        request_id: None,
         cmd: session.cmd.clone(),
         timeout_ns: a3s_box_core::exec::DEFAULT_EXEC_TIMEOUT_NS,
         env: vec![],

--- a/src/cri/src/streaming.rs
+++ b/src/cri/src/streaming.rs
@@ -363,6 +363,7 @@ async fn handle_exec_oneshot(
     }
 
     let exec_req = a3s_box_core::exec::ExecRequest {
+        request_id: None,
         cmd: session.cmd.clone(),
         timeout_ns: a3s_box_core::exec::DEFAULT_EXEC_TIMEOUT_NS,
         env: vec![],
@@ -401,6 +402,7 @@ async fn handle_exec_stdin_stream(
     session: &StreamingSession,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let exec_req = a3s_box_core::exec::ExecRequest {
+        request_id: None,
         cmd: session.cmd.clone(),
         timeout_ns: a3s_box_core::exec::DEFAULT_EXEC_TIMEOUT_NS,
         env: vec![],
@@ -1292,6 +1294,7 @@ mod tests {
                 stdout: b"hello\n".to_vec(),
                 stderr: b"warn\n".to_vec(),
                 exit_code: 23,
+                truncated: false,
             };
             writer
                 .write_data(&serde_json::to_vec(&output).unwrap())
@@ -1624,6 +1627,7 @@ mod tests {
             .await
             .unwrap();
         let exec_req = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: vec!["cat".to_string()],
             timeout_ns: a3s_box_core::exec::DEFAULT_EXEC_TIMEOUT_NS,
             env: vec![],

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -9,9 +9,9 @@ use std::io::Read;
 use std::io::Write;
 #[cfg(target_os = "linux")]
 use std::path::Path;
-use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::mpsc;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::Duration;
 
 use a3s_box_core::exec::{
@@ -320,9 +320,9 @@ impl ExecReplayCache {
         loop {
             let existing = state.entries.get(request_id).map(|entry| match entry {
                 ExecReplayEntry::InFlight { digest } => ExistingReplay::InFlight(*digest),
-                ExecReplayEntry::Ready {
-                    digest, output, ..
-                } => ExistingReplay::Ready(*digest, Arc::clone(output)),
+                ExecReplayEntry::Ready { digest, output, .. } => {
+                    ExistingReplay::Ready(*digest, Arc::clone(output))
+                }
             });
             match existing {
                 Some(ExistingReplay::Ready(existing_digest, output)) => {
@@ -341,9 +341,10 @@ impl ExecReplayCache {
                             "exec request ID {request_id:?} conflicts with in-flight content"
                         ));
                     }
-                    let remaining = wait_timeout.checked_sub(started.elapsed()).ok_or_else(|| {
-                        format!("timed out waiting for exec request {request_id:?} to complete")
-                    })?;
+                    let remaining =
+                        wait_timeout.checked_sub(started.elapsed()).ok_or_else(|| {
+                            format!("timed out waiting for exec request {request_id:?} to complete")
+                        })?;
                     if remaining.is_zero() {
                         return Err(format!(
                             "timed out waiting for exec request {request_id:?} to complete"
@@ -371,10 +372,9 @@ impl ExecReplayCache {
                     if state.in_flight >= self.max_in_flight {
                         return Err("exec replay in-flight limit reached".to_string());
                     }
-                    state.entries.insert(
-                        request_id.to_string(),
-                        ExecReplayEntry::InFlight { digest },
-                    );
+                    state
+                        .entries
+                        .insert(request_id.to_string(), ExecReplayEntry::InFlight { digest });
                     state.in_flight += 1;
                     return Ok(ExecReplayAcquire::Execute(ExecReplayClaim {
                         cache: self,
@@ -501,9 +501,7 @@ struct ExecReplayClaim<'a> {
 
 impl ExecReplayClaim<'_> {
     fn complete(mut self, output: ExecOutput) -> Result<Arc<ExecOutput>, String> {
-        let result = self
-            .cache
-            .complete(&self.request_id, self.digest, output);
+        let result = self.cache.complete(&self.request_id, self.digest, output);
         if result.is_ok() {
             self.completed = true;
         }
@@ -785,11 +783,7 @@ fn handle_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::error:
                 return Ok(());
             }
         };
-        match exec_replay_cache().acquire(
-            request_id,
-            digest,
-            exec_replay_wait_timeout(&exec_req),
-        ) {
+        match exec_replay_cache().acquire(request_id, digest, exec_replay_wait_timeout(&exec_req)) {
             Ok(ExecReplayAcquire::Execute(claim)) => Some(claim),
             Ok(ExecReplayAcquire::Replay(output)) => {
                 // The original result was cached before its response write, so
@@ -2539,9 +2533,7 @@ mod tests {
             done_tx.send(replayed).unwrap();
         });
         started_rx.recv().unwrap();
-        assert!(done_rx
-            .recv_timeout(Duration::from_millis(20))
-            .is_err());
+        assert!(done_rx.recv_timeout(Duration::from_millis(20)).is_err());
 
         let expected = ExecOutput {
             stdout: b"completed\n".to_vec(),
@@ -2551,7 +2543,10 @@ mod tests {
         };
         claim.complete(expected.clone()).unwrap();
         assert_eq!(
-            done_rx.recv_timeout(Duration::from_secs(1)).unwrap().as_ref(),
+            done_rx
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .as_ref(),
             &expected
         );
         waiter.join().unwrap();

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use a3s_box_core::exec::{
     ExecChunk, ExecExit, ExecOutput, ExecRequest, StreamType, DEFAULT_EXEC_TIMEOUT_NS,
-    EXEC_VSOCK_PORT, MAX_ONE_SHOT_OUTPUT_BYTES, MAX_OUTPUT_BYTES,
+    EXEC_VSOCK_PORT, MAX_ONE_SHOT_OUTPUT_BYTES,
 };
 use a3s_transport::{FrameType, MAX_PAYLOAD_SIZE};
 use sha2::{Digest, Sha256};

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -4,19 +4,22 @@
 //! Each connection: read a Data frame (JSON ExecRequest), execute,
 //! then send either a one-shot `ExecOutput` or streaming chunk/exit frames.
 
+use std::collections::{HashMap, VecDeque};
 use std::io::Read;
 use std::io::Write;
 #[cfg(target_os = "linux")]
 use std::path::Path;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
 use a3s_box_core::exec::{
-    ExecChunk, ExecExit, ExecOutput, StreamType, DEFAULT_EXEC_TIMEOUT_NS, EXEC_VSOCK_PORT,
-    MAX_OUTPUT_BYTES,
+    ExecChunk, ExecExit, ExecOutput, ExecRequest, StreamType, DEFAULT_EXEC_TIMEOUT_NS,
+    EXEC_VSOCK_PORT, MAX_OUTPUT_BYTES,
 };
 use a3s_transport::FrameType;
+use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
 use crate::user::{parse_process_user, ProcessUser};
@@ -260,6 +263,300 @@ const EXEC_CONTROL_FLUSH: &[u8] = b"flush";
 /// match the host's `EXEC_FLUSH_ACK` in `runtime/src/grpc/exec.rs`.
 const EXEC_FLUSH_ACK: &[u8] = b"flush-ack";
 
+/// Guest-local ambiguity window for one-shot exec requests. Runtime persists
+/// the final receipt on the host; this cache closes the smaller window where a
+/// command completed in the guest but its response was lost before that host
+/// receipt could be committed.
+const EXEC_REPLAY_MAX_ENTRIES: usize = 128;
+const EXEC_REPLAY_MAX_IN_FLIGHT: usize = 32;
+const EXEC_REPLAY_MAX_RESULT_BYTES: usize = 64 * 1024 * 1024;
+const EXEC_REPLAY_WAIT_SLACK: Duration = Duration::from_secs(10);
+
+static EXEC_REPLAY_CACHE: OnceLock<ExecReplayCache> = OnceLock::new();
+
+fn exec_replay_cache() -> &'static ExecReplayCache {
+    EXEC_REPLAY_CACHE.get_or_init(ExecReplayCache::default)
+}
+
+struct ExecReplayCache {
+    state: Mutex<ExecReplayState>,
+    changed: Condvar,
+    max_entries: usize,
+    max_in_flight: usize,
+    max_result_bytes: usize,
+}
+
+impl Default for ExecReplayCache {
+    fn default() -> Self {
+        Self::with_limits(
+            EXEC_REPLAY_MAX_ENTRIES,
+            EXEC_REPLAY_MAX_IN_FLIGHT,
+            EXEC_REPLAY_MAX_RESULT_BYTES,
+        )
+    }
+}
+
+impl ExecReplayCache {
+    fn with_limits(max_entries: usize, max_in_flight: usize, max_result_bytes: usize) -> Self {
+        Self {
+            state: Mutex::new(ExecReplayState::default()),
+            changed: Condvar::new(),
+            max_entries,
+            max_in_flight,
+            max_result_bytes,
+        }
+    }
+
+    fn acquire(
+        &self,
+        request_id: &str,
+        digest: [u8; 32],
+        wait_timeout: Duration,
+    ) -> Result<ExecReplayAcquire<'_>, String> {
+        validate_exec_request_id(request_id)?;
+        let started = std::time::Instant::now();
+        let mut state = self.lock_state();
+
+        loop {
+            let existing = state.entries.get(request_id).map(|entry| match entry {
+                ExecReplayEntry::InFlight { digest } => ExistingReplay::InFlight(*digest),
+                ExecReplayEntry::Ready {
+                    digest, output, ..
+                } => ExistingReplay::Ready(*digest, Arc::clone(output)),
+            });
+            match existing {
+                Some(ExistingReplay::Ready(existing_digest, output)) => {
+                    if existing_digest != digest {
+                        return Err(format!(
+                            "exec request ID {request_id:?} conflicts with cached content"
+                        ));
+                    }
+                    state.completed_order.retain(|value| value != request_id);
+                    state.completed_order.push_back(request_id.to_string());
+                    return Ok(ExecReplayAcquire::Replay(output));
+                }
+                Some(ExistingReplay::InFlight(existing_digest)) => {
+                    if existing_digest != digest {
+                        return Err(format!(
+                            "exec request ID {request_id:?} conflicts with in-flight content"
+                        ));
+                    }
+                    let remaining = wait_timeout.checked_sub(started.elapsed()).ok_or_else(|| {
+                        format!("timed out waiting for exec request {request_id:?} to complete")
+                    })?;
+                    if remaining.is_zero() {
+                        return Err(format!(
+                            "timed out waiting for exec request {request_id:?} to complete"
+                        ));
+                    }
+                    let waited = self
+                        .changed
+                        .wait_timeout(state, remaining)
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    state = waited.0;
+                    if waited.1.timed_out() {
+                        return Err(format!(
+                            "timed out waiting for exec request {request_id:?} to complete"
+                        ));
+                    }
+                }
+                None => {
+                    while state.entries.len() >= self.max_entries {
+                        if !evict_oldest_completed(&mut state) {
+                            return Err(
+                                "exec replay cache is full of in-flight requests".to_string()
+                            );
+                        }
+                    }
+                    if state.in_flight >= self.max_in_flight {
+                        return Err("exec replay in-flight limit reached".to_string());
+                    }
+                    state.entries.insert(
+                        request_id.to_string(),
+                        ExecReplayEntry::InFlight { digest },
+                    );
+                    state.in_flight += 1;
+                    return Ok(ExecReplayAcquire::Execute(ExecReplayClaim {
+                        cache: self,
+                        request_id: request_id.to_string(),
+                        digest,
+                        completed: false,
+                    }));
+                }
+            }
+        }
+    }
+
+    fn complete(
+        &self,
+        request_id: &str,
+        digest: [u8; 32],
+        output: ExecOutput,
+    ) -> Result<Arc<ExecOutput>, String> {
+        let result_bytes = output
+            .stdout
+            .len()
+            .checked_add(output.stderr.len())
+            .and_then(|value| value.checked_add(std::mem::size_of::<ExecOutput>()))
+            .ok_or_else(|| "exec replay result size overflowed".to_string())?;
+        if result_bytes > self.max_result_bytes {
+            return Err("exec result exceeds the replay cache byte bound".to_string());
+        }
+
+        let mut state = self.lock_state();
+        match state.entries.get(request_id) {
+            Some(ExecReplayEntry::InFlight {
+                digest: existing_digest,
+            }) if *existing_digest == digest => {}
+            Some(_) => {
+                return Err(format!(
+                    "exec replay claim for {request_id:?} changed before completion"
+                ))
+            }
+            None => {
+                return Err(format!(
+                    "exec replay claim for {request_id:?} disappeared before completion"
+                ))
+            }
+        }
+
+        let output = Arc::new(output);
+        state.entries.insert(
+            request_id.to_string(),
+            ExecReplayEntry::Ready {
+                digest,
+                output: Arc::clone(&output),
+                result_bytes,
+            },
+        );
+        state.in_flight = state.in_flight.saturating_sub(1);
+        state.completed_bytes = state.completed_bytes.saturating_add(result_bytes);
+        state.completed_order.retain(|value| value != request_id);
+        state.completed_order.push_back(request_id.to_string());
+        while state.completed_bytes > self.max_result_bytes {
+            if !evict_oldest_completed(&mut state) {
+                break;
+            }
+        }
+        self.changed.notify_all();
+        Ok(output)
+    }
+
+    fn abort(&self, request_id: &str, digest: [u8; 32]) {
+        let mut state = self.lock_state();
+        if matches!(
+            state.entries.get(request_id),
+            Some(ExecReplayEntry::InFlight {
+                digest: existing_digest
+            }) if *existing_digest == digest
+        ) {
+            state.entries.remove(request_id);
+            state.in_flight = state.in_flight.saturating_sub(1);
+            self.changed.notify_all();
+        }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, ExecReplayState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[derive(Default)]
+struct ExecReplayState {
+    entries: HashMap<String, ExecReplayEntry>,
+    completed_order: VecDeque<String>,
+    completed_bytes: usize,
+    in_flight: usize,
+}
+
+enum ExecReplayEntry {
+    InFlight {
+        digest: [u8; 32],
+    },
+    Ready {
+        digest: [u8; 32],
+        output: Arc<ExecOutput>,
+        result_bytes: usize,
+    },
+}
+
+enum ExistingReplay {
+    InFlight([u8; 32]),
+    Ready([u8; 32], Arc<ExecOutput>),
+}
+
+enum ExecReplayAcquire<'a> {
+    Execute(ExecReplayClaim<'a>),
+    Replay(Arc<ExecOutput>),
+}
+
+struct ExecReplayClaim<'a> {
+    cache: &'a ExecReplayCache,
+    request_id: String,
+    digest: [u8; 32],
+    completed: bool,
+}
+
+impl ExecReplayClaim<'_> {
+    fn complete(mut self, output: ExecOutput) -> Result<Arc<ExecOutput>, String> {
+        let result = self
+            .cache
+            .complete(&self.request_id, self.digest, output);
+        if result.is_ok() {
+            self.completed = true;
+        }
+        result
+    }
+}
+
+impl Drop for ExecReplayClaim<'_> {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.cache.abort(&self.request_id, self.digest);
+        }
+    }
+}
+
+fn evict_oldest_completed(state: &mut ExecReplayState) -> bool {
+    while let Some(request_id) = state.completed_order.pop_front() {
+        let result_bytes = match state.entries.get(&request_id) {
+            Some(ExecReplayEntry::Ready { result_bytes, .. }) => *result_bytes,
+            _ => continue,
+        };
+        state.entries.remove(&request_id);
+        state.completed_bytes = state.completed_bytes.saturating_sub(result_bytes);
+        return true;
+    }
+    false
+}
+
+fn validate_exec_request_id(request_id: &str) -> Result<(), String> {
+    if request_id.is_empty() || request_id.len() > 512 || request_id.contains('\0') {
+        return Err("exec request ID is invalid".to_string());
+    }
+    Ok(())
+}
+
+fn exec_request_digest(request: &ExecRequest) -> Result<[u8; 32], String> {
+    let payload = serde_json::to_vec(request)
+        .map_err(|error| format!("could not encode exec request identity: {error}"))?;
+    let digest = Sha256::digest(payload);
+    let mut output = [0_u8; 32];
+    output.copy_from_slice(&digest);
+    Ok(output)
+}
+
+fn exec_replay_wait_timeout(request: &ExecRequest) -> Duration {
+    let timeout_ns = if request.timeout_ns == 0 {
+        DEFAULT_EXEC_TIMEOUT_NS
+    } else {
+        request.timeout_ns
+    };
+    Duration::from_nanos(timeout_ns).saturating_add(EXEC_REPLAY_WAIT_SLACK)
+}
+
 /// A bound, listening exec-server socket — produced by [`bind_exec_server`] and
 /// consumed by [`serve_exec_server`].
 ///
@@ -389,7 +686,6 @@ fn run_accept_loop(sock_fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::err
 /// 3. Send either a one-shot ExecOutput frame or streaming exec frames
 #[cfg(target_os = "linux")]
 fn handle_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::error::Error>> {
-    use a3s_box_core::exec::ExecRequest;
     use tracing::debug;
 
     // Transfer ownership into File. Constructing a second owner with
@@ -473,6 +769,45 @@ fn handle_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::error:
         }
     };
 
+    if exec_req.streaming && exec_req.request_id.is_some() {
+        send_error_frame(
+            &mut stream,
+            "Idempotent request IDs are supported only for one-shot exec",
+        )?;
+        return Ok(());
+    }
+
+    let replay_claim = if let Some(request_id) = exec_req.request_id.as_deref() {
+        let digest = match exec_request_digest(&exec_req) {
+            Ok(digest) => digest,
+            Err(error) => {
+                send_error_frame(&mut stream, &error)?;
+                return Ok(());
+            }
+        };
+        match exec_replay_cache().acquire(
+            request_id,
+            digest,
+            exec_replay_wait_timeout(&exec_req),
+        ) {
+            Ok(ExecReplayAcquire::Execute(claim)) => Some(claim),
+            Ok(ExecReplayAcquire::Replay(output)) => {
+                // The original result was cached before its response write, so
+                // this is the exact logical result even when that write was
+                // the ambiguous failure that triggered this retry.
+                let response_payload = serde_json::to_vec(output.as_ref())?;
+                write_frame(&mut stream, FrameType::Data as u8, &response_payload)?;
+                return Ok(());
+            }
+            Err(error) => {
+                send_error_frame(&mut stream, &error)?;
+                return Ok(());
+            }
+        }
+    } else {
+        None
+    };
+
     if exec_req.streaming {
         let input_rx = spawn_exec_input_monitor(&stream)?;
         execute_command_streaming(
@@ -501,8 +836,22 @@ fn handle_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::error:
             exec_req.user.as_deref(),
         );
 
+        // Publish the result to the replay cache before the first response
+        // byte. A lost connection after this point is therefore recoverable by
+        // an exact retry without executing the command again.
+        let output = match replay_claim {
+            Some(claim) => match claim.complete(output) {
+                Ok(output) => output,
+                Err(error) => {
+                    send_error_frame(&mut stream, &error)?;
+                    return Ok(());
+                }
+            },
+            None => Arc::new(output),
+        };
+
         // Send response as Data frame with JSON payload
-        let response_payload = serde_json::to_vec(&output)?;
+        let response_payload = serde_json::to_vec(output.as_ref())?;
         write_frame(&mut stream, FrameType::Data as u8, &response_payload)?;
     }
 
@@ -829,6 +1178,7 @@ fn build_command(
             stdout: vec![],
             stderr: b"Empty command".to_vec(),
             exit_code: 1,
+            truncated: false,
         });
     }
 
@@ -854,6 +1204,7 @@ fn build_command(
                 stdout: vec![],
                 stderr: error.into_bytes(),
                 exit_code: 1,
+                truncated: false,
             });
         }
     };
@@ -878,6 +1229,7 @@ fn build_command(
                 stdout: vec![],
                 stderr: format!("Invalid rootfs path: {rootfs}").into_bytes(),
                 exit_code: 1,
+                truncated: false,
             });
         }
 
@@ -887,6 +1239,7 @@ fn build_command(
                 stdout: vec![],
                 stderr: b"Rootfs execution requires a Linux guest".to_vec(),
                 exit_code: 1,
+                truncated: false,
             });
         }
 
@@ -925,6 +1278,7 @@ fn build_command(
                     stdout: vec![],
                     stderr: format!("Rootfs path is not a directory: {rootfs}").into_bytes(),
                     exit_code: 1,
+                    truncated: false,
                 });
             }
             Err(e) => {
@@ -932,6 +1286,7 @@ fn build_command(
                     stdout: vec![],
                     stderr: format!("Rootfs path is unavailable: {rootfs} ({e})").into_bytes(),
                     exit_code: 1,
+                    truncated: false,
                 });
             }
         }
@@ -1142,6 +1497,7 @@ fn execute_command(
                 stdout: vec![],
                 stderr: format!("Failed to spawn command '{}': {}", cmd[0], e).into_bytes(),
                 exit_code: 127,
+                truncated: false,
             };
         }
     };
@@ -1157,11 +1513,7 @@ fn execute_command(
             Ok(Some(status)) => {
                 let (stdout, stderr) = read_child_output(&mut child);
 
-                return ExecOutput {
-                    stdout: truncate_output(stdout),
-                    stderr: truncate_output(stderr),
-                    exit_code: status.code().unwrap_or(1),
-                };
+                return bounded_exec_output(stdout, stderr, status.code().unwrap_or(1));
             }
             Ok(None) => {
                 if start.elapsed() >= timeout {
@@ -1172,28 +1524,21 @@ fn execute_command(
 
                     stderr.extend_from_slice(b"\nProcess killed: timeout exceeded");
 
-                    return ExecOutput {
-                        stdout: truncate_output(stdout),
-                        stderr: truncate_output(stderr),
-                        exit_code: 137,
-                    };
+                    return bounded_exec_output(stdout, stderr, 137);
                 }
                 std::thread::sleep(poll_interval);
             }
             Err(ref e) if e.raw_os_error() == Some(libc::ECHILD) => {
                 // Child already reaped (timing race in microVM PID 1 context).
                 let (stdout, stderr) = read_child_output(&mut child);
-                return ExecOutput {
-                    stdout: truncate_output(stdout),
-                    stderr: truncate_output(stderr),
-                    exit_code: 0,
-                };
+                return bounded_exec_output(stdout, stderr, 0);
             }
             Err(e) => {
                 return ExecOutput {
                     stdout: vec![],
                     stderr: format!("Failed to wait for command: {}", e).into_bytes(),
                     exit_code: 1,
+                    truncated: false,
                 };
             }
         }
@@ -1447,6 +1792,7 @@ fn execute_command_streaming(
                 stdout: vec![],
                 stderr: format!("Failed to spawn command '{}': {}", spec.cmd[0], e).into_bytes(),
                 exit_code: 127,
+                truncated: false,
             };
             write_exec_stream_response(writer, &output)?;
             return Ok(());
@@ -2019,6 +2365,16 @@ fn truncate_output(mut data: Vec<u8>) -> Vec<u8> {
     data
 }
 
+fn bounded_exec_output(stdout: Vec<u8>, stderr: Vec<u8>, exit_code: i32) -> ExecOutput {
+    let truncated = stdout.len() > MAX_OUTPUT_BYTES || stderr.len() > MAX_OUTPUT_BYTES;
+    ExecOutput {
+        stdout: truncate_output(stdout),
+        stderr: truncate_output(stderr),
+        exit_code,
+        truncated,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2104,6 +2460,116 @@ mod tests {
         let data = vec![];
         let result = truncate_output(data);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn bounded_exec_output_reports_real_truncation() {
+        let output = bounded_exec_output(
+            vec![b'o'; MAX_OUTPUT_BYTES + 1],
+            vec![b'e'; MAX_OUTPUT_BYTES],
+            17,
+        );
+        assert_eq!(output.stdout.len(), MAX_OUTPUT_BYTES);
+        assert_eq!(output.stderr.len(), MAX_OUTPUT_BYTES);
+        assert_eq!(output.exit_code, 17);
+        assert!(output.truncated);
+
+        let exact = bounded_exec_output(vec![b'o'; 4], vec![b'e'; 4], 0);
+        assert!(!exact.truncated);
+    }
+
+    #[test]
+    fn exec_replay_cache_replays_exact_result_and_rejects_conflicting_content() {
+        let cache = ExecReplayCache::with_limits(4, 2, 1024);
+        let digest = [7_u8; 32];
+        let claim = match cache
+            .acquire("request-1", digest, Duration::from_secs(1))
+            .unwrap()
+        {
+            ExecReplayAcquire::Execute(claim) => claim,
+            ExecReplayAcquire::Replay(_) => panic!("first request must own execution"),
+        };
+        assert!(cache
+            .acquire("request-1", [8_u8; 32], Duration::from_secs(1))
+            .err()
+            .unwrap()
+            .contains("conflicts"));
+
+        let expected = ExecOutput {
+            stdout: b"once\n".to_vec(),
+            stderr: Vec::new(),
+            exit_code: 0,
+            truncated: false,
+        };
+        claim.complete(expected.clone()).unwrap();
+        let replayed = match cache
+            .acquire("request-1", digest, Duration::from_secs(1))
+            .unwrap()
+        {
+            ExecReplayAcquire::Replay(output) => output,
+            ExecReplayAcquire::Execute(_) => panic!("completed request must replay"),
+        };
+        assert_eq!(replayed.as_ref(), &expected);
+    }
+
+    #[test]
+    fn exec_replay_cache_waits_for_in_flight_owner_and_claim_drop_is_retryable() {
+        let cache = Arc::new(ExecReplayCache::with_limits(4, 2, 1024));
+        let digest = [9_u8; 32];
+        let claim = match cache
+            .acquire("request-2", digest, Duration::from_secs(1))
+            .unwrap()
+        {
+            ExecReplayAcquire::Execute(claim) => claim,
+            ExecReplayAcquire::Replay(_) => panic!("first request must own execution"),
+        };
+
+        let waiter_cache = Arc::clone(&cache);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let replayed = match waiter_cache
+                .acquire("request-2", digest, Duration::from_secs(1))
+                .unwrap()
+            {
+                ExecReplayAcquire::Replay(output) => output,
+                ExecReplayAcquire::Execute(_) => panic!("waiter must not execute twice"),
+            };
+            done_tx.send(replayed).unwrap();
+        });
+        started_rx.recv().unwrap();
+        assert!(done_rx
+            .recv_timeout(Duration::from_millis(20))
+            .is_err());
+
+        let expected = ExecOutput {
+            stdout: b"completed\n".to_vec(),
+            stderr: Vec::new(),
+            exit_code: 0,
+            truncated: false,
+        };
+        claim.complete(expected.clone()).unwrap();
+        assert_eq!(
+            done_rx.recv_timeout(Duration::from_secs(1)).unwrap().as_ref(),
+            &expected
+        );
+        waiter.join().unwrap();
+
+        let abandoned = match cache
+            .acquire("request-3", [3_u8; 32], Duration::from_secs(1))
+            .unwrap()
+        {
+            ExecReplayAcquire::Execute(claim) => claim,
+            ExecReplayAcquire::Replay(_) => panic!("new request must own execution"),
+        };
+        drop(abandoned);
+        assert!(matches!(
+            cache
+                .acquire("request-3", [3_u8; 32], Duration::from_secs(1))
+                .unwrap(),
+            ExecReplayAcquire::Execute(_)
+        ));
     }
 
     #[test]
@@ -2340,6 +2806,7 @@ mod tests {
             stdout: b"hello".to_vec(),
             stderr: b"warn".to_vec(),
             exit_code: 42,
+            truncated: false,
         };
 
         let mut buf = Vec::new();
@@ -2373,6 +2840,7 @@ mod tests {
             stdout: vec![b'a'; STREAM_CHUNK_BYTES + 7],
             stderr: vec![],
             exit_code: 0,
+            truncated: false,
         };
 
         let mut buf = Vec::new();

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -16,9 +16,9 @@ use std::time::Duration;
 
 use a3s_box_core::exec::{
     ExecChunk, ExecExit, ExecOutput, ExecRequest, StreamType, DEFAULT_EXEC_TIMEOUT_NS,
-    EXEC_VSOCK_PORT, MAX_OUTPUT_BYTES,
+    EXEC_VSOCK_PORT, MAX_ONE_SHOT_OUTPUT_BYTES, MAX_OUTPUT_BYTES,
 };
-use a3s_transport::FrameType;
+use a3s_transport::{FrameType, MAX_PAYLOAD_SIZE};
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
@@ -829,6 +829,12 @@ fn handle_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::error:
             exec_req.stdin.as_deref(),
             exec_req.user.as_deref(),
         );
+        let output = bounded_exec_output_with_truncation(
+            output.stdout,
+            output.stderr,
+            output.exit_code,
+            output.truncated,
+        );
 
         // Publish the result to the replay cache before the first response
         // byte. A lost connection after this point is therefore recoverable by
@@ -975,6 +981,15 @@ impl<W: Write> Write for ArchiveFrameWriter<'_, W> {
 /// Write a frame: [type:u8][length:u32 BE][payload].
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn write_frame(w: &mut impl Write, frame_type: u8, payload: &[u8]) -> std::io::Result<()> {
+    if payload.len() > MAX_PAYLOAD_SIZE as usize {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "Frame too large: {} bytes (max {MAX_PAYLOAD_SIZE})",
+                payload.len()
+            ),
+        ));
+    }
     let len = payload.len() as u32;
     w.write_all(&[frame_type])?;
     w.write_all(&len.to_be_bytes())?;
@@ -995,10 +1010,10 @@ fn read_frame(r: &mut impl Read) -> std::io::Result<Option<(u8, Vec<u8>)>> {
     let frame_type = header[0];
     let len = u32::from_be_bytes([header[1], header[2], header[3], header[4]]) as usize;
 
-    if len > 16 * 1024 * 1024 {
+    if len > MAX_PAYLOAD_SIZE as usize {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("Frame too large: {} bytes", len),
+            format!("Frame too large: {len} bytes (max {MAX_PAYLOAD_SIZE})"),
         ));
     }
 
@@ -1440,17 +1455,83 @@ fn write_child_stdin(child: &mut std::process::Child, stdin_data: Option<&[u8]>,
     }
 }
 
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-fn read_child_output(child: &mut std::process::Child) -> (Vec<u8>, Vec<u8>) {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    if let Some(ref mut out) = child.stdout {
-        let _ = out.read_to_end(&mut stdout);
+#[derive(Default)]
+struct BoundedPipeOutput {
+    bytes: Vec<u8>,
+    truncated: bool,
+    read_error: Option<String>,
+}
+
+type PipeReader = std::thread::JoinHandle<BoundedPipeOutput>;
+
+struct ChildOutputReaders {
+    stdout: Option<PipeReader>,
+    stderr: Option<PipeReader>,
+}
+
+impl ChildOutputReaders {
+    fn start(child: &mut std::process::Child) -> Self {
+        Self {
+            stdout: child.stdout.take().map(|pipe| {
+                std::thread::spawn(move || read_bounded_pipe(pipe, MAX_ONE_SHOT_OUTPUT_BYTES))
+            }),
+            stderr: child.stderr.take().map(|pipe| {
+                std::thread::spawn(move || read_bounded_pipe(pipe, MAX_ONE_SHOT_OUTPUT_BYTES))
+            }),
+        }
     }
-    if let Some(ref mut err) = child.stderr {
-        let _ = err.read_to_end(&mut stderr);
+
+    fn finish(self) -> (Vec<u8>, Vec<u8>, bool) {
+        let stdout = finish_pipe_reader(self.stdout, "stdout");
+        let mut stderr = finish_pipe_reader(self.stderr, "stderr");
+        let mut truncated = stdout.truncated || stderr.truncated;
+        for error in [stdout.read_error.as_deref(), stderr.read_error.as_deref()]
+            .into_iter()
+            .flatten()
+        {
+            stderr
+                .bytes
+                .extend_from_slice(format!("\nFailed to read command output: {error}").as_bytes());
+        }
+        if stderr.bytes.len() > MAX_ONE_SHOT_OUTPUT_BYTES {
+            truncated = true;
+        }
+        (stdout.bytes, stderr.bytes, truncated)
     }
-    (stdout, stderr)
+}
+
+fn finish_pipe_reader(reader: Option<PipeReader>, stream: &'static str) -> BoundedPipeOutput {
+    let Some(reader) = reader else {
+        return BoundedPipeOutput::default();
+    };
+    reader.join().unwrap_or_else(|_| BoundedPipeOutput {
+        read_error: Some(format!("{stream} reader thread panicked")),
+        ..Default::default()
+    })
+}
+
+fn read_bounded_pipe(mut pipe: impl Read, limit: usize) -> BoundedPipeOutput {
+    let mut output = BoundedPipeOutput {
+        bytes: Vec::with_capacity(limit.min(64 * 1024)),
+        ..Default::default()
+    };
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        match pipe.read(&mut buffer) {
+            Ok(0) => return output,
+            Ok(read) => {
+                let retained = read.min(limit.saturating_sub(output.bytes.len()));
+                output.bytes.extend_from_slice(&buffer[..retained]);
+                if retained < read {
+                    output.truncated = true;
+                }
+            }
+            Err(error) => {
+                output.read_error = Some(error.to_string());
+                return output;
+            }
+        }
+    }
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
@@ -1496,6 +1577,7 @@ fn execute_command(
         }
     };
 
+    let output_readers = ChildOutputReaders::start(&mut child);
     write_child_stdin(&mut child, stdin_data, false);
 
     // Wait with timeout using a polling loop
@@ -1505,35 +1587,40 @@ fn execute_command(
     loop {
         match child.try_wait() {
             Ok(Some(status)) => {
-                let (stdout, stderr) = read_child_output(&mut child);
+                let (stdout, stderr, truncated) = output_readers.finish();
 
-                return bounded_exec_output(stdout, stderr, status.code().unwrap_or(1));
+                return bounded_exec_output_with_truncation(
+                    stdout,
+                    stderr,
+                    status.code().unwrap_or(1),
+                    truncated,
+                );
             }
             Ok(None) => {
                 if start.elapsed() >= timeout {
                     warn!("Exec command timed out after {:?}, killing", timeout);
                     kill_child_process_group(&mut child);
 
-                    let (stdout, mut stderr) = read_child_output(&mut child);
+                    let (stdout, mut stderr, truncated) = output_readers.finish();
 
                     stderr.extend_from_slice(b"\nProcess killed: timeout exceeded");
 
-                    return bounded_exec_output(stdout, stderr, 137);
+                    return bounded_exec_output_with_truncation(
+                        stdout, stderr, 137, truncated,
+                    );
                 }
                 std::thread::sleep(poll_interval);
             }
             Err(ref e) if e.raw_os_error() == Some(libc::ECHILD) => {
                 // Child already reaped (timing race in microVM PID 1 context).
-                let (stdout, stderr) = read_child_output(&mut child);
-                return bounded_exec_output(stdout, stderr, 0);
+                let (stdout, stderr, truncated) = output_readers.finish();
+                return bounded_exec_output_with_truncation(stdout, stderr, 0, truncated);
             }
             Err(e) => {
-                return ExecOutput {
-                    stdout: vec![],
-                    stderr: format!("Failed to wait for command: {}", e).into_bytes(),
-                    exit_code: 1,
-                    truncated: false,
-                };
+                kill_child_process_group(&mut child);
+                let (stdout, mut stderr, truncated) = output_readers.finish();
+                stderr.extend_from_slice(format!("\nFailed to wait for command: {e}").as_bytes());
+                return bounded_exec_output_with_truncation(stdout, stderr, 1, truncated);
             }
         }
     }
@@ -2350,17 +2437,28 @@ fn kill_child_process_group(child: &mut std::process::Child) {
     let _ = child.wait();
 }
 
-/// Truncate output to MAX_OUTPUT_BYTES if it exceeds the limit.
+/// Truncate one-shot output to its wire-safe bound.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn truncate_output(mut data: Vec<u8>) -> Vec<u8> {
-    if data.len() > MAX_OUTPUT_BYTES {
-        data.truncate(MAX_OUTPUT_BYTES);
+    if data.len() > MAX_ONE_SHOT_OUTPUT_BYTES {
+        data.truncate(MAX_ONE_SHOT_OUTPUT_BYTES);
     }
     data
 }
 
 fn bounded_exec_output(stdout: Vec<u8>, stderr: Vec<u8>, exit_code: i32) -> ExecOutput {
-    let truncated = stdout.len() > MAX_OUTPUT_BYTES || stderr.len() > MAX_OUTPUT_BYTES;
+    bounded_exec_output_with_truncation(stdout, stderr, exit_code, false)
+}
+
+fn bounded_exec_output_with_truncation(
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    exit_code: i32,
+    already_truncated: bool,
+) -> ExecOutput {
+    let truncated = already_truncated
+        || stdout.len() > MAX_ONE_SHOT_OUTPUT_BYTES
+        || stderr.len() > MAX_ONE_SHOT_OUTPUT_BYTES;
     ExecOutput {
         stdout: truncate_output(stdout),
         stderr: truncate_output(stderr),
@@ -2437,16 +2535,16 @@ mod tests {
 
     #[test]
     fn test_truncate_output_exceeds_limit() {
-        let data = vec![0u8; MAX_OUTPUT_BYTES + 1000];
+        let data = vec![0u8; MAX_ONE_SHOT_OUTPUT_BYTES + 1000];
         let result = truncate_output(data);
-        assert_eq!(result.len(), MAX_OUTPUT_BYTES);
+        assert_eq!(result.len(), MAX_ONE_SHOT_OUTPUT_BYTES);
     }
 
     #[test]
     fn test_truncate_output_at_limit() {
-        let data = vec![0u8; MAX_OUTPUT_BYTES];
+        let data = vec![0u8; MAX_ONE_SHOT_OUTPUT_BYTES];
         let result = truncate_output(data);
-        assert_eq!(result.len(), MAX_OUTPUT_BYTES);
+        assert_eq!(result.len(), MAX_ONE_SHOT_OUTPUT_BYTES);
     }
 
     #[test]
@@ -2459,17 +2557,35 @@ mod tests {
     #[test]
     fn bounded_exec_output_reports_real_truncation() {
         let output = bounded_exec_output(
-            vec![b'o'; MAX_OUTPUT_BYTES + 1],
-            vec![b'e'; MAX_OUTPUT_BYTES],
+            vec![b'o'; MAX_ONE_SHOT_OUTPUT_BYTES + 1],
+            vec![b'e'; MAX_ONE_SHOT_OUTPUT_BYTES],
             17,
         );
-        assert_eq!(output.stdout.len(), MAX_OUTPUT_BYTES);
-        assert_eq!(output.stderr.len(), MAX_OUTPUT_BYTES);
+        assert_eq!(output.stdout.len(), MAX_ONE_SHOT_OUTPUT_BYTES);
+        assert_eq!(output.stderr.len(), MAX_ONE_SHOT_OUTPUT_BYTES);
         assert_eq!(output.exit_code, 17);
         assert!(output.truncated);
 
         let exact = bounded_exec_output(vec![b'o'; 4], vec![b'e'; 4], 0);
         assert!(!exact.truncated);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_pipe_reader_drains_excess_without_blocking_the_writer() {
+        use std::os::unix::net::UnixStream;
+
+        let (mut writer, reader) = UnixStream::pair().unwrap();
+        let produced = MAX_ONE_SHOT_OUTPUT_BYTES + 128 * 1024;
+        let writer = std::thread::spawn(move || {
+            writer.write_all(&vec![b'x'; produced]).unwrap();
+        });
+
+        let output = read_bounded_pipe(reader, MAX_ONE_SHOT_OUTPUT_BYTES);
+        writer.join().unwrap();
+        assert_eq!(output.bytes.len(), MAX_ONE_SHOT_OUTPUT_BYTES);
+        assert!(output.truncated);
+        assert!(output.read_error.is_none());
     }
 
     #[test]

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -2444,6 +2444,7 @@ fn truncate_output(mut data: Vec<u8>) -> Vec<u8> {
     data
 }
 
+#[cfg(test)]
 fn bounded_exec_output(stdout: Vec<u8>, stderr: Vec<u8>, exit_code: i32) -> ExecOutput {
     bounded_exec_output_with_truncation(stdout, stderr, exit_code, false)
 }

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -1605,9 +1605,7 @@ fn execute_command(
 
                     stderr.extend_from_slice(b"\nProcess killed: timeout exceeded");
 
-                    return bounded_exec_output_with_truncation(
-                        stdout, stderr, 137, truncated,
-                    );
+                    return bounded_exec_output_with_truncation(stdout, stderr, 137, truncated);
                 }
                 std::thread::sleep(poll_interval);
             }

--- a/src/guest/init/src/main.rs
+++ b/src/guest/init/src/main.rs
@@ -1488,7 +1488,8 @@ fn mount_user_volumes() -> Result<(), Box<dyn std::error::Error>> {
 /// Mount tmpfs volumes passed via BOX_TMPFS_* environment variables.
 ///
 /// Each variable has the format: `<path>[:<options>]`
-/// Options are passed directly to mount (e.g., "size=100m").
+/// Data options are passed directly to mount (e.g., "size=100m"); `ro` and
+/// `rw` select the mount access mode.
 fn mount_tmpfs_volumes() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "linux")]
     {
@@ -1499,15 +1500,12 @@ fn mount_tmpfs_volumes() -> Result<(), Box<dyn std::error::Error>> {
             let env_key = format!("BOX_TMPFS_{}", index);
             match std::env::var(&env_key) {
                 Ok(value) => {
-                    // Format: "/path" or "/path:options"
-                    let (path, options) = match value.split_once(':') {
-                        Some((p, opts)) => (p, Some(opts.to_string())),
-                        None => (value.as_str(), None),
-                    };
+                    let (path, options, read_only) = parse_tmpfs_mount(&value)?;
 
                     info!(
                         path = path,
                         options = ?options,
+                        read_only = read_only,
                         "Mounting tmpfs"
                     );
 
@@ -1518,7 +1516,11 @@ fn mount_tmpfs_volumes() -> Result<(), Box<dyn std::error::Error>> {
                         None::<&str>,
                         path,
                         Some("tmpfs"),
-                        MsFlags::empty(),
+                        if read_only {
+                            MsFlags::MS_RDONLY
+                        } else {
+                            MsFlags::empty()
+                        },
                         options.as_deref(),
                     )?;
 
@@ -1539,6 +1541,45 @@ fn mount_tmpfs_volumes() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn parse_tmpfs_mount(value: &str) -> std::io::Result<(&str, Option<String>, bool)> {
+    let (path, options) = value
+        .split_once(':')
+        .map_or((value, None), |(path, options)| (path, Some(options)));
+    if path.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "tmpfs mount path cannot be empty",
+        ));
+    }
+
+    let mut data = Vec::new();
+    let mut read_only = None;
+    for option in options
+        .into_iter()
+        .flat_map(|options| options.split(','))
+        .filter(|option| !option.is_empty())
+    {
+        match option {
+            "ro" | "rw" => {
+                let requested = option == "ro";
+                if read_only.replace(requested).is_some() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!("tmpfs mount has duplicate or conflicting access modes: {value:?}"),
+                    ));
+                }
+            }
+            _ => data.push(option),
+        }
+    }
+
+    Ok((
+        path,
+        (!data.is_empty()).then(|| data.join(",")),
+        read_only.unwrap_or(false),
+    ))
 }
 
 /// Remount the container rootfs as read-only if `BOX_READONLY=1` is set.
@@ -1869,6 +1910,23 @@ mod tests {
             console_handoff_delay(BootstrapMode::Microvm),
             std::time::Duration::from_millis(250)
         );
+    }
+
+    #[test]
+    fn tmpfs_mount_parser_separates_access_mode_from_mount_data() {
+        assert_eq!(
+            parse_tmpfs_mount("/scratch:size=1048576,rw").unwrap(),
+            ("/scratch", Some("size=1048576".into()), false)
+        );
+        assert_eq!(
+            parse_tmpfs_mount("/sealed:size=4096,ro").unwrap(),
+            ("/sealed", Some("size=4096".into()), true)
+        );
+        assert_eq!(
+            parse_tmpfs_mount("/ephemeral").unwrap(),
+            ("/ephemeral", None, false)
+        );
+        assert!(parse_tmpfs_mount("/scratch:ro,rw").is_err());
     }
 
     fn set_sidecar_env(image: &str, vsock_port: u32, env: &[(&str, &str)]) {

--- a/src/guest/init/src/network.rs
+++ b/src/guest/init/src/network.rs
@@ -226,7 +226,11 @@ fn set_interface_up(name: &str) -> Result<(), Box<dyn std::error::Error>> {
     let name_bytes = ifname.as_bytes();
     let copy_len = name_bytes.len().min(libc::IFNAMSIZ - 1);
     unsafe {
-        std::ptr::copy_nonoverlapping(name_bytes.as_ptr(), ifr.ifr_name.as_mut_ptr(), copy_len);
+        std::ptr::copy_nonoverlapping(
+            name_bytes.as_ptr().cast(),
+            ifr.ifr_name.as_mut_ptr(),
+            copy_len,
+        );
     }
 
     // Get current flags
@@ -284,7 +288,11 @@ fn add_address(ifname: &str, ip_cidr: &str) -> Result<(), Box<dyn std::error::Er
     let name_bytes = if_cstr.as_bytes();
     let copy_len = name_bytes.len().min(libc::IFNAMSIZ - 1);
     unsafe {
-        std::ptr::copy_nonoverlapping(name_bytes.as_ptr(), ifr.ifr_name.as_mut_ptr(), copy_len);
+        std::ptr::copy_nonoverlapping(
+            name_bytes.as_ptr().cast(),
+            ifr.ifr_name.as_mut_ptr(),
+            copy_len,
+        );
     }
 
     // Set IP address

--- a/src/guest/init/src/network.rs
+++ b/src/guest/init/src/network.rs
@@ -226,11 +226,7 @@ fn set_interface_up(name: &str) -> Result<(), Box<dyn std::error::Error>> {
     let name_bytes = ifname.as_bytes();
     let copy_len = name_bytes.len().min(libc::IFNAMSIZ - 1);
     unsafe {
-        std::ptr::copy_nonoverlapping(
-            name_bytes.as_ptr(),
-            ifr.ifr_name.as_mut_ptr() as *mut u8,
-            copy_len,
-        );
+        std::ptr::copy_nonoverlapping(name_bytes.as_ptr(), ifr.ifr_name.as_mut_ptr(), copy_len);
     }
 
     // Get current flags
@@ -288,11 +284,7 @@ fn add_address(ifname: &str, ip_cidr: &str) -> Result<(), Box<dyn std::error::Er
     let name_bytes = if_cstr.as_bytes();
     let copy_len = name_bytes.len().min(libc::IFNAMSIZ - 1);
     unsafe {
-        std::ptr::copy_nonoverlapping(
-            name_bytes.as_ptr(),
-            ifr.ifr_name.as_mut_ptr() as *mut u8,
-            copy_len,
-        );
+        std::ptr::copy_nonoverlapping(name_bytes.as_ptr(), ifr.ifr_name.as_mut_ptr(), copy_len);
     }
 
     // Set IP address

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -57,6 +57,7 @@ base64 = { workspace = true }
 
 # HTTP client
 reqwest = { workspace = true }
+url = { workspace = true }
 oci-reqwest = { package = "reqwest", version = "0.12", default-features = false, features = ["json", "stream"] }
 
 # Time
@@ -119,6 +120,9 @@ ring = { workspace = true }
 # stay off Windows where .tar/.tar.gz remain supported without a C toolchain.
 bzip2 = "0.5"
 xz2 = "0.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+a3s-runtime = { workspace = true }
 
 [dev-dependencies]
 axum = { workspace = true }

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests.rs
@@ -26,6 +26,9 @@ use self::fixture::BoxRuntimeConformanceFixture;
 
 type Result<T> = RuntimeResult<T>;
 
+const R17_RUNNER_STACK_BYTES: usize = 32 * 1024 * 1024;
+const R17_WORKER_STACK_BYTES: usize = 8 * 1024 * 1024;
+
 fn failure(message: impl Into<String>) -> RuntimeError {
     RuntimeError::ProviderUnavailable(message.into())
 }
@@ -50,9 +53,27 @@ fn require(condition: bool, message: impl Into<String>) -> Result<()> {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[test]
 #[ignore = "requires a dedicated A3S OS Sandbox certification home"]
-async fn box_runtime_passes_all_advertised_profiles() {
+fn box_runtime_passes_all_advertised_profiles() {
+    let runner = std::thread::Builder::new()
+        .name("a3s-box-r17".into())
+        .stack_size(R17_RUNNER_STACK_BYTES)
+        .spawn(|| {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
+                .thread_name("a3s-box-r17-worker")
+                .thread_stack_size(R17_WORKER_STACK_BYTES)
+                .enable_all()
+                .build()
+                .expect("R17 Tokio runtime must start");
+            runtime.block_on(run_all_advertised_profiles());
+        })
+        .expect("R17 runner thread must start");
+    runner.join().expect("R17 runner thread must not panic");
+}
+
+async fn run_all_advertised_profiles() {
     let fixture = BoxRuntimeConformanceFixture::from_environment()
         .expect("R17 Box conformance preflight must pass");
     let client = fixture.primary_client();

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests.rs
@@ -1,0 +1,92 @@
+//! Opt-in real-provider certification for the Box Sandbox Runtime driver.
+//!
+//! This module is deliberately compiled only for tests and its single test is
+//! ignored by default. The exact test name, explicit acknowledgement variable,
+//! dedicated home, certified runtime, pinned image, and single-threaded test
+//! selection are all release-gate prerequisites.
+
+mod cases;
+mod exec_profile;
+mod fixture;
+mod logs_profile;
+mod networking_profile;
+mod recovery_profile;
+mod resources_profile;
+mod security_profile;
+
+use std::fmt::Display;
+
+use a3s_runtime::{
+    required_runtime_profiles, verify_runtime_profiles, RuntimeClient, RuntimeConformanceProfile,
+    RuntimeError, RuntimeResult,
+};
+
+use self::fixture::BoxRuntimeConformanceFixture;
+
+type Result<T> = RuntimeResult<T>;
+
+fn failure(message: impl Into<String>) -> RuntimeError {
+    RuntimeError::ProviderUnavailable(message.into())
+}
+
+fn protocol(message: impl Into<String>) -> RuntimeError {
+    RuntimeError::Protocol(message.into())
+}
+
+fn invalid(message: impl Into<String>) -> RuntimeError {
+    RuntimeError::InvalidRequest(message.into())
+}
+
+fn external(context: &str, error: impl Display) -> RuntimeError {
+    RuntimeError::ProviderUnavailable(format!("{context}: {error}"))
+}
+
+fn require(condition: bool, message: impl Into<String>) -> Result<()> {
+    if condition {
+        Ok(())
+    } else {
+        Err(protocol(message))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires a dedicated A3S OS Sandbox certification home"]
+async fn box_runtime_passes_all_advertised_profiles() {
+    let fixture = BoxRuntimeConformanceFixture::from_environment()
+        .expect("R17 Box conformance preflight must pass");
+    let client = fixture.primary_client();
+    let capabilities = client
+        .capabilities()
+        .await
+        .expect("R17 Box capabilities must be available");
+    let required = required_runtime_profiles(&capabilities)
+        .expect("R17 Box capabilities must derive valid profiles");
+    let expected = [
+        RuntimeConformanceProfile::Base,
+        RuntimeConformanceProfile::Recovery,
+        RuntimeConformanceProfile::Networking,
+        RuntimeConformanceProfile::Resources,
+        RuntimeConformanceProfile::Logs,
+        RuntimeConformanceProfile::Exec,
+        RuntimeConformanceProfile::Security,
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(
+        required, expected,
+        "R17 must execute every profile activated by Box capabilities"
+    );
+
+    let report = verify_runtime_profiles(&client, &fixture)
+        .await
+        .expect("R17 Box real-provider conformance must pass");
+    assert_eq!(report.inventory_after, report.inventory_before);
+    assert_eq!(
+        report
+            .profiles
+            .iter()
+            .map(|evidence| evidence.profile)
+            .collect::<std::collections::BTreeSet<_>>(),
+        expected
+    );
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests.rs
@@ -9,6 +9,7 @@ mod cases;
 mod exec_profile;
 mod fixture;
 mod logs_profile;
+mod mounts_profile;
 mod networking_profile;
 mod recovery_profile;
 mod resources_profile;
@@ -65,6 +66,7 @@ async fn box_runtime_passes_all_advertised_profiles() {
         RuntimeConformanceProfile::Base,
         RuntimeConformanceProfile::Recovery,
         RuntimeConformanceProfile::Networking,
+        RuntimeConformanceProfile::Mounts,
         RuntimeConformanceProfile::Resources,
         RuntimeConformanceProfile::Logs,
         RuntimeConformanceProfile::Exec,

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/cases.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/cases.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
 use a3s_runtime::contract::{
-    ArtifactRef, IsolationLevel, NetworkMode, ResourceLimits, RestartPolicy,
-    RuntimeActionRequest, RuntimeApplyRequest, RuntimeExecRequest, RuntimeLogQuery,
-    RuntimeLogStream, RuntimeNetworkSpec, RuntimeProcessSpec, RuntimeUnitClass, RuntimeUnitSpec,
+    ArtifactRef, IsolationLevel, NetworkMode, ResourceLimits, RestartPolicy, RuntimeActionRequest,
+    RuntimeApplyRequest, RuntimeExecRequest, RuntimeLogQuery, RuntimeLogStream, RuntimeNetworkSpec,
+    RuntimeProcessSpec, RuntimeUnitClass, RuntimeUnitSpec,
 };
 use a3s_runtime::{RuntimeBaseConformanceCase, RuntimeConformanceCase};
 
@@ -77,7 +77,10 @@ impl CaseFactory {
         let media_type = std::env::var("A3S_BOX_RUNTIME_CONFORMANCE_MEDIA_TYPE")
             .unwrap_or_else(|_| DOCKER_IMAGE_MANIFEST.to_string());
         require(
-            matches!(media_type.as_str(), OCI_IMAGE_MANIFEST | DOCKER_IMAGE_MANIFEST),
+            matches!(
+                media_type.as_str(),
+                OCI_IMAGE_MANIFEST | DOCKER_IMAGE_MANIFEST
+            ),
             "A3S_BOX_RUNTIME_CONFORMANCE_MEDIA_TYPE is not a supported image manifest",
         )?;
         let digest = format!("sha256:{digest_hex}");
@@ -105,11 +108,7 @@ impl CaseFactory {
             "printf 'r17-base-task-failure\\n' >&2; exit 17",
             DEFAULT_TASK_TIMEOUT_MS,
         );
-        let task_timeout_apply = self.task(
-            "base-task-timeout",
-            "exec sleep 3600",
-            500,
-        );
+        let task_timeout_apply = self.task("base-task-timeout", "exec sleep 3600", 500);
         let generation_apply = self.service(
             "base-generation",
             "printf 'r17-base-generation\\n'; exec sleep 3600",
@@ -130,18 +129,9 @@ impl CaseFactory {
                 task_apply,
                 service_apply,
             },
-            task_failure_remove: self.action(
-                "base-task-failure-remove",
-                &task_failure_apply.spec,
-            ),
-            task_timeout_remove: self.action(
-                "base-task-timeout-remove",
-                &task_timeout_apply.spec,
-            ),
-            generation_remove: self.action(
-                "base-generation-remove",
-                &generation_apply.spec,
-            ),
+            task_failure_remove: self.action("base-task-failure-remove", &task_failure_apply.spec),
+            task_timeout_remove: self.action("base-task-timeout-remove", &task_timeout_apply.spec),
+            generation_remove: self.action("base-generation-remove", &generation_apply.spec),
             task_failure_apply,
             task_timeout_apply,
             generation_apply,
@@ -149,12 +139,7 @@ impl CaseFactory {
         }
     }
 
-    pub(super) fn task(
-        &self,
-        label: &str,
-        script: &str,
-        timeout_ms: u64,
-    ) -> RuntimeApplyRequest {
+    pub(super) fn task(&self, label: &str, script: &str, timeout_ms: u64) -> RuntimeApplyRequest {
         self.apply(
             label,
             RuntimeUnitClass::Task,

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/cases.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/cases.rs
@@ -1,0 +1,275 @@
+use std::collections::BTreeMap;
+
+use a3s_runtime::contract::{
+    ArtifactRef, IsolationLevel, NetworkMode, ResourceLimits, RestartPolicy,
+    RuntimeActionRequest, RuntimeApplyRequest, RuntimeExecRequest, RuntimeLogQuery,
+    RuntimeLogStream, RuntimeNetworkSpec, RuntimeProcessSpec, RuntimeUnitClass, RuntimeUnitSpec,
+};
+use a3s_runtime::{RuntimeBaseConformanceCase, RuntimeConformanceCase};
+
+use super::super::{DOCKER_IMAGE_MANIFEST, OCI_IMAGE_MANIFEST};
+use super::{require, Result};
+
+const DEFAULT_CPU_MILLIS: u64 = 500;
+const DEFAULT_MEMORY_BYTES: u64 = 128 * 1024 * 1024;
+const DEFAULT_PIDS: u32 = 64;
+const DEFAULT_TASK_TIMEOUT_MS: u64 = 10_000;
+
+#[derive(Debug, Clone)]
+pub(super) struct CaseFactory {
+    prefix: String,
+    artifact: ArtifactRef,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ResourceShape {
+    pub cpu_millis: u64,
+    pub memory_bytes: u64,
+    pub pids: u32,
+    pub execution_timeout_ms: Option<u64>,
+}
+
+impl ResourceShape {
+    pub const fn service() -> Self {
+        Self {
+            cpu_millis: DEFAULT_CPU_MILLIS,
+            memory_bytes: DEFAULT_MEMORY_BYTES,
+            pids: DEFAULT_PIDS,
+            execution_timeout_ms: None,
+        }
+    }
+
+    pub const fn task(timeout_ms: u64) -> Self {
+        Self {
+            execution_timeout_ms: Some(timeout_ms),
+            ..Self::service()
+        }
+    }
+}
+
+impl CaseFactory {
+    pub(super) fn from_environment(prefix: String) -> Result<Self> {
+        let image = std::env::var("A3S_BOX_RUNTIME_CONFORMANCE_IMAGE").map_err(|_| {
+            super::failure(
+                "A3S_BOX_RUNTIME_CONFORMANCE_IMAGE must be a digest-pinned image reference",
+            )
+        })?;
+        let (repository, digest_hex) = image.rsplit_once("@sha256:").ok_or_else(|| {
+            super::failure(
+                "A3S_BOX_RUNTIME_CONFORMANCE_IMAGE must end in @sha256:<64 lowercase hex>",
+            )
+        })?;
+        require(
+            !repository.is_empty()
+                && digest_hex.len() == 64
+                && digest_hex
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+            "A3S_BOX_RUNTIME_CONFORMANCE_IMAGE has an invalid sha256 digest",
+        )?;
+        require(
+            !repository.contains("//")
+                && !repository.contains('@')
+                && !repository.contains('?')
+                && !repository.contains('#'),
+            "A3S_BOX_RUNTIME_CONFORMANCE_IMAGE is not canonical",
+        )?;
+        let media_type = std::env::var("A3S_BOX_RUNTIME_CONFORMANCE_MEDIA_TYPE")
+            .unwrap_or_else(|_| DOCKER_IMAGE_MANIFEST.to_string());
+        require(
+            matches!(media_type.as_str(), OCI_IMAGE_MANIFEST | DOCKER_IMAGE_MANIFEST),
+            "A3S_BOX_RUNTIME_CONFORMANCE_MEDIA_TYPE is not a supported image manifest",
+        )?;
+        let digest = format!("sha256:{digest_hex}");
+        let artifact = ArtifactRef {
+            uri: format!("oci://{repository}@{digest}"),
+            digest,
+            media_type,
+        };
+        artifact.validate().map_err(super::invalid)?;
+        Ok(Self { prefix, artifact })
+    }
+
+    pub(super) fn base_case(&self) -> RuntimeBaseConformanceCase {
+        let task_apply = self.task(
+            "base-task-success",
+            "printf 'r17-base-task-success\\n'",
+            DEFAULT_TASK_TIMEOUT_MS,
+        );
+        let service_apply = self.service(
+            "base-service",
+            "printf 'r17-base-service-out\\n'; printf 'r17-base-service-err\\n' >&2; exec sleep 3600",
+        );
+        let task_failure_apply = self.task(
+            "base-task-failure",
+            "printf 'r17-base-task-failure\\n' >&2; exit 17",
+            DEFAULT_TASK_TIMEOUT_MS,
+        );
+        let task_timeout_apply = self.task(
+            "base-task-timeout",
+            "exec sleep 3600",
+            500,
+        );
+        let generation_apply = self.service(
+            "base-generation",
+            "printf 'r17-base-generation\\n'; exec sleep 3600",
+        );
+        let mut generation_conflict_apply = generation_apply.clone();
+        generation_conflict_apply.request_id = self.request_id("base-generation-conflict");
+        generation_conflict_apply
+            .spec
+            .process
+            .environment
+            .insert("R17_CONFLICT".into(), "true".into());
+
+        RuntimeBaseConformanceCase {
+            lifecycle: RuntimeConformanceCase {
+                task_remove: self.action("base-task-remove", &task_apply.spec),
+                service_stop: self.action("base-service-stop", &service_apply.spec),
+                service_remove: self.action("base-service-remove", &service_apply.spec),
+                task_apply,
+                service_apply,
+            },
+            task_failure_remove: self.action(
+                "base-task-failure-remove",
+                &task_failure_apply.spec,
+            ),
+            task_timeout_remove: self.action(
+                "base-task-timeout-remove",
+                &task_timeout_apply.spec,
+            ),
+            generation_remove: self.action(
+                "base-generation-remove",
+                &generation_apply.spec,
+            ),
+            task_failure_apply,
+            task_timeout_apply,
+            generation_apply,
+            generation_conflict_apply,
+        }
+    }
+
+    pub(super) fn task(
+        &self,
+        label: &str,
+        script: &str,
+        timeout_ms: u64,
+    ) -> RuntimeApplyRequest {
+        self.apply(
+            label,
+            RuntimeUnitClass::Task,
+            script,
+            ResourceShape::task(timeout_ms),
+            RestartPolicy::Never,
+        )
+    }
+
+    pub(super) fn service(&self, label: &str, script: &str) -> RuntimeApplyRequest {
+        self.apply(
+            label,
+            RuntimeUnitClass::Service,
+            script,
+            ResourceShape::service(),
+            RestartPolicy::Never,
+        )
+    }
+
+    pub(super) fn apply(
+        &self,
+        label: &str,
+        class: RuntimeUnitClass,
+        script: &str,
+        resources: ResourceShape,
+        restart: RestartPolicy,
+    ) -> RuntimeApplyRequest {
+        RuntimeApplyRequest {
+            schema: RuntimeApplyRequest::SCHEMA.into(),
+            request_id: self.request_id(&format!("{label}-apply")),
+            deadline_at_ms: None,
+            spec: RuntimeUnitSpec {
+                schema: RuntimeUnitSpec::SCHEMA.into(),
+                unit_id: self.unit_id(label),
+                generation: 1,
+                class,
+                artifact: self.artifact.clone(),
+                process: RuntimeProcessSpec {
+                    command: vec!["/bin/sh".into(), "-c".into()],
+                    args: vec![script.into()],
+                    working_directory: Some("/".into()),
+                    environment: BTreeMap::from([("R17_CASE".into(), label.into())]),
+                },
+                mounts: Vec::new(),
+                secrets: Vec::new(),
+                network: RuntimeNetworkSpec {
+                    mode: NetworkMode::None,
+                    ports: Vec::new(),
+                },
+                resources: ResourceLimits {
+                    cpu_millis: resources.cpu_millis,
+                    memory_bytes: resources.memory_bytes,
+                    pids: resources.pids,
+                    ephemeral_storage_bytes: None,
+                    execution_timeout_ms: resources.execution_timeout_ms,
+                },
+                isolation: IsolationLevel::Sandbox,
+                health: None,
+                restart,
+                outputs: Vec::new(),
+                semantics_profile_digest: None,
+            },
+        }
+    }
+
+    pub(super) fn action(&self, label: &str, spec: &RuntimeUnitSpec) -> RuntimeActionRequest {
+        RuntimeActionRequest {
+            schema: RuntimeActionRequest::SCHEMA.into(),
+            request_id: self.request_id(label),
+            unit_id: spec.unit_id.clone(),
+            generation: spec.generation,
+            deadline_at_ms: None,
+        }
+    }
+
+    pub(super) fn exec(
+        &self,
+        label: &str,
+        spec: &RuntimeUnitSpec,
+        command: Vec<String>,
+        timeout_ms: u64,
+    ) -> RuntimeExecRequest {
+        RuntimeExecRequest {
+            schema: RuntimeExecRequest::SCHEMA.into(),
+            request_id: self.request_id(label),
+            unit_id: spec.unit_id.clone(),
+            generation: spec.generation,
+            command,
+            timeout_ms,
+            deadline_at_ms: None,
+        }
+    }
+
+    pub(super) fn logs(
+        &self,
+        spec: &RuntimeUnitSpec,
+        cursor: Option<String>,
+        limit: u32,
+        stream: Option<RuntimeLogStream>,
+    ) -> RuntimeLogQuery {
+        RuntimeLogQuery {
+            schema: RuntimeLogQuery::SCHEMA.into(),
+            unit_id: spec.unit_id.clone(),
+            generation: spec.generation,
+            cursor,
+            limit,
+            stream,
+        }
+    }
+
+    pub(super) fn request_id(&self, label: &str) -> String {
+        format!("{}-{label}", self.prefix)
+    }
+
+    pub(super) fn unit_id(&self, label: &str) -> String {
+        format!("{}-{label}", self.prefix)
+    }
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/exec_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/exec_profile.rs
@@ -1,0 +1,117 @@
+use a3s_runtime::contract::RuntimeUnitState;
+use a3s_runtime::{RuntimeClient, RuntimeError};
+
+use super::fixture::BoxRuntimeConformanceFixture;
+use super::{require, Result};
+
+pub(super) async fn run(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let service = fixture.cases.service(
+        "exec-service",
+        "printf 'r17-exec-ready\\n'; exec sleep 3600",
+    );
+    let running = client.apply(&service).await?;
+    require(
+        running.state == RuntimeUnitState::Running,
+        "exec fixture Service did not reach running",
+    )?;
+
+    let basic_request = fixture.cases.exec(
+        "exec-exit-code",
+        &service.spec,
+        vec![
+            "/bin/sh".into(),
+            "-c".into(),
+            "printf 'r17-exec-stdout\\n'; printf 'r17-exec-stderr\\n' >&2; exit 23".into(),
+        ],
+        5_000,
+    );
+    let basic = client.exec(&basic_request).await?;
+    require(
+        basic.exit_code == 23
+            && basic.stdout == "r17-exec-stdout\n"
+            && basic.stderr == "r17-exec-stderr\n"
+            && !basic.truncated,
+        "Box exec did not preserve exit code and stream identity",
+    )?;
+    let replay = client.exec(&basic_request).await?;
+    require(replay == basic, "Box exec exact replay changed its result")?;
+
+    let mut conflict = basic_request.clone();
+    conflict.command = vec!["/bin/true".into()];
+    require(
+        matches!(
+            client.exec(&conflict).await,
+            Err(RuntimeError::RequestConflict { .. })
+        ),
+        "Box exec accepted conflicting content for one request ID",
+    )?;
+
+    let timeout_request = fixture.cases.exec(
+        "exec-timeout",
+        &service.spec,
+        vec!["/bin/sh".into(), "-c".into(), "exec sleep 3600".into()],
+        150,
+    );
+    let timeout = client.exec(&timeout_request).await?;
+    require(
+        timeout.exit_code == 137 && timeout.stderr.contains("timeout exceeded"),
+        "Box exec timeout did not kill and report the command",
+    )?;
+    require(
+        client.exec(&timeout_request).await? == timeout,
+        "timed-out Box exec was re-executed instead of replayed",
+    )?;
+
+    let output = client
+        .exec(&fixture.cases.exec(
+            "exec-output-bounds",
+            &service.spec,
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "yes o | head -c 1100000; yes e | head -c 1100000 >&2".into(),
+            ],
+            15_000,
+        ))
+        .await?;
+    require(
+        output.truncated
+            && output.stdout.len() == 1024 * 1024
+            && output.stderr.len() == 1024 * 1024,
+        "Box exec did not enforce the one-MiB per-stream output bound",
+    )?;
+
+    let mut wrong_generation = fixture.cases.exec(
+        "exec-wrong-generation",
+        &service.spec,
+        vec!["/bin/true".into()],
+        5_000,
+    );
+    wrong_generation.generation += 1;
+    require(
+        client.exec(&wrong_generation).await.is_err(),
+        "Box exec accepted a request for another generation",
+    )?;
+
+    let stop = fixture.cases.action("exec-service-stop", &service.spec);
+    client.stop(&stop).await?;
+    let stopped_exec = fixture.cases.exec(
+        "exec-stopped-state",
+        &service.spec,
+        vec!["/bin/true".into()],
+        5_000,
+    );
+    require(
+        matches!(
+            client.exec(&stopped_exec).await,
+            Err(RuntimeError::InvalidRequest(_))
+        ),
+        "Box exec accepted a stopped Service",
+    )?;
+    fixture
+        .remove_unit(client, &service.spec, "exec-service")
+        .await
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/exec_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/exec_profile.rs
@@ -4,6 +4,15 @@ use a3s_runtime::{RuntimeClient, RuntimeError};
 use super::fixture::BoxRuntimeConformanceFixture;
 use super::{require, Result};
 
+fn case_error(case_id: &str, error: RuntimeError) -> RuntimeError {
+    match error {
+        RuntimeError::DeadlineExceeded(message) => {
+            RuntimeError::DeadlineExceeded(format!("{case_id}: {message}"))
+        }
+        error => RuntimeError::ProviderUnavailable(format!("{case_id}: {error}")),
+    }
+}
+
 pub(super) async fn run(
     fixture: &BoxRuntimeConformanceFixture,
     client: &dyn RuntimeClient,
@@ -28,7 +37,10 @@ pub(super) async fn run(
         ],
         5_000,
     );
-    let basic = client.exec(&basic_request).await?;
+    let basic = client
+        .exec(&basic_request)
+        .await
+        .map_err(|error| case_error("exec-exit-code", error))?;
     require(
         basic.exit_code == 23
             && basic.stdout == "r17-exec-stdout\n"
@@ -36,7 +48,10 @@ pub(super) async fn run(
             && !basic.truncated,
         "Box exec did not preserve exit code and stream identity",
     )?;
-    let replay = client.exec(&basic_request).await?;
+    let replay = client
+        .exec(&basic_request)
+        .await
+        .map_err(|error| case_error("exec-exit-code replay", error))?;
     require(replay == basic, "Box exec exact replay changed its result")?;
 
     let mut conflict = basic_request.clone();
@@ -55,13 +70,20 @@ pub(super) async fn run(
         vec!["/bin/sh".into(), "-c".into(), "exec sleep 3600".into()],
         150,
     );
-    let timeout = client.exec(&timeout_request).await?;
+    let timeout = client
+        .exec(&timeout_request)
+        .await
+        .map_err(|error| case_error("exec-timeout", error))?;
     require(
         timeout.exit_code == 137 && timeout.stderr.contains("timeout exceeded"),
         "Box exec timeout did not kill and report the command",
     )?;
     require(
-        client.exec(&timeout_request).await? == timeout,
+        client
+            .exec(&timeout_request)
+            .await
+            .map_err(|error| case_error("exec-timeout replay", error))?
+            == timeout,
         "timed-out Box exec was re-executed instead of replayed",
     )?;
 
@@ -72,16 +94,25 @@ pub(super) async fn run(
             vec![
                 "/bin/sh".into(),
                 "-c".into(),
-                "yes o | head -c 1100000; yes e | head -c 1100000 >&2".into(),
+                "awk 'BEGIN { s=\"o\"; for (i=0; i<21; i++) s=s s; printf \"%s\", s; printf \"%s\", s > \"/dev/stderr\" }'"
+                    .into(),
             ],
             15_000,
         ))
-        .await?;
+        .await
+        .map_err(|error| case_error("exec-output-bounds", error))?;
     require(
         output.truncated
             && output.stdout.len() == 1024 * 1024
             && output.stderr.len() == 1024 * 1024,
-        "Box exec did not enforce the one-MiB per-stream output bound",
+        format!(
+            "Box exec did not enforce the one-MiB per-stream output bound: \
+             truncated={} stdout_len={} stderr_len={} exit_code={}",
+            output.truncated,
+            output.stdout.len(),
+            output.stderr.len(),
+            output.exit_code,
+        ),
     )?;
 
     let mut wrong_generation = fixture.cases.exec(

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -28,7 +28,6 @@ struct SeenResource {
 
 pub(super) struct BoxRuntimeConformanceFixture {
     pub(super) home_dir: PathBuf,
-    pub(super) state_root: PathBuf,
     pub(super) driver: Arc<BoxRuntimeDriver>,
     pub(super) state: Arc<FileRuntimeStateStore>,
     pub(super) cases: CaseFactory,
@@ -80,7 +79,6 @@ impl BoxRuntimeConformanceFixture {
         let state = Arc::new(FileRuntimeStateStore::new(&state_root));
         Ok(Self {
             home_dir,
-            state_root: state_root.clone(),
             driver: driver.clone(),
             state,
             cases,

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -125,13 +125,13 @@ impl BoxRuntimeConformanceFixture {
     }
 
     pub(super) async fn record_for(&self, spec: &RuntimeUnitSpec) -> Result<crate::BoxRecord> {
-        let record = self
-            .driver
-            .find_generation(spec)
-            .await?
-            .ok_or_else(|| RuntimeError::NotFound {
-                unit_id: spec.unit_id.clone(),
-            })?;
+        let record =
+            self.driver
+                .find_generation(spec)
+                .await?
+                .ok_or_else(|| RuntimeError::NotFound {
+                    unit_id: spec.unit_id.clone(),
+                })?;
         self.remember(&self.home_dir, &record);
         Ok(record)
     }
@@ -198,11 +198,9 @@ impl BoxRuntimeConformanceFixture {
         entry.pid = record.pid;
         entry.pid_start_time = record.pid_start_time;
         #[cfg(target_os = "linux")]
-        if let Ok(Some(runtime)) = crate::vm::reap::load_recorded_sandbox_runtime(
-            home,
-            &record.box_dir,
-            &record.id,
-        ) {
+        if let Ok(Some(runtime)) =
+            crate::vm::reap::load_recorded_sandbox_runtime(home, &record.box_dir, &record.id)
+        {
             entry.log_worker_pid = runtime.log_worker_pid;
             entry.log_worker_pid_start_time = runtime.log_worker_pid_start_time;
         }
@@ -221,11 +219,7 @@ impl BoxRuntimeConformanceFixture {
                 self.remember(&driver.config.home_dir, &record);
                 let (_, generation, state) = local_identity(&record)?;
                 entries.insert(
-                    format!(
-                        "record:{}:{}",
-                        driver.config.home_dir.display(),
-                        record.id
-                    ),
+                    format!("record:{}:{}", driver.config.home_dir.display(), record.id),
                     format!("generation={} state={state}", generation.get()),
                 );
             }
@@ -241,10 +235,7 @@ impl BoxRuntimeConformanceFixture {
                     "socket-dir",
                     PathBuf::from("/tmp/a3s-box-sockets").join(&id),
                 ),
-                (
-                    "cgroup",
-                    PathBuf::from("/sys/fs/cgroup/a3s-box").join(&id),
-                ),
+                ("cgroup", PathBuf::from("/sys/fs/cgroup/a3s-box").join(&id)),
             ] {
                 if path.exists() {
                     entries.insert(
@@ -254,10 +245,7 @@ impl BoxRuntimeConformanceFixture {
                 }
             }
             if mountinfo.lines().any(|line| line.contains(&id)) {
-                entries.insert(
-                    format!("mount:{}:{id}", home.display()),
-                    "present".into(),
-                );
+                entries.insert(format!("mount:{}:{id}", home.display()), "present".into());
             }
             for (kind, pid, start_time) in [
                 ("init", resource.pid, resource.pid_start_time),
@@ -395,12 +383,8 @@ impl RuntimeConformanceFixture for BoxRuntimeConformanceFixture {
             RuntimeConformanceProfile::Resources => {
                 super::resources_profile::run(self, client).await?
             }
-            RuntimeConformanceProfile::Logs => {
-                super::logs_profile::run(self, client).await?
-            }
-            RuntimeConformanceProfile::Exec => {
-                super::exec_profile::run(self, client).await?
-            }
+            RuntimeConformanceProfile::Logs => super::logs_profile::run(self, client).await?,
+            RuntimeConformanceProfile::Exec => super::exec_profile::run(self, client).await?,
             RuntimeConformanceProfile::Security => {
                 super::security_profile::run(self, client).await?
             }

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -352,6 +352,7 @@ impl RuntimeConformanceFixture for BoxRuntimeConformanceFixture {
         BTreeSet::from([
             RuntimeConformanceProfile::Recovery,
             RuntimeConformanceProfile::Networking,
+            RuntimeConformanceProfile::Mounts,
             RuntimeConformanceProfile::Resources,
             RuntimeConformanceProfile::Logs,
             RuntimeConformanceProfile::Exec,
@@ -376,6 +377,7 @@ impl RuntimeConformanceFixture for BoxRuntimeConformanceFixture {
             RuntimeConformanceProfile::Networking => {
                 super::networking_profile::run(self, client).await?
             }
+            RuntimeConformanceProfile::Mounts => super::mounts_profile::run(self, client).await?,
             RuntimeConformanceProfile::Resources => {
                 super::resources_profile::run(self, client).await?
             }

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -3,15 +3,13 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use a3s_box_core::ExecutionManager;
 use a3s_runtime::contract::{
     RuntimeCapabilities, RuntimeInspection, RuntimeUnitSpec, RuntimeUnitState,
 };
 use a3s_runtime::{
     runtime_profile_requirements, FileRuntimeStateStore, ManagedRuntimeClient, RuntimeClient,
     RuntimeConformanceFixture, RuntimeConformanceInventory, RuntimeConformanceProfile,
-    RuntimeConformanceProfileEvidence, RuntimeDriver, RuntimeError, RuntimeResult,
-    RuntimeStateStore,
+    RuntimeConformanceProfileEvidence, RuntimeError, RuntimeResult,
 };
 use async_trait::async_trait;
 

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -1,0 +1,486 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use a3s_box_core::ExecutionManager;
+use a3s_runtime::contract::{
+    RuntimeCapabilities, RuntimeInspection, RuntimeUnitSpec, RuntimeUnitState,
+};
+use a3s_runtime::{
+    runtime_profile_requirements, FileRuntimeStateStore, ManagedRuntimeClient, RuntimeClient,
+    RuntimeConformanceFixture, RuntimeConformanceInventory, RuntimeConformanceProfile,
+    RuntimeConformanceProfileEvidence, RuntimeDriver, RuntimeError, RuntimeResult,
+    RuntimeStateStore,
+};
+use async_trait::async_trait;
+
+use super::super::metadata::{local_identity, UNIT_LABEL};
+use super::super::{BoxRuntimeDriver, BoxRuntimeDriverConfig};
+use super::cases::CaseFactory;
+use super::{external, failure, require, Result};
+
+#[derive(Debug, Clone, Default)]
+struct SeenResource {
+    pid: Option<u32>,
+    pid_start_time: Option<u64>,
+    log_worker_pid: Option<u32>,
+    log_worker_pid_start_time: Option<u64>,
+}
+
+pub(super) struct BoxRuntimeConformanceFixture {
+    pub(super) home_dir: PathBuf,
+    pub(super) state_root: PathBuf,
+    pub(super) driver: Arc<BoxRuntimeDriver>,
+    pub(super) state: Arc<FileRuntimeStateStore>,
+    pub(super) cases: CaseFactory,
+    base_case: a3s_runtime::RuntimeBaseConformanceCase,
+    drivers: Mutex<Vec<Arc<BoxRuntimeDriver>>>,
+    state_roots: Mutex<BTreeSet<PathBuf>>,
+    removable_homes: Mutex<BTreeSet<PathBuf>>,
+    seen: Mutex<BTreeMap<(PathBuf, String), SeenResource>>,
+}
+
+impl BoxRuntimeConformanceFixture {
+    pub(super) fn from_environment() -> Result<Self> {
+        require(
+            std::env::var("A3S_BOX_RUNTIME_CONFORMANCE").as_deref() == Ok("1"),
+            "set A3S_BOX_RUNTIME_CONFORMANCE=1 to acknowledge the destructive R17 suite",
+        )?;
+        let home_dir = std::env::var_os("A3S_HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| failure("A3S_HOME must select a dedicated R17 home"))?;
+        require(home_dir.is_absolute(), "A3S_HOME must be absolute")?;
+        require(
+            home_dir
+                .file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|value| value.contains("runtime-conformance")),
+            "A3S_HOME final component must contain runtime-conformance",
+        )?;
+        let canonical_home = home_dir
+            .canonicalize()
+            .map_err(|error| external("canonicalize A3S_HOME", error))?;
+        require(
+            canonical_home == home_dir,
+            "A3S_HOME must already be canonical and must not be a symlink",
+        )?;
+        validate_runtime_assets(&home_dir)?;
+
+        let state_root = home_dir.join("runtime-state");
+        require(
+            !state_root.exists(),
+            "dedicated R17 Runtime state root already exists",
+        )?;
+        let prefix = format!("r17-{}", uuid::Uuid::new_v4().simple());
+        let cases = CaseFactory::from_environment(prefix)?;
+        let base_case = cases.base_case();
+        base_case.validate().map_err(super::invalid)?;
+
+        let config = driver_config(home_dir.clone());
+        let driver = Arc::new(BoxRuntimeDriver::new(config)?);
+        let state = Arc::new(FileRuntimeStateStore::new(&state_root));
+        Ok(Self {
+            home_dir,
+            state_root: state_root.clone(),
+            driver: driver.clone(),
+            state,
+            cases,
+            base_case,
+            drivers: Mutex::new(vec![driver]),
+            state_roots: Mutex::new(BTreeSet::from([state_root])),
+            removable_homes: Mutex::new(BTreeSet::new()),
+            seen: Mutex::new(BTreeMap::new()),
+        })
+    }
+
+    pub(super) fn primary_client(&self) -> ManagedRuntimeClient {
+        self.client_with(self.driver.clone(), self.state.clone())
+    }
+
+    pub(super) fn client_with(
+        &self,
+        driver: Arc<BoxRuntimeDriver>,
+        state: Arc<FileRuntimeStateStore>,
+    ) -> ManagedRuntimeClient {
+        ManagedRuntimeClient::new(state, driver)
+    }
+
+    pub(super) fn restarted_driver(&self) -> Result<Arc<BoxRuntimeDriver>> {
+        let driver = Arc::new(BoxRuntimeDriver::new(driver_config(self.home_dir.clone()))?);
+        self.register_driver(driver.clone());
+        Ok(driver)
+    }
+
+    pub(super) fn register_driver(&self, driver: Arc<BoxRuntimeDriver>) {
+        self.drivers.lock().unwrap().push(driver);
+    }
+
+    pub(super) fn register_state_root(&self, root: PathBuf) {
+        self.state_roots.lock().unwrap().insert(root);
+    }
+
+    pub(super) fn register_removable_home(&self, home: PathBuf) {
+        self.removable_homes.lock().unwrap().insert(home);
+    }
+
+    pub(super) async fn record_for(&self, spec: &RuntimeUnitSpec) -> Result<crate::BoxRecord> {
+        let record = self
+            .driver
+            .find_generation(spec)
+            .await?
+            .ok_or_else(|| RuntimeError::NotFound {
+                unit_id: spec.unit_id.clone(),
+            })?;
+        self.remember(&self.home_dir, &record);
+        Ok(record)
+    }
+
+    pub(super) async fn records_for(
+        &self,
+        driver: &BoxRuntimeDriver,
+        spec: &RuntimeUnitSpec,
+    ) -> Result<Vec<crate::BoxRecord>> {
+        let records = driver.unit_records(&spec.unit_id).await?;
+        for record in &records {
+            self.remember(driver.config.home_dir.as_path(), record);
+        }
+        Ok(records)
+    }
+
+    pub(super) async fn remove_unit(
+        &self,
+        client: &dyn RuntimeClient,
+        spec: &RuntimeUnitSpec,
+        label: &str,
+    ) -> Result<()> {
+        if spec.class == a3s_runtime::contract::RuntimeUnitClass::Service {
+            let stop = self.cases.action(&format!("{label}-stop"), spec);
+            let inspection = client.stop(&stop).await?;
+            if let RuntimeInspection::Found { observation, .. } = inspection {
+                require(
+                    matches!(
+                        observation.state,
+                        RuntimeUnitState::Stopped
+                            | RuntimeUnitState::Failed
+                            | RuntimeUnitState::Unknown
+                    ),
+                    format!("{label} stop returned an active state"),
+                )?;
+            }
+        }
+        let remove = self.cases.action(&format!("{label}-remove"), spec);
+        let removal = client.remove(&remove).await?;
+        require(
+            removal.unit_id == spec.unit_id && removal.generation == spec.generation,
+            format!("{label} removal changed immutable identity"),
+        )
+    }
+
+    pub(super) fn evidence(
+        &self,
+        capabilities: &RuntimeCapabilities,
+        profile: RuntimeConformanceProfile,
+    ) -> Result<RuntimeConformanceProfileEvidence> {
+        let required = runtime_profile_requirements(capabilities, profile)?;
+        Ok(RuntimeConformanceProfileEvidence {
+            profile,
+            case_ids: required.case_ids,
+            capability_claims: required.capability_claims,
+        })
+    }
+
+    fn remember(&self, home: &Path, record: &crate::BoxRecord) {
+        let mut seen = self.seen.lock().unwrap();
+        let entry = seen
+            .entry((home.to_path_buf(), record.id.clone()))
+            .or_default();
+        entry.pid = record.pid;
+        entry.pid_start_time = record.pid_start_time;
+        #[cfg(target_os = "linux")]
+        if let Ok(Some(runtime)) = crate::vm::reap::load_recorded_sandbox_runtime(
+            home,
+            &record.box_dir,
+            &record.id,
+        ) {
+            entry.log_worker_pid = runtime.log_worker_pid;
+            entry.log_worker_pid_start_time = runtime.log_worker_pid_start_time;
+        }
+    }
+
+    async fn provider_inventory(&self) -> Result<RuntimeConformanceInventory> {
+        let drivers = self.drivers.lock().unwrap().clone();
+        let mut entries = BTreeMap::new();
+        for driver in &drivers {
+            let records = driver
+                .manager
+                .managed_records()
+                .await
+                .map_err(|error| external("load Box managed inventory", error))?;
+            for record in records {
+                self.remember(&driver.config.home_dir, &record);
+                let (_, generation, state) = local_identity(&record)?;
+                entries.insert(
+                    format!(
+                        "record:{}:{}",
+                        driver.config.home_dir.display(),
+                        record.id
+                    ),
+                    format!("generation={} state={state}", generation.get()),
+                );
+            }
+        }
+
+        let seen = self.seen.lock().unwrap().clone();
+        let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").unwrap_or_default();
+        for ((home, id), resource) in seen {
+            for (kind, path) in [
+                ("box-dir", home.join("boxes").join(&id)),
+                ("crun-root", home.join("run/crun").join(&id)),
+                (
+                    "socket-dir",
+                    PathBuf::from("/tmp/a3s-box-sockets").join(&id),
+                ),
+                (
+                    "cgroup",
+                    PathBuf::from("/sys/fs/cgroup/a3s-box").join(&id),
+                ),
+            ] {
+                if path.exists() {
+                    entries.insert(
+                        format!("{kind}:{}:{id}", home.display()),
+                        path.display().to_string(),
+                    );
+                }
+            }
+            if mountinfo.lines().any(|line| line.contains(&id)) {
+                entries.insert(
+                    format!("mount:{}:{id}", home.display()),
+                    "present".into(),
+                );
+            }
+            for (kind, pid, start_time) in [
+                ("init", resource.pid, resource.pid_start_time),
+                (
+                    "log-worker",
+                    resource.log_worker_pid,
+                    resource.log_worker_pid_start_time,
+                ),
+            ] {
+                if let Some(pid) = pid {
+                    if crate::process::is_process_alive_with_identity(pid, start_time) {
+                        entries.insert(
+                            format!("process:{kind}:{}:{id}", home.display()),
+                            pid.to_string(),
+                        );
+                    }
+                }
+            }
+        }
+
+        for root in self.state_roots.lock().unwrap().iter() {
+            if root.exists() {
+                entries.insert(
+                    format!("runtime-state:{}", root.display()),
+                    directory_shape(root)?,
+                );
+            }
+        }
+        for home in self.removable_homes.lock().unwrap().iter() {
+            if home.exists() {
+                entries.insert(
+                    format!("provider-home:{}", home.display()),
+                    directory_shape(home)?,
+                );
+            }
+        }
+        Ok(RuntimeConformanceInventory { entries })
+    }
+
+    async fn cleanup_all(&self) -> Result<()> {
+        let drivers = self.drivers.lock().unwrap().clone();
+        let mut failures = Vec::new();
+        for driver in drivers.iter().rev() {
+            let records = match driver.manager.managed_records().await {
+                Ok(records) => records,
+                Err(error) => {
+                    failures.push(format!(
+                        "load cleanup inventory for {}: {error}",
+                        driver.config.home_dir.display()
+                    ));
+                    continue;
+                }
+            };
+            for record in records {
+                self.remember(&driver.config.home_dir, &record);
+                let unit_id = record
+                    .labels
+                    .get(UNIT_LABEL)
+                    .cloned()
+                    .unwrap_or_else(|| "r17-cleanup".into());
+                if let Err(error) = driver.retire_record(record, &unit_id).await {
+                    failures.push(format!("retire {unit_id}: {error}"));
+                }
+            }
+        }
+
+        for root in self.state_roots.lock().unwrap().iter() {
+            if let Err(error) = remove_tree(root) {
+                failures.push(format!("remove Runtime state {}: {error}", root.display()));
+            }
+        }
+        for home in self.removable_homes.lock().unwrap().iter() {
+            if let Err(error) = remove_tree(home) {
+                failures.push(format!("remove provider home {}: {error}", home.display()));
+            }
+        }
+        for path in [
+            self.home_dir.join("boxes.json"),
+            self.home_dir.join("boxes.json.lock"),
+            self.home_dir.join("boxes.json.tmp"),
+        ] {
+            if let Err(error) = remove_file(&path) {
+                failures.push(format!("remove provider state {}: {error}", path.display()));
+            }
+        }
+        remove_empty_directory(&self.home_dir.join("boxes"));
+        remove_empty_directory(&self.home_dir.join("run/crun"));
+        remove_empty_directory(&self.home_dir.join("run"));
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(failure(format!(
+                "R17 cleanup was incomplete: {}",
+                failures.join("; ")
+            )))
+        }
+    }
+}
+
+#[async_trait]
+impl RuntimeConformanceFixture for BoxRuntimeConformanceFixture {
+    fn base_case(&self) -> &a3s_runtime::RuntimeBaseConformanceCase {
+        &self.base_case
+    }
+
+    fn available_profiles(&self) -> BTreeSet<RuntimeConformanceProfile> {
+        BTreeSet::from([
+            RuntimeConformanceProfile::Recovery,
+            RuntimeConformanceProfile::Networking,
+            RuntimeConformanceProfile::Resources,
+            RuntimeConformanceProfile::Logs,
+            RuntimeConformanceProfile::Exec,
+            RuntimeConformanceProfile::Security,
+        ])
+    }
+
+    async fn inventory(&self) -> RuntimeResult<RuntimeConformanceInventory> {
+        self.provider_inventory().await
+    }
+
+    async fn run_profile(
+        &self,
+        client: &dyn RuntimeClient,
+        capabilities: &RuntimeCapabilities,
+        profile: RuntimeConformanceProfile,
+    ) -> RuntimeResult<RuntimeConformanceProfileEvidence> {
+        match profile {
+            RuntimeConformanceProfile::Recovery => {
+                super::recovery_profile::run(self, client).await?
+            }
+            RuntimeConformanceProfile::Networking => {
+                super::networking_profile::run(self, client).await?
+            }
+            RuntimeConformanceProfile::Resources => {
+                super::resources_profile::run(self, client).await?
+            }
+            RuntimeConformanceProfile::Logs => {
+                super::logs_profile::run(self, client).await?
+            }
+            RuntimeConformanceProfile::Exec => {
+                super::exec_profile::run(self, client).await?
+            }
+            RuntimeConformanceProfile::Security => {
+                super::security_profile::run(self, client).await?
+            }
+            unsupported => {
+                return Err(RuntimeError::Protocol(format!(
+                    "Box R17 fixture cannot execute unexpected {} profile",
+                    unsupported.as_str()
+                )))
+            }
+        }
+        self.evidence(capabilities, profile)
+    }
+
+    async fn cleanup(&self) -> RuntimeResult<()> {
+        self.cleanup_all().await
+    }
+}
+
+fn driver_config(home_dir: PathBuf) -> BoxRuntimeDriverConfig {
+    BoxRuntimeDriverConfig {
+        home_dir,
+        control_timeout: Duration::from_secs(120),
+        task_poll_interval: Duration::from_millis(25),
+    }
+}
+
+fn validate_runtime_assets(home_dir: &Path) -> Result<()> {
+    let crun = std::env::var_os("A3S_BOX_CRUN_PATH")
+        .map(PathBuf::from)
+        .ok_or_else(|| failure("A3S_BOX_CRUN_PATH must select the certified crun artifact"))?;
+    let expected = home_dir.join("bin/crun");
+    let canonical_crun = crun
+        .canonicalize()
+        .map_err(|error| external("canonicalize A3S_BOX_CRUN_PATH", error))?;
+    let canonical_expected = expected
+        .canonicalize()
+        .map_err(|error| external("canonicalize A3S_HOME/bin/crun", error))?;
+    require(
+        canonical_crun == canonical_expected,
+        "A3S_BOX_CRUN_PATH must equal A3S_HOME/bin/crun",
+    )?;
+    for binary in ["a3s-box-guest-init", "a3s-box-shim"] {
+        let path = home_dir.join("bin").join(binary);
+        require(
+            path.is_file(),
+            format!("required R17 binary is missing: {}", path.display()),
+        )?;
+    }
+    let snapshot = crate::sandbox::probe_sandbox_capabilities(Some(&canonical_crun));
+    snapshot
+        .require_ready()
+        .map_err(|error| failure(error.to_string()))
+}
+
+fn directory_shape(path: &Path) -> Result<String> {
+    let mut entries = std::fs::read_dir(path)
+        .map_err(|error| external("read inventory directory", error))?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    entries.sort();
+    Ok(entries.join(","))
+}
+
+fn remove_tree(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_file(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_empty_directory(path: &Path) {
+    let _ = std::fs::remove_dir(path);
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/logs_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/logs_profile.rs
@@ -1,0 +1,214 @@
+use std::io::Write;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use a3s_box_core::log::LogEntry;
+use a3s_runtime::contract::{RuntimeLogChunk, RuntimeLogStream};
+use a3s_runtime::{RuntimeClient, RuntimeError};
+
+use super::fixture::BoxRuntimeConformanceFixture;
+use super::{require, Result};
+
+pub(super) async fn run(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let service = fixture.cases.service(
+        "logs-service",
+        "printf 'r17-log-stdout\\n'; printf 'r17-log-stderr\\n' >&2; exec sleep 3600",
+    );
+    client.apply(&service).await?;
+    let initial = wait_for_initial_logs(fixture, client, &service.spec).await?;
+    require(
+        initial.windows(2).all(|pair| pair[0].sequence < pair[1].sequence),
+        "Box logs are not in strict total order",
+    )?;
+    let stdout = initial
+        .iter()
+        .find(|chunk| chunk.data.contains("r17-log-stdout"))
+        .ok_or_else(|| super::protocol("Box logs omitted stdout"))?;
+    let stderr = initial
+        .iter()
+        .find(|chunk| chunk.data.contains("r17-log-stderr"))
+        .ok_or_else(|| super::protocol("Box logs omitted stderr"))?;
+    require(
+        stdout.stream == RuntimeLogStream::Stdout
+            && stderr.stream == RuntimeLogStream::Stderr,
+        "Box log streams were mislabeled",
+    )?;
+
+    let stderr_only = client
+        .logs(&fixture.cases.logs(
+            &service.spec,
+            None,
+            100,
+            Some(RuntimeLogStream::Stderr),
+        ))
+        .await?;
+    require(
+        !stderr_only.is_empty()
+            && stderr_only
+                .iter()
+                .all(|chunk| chunk.stream == RuntimeLogStream::Stderr),
+        "Box stderr filter leaked another stream",
+    )?;
+    let limited = client
+        .logs(&fixture.cases.logs(&service.spec, None, 1, None))
+        .await?;
+    require(limited.len() == 1, "Box log limit was not enforced")?;
+    let resumed = client
+        .logs(&fixture.cases.logs(
+            &service.spec,
+            Some(initial[0].cursor.clone()),
+            100,
+            None,
+        ))
+        .await?;
+    require(
+        resumed.first().map(|chunk| chunk.cursor.as_str())
+            == initial.get(1).map(|chunk| chunk.cursor.as_str()),
+        "Box log cursor did not resume after the addressed record",
+    )?;
+
+    let stop = fixture.cases.action("logs-service-stop", &service.spec);
+    client.stop(&stop).await?;
+    let retained = client
+        .logs(&fixture.cases.logs(&service.spec, None, 100, None))
+        .await?;
+    require(
+        retained.iter().any(|chunk| chunk.data.contains("r17-log-stdout")),
+        "stopped Service did not retain its logs",
+    )?;
+
+    let record = fixture.record_for(&service.spec).await?;
+    let structured = record.box_dir.join("logs/container.json");
+    append_entries(
+        &structured,
+        &[
+            LogEntry {
+                log: "r17-same-time-one\\n".into(),
+                stream: "stdout".into(),
+                time: "2026-07-17T12:00:00.123456789Z".into(),
+            },
+            LogEntry {
+                log: "r17-same-time-two\\n".into(),
+                stream: "stderr".into(),
+                time: "2026-07-17T12:00:00.123456789Z".into(),
+            },
+        ],
+    )?;
+    let same_time = client
+        .logs(&fixture.cases.logs(&service.spec, None, 10_000, None))
+        .await?;
+    let same_time = same_time
+        .iter()
+        .filter(|chunk| chunk.data.starts_with("r17-same-time-"))
+        .collect::<Vec<_>>();
+    require(
+        same_time.len() == 2 && same_time[0].sequence < same_time[1].sequence,
+        "same-timestamp Box log records lost total order",
+    )?;
+    let rotation_cursor = same_time[0].cursor.clone();
+
+    write_entries(
+        &structured,
+        &[LogEntry {
+            log: "r17-after-rotation\\n".into(),
+            stream: "stdout".into(),
+            time: "2026-07-17T12:00:01Z".into(),
+        }],
+    )?;
+    let gap = client
+        .logs(&fixture.cases.logs(
+            &service.spec,
+            Some(rotation_cursor),
+            100,
+            None,
+        ))
+        .await
+        .unwrap_err();
+    require(
+        matches!(gap, RuntimeError::Protocol(ref message) if message.contains("rotation gap")),
+        format!("missing Box log cursor did not report a rotation gap: {gap}"),
+    )?;
+
+    write_entries(
+        &structured,
+        &[LogEntry {
+            log: "x".repeat(1024 * 1024 + 1),
+            stream: "stdout".into(),
+            time: "2026-07-17T12:00:02Z".into(),
+        }],
+    )?;
+    let oversized = client
+        .logs(&fixture.cases.logs(&service.spec, None, 100, None))
+        .await
+        .unwrap_err();
+    require(
+        matches!(oversized, RuntimeError::Protocol(ref message) if message.contains("one-MiB")),
+        format!("oversized Box log record did not fail closed: {oversized}"),
+    )?;
+
+    fixture
+        .remove_unit(client, &service.spec, "logs-service")
+        .await?;
+    let removed = client
+        .logs(&fixture.cases.logs(&service.spec, None, 100, None))
+        .await;
+    require(
+        matches!(removed, Err(RuntimeError::NotFound { .. })),
+        "removed Service still exposed provider logs",
+    )
+}
+
+async fn wait_for_initial_logs(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+    spec: &a3s_runtime::contract::RuntimeUnitSpec,
+) -> Result<Vec<RuntimeLogChunk>> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let chunks = client
+            .logs(&fixture.cases.logs(spec, None, 100, None))
+            .await?;
+        if chunks.iter().any(|chunk| chunk.data.contains("r17-log-stdout"))
+            && chunks.iter().any(|chunk| chunk.data.contains("r17-log-stderr"))
+        {
+            return Ok(chunks);
+        }
+        if Instant::now() >= deadline {
+            return Err(super::protocol(
+                "Box log worker did not publish both streams within five seconds",
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+fn append_entries(path: &Path, entries: &[LogEntry]) -> Result<()> {
+    let mut output = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| super::external("open structured log for append", error))?;
+    write_to(&mut output, entries)
+}
+
+fn write_entries(path: &Path, entries: &[LogEntry]) -> Result<()> {
+    let mut output = std::fs::File::create(path)
+        .map_err(|error| super::external("replace structured log", error))?;
+    write_to(&mut output, entries)
+}
+
+fn write_to(output: &mut std::fs::File, entries: &[LogEntry]) -> Result<()> {
+    for entry in entries {
+        serde_json::to_writer(&mut *output, entry)
+            .map_err(|error| super::external("encode structured log entry", error))?;
+        output
+            .write_all(b"\n")
+            .map_err(|error| super::external("write structured log entry", error))?;
+    }
+    output
+        .sync_all()
+        .map_err(|error| super::external("sync structured log entries", error))
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/logs_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/logs_profile.rs
@@ -20,7 +20,9 @@ pub(super) async fn run(
     client.apply(&service).await?;
     let initial = wait_for_initial_logs(fixture, client, &service.spec).await?;
     require(
-        initial.windows(2).all(|pair| pair[0].sequence < pair[1].sequence),
+        initial
+            .windows(2)
+            .all(|pair| pair[0].sequence < pair[1].sequence),
         "Box logs are not in strict total order",
     )?;
     let stdout = initial
@@ -32,18 +34,16 @@ pub(super) async fn run(
         .find(|chunk| chunk.data.contains("r17-log-stderr"))
         .ok_or_else(|| super::protocol("Box logs omitted stderr"))?;
     require(
-        stdout.stream == RuntimeLogStream::Stdout
-            && stderr.stream == RuntimeLogStream::Stderr,
+        stdout.stream == RuntimeLogStream::Stdout && stderr.stream == RuntimeLogStream::Stderr,
         "Box log streams were mislabeled",
     )?;
 
     let stderr_only = client
-        .logs(&fixture.cases.logs(
-            &service.spec,
-            None,
-            100,
-            Some(RuntimeLogStream::Stderr),
-        ))
+        .logs(
+            &fixture
+                .cases
+                .logs(&service.spec, None, 100, Some(RuntimeLogStream::Stderr)),
+        )
         .await?;
     require(
         !stderr_only.is_empty()
@@ -57,12 +57,11 @@ pub(super) async fn run(
         .await?;
     require(limited.len() == 1, "Box log limit was not enforced")?;
     let resumed = client
-        .logs(&fixture.cases.logs(
-            &service.spec,
-            Some(initial[0].cursor.clone()),
-            100,
-            None,
-        ))
+        .logs(
+            &fixture
+                .cases
+                .logs(&service.spec, Some(initial[0].cursor.clone()), 100, None),
+        )
         .await?;
     require(
         resumed.first().map(|chunk| chunk.cursor.as_str())
@@ -76,7 +75,9 @@ pub(super) async fn run(
         .logs(&fixture.cases.logs(&service.spec, None, 100, None))
         .await?;
     require(
-        retained.iter().any(|chunk| chunk.data.contains("r17-log-stdout")),
+        retained
+            .iter()
+            .any(|chunk| chunk.data.contains("r17-log-stdout")),
         "stopped Service did not retain its logs",
     )?;
 
@@ -119,12 +120,11 @@ pub(super) async fn run(
         }],
     )?;
     let gap = client
-        .logs(&fixture.cases.logs(
-            &service.spec,
-            Some(rotation_cursor),
-            100,
-            None,
-        ))
+        .logs(
+            &fixture
+                .cases
+                .logs(&service.spec, Some(rotation_cursor), 100, None),
+        )
         .await
         .unwrap_err();
     require(
@@ -171,8 +171,12 @@ async fn wait_for_initial_logs(
         let chunks = client
             .logs(&fixture.cases.logs(spec, None, 100, None))
             .await?;
-        if chunks.iter().any(|chunk| chunk.data.contains("r17-log-stdout"))
-            && chunks.iter().any(|chunk| chunk.data.contains("r17-log-stderr"))
+        if chunks
+            .iter()
+            .any(|chunk| chunk.data.contains("r17-log-stdout"))
+            && chunks
+                .iter()
+                .any(|chunk| chunk.data.contains("r17-log-stderr"))
         {
             return Ok(chunks);
         }

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/logs_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/logs_profile.rs
@@ -83,18 +83,21 @@ pub(super) async fn run(
 
     let record = fixture.record_for(&service.spec).await?;
     let structured = record.box_dir.join("logs/container.json");
+    let same_timestamp = timestamp_after(&initial, 1_000)?;
+    let rotation_timestamp = timestamp_after(&initial, 2_000)?;
+    let oversized_timestamp = timestamp_after(&initial, 3_000)?;
     append_entries(
         &structured,
         &[
             LogEntry {
                 log: "r17-same-time-one\\n".into(),
                 stream: "stdout".into(),
-                time: "2026-07-17T12:00:00.123456789Z".into(),
+                time: same_timestamp.clone(),
             },
             LogEntry {
                 log: "r17-same-time-two\\n".into(),
                 stream: "stderr".into(),
-                time: "2026-07-17T12:00:00.123456789Z".into(),
+                time: same_timestamp,
             },
         ],
     )?;
@@ -116,7 +119,7 @@ pub(super) async fn run(
         &[LogEntry {
             log: "r17-after-rotation\\n".into(),
             stream: "stdout".into(),
-            time: "2026-07-17T12:00:01Z".into(),
+            time: rotation_timestamp,
         }],
     )?;
     let gap = client
@@ -137,7 +140,7 @@ pub(super) async fn run(
         &[LogEntry {
             log: "x".repeat(1024 * 1024 + 1),
             stream: "stdout".into(),
-            time: "2026-07-17T12:00:02Z".into(),
+            time: oversized_timestamp,
         }],
     )?;
     let oversized = client
@@ -187,6 +190,20 @@ async fn wait_for_initial_logs(
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
+}
+
+fn timestamp_after(chunks: &[RuntimeLogChunk], offset_ms: u64) -> Result<String> {
+    let latest = chunks
+        .iter()
+        .map(|chunk| chunk.observed_at_ms)
+        .max()
+        .ok_or_else(|| super::protocol("Box log timestamp fixture has no source record"))?;
+    let timestamp_ms = latest
+        .checked_add(offset_ms)
+        .and_then(|value| i64::try_from(value).ok())
+        .and_then(chrono::DateTime::from_timestamp_millis)
+        .ok_or_else(|| super::protocol("Box log timestamp fixture overflowed"))?;
+    Ok(timestamp_ms.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
 }
 
 fn append_entries(path: &Path, entries: &[LogEntry]) -> Result<()> {

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/mounts_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/mounts_profile.rs
@@ -1,0 +1,222 @@
+use std::path::Path;
+
+use a3s_runtime::contract::{RestartPolicy, RuntimeMount, RuntimeMountSource, RuntimeUnitState};
+use a3s_runtime::RuntimeClient;
+
+use super::fixture::BoxRuntimeConformanceFixture;
+use super::{require, Result};
+
+const TMPFS_SIZE_BYTES: u64 = 4 * 1024 * 1024;
+
+pub(super) async fn run(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    read_only_enforcement(fixture, client).await?;
+    tmpfs_isolation(fixture, client).await?;
+    mount_cleanup(fixture, client).await
+}
+
+async fn read_only_enforcement(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    const TARGET: &str = "/mnt/r17-read-only";
+    let mut request = fixture.cases.task(
+        "mount-read-only",
+        "if sh -c 'printf forbidden > /mnt/r17-read-only/forbidden' 2>/dev/null; then printf 'read-only tmpfs accepted a write\\n' >&2; exit 71; fi; test ! -e /mnt/r17-read-only/forbidden",
+        10_000,
+    );
+    request.spec.mounts = vec![tmpfs("sealed", TARGET, true)];
+
+    let observation = client.apply(&request).await?;
+    require(
+        observation.state == RuntimeUnitState::Succeeded,
+        "read-only tmpfs accepted a workload write",
+    )?;
+    let record = fixture.record_for(&request.spec).await?;
+    require_tmpfs_config(&record, TARGET, true)?;
+    fixture
+        .remove_unit(client, &request.spec, "mount-read-only")
+        .await
+}
+
+async fn tmpfs_isolation(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    const TARGET: &str = "/mnt/r17-isolation";
+    let mut request = fixture.cases.task(
+        "mount-tmpfs-isolation",
+        "if [ ! -e /r17-tmpfs-restart-marker ]; then touch /r17-tmpfs-restart-marker; printf private > /mnt/r17-isolation/token; exit 17; fi; test ! -e /mnt/r17-isolation/token",
+        10_000,
+    );
+    request.spec.mounts = vec![tmpfs("scratch", TARGET, false)];
+    request.spec.restart = RestartPolicy::OnFailure { max_retries: 1 };
+    let isolated = client.apply(&request).await?;
+    require(
+        isolated.state == RuntimeUnitState::Succeeded,
+        "a restarted Runtime unit observed its prior tmpfs contents",
+    )?;
+
+    let record = fixture.record_for(&request.spec).await?;
+    require(
+        record
+            .managed_execution
+            .as_ref()
+            .is_some_and(|metadata| metadata.generation.get() == 2),
+        "tmpfs isolation fixture did not execute its required restart",
+    )?;
+    require_tmpfs_config(&record, TARGET, false)?;
+    fixture
+        .remove_unit(client, &request.spec, "mount-tmpfs-isolation")
+        .await
+}
+
+async fn mount_cleanup(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    const TARGET: &str = "/mnt/r17-cleanup";
+    let mut service = fixture.cases.service(
+        "mount-cleanup",
+        "printf mounted > /mnt/r17-cleanup/marker; exec sleep 3600",
+    );
+    service.spec.mounts = vec![tmpfs("ephemeral", TARGET, false)];
+    let running = client.apply(&service).await?;
+    require(
+        running.state == RuntimeUnitState::Running,
+        "tmpfs cleanup fixture Service did not reach running",
+    )?;
+
+    let record = fixture.record_for(&service.spec).await?;
+    require_live_tmpfs_mount(&record, TARGET, false)?;
+    let pid = record
+        .pid
+        .ok_or_else(|| super::protocol("tmpfs cleanup fixture has no Sandbox init PID"))?;
+    let mountinfo =
+        std::fs::read_to_string(Path::new("/proc").join(pid.to_string()).join("mountinfo"))
+            .map_err(|error| super::external("read tmpfs cleanup mount namespace", error))?;
+    require(
+        mountinfo
+            .lines()
+            .any(|line| line.contains(&format!(" {TARGET} ")) && line.contains(" - tmpfs ")),
+        "running Sandbox did not expose the requested tmpfs mount",
+    )?;
+    let pid_start_time = record
+        .pid_start_time
+        .ok_or_else(|| super::protocol("tmpfs cleanup fixture has no init PID start time"))?;
+    let box_dir = record.box_dir.clone();
+    let (log_worker_pid, log_worker_pid_start_time) =
+        require_log_worker_identity(fixture, &record)?;
+
+    fixture
+        .remove_unit(client, &service.spec, "mount-cleanup")
+        .await?;
+    require(
+        !crate::process::is_process_alive_with_identity(pid, Some(pid_start_time)),
+        "tmpfs owner process survived Runtime removal",
+    )?;
+    require(
+        !crate::process::is_process_alive_with_identity(
+            log_worker_pid,
+            Some(log_worker_pid_start_time),
+        ),
+        "tmpfs log worker survived Runtime removal",
+    )?;
+    require(
+        fixture
+            .driver
+            .find_generation(&service.spec)
+            .await?
+            .is_none(),
+        "tmpfs cleanup left a provider execution record",
+    )?;
+    require(
+        !box_dir.exists(),
+        "tmpfs cleanup left its provider filesystem",
+    )
+}
+
+fn require_log_worker_identity(
+    fixture: &BoxRuntimeConformanceFixture,
+    record: &crate::BoxRecord,
+) -> Result<(u32, u64)> {
+    let runtime = crate::vm::reap::load_recorded_sandbox_runtime(
+        &fixture.home_dir,
+        &record.box_dir,
+        &record.id,
+    )
+    .map_err(|error| super::external("load tmpfs cleanup runtime", error))?
+    .ok_or_else(|| super::protocol("tmpfs cleanup runtime record disappeared"))?;
+    let pid = runtime
+        .log_worker_pid
+        .ok_or_else(|| super::protocol("tmpfs cleanup fixture has no log-worker PID"))?;
+    let start_time = runtime
+        .log_worker_pid_start_time
+        .ok_or_else(|| super::protocol("tmpfs cleanup fixture has no log-worker start time"))?;
+    Ok((pid, start_time))
+}
+
+fn tmpfs(name: &str, target: &str, read_only: bool) -> RuntimeMount {
+    RuntimeMount {
+        name: name.into(),
+        source: RuntimeMountSource::Tmpfs {
+            size_bytes: TMPFS_SIZE_BYTES,
+        },
+        target: target.into(),
+        read_only,
+    }
+}
+
+fn require_tmpfs_config(record: &crate::BoxRecord, target: &str, read_only: bool) -> Result<()> {
+    let config = &record
+        .managed_execution
+        .as_ref()
+        .ok_or_else(|| super::protocol("tmpfs fixture lost managed metadata"))?
+        .request
+        .config;
+    let expected = format!(
+        "{target}:size={TMPFS_SIZE_BYTES},{}",
+        if read_only { "ro" } else { "rw" }
+    );
+    require(
+        config.tmpfs == vec![expected],
+        "Runtime tmpfs intent changed before provider launch",
+    )
+}
+
+fn require_live_tmpfs_mount(
+    record: &crate::BoxRecord,
+    target: &str,
+    read_only: bool,
+) -> Result<()> {
+    require_tmpfs_config(record, target, read_only)?;
+    let bundle = record.box_dir.join("sandbox/bundle/config.json");
+    let value: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&bundle)
+            .map_err(|error| super::external("read tmpfs Sandbox OCI configuration", error))?,
+    )
+    .map_err(|error| super::external("decode tmpfs Sandbox OCI configuration", error))?;
+    let mount = value["mounts"]
+        .as_array()
+        .and_then(|mounts| {
+            mounts
+                .iter()
+                .find(|mount| mount["destination"].as_str() == Some(target))
+        })
+        .ok_or_else(|| super::protocol("Sandbox OCI configuration omitted the Runtime tmpfs"))?;
+    let options = mount["options"]
+        .as_array()
+        .ok_or_else(|| super::protocol("Runtime tmpfs has no OCI mount options"))?;
+    let expected_mode = if read_only { "ro" } else { "rw" };
+    let expected_size = format!("size={TMPFS_SIZE_BYTES}");
+    require(
+        mount["type"] == "tmpfs"
+            && options.iter().any(|option| option == expected_mode)
+            && options
+                .iter()
+                .any(|option| option.as_str() == Some(expected_size.as_str())),
+        "Sandbox OCI tmpfs did not preserve size and access mode",
+    )
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/networking_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/networking_profile.rs
@@ -1,0 +1,53 @@
+use std::time::Duration;
+
+use a3s_box_core::NetworkMode;
+use a3s_runtime::contract::RuntimeUnitState;
+use a3s_runtime::RuntimeClient;
+
+use super::fixture::BoxRuntimeConformanceFixture;
+use super::{require, Result};
+
+pub(super) async fn run(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .await
+        .map_err(|error| super::external("bind loopback network oracle", error))?;
+    let port = listener
+        .local_addr()
+        .map_err(|error| super::external("read loopback network oracle address", error))?
+        .port();
+    let request = fixture.cases.task(
+        "network-none",
+        &format!(
+            "if wget -q -T 1 -O /dev/null http://127.0.0.1:{port}; then printf 'unexpected-network-access\\n' >&2; exit 41; else printf 'r17-network-none-denied\\n'; fi"
+        ),
+        10_000,
+    );
+    let observation = client.apply(&request).await?;
+    require(
+        observation.state == RuntimeUnitState::Succeeded,
+        "NetworkMode::None workload reached the host loopback listener",
+    )?;
+    let record = fixture.record_for(&request.spec).await?;
+    let config = &record
+        .managed_execution
+        .as_ref()
+        .ok_or_else(|| super::protocol("network fixture lost managed metadata"))?
+        .request
+        .config;
+    require(
+        config.network == NetworkMode::None,
+        "NetworkMode::None was not preserved in provider configuration",
+    )?;
+    require(
+        tokio::time::timeout(Duration::from_millis(200), listener.accept())
+            .await
+            .is_err(),
+        "NetworkMode::None connected to a host loopback service",
+    )?;
+    fixture
+        .remove_unit(client, &request.spec, "network-none")
+        .await
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
@@ -136,11 +136,7 @@ async fn external_deletion_and_single_replacement(
     let box_dir = record.box_dir.clone();
     let cleanup_id = record.id.clone();
     tokio::task::spawn_blocking(move || {
-        crate::vm::reap::cleanup_recorded_sandbox_runtime_in(
-            &home,
-            &box_dir,
-            &cleanup_id,
-        )
+        crate::vm::reap::cleanup_recorded_sandbox_runtime_in(&home, &box_dir, &cleanup_id)
     })
     .await
     .map_err(|error| super::external("join external deletion", error))?
@@ -204,11 +200,9 @@ async fn duplicate_resource_detection(
     );
     client.apply(&request).await?;
 
-    let injection_operation = OperationId::new(format!(
-        "r17-duplicate-injection:{}",
-        uuid::Uuid::new_v4()
-    ))
-    .map_err(|error| super::invalid(error.to_string()))?;
+    let injection_operation =
+        OperationId::new(format!("r17-duplicate-injection:{}", uuid::Uuid::new_v4()))
+            .map_err(|error| super::invalid(error.to_string()))?;
     let reservation = fixture
         .driver
         .manager
@@ -244,10 +238,7 @@ async fn duplicate_resource_detection(
         .driver
         .retire_record(injected, &request.spec.unit_id)
         .await?;
-    let remaining = fixture
-        .driver
-        .unit_records(&request.spec.unit_id)
-        .await?;
+    let remaining = fixture.driver.unit_records(&request.spec.unit_id).await?;
     require(
         remaining.len() == 1,
         "duplicate cleanup did not preserve exactly one original resource",

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use a3s_box_core::{ExecutionManager, OperationId};

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
@@ -1,0 +1,258 @@
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use a3s_box_core::{ExecutionManager, OperationId};
+use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitState};
+use a3s_runtime::{RuntimeClient, RuntimeDriver, RuntimeError, RuntimeStateStore};
+
+use super::super::mapping::creation_request;
+use super::fixture::BoxRuntimeConformanceFixture;
+use super::{require, Result};
+
+pub(super) async fn run(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    create_before_ack_and_client_restart(fixture).await?;
+    completed_client_restart(fixture, client).await?;
+    provider_restart(fixture, client).await?;
+    external_deletion_and_single_replacement(fixture, client).await?;
+    duplicate_resource_detection(fixture, client).await
+}
+
+async fn create_before_ack_and_client_restart(
+    fixture: &BoxRuntimeConformanceFixture,
+) -> Result<()> {
+    let request = fixture.cases.service(
+        "recovery-create-before-ack",
+        "printf 'r17-create-before-ack\\n'; exec sleep 3600",
+    );
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64;
+    let reservation = fixture.state.reserve_apply(&request, now_ms).await?;
+    require(
+        reservation.dispatch,
+        "create-before-ack reservation did not require provider work",
+    )?;
+    let created = fixture
+        .driver
+        .apply(&request.spec, &reservation.record.observation)
+        .await?;
+    require(
+        created.state == RuntimeUnitState::Running,
+        "create-before-ack provider effect did not start a Service",
+    )?;
+    let original_id = created
+        .provider_resource_id
+        .clone()
+        .ok_or_else(|| super::protocol("create-before-ack returned no provider identity"))?;
+
+    // Deliberately omit RuntimeStateStore::update_observation: this is the
+    // exact provider-effect-before-durable-ack crash window.
+    let restarted_driver = fixture.restarted_driver()?;
+    let restarted = fixture.client_with(restarted_driver, fixture.state.clone());
+    let recovered = restarted.apply(&request).await?;
+    require(
+        recovered.provider_resource_id.as_deref() == Some(original_id.as_str()),
+        "pending replay substituted provider identity after create-before-ack",
+    )?;
+    let records = fixture.records_for(&fixture.driver, &request.spec).await?;
+    require(
+        records.len() == 1 && records[0].id == original_id,
+        "create-before-ack recovery left duplicate provider resources",
+    )?;
+    fixture
+        .remove_unit(&restarted, &request.spec, "recovery-create-before-ack")
+        .await
+}
+
+async fn completed_client_restart(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let request = fixture.cases.service(
+        "recovery-client-restart",
+        "printf 'r17-client-restart\\n'; exec sleep 3600",
+    );
+    let first = client.apply(&request).await?;
+    let restarted = fixture.client_with(fixture.driver.clone(), fixture.state.clone());
+    let replay = restarted.apply(&request).await?;
+    require(
+        replay == first,
+        "completed request changed after Runtime client restart",
+    )?;
+    fixture
+        .remove_unit(&restarted, &request.spec, "recovery-client-restart")
+        .await
+}
+
+async fn provider_restart(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let request = fixture.cases.service(
+        "recovery-provider-restart",
+        "printf 'r17-provider-restart\\n'; exec sleep 3600",
+    );
+    let running = client.apply(&request).await?;
+    let provider_id = running.provider_resource_id.clone();
+    let restarted_driver = fixture.restarted_driver()?;
+    let restarted = fixture.client_with(restarted_driver, fixture.state.clone());
+    let RuntimeInspection::Found { observation, .. } =
+        restarted.inspect(&request.spec.unit_id).await?
+    else {
+        return Err(super::protocol(
+            "provider restart lost a running Sandbox Service",
+        ));
+    };
+    require(
+        observation.state == RuntimeUnitState::Running
+            && observation.provider_resource_id == provider_id,
+        "provider restart changed running Sandbox identity",
+    )?;
+    fixture
+        .remove_unit(&restarted, &request.spec, "recovery-provider-restart")
+        .await
+}
+
+async fn external_deletion_and_single_replacement(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let first_request = fixture.cases.service(
+        "recovery-external-loss",
+        "printf 'r17-external-loss\\n'; exec sleep 3600",
+    );
+    let running = client.apply(&first_request).await?;
+    let lost_id = running
+        .provider_resource_id
+        .clone()
+        .ok_or_else(|| super::protocol("external-loss fixture returned no provider identity"))?;
+    let record = fixture.record_for(&first_request.spec).await?;
+    let home = fixture.home_dir.clone();
+    let box_dir = record.box_dir.clone();
+    let cleanup_id = record.id.clone();
+    tokio::task::spawn_blocking(move || {
+        crate::vm::reap::cleanup_recorded_sandbox_runtime_in(
+            &home,
+            &box_dir,
+            &cleanup_id,
+        )
+    })
+    .await
+    .map_err(|error| super::external("join external deletion", error))?
+    .map_err(|error| super::external("delete external Sandbox resource", error))?;
+
+    let restarted_driver = fixture.restarted_driver()?;
+    let restarted = fixture.client_with(restarted_driver, fixture.state.clone());
+    let RuntimeInspection::Found { observation, .. } =
+        restarted.inspect(&first_request.spec.unit_id).await?
+    else {
+        return Err(super::protocol(
+            "external deletion did not preserve durable Runtime identity",
+        ));
+    };
+    require(
+        observation.state == RuntimeUnitState::Unknown,
+        "external deletion did not persist unknown before replacement",
+    )?;
+
+    let mut replacement_request = first_request.clone();
+    replacement_request.request_id = fixture
+        .cases
+        .request_id("recovery-external-loss-replacement");
+    let replacement = restarted.apply(&replacement_request).await?;
+    let replacement_id = replacement
+        .provider_resource_id
+        .clone()
+        .ok_or_else(|| super::protocol("replacement returned no provider identity"))?;
+    require(
+        replacement_id != lost_id,
+        "confirmed provider loss reused the deleted identity",
+    )?;
+    let exact = restarted.apply(&replacement_request).await?;
+    require(
+        exact.provider_resource_id.as_deref() == Some(replacement_id.as_str()),
+        "replacement replay created another provider identity",
+    )?;
+    let records = fixture
+        .records_for(&fixture.driver, &replacement_request.spec)
+        .await?;
+    require(
+        records.len() == 1 && records[0].id == replacement_id,
+        "external-loss recovery did not converge to exactly one replacement",
+    )?;
+    fixture
+        .remove_unit(
+            &restarted,
+            &replacement_request.spec,
+            "recovery-external-loss",
+        )
+        .await
+}
+
+async fn duplicate_resource_detection(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let request = fixture.cases.service(
+        "recovery-duplicate",
+        "printf 'r17-duplicate\\n'; exec sleep 3600",
+    );
+    client.apply(&request).await?;
+
+    let injection_operation = OperationId::new(format!(
+        "r17-duplicate-injection:{}",
+        uuid::Uuid::new_v4()
+    ))
+    .map_err(|error| super::invalid(error.to_string()))?;
+    let reservation = fixture
+        .driver
+        .manager
+        .create(creation_request(&request.spec)?, &injection_operation)
+        .await
+        .map_err(|error| super::external("reserve duplicate Sandbox", error))?;
+    fixture
+        .driver
+        .manager
+        .start(&reservation.execution_id, reservation.generation)
+        .await
+        .map_err(|error| super::external("start duplicate Sandbox", error))?;
+
+    let error = client.inspect(&request.spec.unit_id).await.unwrap_err();
+    require(
+        matches!(error, RuntimeError::Protocol(_)),
+        format!("duplicate provider resource did not fail closed: {error}"),
+    )?;
+    let records = fixture.records_for(&fixture.driver, &request.spec).await;
+    require(
+        matches!(records, Err(RuntimeError::Protocol(_))),
+        "duplicate provider records were accepted as one resource",
+    )?;
+
+    let injected = fixture
+        .driver
+        .manager
+        .managed_record(&reservation.execution_id)
+        .await
+        .map_err(|error| super::external("load duplicate Sandbox", error))?
+        .ok_or_else(|| super::protocol("duplicate Sandbox disappeared before cleanup"))?;
+    fixture
+        .driver
+        .retire_record(injected, &request.spec.unit_id)
+        .await?;
+    let remaining = fixture
+        .driver
+        .unit_records(&request.spec.unit_id)
+        .await?;
+    require(
+        remaining.len() == 1,
+        "duplicate cleanup did not preserve exactly one original resource",
+    )?;
+    fixture
+        .remove_unit(client, &request.spec, "recovery-duplicate")
+        .await
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
@@ -18,13 +18,15 @@ pub(super) async fn run(
     fixture: &BoxRuntimeConformanceFixture,
     client: &dyn RuntimeClient,
 ) -> Result<()> {
-    partial_creation_replays_same_provider_identity(fixture).await?;
-    create_before_ack_and_client_restart(fixture).await?;
-    cancelled_task_apply_is_replayable(fixture).await?;
-    completed_client_restart(fixture, client).await?;
-    provider_restart(fixture, client).await?;
-    external_deletion_and_single_replacement(fixture, client).await?;
-    duplicate_resource_detection(fixture, client).await
+    // Keep the real-provider scenario state machines off libtest's default
+    // thread stack as this profile grows.
+    Box::pin(partial_creation_replays_same_provider_identity(fixture)).await?;
+    Box::pin(create_before_ack_and_client_restart(fixture)).await?;
+    Box::pin(cancelled_task_apply_is_replayable(fixture)).await?;
+    Box::pin(completed_client_restart(fixture, client)).await?;
+    Box::pin(provider_restart(fixture, client)).await?;
+    Box::pin(external_deletion_and_single_replacement(fixture, client)).await?;
+    Box::pin(duplicate_resource_detection(fixture, client)).await
 }
 
 async fn partial_creation_replays_same_provider_identity(

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
@@ -1,10 +1,16 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::Arc;
+use std::time::Duration;
 
 use a3s_box_core::{ExecutionManager, OperationId};
 use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitState};
-use a3s_runtime::{RuntimeClient, RuntimeDriver, RuntimeError, RuntimeStateStore};
+use a3s_runtime::{
+    RuntimeClient, RuntimeDriver, RuntimeError, RuntimeRequestState, RuntimeStateStore,
+};
 
-use super::super::mapping::creation_request;
+use crate::ManagedExecutionState;
+
+use super::super::mapping::{creation_request, operation};
+use super::super::metadata::{local_identity, now_ms};
 use super::fixture::BoxRuntimeConformanceFixture;
 use super::{require, Result};
 
@@ -12,11 +18,65 @@ pub(super) async fn run(
     fixture: &BoxRuntimeConformanceFixture,
     client: &dyn RuntimeClient,
 ) -> Result<()> {
+    partial_creation_replays_same_provider_identity(fixture).await?;
     create_before_ack_and_client_restart(fixture).await?;
+    cancelled_task_apply_is_replayable(fixture).await?;
     completed_client_restart(fixture, client).await?;
     provider_restart(fixture, client).await?;
     external_deletion_and_single_replacement(fixture, client).await?;
     duplicate_resource_detection(fixture, client).await
+}
+
+async fn partial_creation_replays_same_provider_identity(
+    fixture: &BoxRuntimeConformanceFixture,
+) -> Result<()> {
+    let request = fixture.cases.service(
+        "recovery-partial-creation",
+        "printf 'r17-partial-creation\\n'; exec sleep 3600",
+    );
+    let state_reservation = fixture.state.reserve_apply(&request, now_ms()).await?;
+    require(
+        state_reservation.dispatch,
+        "partial-creation reservation did not require provider work",
+    )?;
+
+    let provider_reservation = fixture
+        .driver
+        .manager
+        .create(creation_request(&request.spec)?, &operation(&request.spec)?)
+        .await
+        .map_err(|error| super::external("reserve partial Sandbox creation", error))?;
+    let provider_id = provider_reservation.execution_id.to_string();
+    let created = fixture
+        .driver
+        .manager
+        .managed_record(&provider_reservation.execution_id)
+        .await
+        .map_err(|error| super::external("load partial Sandbox creation", error))?
+        .ok_or_else(|| super::protocol("partial Sandbox creation was not durable"))?;
+    require(
+        local_identity(&created)?.2 == ManagedExecutionState::Created,
+        "partial Sandbox creation advanced before Runtime replay",
+    )?;
+
+    let restarted_driver = fixture.restarted_driver()?;
+    let restarted = fixture.client_with(restarted_driver.clone(), fixture.state.clone());
+    let recovered = restarted.apply(&request).await?;
+    require(
+        recovered.state == RuntimeUnitState::Running
+            && recovered.provider_resource_id.as_deref() == Some(provider_id.as_str()),
+        "partial-creation replay did not start the reserved provider identity",
+    )?;
+    let records = fixture
+        .records_for(&restarted_driver, &request.spec)
+        .await?;
+    require(
+        records.len() == 1 && records[0].id == provider_id,
+        "partial-creation replay left duplicate provider resources",
+    )?;
+    fixture
+        .remove_unit(&restarted, &request.spec, "recovery-partial-creation")
+        .await
 }
 
 async fn create_before_ack_and_client_restart(
@@ -26,12 +86,7 @@ async fn create_before_ack_and_client_restart(
         "recovery-create-before-ack",
         "printf 'r17-create-before-ack\\n'; exec sleep 3600",
     );
-    let now_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-        .min(u128::from(u64::MAX)) as u64;
-    let reservation = fixture.state.reserve_apply(&request, now_ms).await?;
+    let reservation = fixture.state.reserve_apply(&request, now_ms()).await?;
     require(
         reservation.dispatch,
         "create-before-ack reservation did not require provider work",
@@ -65,6 +120,89 @@ async fn create_before_ack_and_client_restart(
     )?;
     fixture
         .remove_unit(&restarted, &request.spec, "recovery-create-before-ack")
+        .await
+}
+
+async fn cancelled_task_apply_is_replayable(fixture: &BoxRuntimeConformanceFixture) -> Result<()> {
+    let request = fixture.cases.task(
+        "recovery-cancelled-task",
+        "printf 'r17-cancelled-task\\n'; sleep 5",
+        30_000,
+    );
+    let client = Arc::new(fixture.client_with(fixture.driver.clone(), fixture.state.clone()));
+    let apply = {
+        let client = client.clone();
+        let request = request.clone();
+        tokio::spawn(async move { client.apply(&request).await })
+    };
+
+    let provider_id = tokio::time::timeout(Duration::from_secs(120), async {
+        loop {
+            let records = fixture.records_for(&fixture.driver, &request.spec).await?;
+            require(
+                records.len() <= 1,
+                "cancelled Task created duplicate provider resources before cancellation",
+            )?;
+            if let Some(record) = records.first() {
+                match local_identity(record)?.2 {
+                    ManagedExecutionState::Running => break Ok(record.id.clone()),
+                    ManagedExecutionState::Stopped | ManagedExecutionState::Failed => {
+                        break Err(super::protocol(
+                            "cancellation fixture Task became terminal before cancellation",
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+            if apply.is_finished() {
+                break Err(super::protocol(
+                    "cancellation fixture apply completed before cancellation",
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .map_err(|_| super::failure("cancellation fixture did not reach a running Sandbox"))??;
+
+    apply.abort();
+    match apply.await {
+        Err(error) if error.is_cancelled() => {}
+        Ok(result) => {
+            return Err(super::protocol(format!(
+                "cancelled Task apply completed unexpectedly: {result:?}"
+            )));
+        }
+        Err(error) => {
+            return Err(super::external("join cancelled Task apply", error));
+        }
+    }
+    let pending = fixture
+        .state
+        .load_request(&request.spec.unit_id, &request.request_id)
+        .await?;
+    require(
+        pending.state == RuntimeRequestState::Pending,
+        "cancelled Task apply did not preserve a replayable pending receipt",
+    )?;
+
+    let restarted_driver = fixture.restarted_driver()?;
+    let restarted = fixture.client_with(restarted_driver.clone(), fixture.state.clone());
+    let recovered = restarted.apply(&request).await?;
+    require(
+        recovered.state == RuntimeUnitState::Succeeded
+            && recovered.provider_resource_id.as_deref() == Some(provider_id.as_str()),
+        "cancelled Task replay did not reattach to the original provider identity",
+    )?;
+    let records = fixture
+        .records_for(&restarted_driver, &request.spec)
+        .await?;
+    require(
+        records.len() == 1 && records[0].id == provider_id,
+        "cancelled Task replay left duplicate provider resources",
+    )?;
+    fixture
+        .remove_unit(&restarted, &request.spec, "recovery-cancelled-task")
         .await
 }
 

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
@@ -1,0 +1,213 @@
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitState};
+use a3s_runtime::RuntimeClient;
+
+use super::cases::ResourceShape;
+use super::fixture::BoxRuntimeConformanceFixture;
+use super::{require, Result};
+
+const CPU_MILLIS: u64 = 100;
+const CPU_PERIOD_US: u64 = 100_000;
+const CPU_QUOTA_US: u64 = CPU_MILLIS * (CPU_PERIOD_US / 1_000);
+const MEMORY_BYTES: u64 = 128 * 1024 * 1024;
+const PIDS: u32 = 32;
+
+pub(super) async fn run(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let service = fixture.cases.apply(
+        "resources-service",
+        a3s_runtime::contract::RuntimeUnitClass::Service,
+        "printf 'r17-resources-ready\\n'; exec sleep 3600",
+        ResourceShape {
+            cpu_millis: CPU_MILLIS,
+            memory_bytes: MEMORY_BYTES,
+            pids: PIDS,
+            execution_timeout_ms: None,
+        },
+        a3s_runtime::contract::RestartPolicy::Never,
+    );
+    let running = client.apply(&service).await?;
+    require(
+        running.state == RuntimeUnitState::Running,
+        "resource fixture Service did not reach running",
+    )?;
+    let record = fixture.record_for(&service.spec).await?;
+    let config = &record
+        .managed_execution
+        .as_ref()
+        .ok_or_else(|| super::protocol("resource fixture lost managed metadata"))?
+        .request
+        .config;
+    require(
+        config.resource_limits.cpu_quota == Some(CPU_QUOTA_US as i64)
+            && config.resource_limits.cpu_period == Some(CPU_PERIOD_US),
+        "CPU limits changed before provider launch",
+    )?;
+    require(
+        config.resource_limits.sandbox_memory_limit_bytes == Some(MEMORY_BYTES)
+            && config.resource_limits.memory_swap == Some(MEMORY_BYTES as i64),
+        "memory limits changed before provider launch",
+    )?;
+    require(
+        config.resource_limits.pids_limit == Some(u64::from(PIDS)),
+        "PID limit changed before provider launch",
+    )?;
+
+    let cgroup = Path::new("/sys/fs/cgroup/a3s-box").join(&record.id);
+    require(cgroup.is_dir(), "Sandbox cgroup was not created")?;
+    require(
+        read_trimmed(&cgroup.join("cpu.max"))?
+            == format!("{CPU_QUOTA_US} {CPU_PERIOD_US}"),
+        "cpu.max does not match the Runtime CPU request",
+    )?;
+    require(
+        read_trimmed(&cgroup.join("memory.max"))? == MEMORY_BYTES.to_string(),
+        "memory.max does not match the exact Runtime byte limit",
+    )?;
+    require(
+        read_trimmed(&cgroup.join("pids.max"))? == PIDS.to_string(),
+        "pids.max does not match the Runtime PID request",
+    )?;
+
+    let visible = client
+        .exec(&fixture.cases.exec(
+            "resources-visible-config",
+            &service.spec,
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "cat /sys/fs/cgroup/cpu.max; cat /sys/fs/cgroup/memory.max; cat /sys/fs/cgroup/pids.max"
+                    .into(),
+            ],
+            5_000,
+        ))
+        .await?;
+    require(
+        visible.stdout.contains(&format!("{CPU_QUOTA_US} {CPU_PERIOD_US}"))
+            && visible.stdout.contains(&MEMORY_BYTES.to_string())
+            && visible.stdout.contains(&PIDS.to_string()),
+        "workload did not observe its configured cgroup limits",
+    )?;
+
+    let throttled_before = counter(&cgroup.join("cpu.stat"), "nr_throttled")?;
+    let cpu = client
+        .exec(&fixture.cases.exec(
+            "resources-cpu-behavior",
+            &service.spec,
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "timeout 1 sh -c 'while :; do :; done'".into(),
+            ],
+            5_000,
+        ))
+        .await?;
+    require(
+        cpu.exit_code == 124,
+        format!("CPU saturation oracle exited with {}", cpu.exit_code),
+    )?;
+    let throttled_after = counter(&cgroup.join("cpu.stat"), "nr_throttled")?;
+    require(
+        throttled_after > throttled_before,
+        "CPU workload was never throttled by the configured quota",
+    )?;
+
+    let pid_max_before = counter(&cgroup.join("pids.events"), "max")?;
+    let _ = client
+        .exec(&fixture.cases.exec(
+            "resources-pids-behavior",
+            &service.spec,
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "i=0; while [ \"$i\" -lt 96 ]; do sleep 1 & i=$((i + 1)); done; wait"
+                    .into(),
+            ],
+            15_000,
+        ))
+        .await?;
+    let pid_max_after = counter(&cgroup.join("pids.events"), "max")?;
+    require(
+        pid_max_after > pid_max_before,
+        "PID-heavy workload did not hit the configured pids.max",
+    )?;
+
+    let oom_before = counter(&cgroup.join("memory.events"), "oom_kill")?;
+    let memory = client
+        .exec(&fixture.cases.exec(
+            "resources-memory-behavior",
+            &service.spec,
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "awk 'BEGIN { s=\"0123456789abcdef\"; for (i=0; i<25; i++) s=s s; print length(s) }'"
+                    .into(),
+            ],
+            15_000,
+        ))
+        .await?;
+    let oom_after = counter(&cgroup.join("memory.events"), "oom_kill")?;
+    require(
+        oom_after > oom_before && memory.exit_code != 0,
+        "memory-heavy workload was not killed by the exact memory limit",
+    )?;
+    let RuntimeInspection::Found { observation, .. } =
+        client.inspect(&service.spec.unit_id).await?
+    else {
+        return Err(super::protocol(
+            "resource probes lost the long-running Service",
+        ));
+    };
+    require(
+        observation.state == RuntimeUnitState::Running,
+        "resource-limit probes killed the Sandbox Service",
+    )?;
+
+    let timeout = fixture
+        .cases
+        .task("resources-execution-timeout", "exec sleep 3600", 400);
+    let started = Instant::now();
+    let timed_out = client.apply(&timeout).await?;
+    require(
+        timed_out.state == RuntimeUnitState::Failed
+            && timed_out.failure.as_ref().is_some_and(|failure| {
+                failure.code == "execution_timeout" && !failure.retryable
+            })
+            && started.elapsed() < Duration::from_secs(5),
+        "Task execution timeout was not behaviorally enforced",
+    )?;
+    fixture
+        .remove_unit(client, &timeout.spec, "resources-execution-timeout")
+        .await?;
+    fixture
+        .remove_unit(client, &service.spec, "resources-service")
+        .await
+}
+
+fn read_trimmed(path: &Path) -> Result<String> {
+    std::fs::read_to_string(path)
+        .map(|value| value.trim().to_string())
+        .map_err(|error| super::external(&format!("read {}", path.display()), error))
+}
+
+fn counter(path: &Path, key: &str) -> Result<u64> {
+    let value = read_trimmed(path)?;
+    value
+        .lines()
+        .find_map(|line| {
+            let mut fields = line.split_whitespace();
+            (fields.next() == Some(key))
+                .then(|| fields.next()?.parse::<u64>().ok())
+                .flatten()
+        })
+        .ok_or_else(|| {
+            super::protocol(format!(
+                "cgroup counter {key:?} is missing from {}",
+                path.display()
+            ))
+        })
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
@@ -102,14 +102,17 @@ pub(super) async fn run(
             vec![
                 "/bin/sh".into(),
                 "-c".into(),
-                "timeout 1 sh -c 'while :; do :; done'".into(),
+                "timeout 1 sh -c 'trap \"exit 124\" TERM; while :; do :; done'".into(),
             ],
             5_000,
         ))
         .await?;
     require(
         cpu.exit_code == 124,
-        format!("CPU saturation oracle exited with {}", cpu.exit_code),
+        format!(
+            "CPU saturation oracle exited with {}; stdout={:?}; stderr={:?}",
+            cpu.exit_code, cpu.stdout, cpu.stderr
+        ),
     )?;
     let throttled_after = counter(&cgroup.join("cpu.stat"), "nr_throttled")?;
     require(

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
@@ -60,8 +60,7 @@ pub(super) async fn run(
     let cgroup = Path::new("/sys/fs/cgroup/a3s-box").join(&record.id);
     require(cgroup.is_dir(), "Sandbox cgroup was not created")?;
     require(
-        read_trimmed(&cgroup.join("cpu.max"))?
-            == format!("{CPU_QUOTA_US} {CPU_PERIOD_US}"),
+        read_trimmed(&cgroup.join("cpu.max"))? == format!("{CPU_QUOTA_US} {CPU_PERIOD_US}"),
         "cpu.max does not match the Runtime CPU request",
     )?;
     require(
@@ -87,7 +86,9 @@ pub(super) async fn run(
         ))
         .await?;
     require(
-        visible.stdout.contains(&format!("{CPU_QUOTA_US} {CPU_PERIOD_US}"))
+        visible
+            .stdout
+            .contains(&format!("{CPU_QUOTA_US} {CPU_PERIOD_US}"))
             && visible.stdout.contains(&MEMORY_BYTES.to_string())
             && visible.stdout.contains(&PIDS.to_string()),
         "workload did not observe its configured cgroup limits",
@@ -124,8 +125,7 @@ pub(super) async fn run(
             vec![
                 "/bin/sh".into(),
                 "-c".into(),
-                "i=0; while [ \"$i\" -lt 96 ]; do sleep 1 & i=$((i + 1)); done; wait"
-                    .into(),
+                "i=0; while [ \"$i\" -lt 96 ]; do sleep 1 & i=$((i + 1)); done; wait".into(),
             ],
             15_000,
         ))
@@ -174,9 +174,10 @@ pub(super) async fn run(
     let timed_out = client.apply(&timeout).await?;
     require(
         timed_out.state == RuntimeUnitState::Failed
-            && timed_out.failure.as_ref().is_some_and(|failure| {
-                failure.code == "execution_timeout" && !failure.retryable
-            })
+            && timed_out
+                .failure
+                .as_ref()
+                .is_some_and(|failure| failure.code == "execution_timeout" && !failure.retryable)
             && started.elapsed() < Duration::from_secs(5),
         "Task execution timeout was not behaviorally enforced",
     )?;

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -20,9 +20,12 @@ pub(super) async fn run(
         "security-service",
         "printf 'r17-security-ready\\n'; exec sleep 3600",
     );
-    let before = fixture.driver.manager.managed_records().await.map_err(|error| {
-        super::external("load security pre-mutation provider inventory", error)
-    })?;
+    let before = fixture
+        .driver
+        .manager
+        .managed_records()
+        .await
+        .map_err(|error| super::external("load security pre-mutation provider inventory", error))?;
     reject_hostile_inputs(fixture, client, &service, before.len()).await?;
 
     let running = client.apply(&service).await?;
@@ -59,10 +62,8 @@ async fn reject_hostile_inputs(
     let mut mismatch = template.clone();
     mismatch.request_id = fixture.cases.request_id("security-digest-mismatch");
     mismatch.spec.unit_id = fixture.cases.unit_id("security-digest-mismatch");
-    mismatch.spec.artifact.uri = format!(
-        "oci://docker.io/library/alpine@sha256:{}",
-        "0".repeat(64)
-    );
+    mismatch.spec.artifact.uri =
+        format!("oci://docker.io/library/alpine@sha256:{}", "0".repeat(64));
     require(
         client.apply(&mismatch).await.is_err(),
         "Box accepted an artifact URI/digest mismatch",
@@ -71,11 +72,12 @@ async fn reject_hostile_inputs(
     let mut credentials = template.clone();
     credentials.request_id = fixture.cases.request_id("security-uri-credentials");
     credentials.spec.unit_id = fixture.cases.unit_id("security-uri-credentials");
-    credentials.spec.artifact.uri = credentials
-        .spec
-        .artifact
-        .uri
-        .replacen("oci://", "oci://user:secret@", 1);
+    credentials.spec.artifact.uri =
+        credentials
+            .spec
+            .artifact
+            .uri
+            .replacen("oci://", "oci://user:secret@", 1);
     require(
         client.apply(&credentials).await.is_err(),
         "Box accepted registry credentials in an artifact URI",
@@ -89,9 +91,14 @@ async fn reject_hostile_inputs(
         "Box accepted a path-like Runtime unit identity",
     )?;
 
-    let after = fixture.driver.manager.managed_records().await.map_err(|error| {
-        super::external("load security post-mutation provider inventory", error)
-    })?;
+    let after = fixture
+        .driver
+        .manager
+        .managed_records()
+        .await
+        .map_err(|error| {
+            super::external("load security post-mutation provider inventory", error)
+        })?;
     require(
         after.len() == baseline_records,
         "hostile input mutated provider inventory before rejection",
@@ -110,8 +117,7 @@ fn verify_digest_pin(
         .config
         .image;
     require(
-        image.ends_with(&format!("@{}", spec.artifact.digest))
-            && image.matches('@').count() == 1,
+        image.ends_with(&format!("@{}", spec.artifact.digest)) && image.matches('@').count() == 1,
         "provider creation was not bound to the requested image digest",
     )
 }
@@ -124,10 +130,19 @@ fn verify_least_privilege(record: &crate::BoxRecord) -> Result<()> {
     )
     .map_err(|error| super::external("decode Sandbox OCI configuration", error))?;
     require(
-        config.pointer("/process/noNewPrivileges").and_then(|v| v.as_bool()) == Some(true),
+        config
+            .pointer("/process/noNewPrivileges")
+            .and_then(|v| v.as_bool())
+            == Some(true),
         "Sandbox OCI process did not enable no-new-privileges",
     )?;
-    for set in ["bounding", "effective", "inheritable", "permitted", "ambient"] {
+    for set in [
+        "bounding",
+        "effective",
+        "inheritable",
+        "permitted",
+        "ambient",
+    ] {
         require(
             config
                 .pointer(&format!("/process/capabilities/{set}"))
@@ -164,7 +179,9 @@ fn verify_least_privilege(record: &crate::BoxRecord) -> Result<()> {
         "Sandbox container root maps to host root",
     )?;
     require(
-        config.pointer("/linux/cgroupsPath").and_then(|value| value.as_str())
+        config
+            .pointer("/linux/cgroupsPath")
+            .and_then(|value| value.as_str())
             == Some(format!("a3s-box/{}", record.id).as_str()),
         "Sandbox OCI cgroup path is not execution-scoped",
     )?;

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -1,8 +1,11 @@
+use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitState};
+use a3s_runtime::contract::{
+    RuntimeInspection, RuntimeMount, RuntimeMountSource, RuntimeUnitState,
+};
 use a3s_runtime::{
     FileRuntimeStateStore, RuntimeClient, RuntimeDriver, RuntimeError, RuntimeStateStore,
 };
@@ -36,6 +39,7 @@ pub(super) async fn run(
     let record = fixture.record_for(&service.spec).await?;
     verify_digest_pin(&record, &service.spec)?;
     verify_least_privilege(&record)?;
+    verify_workload_least_privilege(fixture, client, &service.spec).await?;
     metadata_tamper_fails_closed(fixture, client, &service.spec, &record.id).await?;
     namespace_separation(fixture).await?;
 
@@ -91,6 +95,22 @@ async fn reject_hostile_inputs(
         "Box accepted a path-like Runtime unit identity",
     )?;
 
+    let mut protected_mount = template.clone();
+    protected_mount.request_id = fixture.cases.request_id("security-protected-mount");
+    protected_mount.spec.unit_id = fixture.cases.unit_id("security-protected-mount");
+    protected_mount.spec.mounts = vec![RuntimeMount {
+        name: "host-proc".into(),
+        source: RuntimeMountSource::Tmpfs {
+            size_bytes: 1024 * 1024,
+        },
+        target: "/proc/r17-escape".into(),
+        read_only: false,
+    }];
+    require(
+        client.apply(&protected_mount).await.is_err(),
+        "Box accepted a tmpfs mount below a protected host interface",
+    )?;
+
     let after = fixture
         .driver
         .manager
@@ -123,6 +143,21 @@ fn verify_digest_pin(
 }
 
 fn verify_least_privilege(record: &crate::BoxRecord) -> Result<()> {
+    const BOOTSTRAP_CAPABILITIES: [&str; 11] = [
+        "CAP_CHOWN",
+        "CAP_DAC_OVERRIDE",
+        "CAP_FOWNER",
+        "CAP_FSETID",
+        "CAP_KILL",
+        "CAP_NET_ADMIN",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_SETGID",
+        "CAP_SETPCAP",
+        "CAP_SETUID",
+        "CAP_SYS_CHROOT",
+    ];
+    const BOOTSTRAP_CAPABILITY_MASK: u64 = 0x415fb;
+
     let path = record.box_dir.join("sandbox/bundle/config.json");
     let config: serde_json::Value = serde_json::from_slice(
         &std::fs::read(&path)
@@ -136,13 +171,23 @@ fn verify_least_privilege(record: &crate::BoxRecord) -> Result<()> {
             == Some(true),
         "Sandbox OCI process did not enable no-new-privileges",
     )?;
-    for set in [
-        "bounding",
-        "effective",
-        "inheritable",
-        "permitted",
-        "ambient",
-    ] {
+    let expected = BOOTSTRAP_CAPABILITIES.into_iter().collect::<BTreeSet<_>>();
+    for set in ["bounding", "effective", "permitted"] {
+        let actual = config
+            .pointer(&format!("/process/capabilities/{set}"))
+            .and_then(|value| value.as_array())
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|value| value.as_str())
+                    .collect::<BTreeSet<_>>()
+            });
+        require(
+            actual.as_ref() == Some(&expected),
+            format!("Sandbox OCI bootstrap capability set {set} changed: actual={actual:?}"),
+        )?;
+    }
+    for set in ["inheritable", "ambient"] {
         require(
             config
                 .pointer(&format!("/process/capabilities/{set}"))
@@ -199,9 +244,11 @@ fn verify_least_privilege(record: &crate::BoxRecord) -> Result<()> {
         .lines()
         .find_map(|line| line.strip_prefix("CapEff:\t"))
         .ok_or_else(|| super::protocol("Sandbox init process has no CapEff evidence"))?;
+    let effective = u64::from_str_radix(effective, 16)
+        .map_err(|error| super::external("decode Sandbox init CapEff", error))?;
     require(
-        effective.bytes().all(|byte| byte == b'0'),
-        "Sandbox init process retained an effective capability",
+        effective & !BOOTSTRAP_CAPABILITY_MASK == 0,
+        format!("Sandbox init process escaped its bootstrap capability set: {effective:#x}"),
     )?;
     let host_uid = status
         .lines()
@@ -210,6 +257,47 @@ fn verify_least_privilege(record: &crate::BoxRecord) -> Result<()> {
         .and_then(|value| value.parse::<u32>().ok())
         .ok_or_else(|| super::protocol("Sandbox init process has no host UID evidence"))?;
     require(host_uid != 0, "Sandbox init process runs as host root")
+}
+
+async fn verify_workload_least_privilege(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+    spec: &a3s_runtime::contract::RuntimeUnitSpec,
+) -> Result<()> {
+    let output = client
+        .exec(&fixture.cases.exec(
+            "security-workload-capabilities",
+            spec,
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "awk '$1 == \"CapInh:\" || $1 == \"CapPrm:\" || \
+                 $1 == \"CapEff:\" || $1 == \"CapBnd:\" || $1 == \"CapAmb:\" \
+                 { print $1 \"=\" $2 }' /proc/self/status"
+                    .into(),
+            ],
+            5_000,
+        ))
+        .await
+        .map_err(|error| super::external("execute workload capability probe", error))?;
+    let capabilities = output
+        .stdout
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .collect::<Vec<_>>();
+    require(
+        output.exit_code == 0
+            && output.stderr.is_empty()
+            && !output.truncated
+            && capabilities.len() == 5
+            && capabilities
+                .iter()
+                .all(|(_, value)| value.bytes().all(|byte| byte == b'0')),
+        format!(
+            "Sandbox workload retained capabilities: exit_code={} stdout={:?} stderr={:?}",
+            output.exit_code, output.stdout, output.stderr
+        ),
+    )
 }
 
 async fn metadata_tamper_fails_closed(

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use a3s_runtime::contract::{
-    RuntimeInspection, RuntimeMount, RuntimeMountSource, RuntimeUnitState,
+    HealthProbe, NetworkMode, RuntimeHealthCheck, RuntimeInspection, RuntimeMount,
+    RuntimeMountSource, RuntimeUnitState, SecretReference, SecretTarget,
 };
 use a3s_runtime::{
     FileRuntimeStateStore, RuntimeClient, RuntimeDriver, RuntimeError, RuntimeStateStore,
@@ -109,6 +110,80 @@ async fn reject_hostile_inputs(
     require(
         client.apply(&protected_mount).await.is_err(),
         "Box accepted a tmpfs mount below a protected host interface",
+    )?;
+
+    let mut outbound_network = template.clone();
+    outbound_network.request_id = fixture.cases.request_id("security-outbound-network");
+    outbound_network.spec.unit_id = fixture.cases.unit_id("security-outbound-network");
+    outbound_network.spec.network.mode = NetworkMode::Outbound;
+    require(
+        matches!(
+            client.apply(&outbound_network).await,
+            Err(RuntimeError::UnsupportedCapabilities(missing))
+                if missing == vec!["network_mode:Outbound"]
+        ),
+        "Box accepted an unadvertised outbound network",
+    )?;
+
+    let mut volume = template.clone();
+    volume.request_id = fixture.cases.request_id("security-volume");
+    volume.spec.unit_id = fixture.cases.unit_id("security-volume");
+    volume.spec.mounts = vec![RuntimeMount {
+        name: "provider-volume".into(),
+        source: RuntimeMountSource::Volume {
+            volume_id: "r17-provider-volume".into(),
+        },
+        target: "/mnt/provider-volume".into(),
+        read_only: false,
+    }];
+    require(
+        matches!(
+            client.apply(&volume).await,
+            Err(RuntimeError::UnsupportedCapabilities(missing))
+                if missing == vec!["mount_kind:Volume"]
+        ),
+        "Box accepted an unadvertised volume mount",
+    )?;
+
+    let mut health = template.clone();
+    health.request_id = fixture.cases.request_id("security-health");
+    health.spec.unit_id = fixture.cases.unit_id("security-health");
+    health.spec.health = Some(RuntimeHealthCheck {
+        probe: HealthProbe::Command {
+            command: vec!["/bin/true".into()],
+        },
+        interval_ms: 1_000,
+        timeout_ms: 500,
+        start_period_ms: 0,
+        success_threshold: 1,
+        failure_threshold: 3,
+    });
+    require(
+        matches!(
+            client.apply(&health).await,
+            Err(RuntimeError::UnsupportedCapabilities(missing))
+                if missing == vec!["health_check:Command"]
+        ),
+        "Box accepted an unadvertised health check",
+    )?;
+
+    let mut secret = template.clone();
+    secret.request_id = fixture.cases.request_id("security-secret");
+    secret.spec.unit_id = fixture.cases.unit_id("security-secret");
+    secret.spec.secrets = vec![SecretReference {
+        name: "provider-token".into(),
+        reference: "secret://r17/provider-token".into(),
+        target: SecretTarget::Environment {
+            variable: "R17_PROVIDER_TOKEN".into(),
+        },
+    }];
+    require(
+        matches!(
+            client.apply(&secret).await,
+            Err(RuntimeError::UnsupportedCapabilities(missing))
+                if missing == vec!["feature:SecretReferences"]
+        ),
+        "Box accepted an unadvertised secret reference",
     )?;
 
     let after = fixture

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -1,0 +1,291 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitState};
+use a3s_runtime::{
+    FileRuntimeStateStore, RuntimeClient, RuntimeDriver, RuntimeError, RuntimeStateStore,
+};
+
+use super::super::metadata::GENERATION_LABEL;
+use super::super::{BoxRuntimeDriver, BoxRuntimeDriverConfig};
+use super::fixture::BoxRuntimeConformanceFixture;
+use super::{require, Result};
+
+pub(super) async fn run(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let service = fixture.cases.service(
+        "security-service",
+        "printf 'r17-security-ready\\n'; exec sleep 3600",
+    );
+    let before = fixture.driver.manager.managed_records().await.map_err(|error| {
+        super::external("load security pre-mutation provider inventory", error)
+    })?;
+    reject_hostile_inputs(fixture, client, &service, before.len()).await?;
+
+    let running = client.apply(&service).await?;
+    require(
+        running.state == RuntimeUnitState::Running,
+        "security fixture Service did not reach running",
+    )?;
+    let record = fixture.record_for(&service.spec).await?;
+    verify_digest_pin(&record, &service.spec)?;
+    verify_least_privilege(&record)?;
+    metadata_tamper_fails_closed(fixture, client, &service.spec, &record.id).await?;
+    namespace_separation(fixture).await?;
+
+    fixture
+        .remove_unit(client, &service.spec, "security-service")
+        .await
+}
+
+async fn reject_hostile_inputs(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+    template: &a3s_runtime::contract::RuntimeApplyRequest,
+    baseline_records: usize,
+) -> Result<()> {
+    let mut tag_only = template.clone();
+    tag_only.request_id = fixture.cases.request_id("security-tag-only");
+    tag_only.spec.unit_id = fixture.cases.unit_id("security-tag-only");
+    tag_only.spec.artifact.uri = "oci://docker.io/library/alpine:latest".into();
+    require(
+        client.apply(&tag_only).await.is_err(),
+        "Box accepted a mutable artifact tag",
+    )?;
+
+    let mut mismatch = template.clone();
+    mismatch.request_id = fixture.cases.request_id("security-digest-mismatch");
+    mismatch.spec.unit_id = fixture.cases.unit_id("security-digest-mismatch");
+    mismatch.spec.artifact.uri = format!(
+        "oci://docker.io/library/alpine@sha256:{}",
+        "0".repeat(64)
+    );
+    require(
+        client.apply(&mismatch).await.is_err(),
+        "Box accepted an artifact URI/digest mismatch",
+    )?;
+
+    let mut credentials = template.clone();
+    credentials.request_id = fixture.cases.request_id("security-uri-credentials");
+    credentials.spec.unit_id = fixture.cases.unit_id("security-uri-credentials");
+    credentials.spec.artifact.uri = credentials
+        .spec
+        .artifact
+        .uri
+        .replacen("oci://", "oci://user:secret@", 1);
+    require(
+        client.apply(&credentials).await.is_err(),
+        "Box accepted registry credentials in an artifact URI",
+    )?;
+
+    let mut traversal = template.clone();
+    traversal.request_id = fixture.cases.request_id("security-path-traversal");
+    traversal.spec.unit_id = "../r17-provider-escape".into();
+    require(
+        client.apply(&traversal).await.is_err(),
+        "Box accepted a path-like Runtime unit identity",
+    )?;
+
+    let after = fixture.driver.manager.managed_records().await.map_err(|error| {
+        super::external("load security post-mutation provider inventory", error)
+    })?;
+    require(
+        after.len() == baseline_records,
+        "hostile input mutated provider inventory before rejection",
+    )
+}
+
+fn verify_digest_pin(
+    record: &crate::BoxRecord,
+    spec: &a3s_runtime::contract::RuntimeUnitSpec,
+) -> Result<()> {
+    let image = &record
+        .managed_execution
+        .as_ref()
+        .ok_or_else(|| super::protocol("security record lost managed metadata"))?
+        .request
+        .config
+        .image;
+    require(
+        image.ends_with(&format!("@{}", spec.artifact.digest))
+            && image.matches('@').count() == 1,
+        "provider creation was not bound to the requested image digest",
+    )
+}
+
+fn verify_least_privilege(record: &crate::BoxRecord) -> Result<()> {
+    let path = record.box_dir.join("sandbox/bundle/config.json");
+    let config: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&path)
+            .map_err(|error| super::external("read Sandbox OCI configuration", error))?,
+    )
+    .map_err(|error| super::external("decode Sandbox OCI configuration", error))?;
+    require(
+        config.pointer("/process/noNewPrivileges").and_then(|v| v.as_bool()) == Some(true),
+        "Sandbox OCI process did not enable no-new-privileges",
+    )?;
+    for set in ["bounding", "effective", "inheritable", "permitted", "ambient"] {
+        require(
+            config
+                .pointer(&format!("/process/capabilities/{set}"))
+                .and_then(|value| value.as_array())
+                .is_some_and(Vec::is_empty),
+            format!("Sandbox OCI capability set {set} is not empty"),
+        )?;
+    }
+    require(
+        config.pointer("/linux/seccomp/defaultAction").is_some(),
+        "Sandbox OCI configuration omitted seccomp",
+    )?;
+    let namespaces = config
+        .pointer("/linux/namespaces")
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| super::protocol("Sandbox OCI namespaces are missing"))?;
+    for required in ["user", "mount", "pid", "ipc", "uts", "network", "cgroup"] {
+        require(
+            namespaces.iter().any(|namespace| {
+                namespace.get("type").and_then(|value| value.as_str()) == Some(required)
+            }),
+            format!("Sandbox OCI configuration omitted the {required} namespace"),
+        )?;
+    }
+    let mappings = config
+        .pointer("/linux/uidMappings")
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| super::protocol("Sandbox OCI UID mappings are missing"))?;
+    require(
+        mappings.iter().any(|mapping| {
+            mapping.get("containerID").and_then(|value| value.as_u64()) == Some(0)
+                && mapping.get("hostID").and_then(|value| value.as_u64()) != Some(0)
+        }),
+        "Sandbox container root maps to host root",
+    )?;
+    require(
+        config.pointer("/linux/cgroupsPath").and_then(|value| value.as_str())
+            == Some(format!("a3s-box/{}", record.id).as_str()),
+        "Sandbox OCI cgroup path is not execution-scoped",
+    )?;
+
+    let pid = record
+        .pid
+        .ok_or_else(|| super::protocol("running Sandbox record has no init PID"))?;
+    let status = std::fs::read_to_string(Path::new("/proc").join(pid.to_string()).join("status"))
+        .map_err(|error| super::external("read Sandbox init process status", error))?;
+    require(
+        status.lines().any(|line| line == "NoNewPrivs:\t1"),
+        "Sandbox init process does not have no_new_privs",
+    )?;
+    let effective = status
+        .lines()
+        .find_map(|line| line.strip_prefix("CapEff:\t"))
+        .ok_or_else(|| super::protocol("Sandbox init process has no CapEff evidence"))?;
+    require(
+        effective.bytes().all(|byte| byte == b'0'),
+        "Sandbox init process retained an effective capability",
+    )?;
+    let host_uid = status
+        .lines()
+        .find_map(|line| line.strip_prefix("Uid:\t"))
+        .and_then(|line| line.split_whitespace().next())
+        .and_then(|value| value.parse::<u32>().ok())
+        .ok_or_else(|| super::protocol("Sandbox init process has no host UID evidence"))?;
+    require(host_uid != 0, "Sandbox init process runs as host root")
+}
+
+async fn metadata_tamper_fails_closed(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+    spec: &a3s_runtime::contract::RuntimeUnitSpec,
+    execution_id: &str,
+) -> Result<()> {
+    let state_path = fixture.driver.manager.state_path().to_path_buf();
+    crate::BoxStateStore::modify(&state_path, |store| {
+        let record = store.find_by_id_mut(execution_id).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "security record disappeared")
+        })?;
+        record
+            .labels
+            .insert(GENERATION_LABEL.into(), "999999".into());
+        Ok(())
+    })
+    .map_err(|error| super::external("tamper Runtime provider metadata", error))?;
+    let result = client.inspect(&spec.unit_id).await;
+    crate::BoxStateStore::modify(&state_path, |store| {
+        let record = store.find_by_id_mut(execution_id).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "security record disappeared")
+        })?;
+        record
+            .labels
+            .insert(GENERATION_LABEL.into(), spec.generation.to_string());
+        Ok(())
+    })
+    .map_err(|error| super::external("restore Runtime provider metadata", error))?;
+    require(
+        matches!(result, Err(RuntimeError::Protocol(_))),
+        "tampered Runtime provider metadata did not fail closed",
+    )
+}
+
+async fn namespace_separation(fixture: &BoxRuntimeConformanceFixture) -> Result<()> {
+    let sibling_home = fixture
+        .home_dir
+        .join("namespaces")
+        .join(uuid::Uuid::new_v4().simple().to_string());
+    std::fs::create_dir_all(&sibling_home)
+        .map_err(|error| super::external("create sibling provider namespace", error))?;
+    fixture.register_removable_home(sibling_home.clone());
+    let sibling_state_root = sibling_home.join("runtime-state");
+    fixture.register_state_root(sibling_state_root.clone());
+    let sibling_driver = Arc::new(BoxRuntimeDriver::new(BoxRuntimeDriverConfig {
+        home_dir: sibling_home,
+        control_timeout: Duration::from_secs(120),
+        task_poll_interval: Duration::from_millis(25),
+    })?);
+    fixture.register_driver(sibling_driver.clone());
+    let sibling_state = Arc::new(FileRuntimeStateStore::new(&sibling_state_root));
+    let sibling = fixture.client_with(sibling_driver.clone(), sibling_state);
+    let request = fixture.cases.service(
+        "security-sibling-namespace",
+        "printf 'r17-sibling-namespace\\n'; exec sleep 3600",
+    );
+    let running = sibling.apply(&request).await?;
+    let sibling_id = running.provider_resource_id.clone();
+
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64;
+    let reservation = fixture.state.reserve_apply(&request, now_ms).await?;
+    let foreign_probe = fixture.driver.inspect(&reservation.record).await?;
+    require(
+        matches!(foreign_probe, RuntimeInspection::NotFound { .. }),
+        "one Box provider namespace discovered another namespace's resource",
+    )?;
+    let remove = fixture
+        .cases
+        .action("security-foreign-remove", &request.spec);
+    let foreign_remove = fixture.driver.remove(&reservation.record, &remove).await?;
+    require(
+        foreign_remove.already_absent,
+        "one Box provider namespace removed another namespace's resource",
+    )?;
+    let RuntimeInspection::Found { observation, .. } =
+        sibling.inspect(&request.spec.unit_id).await?
+    else {
+        return Err(super::protocol(
+            "foreign namespace probe removed the sibling resource",
+        ));
+    };
+    require(
+        observation.state == RuntimeUnitState::Running
+            && observation.provider_resource_id == sibling_id,
+        "foreign namespace probe changed sibling provider identity",
+    )?;
+    fixture
+        .remove_unit(&sibling, &request.spec, "security-sibling-namespace")
+        .await
+}

--- a/src/runtime/src/a3s_runtime_driver/exec.rs
+++ b/src/runtime/src/a3s_runtime_driver/exec.rs
@@ -15,6 +15,7 @@ use super::metadata::{
 use super::BoxRuntimeDriver;
 
 const NANOS_PER_MILLISECOND: u64 = 1_000_000;
+const EXEC_RESPONSE_BUDGET_MS: u64 = 100;
 
 impl BoxRuntimeDriver {
     pub(super) async fn execute_runtime_command(
@@ -142,17 +143,27 @@ fn validate_exec_identity(
 }
 
 fn effective_timeout(request: &RuntimeExecRequest) -> RuntimeResult<Duration> {
+    effective_timeout_at(request, now_ms())
+}
+
+fn effective_timeout_at(request: &RuntimeExecRequest, now_ms: u64) -> RuntimeResult<Duration> {
     let mut timeout_ms = request.timeout_ms;
     if let Some(deadline_at_ms) = request.deadline_at_ms {
-        let remaining_ms = deadline_at_ms.checked_sub(now_ms()).ok_or_else(|| {
+        let remaining_ms = deadline_at_ms.checked_sub(now_ms).ok_or_else(|| {
             RuntimeError::DeadlineExceeded("exec request expired before provider dispatch".into())
         })?;
-        if remaining_ms == 0 {
-            return Err(RuntimeError::DeadlineExceeded(
-                "exec request expired before provider dispatch".into(),
-            ));
-        }
-        timeout_ms = timeout_ms.min(remaining_ms);
+        let execution_budget_ms = remaining_ms
+            .checked_sub(EXEC_RESPONSE_BUDGET_MS)
+            .filter(|budget| *budget > 0)
+            .ok_or_else(|| {
+                RuntimeError::DeadlineExceeded(
+                    "exec request has insufficient time for a provider response".into(),
+                )
+            })?;
+        // Runtime bounds the complete provider future by this same deadline.
+        // Stop the guest command first so the driver can collect its bounded
+        // output, reconstruct the observation, and return a replayable result.
+        timeout_ms = timeout_ms.min(execution_budget_ms);
     }
     timeout_ms
         .checked_mul(NANOS_PER_MILLISECOND)
@@ -191,6 +202,31 @@ mod tests {
         assert!(matches!(
             effective_timeout(&overflow),
             Err(RuntimeError::InvalidRequest(message)) if message.contains("overflows")
+        ));
+    }
+
+    #[test]
+    fn effective_timeout_reserves_time_for_the_provider_response() {
+        let mut request = RuntimeExecRequest {
+            schema: RuntimeExecRequest::SCHEMA.into(),
+            request_id: "request-1".into(),
+            unit_id: "unit-1".into(),
+            generation: 1,
+            command: vec!["true".into()],
+            timeout_ms: 5_000,
+            deadline_at_ms: Some(1_500),
+        };
+
+        assert_eq!(
+            effective_timeout_at(&request, 1_000).unwrap(),
+            Duration::from_millis(400)
+        );
+
+        request.deadline_at_ms = Some(1_100);
+        assert!(matches!(
+            effective_timeout_at(&request, 1_000),
+            Err(RuntimeError::DeadlineExceeded(message))
+                if message.contains("insufficient time")
         ));
     }
 

--- a/src/runtime/src/a3s_runtime_driver/exec.rs
+++ b/src/runtime/src/a3s_runtime_driver/exec.rs
@@ -1,0 +1,205 @@
+//! Generation-bound, ambiguity-safe Runtime exec mapping.
+
+use std::time::Duration;
+
+use a3s_box_core::{ExecRequest, ExecutionManager, ExecutionSessionManager};
+use a3s_runtime::contract::{
+    RuntimeExecRequest, RuntimeExecResult, RuntimeUnitState,
+};
+use a3s_runtime::{RuntimeError, RuntimeResult, RuntimeUnitRecord};
+
+use crate::ManagedExecutionState;
+
+use super::metadata::{
+    local_identity, map_execution_error, now_ms, provider_identity_matches,
+    validate_record_for_spec,
+};
+use super::BoxRuntimeDriver;
+
+const NANOS_PER_MILLISECOND: u64 = 1_000_000;
+
+impl BoxRuntimeDriver {
+    pub(super) async fn execute_runtime_command(
+        &self,
+        unit: &RuntimeUnitRecord,
+        request: &RuntimeExecRequest,
+    ) -> RuntimeResult<RuntimeExecResult> {
+        unit.validate().map_err(RuntimeError::Protocol)?;
+        request.validate().map_err(RuntimeError::InvalidRequest)?;
+        validate_exec_identity(unit, request)?;
+        if unit.observation.state != RuntimeUnitState::Running {
+            return Err(RuntimeError::InvalidRequest(format!(
+                "Box Runtime exec requires a running unit; {:?} is {:?}",
+                unit.spec.unit_id, unit.observation.state
+            )));
+        }
+
+        let record = self
+            .find_generation(&unit.spec)
+            .await?
+            .ok_or_else(|| RuntimeError::NotFound {
+                unit_id: unit.spec.unit_id.clone(),
+            })?;
+        provider_identity_matches(&unit.observation, &record)?;
+        validate_record_for_spec(&record, &unit.spec)?;
+        let (execution_id, generation, _) = local_identity(&record)?;
+
+        // Refresh provider state before crossing the exec boundary. The
+        // session manager repeats the generation and process-identity checks
+        // after opening the runtime endpoint, preventing a concurrent local
+        // restart from redirecting this command to another generation.
+        self.bounded("exec inspection", async {
+            self.manager
+                .inspect(&execution_id)
+                .await
+                .map_err(|error| map_execution_error(&unit.spec.unit_id, error))
+        })
+        .await?;
+        let record = self
+            .manager
+            .managed_record(&execution_id)
+            .await
+            .map_err(|error| map_execution_error(&unit.spec.unit_id, error))?
+            .ok_or_else(|| RuntimeError::NotFound {
+                unit_id: unit.spec.unit_id.clone(),
+            })?;
+        validate_record_for_spec(&record, &unit.spec)?;
+        let (_, refreshed_generation, state) = local_identity(&record)?;
+        if state != ManagedExecutionState::Running {
+            return Err(RuntimeError::InvalidRequest(format!(
+                "Box Runtime exec requires a running provider resource; execution {} is {state}",
+                record.id
+            )));
+        }
+        if refreshed_generation != generation {
+            return Err(RuntimeError::ProviderUnavailable(format!(
+                "Box execution {} restarted while binding Runtime exec",
+                record.id
+            )));
+        }
+
+        let timeout = effective_timeout(request)?;
+        let timeout_ns = u64::try_from(timeout.as_nanos())
+            .map_err(|_| RuntimeError::InvalidRequest("Runtime exec timeout overflows u64".into()))?;
+        let output = self
+            .manager
+            .execute(
+                &execution_id,
+                refreshed_generation,
+                ExecRequest {
+                    request_id: Some(request.request_id.clone()),
+                    cmd: request.command.clone(),
+                    timeout_ns,
+                    env: Vec::new(),
+                    working_dir: None,
+                    rootfs: None,
+                    stdin: None,
+                    stdin_streaming: false,
+                    user: None,
+                    streaming: false,
+                },
+            )
+            .await
+            .map_err(|error| map_execution_error(&unit.spec.unit_id, error))?;
+
+        // Read the durable record without an additional provider mutation. The
+        // per-unit Runtime operation lease excludes stop/remove/restart while
+        // this call is active, and the session boundary already fenced local
+        // generation changes immediately before dispatch.
+        let record = self
+            .manager
+            .managed_record(&execution_id)
+            .await
+            .map_err(|error| map_execution_error(&unit.spec.unit_id, error))?
+            .ok_or_else(|| RuntimeError::NotFound {
+                unit_id: unit.spec.unit_id.clone(),
+            })?;
+        validate_record_for_spec(&record, &unit.spec)?;
+        let observation = self.observation(&unit.spec, &record, None, None).await?;
+        let result = RuntimeExecResult {
+            schema: RuntimeExecResult::SCHEMA.into(),
+            request_id: request.request_id.clone(),
+            observation,
+            exit_code: output.exit_code,
+            stdout: decode_output("stdout", output.stdout)?,
+            stderr: decode_output("stderr", output.stderr)?,
+            truncated: output.truncated,
+        };
+        result.validate().map_err(RuntimeError::Protocol)?;
+        Ok(result)
+    }
+}
+
+fn validate_exec_identity(
+    unit: &RuntimeUnitRecord,
+    request: &RuntimeExecRequest,
+) -> RuntimeResult<()> {
+    if request.unit_id != unit.spec.unit_id || request.generation != unit.spec.generation {
+        return Err(RuntimeError::InvalidRequest(
+            "Runtime exec identity does not match its unit record".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn effective_timeout(request: &RuntimeExecRequest) -> RuntimeResult<Duration> {
+    let mut timeout_ms = request.timeout_ms;
+    if let Some(deadline_at_ms) = request.deadline_at_ms {
+        let remaining_ms = deadline_at_ms.checked_sub(now_ms()).ok_or_else(|| {
+            RuntimeError::DeadlineExceeded("exec request expired before provider dispatch".into())
+        })?;
+        if remaining_ms == 0 {
+            return Err(RuntimeError::DeadlineExceeded(
+                "exec request expired before provider dispatch".into(),
+            ));
+        }
+        timeout_ms = timeout_ms.min(remaining_ms);
+    }
+    timeout_ms
+        .checked_mul(NANOS_PER_MILLISECOND)
+        .ok_or_else(|| RuntimeError::InvalidRequest("Runtime exec timeout overflows u64".into()))?;
+    Ok(Duration::from_millis(timeout_ms))
+}
+
+fn decode_output(stream: &'static str, bytes: Vec<u8>) -> RuntimeResult<String> {
+    String::from_utf8(bytes).map_err(|error| {
+        RuntimeError::Protocol(format!(
+            "Box Runtime exec {stream} is not valid UTF-8 at byte {}",
+            error.utf8_error().valid_up_to()
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_timeout_honors_relative_bound_and_rejects_overflow() {
+        let request = RuntimeExecRequest {
+            schema: RuntimeExecRequest::SCHEMA.into(),
+            request_id: "request-1".into(),
+            unit_id: "unit-1".into(),
+            generation: 1,
+            command: vec!["true".into()],
+            timeout_ms: 5_000,
+            deadline_at_ms: None,
+        };
+        assert_eq!(effective_timeout(&request).unwrap(), Duration::from_secs(5));
+
+        let mut overflow = request;
+        overflow.timeout_ms = u64::MAX;
+        assert!(matches!(
+            effective_timeout(&overflow),
+            Err(RuntimeError::InvalidRequest(message)) if message.contains("overflows")
+        ));
+    }
+
+    #[test]
+    fn invalid_utf8_fails_closed() {
+        assert!(matches!(
+            decode_output("stdout", vec![0xff]),
+            Err(RuntimeError::Protocol(message)) if message.contains("not valid UTF-8")
+        ));
+    }
+}

--- a/src/runtime/src/a3s_runtime_driver/exec.rs
+++ b/src/runtime/src/a3s_runtime_driver/exec.rs
@@ -3,9 +3,7 @@
 use std::time::Duration;
 
 use a3s_box_core::{ExecRequest, ExecutionManager, ExecutionSessionManager};
-use a3s_runtime::contract::{
-    RuntimeExecRequest, RuntimeExecResult, RuntimeUnitState,
-};
+use a3s_runtime::contract::{RuntimeExecRequest, RuntimeExecResult, RuntimeUnitState};
 use a3s_runtime::{RuntimeError, RuntimeResult, RuntimeUnitRecord};
 
 use crate::ManagedExecutionState;
@@ -34,12 +32,12 @@ impl BoxRuntimeDriver {
             )));
         }
 
-        let record = self
-            .find_generation(&unit.spec)
-            .await?
-            .ok_or_else(|| RuntimeError::NotFound {
-                unit_id: unit.spec.unit_id.clone(),
-            })?;
+        let record =
+            self.find_generation(&unit.spec)
+                .await?
+                .ok_or_else(|| RuntimeError::NotFound {
+                    unit_id: unit.spec.unit_id.clone(),
+                })?;
         provider_identity_matches(&unit.observation, &record)?;
         validate_record_for_spec(&record, &unit.spec)?;
         let (execution_id, generation, _) = local_identity(&record)?;
@@ -79,8 +77,9 @@ impl BoxRuntimeDriver {
         }
 
         let timeout = effective_timeout(request)?;
-        let timeout_ns = u64::try_from(timeout.as_nanos())
-            .map_err(|_| RuntimeError::InvalidRequest("Runtime exec timeout overflows u64".into()))?;
+        let timeout_ns = u64::try_from(timeout.as_nanos()).map_err(|_| {
+            RuntimeError::InvalidRequest("Runtime exec timeout overflows u64".into())
+        })?;
         let output = self
             .manager
             .execute(

--- a/src/runtime/src/a3s_runtime_driver/exec_integration_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/exec_integration_tests.rs
@@ -54,7 +54,10 @@ async fn exec_binds_identity_timeout_replay_and_truncation_to_the_running_genera
     let first = driver.exec(&running_unit, &request).await.unwrap();
     let replayed = driver.exec(&running_unit, &request).await.unwrap();
     assert_eq!(first.request_id, request.request_id);
-    assert_eq!(first.observation.provider_resource_id.as_deref(), Some(provider_id.as_str()));
+    assert_eq!(
+        first.observation.provider_resource_id.as_deref(),
+        Some(provider_id.as_str())
+    );
     assert_eq!(first.exit_code, 23);
     assert_eq!(first.stdout, "replayed stdout\n");
     assert_eq!(first.stderr, "bounded stderr\n");

--- a/src/runtime/src/a3s_runtime_driver/exec_integration_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/exec_integration_tests.rs
@@ -1,0 +1,92 @@
+use a3s_box_core::exec::{ExecOutput, ExecRequest};
+use a3s_runtime::contract::{RuntimeExecRequest, RuntimeUnitClass, RuntimeUnitState};
+use a3s_runtime::{RuntimeDriver, RuntimeError};
+
+use super::test_support::{accepted, action, fake_driver, runtime_spec, unit};
+
+#[cfg(unix)]
+#[tokio::test]
+async fn exec_binds_identity_timeout_replay_and_truncation_to_the_running_generation() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, _backend) = fake_driver(&directory);
+    let spec = runtime_spec("exec-wire", 1, RuntimeUnitClass::Service);
+    let running = driver.apply(&spec, &accepted(&spec)).await.unwrap();
+    let provider_id = running.provider_resource_id.clone().unwrap();
+    let record = driver.find_generation(&spec).await.unwrap().unwrap();
+    std::fs::create_dir_all(record.exec_socket_path.parent().unwrap()).unwrap();
+    let listener = tokio::net::UnixListener::bind(&record.exec_socket_path).unwrap();
+    let (request_tx, mut request_rx) = tokio::sync::mpsc::unbounded_channel();
+    let server = tokio::spawn(async move {
+        for _ in 0..2 {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, write) = tokio::io::split(stream);
+            let mut reader = a3s_transport::FrameReader::new(read);
+            let mut writer = a3s_transport::FrameWriter::new(write);
+            let frame = reader.read_frame().await.unwrap().unwrap();
+            assert_eq!(frame.frame_type, a3s_transport::FrameType::Data);
+            let request: ExecRequest = serde_json::from_slice(&frame.payload).unwrap();
+            request_tx.send(request).unwrap();
+            writer
+                .write_data(
+                    &serde_json::to_vec(&ExecOutput {
+                        stdout: b"replayed stdout\n".to_vec(),
+                        stderr: b"bounded stderr\n".to_vec(),
+                        exit_code: 23,
+                        truncated: true,
+                    })
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+        }
+    });
+
+    let request = RuntimeExecRequest {
+        schema: RuntimeExecRequest::SCHEMA.into(),
+        request_id: "exec-request-1".into(),
+        unit_id: spec.unit_id.clone(),
+        generation: spec.generation,
+        command: vec!["/bin/sh".into(), "-c".into(), "printf ready".into()],
+        timeout_ms: 500,
+        deadline_at_ms: None,
+    };
+    let running_unit = unit(spec.clone(), running.clone());
+    let first = driver.exec(&running_unit, &request).await.unwrap();
+    let replayed = driver.exec(&running_unit, &request).await.unwrap();
+    assert_eq!(first.request_id, request.request_id);
+    assert_eq!(first.observation.provider_resource_id.as_deref(), Some(provider_id.as_str()));
+    assert_eq!(first.exit_code, 23);
+    assert_eq!(first.stdout, "replayed stdout\n");
+    assert_eq!(first.stderr, "bounded stderr\n");
+    assert!(first.truncated);
+    assert_eq!(replayed.exit_code, first.exit_code);
+    assert_eq!(replayed.stdout, first.stdout);
+    assert_eq!(replayed.stderr, first.stderr);
+    assert!(replayed.truncated);
+
+    for _ in 0..2 {
+        let guest_request = request_rx.recv().await.unwrap();
+        assert_eq!(guest_request.request_id.as_deref(), Some("exec-request-1"));
+        assert_eq!(guest_request.cmd, request.command);
+        assert_eq!(guest_request.timeout_ns, 500_000_000);
+        assert!(!guest_request.streaming);
+    }
+    server.await.unwrap();
+
+    let mut wrong_generation = request.clone();
+    wrong_generation.generation += 1;
+    assert!(matches!(
+        driver.exec(&running_unit, &wrong_generation).await,
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("identity")
+    ));
+
+    let stopped = driver
+        .stop(&running_unit, &action("exec-service-stop", &spec))
+        .await
+        .unwrap();
+    assert_eq!(stopped.state, RuntimeUnitState::Stopped);
+    assert!(matches!(
+        driver.exec(&unit(spec, stopped), &request).await,
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("running unit")
+    ));
+}

--- a/src/runtime/src/a3s_runtime_driver/lifecycle.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle.rs
@@ -354,7 +354,11 @@ impl BoxRuntimeDriver {
         validate_record_for_spec(&remaining[0], spec)
     }
 
-    async fn retire_record(&self, mut record: BoxRecord, unit_id: &str) -> RuntimeResult<()> {
+    pub(super) async fn retire_record(
+        &self,
+        mut record: BoxRecord,
+        unit_id: &str,
+    ) -> RuntimeResult<()> {
         let (execution_id, mut generation, mut state) = local_identity(&record)?;
         if matches!(
             state,

--- a/src/runtime/src/a3s_runtime_driver/lifecycle.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle.rs
@@ -1,0 +1,631 @@
+//! Runtime lifecycle projection over Box's durable local execution manager.
+
+use std::time::Duration;
+
+use a3s_box_core::{ExecutionManager, KillOutcome, ReconcileOutcome};
+use a3s_runtime::contract::{
+    RestartPolicy, RuntimeActionRequest, RuntimeFailure, RuntimeInspection, RuntimeObservation,
+    RuntimeRemoval, RuntimeUnitClass, RuntimeUnitSpec, RuntimeUnitState,
+};
+use a3s_runtime::{RuntimeError, RuntimeResult, RuntimeUnitRecord};
+use sha2::{Digest, Sha256};
+
+use crate::{BoxRecord, ManagedExecutionState};
+
+use super::mapping::{creation_request, operation};
+use super::metadata::{
+    local_identity, map_execution_error, now_ms, provider_identity_matches, timestamp_ms,
+    validate_record_for_spec,
+};
+use super::BoxRuntimeDriver;
+
+impl BoxRuntimeDriver {
+    pub(super) async fn apply_unit(
+        &self,
+        spec: &RuntimeUnitSpec,
+        current: &RuntimeObservation,
+    ) -> RuntimeResult<RuntimeObservation> {
+        // Complete validation and conversion before any Box state or provider
+        // mutation. The returned request is reused for identity comparison.
+        let request = creation_request(spec)?;
+        let mut record = self.find_generation(spec).await?;
+
+        if let Some(existing) = record.as_ref() {
+            provider_identity_matches(current, existing)?;
+            if should_replace_confirmed_loss(existing, current)? {
+                self.retire_record(existing.clone(), &spec.unit_id).await?;
+                record = None;
+            }
+        }
+
+        let record = match record {
+            Some(record) => self.ensure_started(spec, record).await?,
+            None => {
+                let operation_id = operation(spec)?;
+                let reservation = self
+                    .bounded("reservation", async {
+                        self.manager
+                            .create(request, &operation_id)
+                            .await
+                            .map_err(|error| map_execution_error(&spec.unit_id, error))
+                    })
+                    .await?;
+                let record = self
+                    .manager
+                    .managed_record(&reservation.execution_id)
+                    .await
+                    .map_err(|error| map_execution_error(&spec.unit_id, error))?
+                    .ok_or_else(|| {
+                        RuntimeError::Protocol(
+                            "Box lost a durable execution immediately after reservation".into(),
+                        )
+                    })?;
+                validate_record_for_spec(&record, spec)?;
+                self.ensure_started(spec, record).await?
+            }
+        };
+
+        // Retire older Runtime generations as soon as the current generation
+        // has a durable provider identity. A retry resumes any partial cleanup.
+        self.retire_stale_generations(spec, &record.id).await?;
+
+        match spec.class {
+            RuntimeUnitClass::Task => self.wait_for_task(spec, record).await,
+            RuntimeUnitClass::Service => self.observation(spec, &record, None, None).await,
+        }
+    }
+
+    pub(super) async fn inspect_unit(
+        &self,
+        unit: &RuntimeUnitRecord,
+    ) -> RuntimeResult<RuntimeInspection> {
+        unit.validate().map_err(RuntimeError::Protocol)?;
+        let Some(record) = self.find_generation(&unit.spec).await? else {
+            return Ok(not_found(&unit.spec));
+        };
+        provider_identity_matches(&unit.observation, &record)?;
+        let before = local_identity(&record)?.2;
+        let record = self.refresh_record(&unit.spec, record).await?;
+        if provider_was_lost(before, &record)? {
+            return Ok(not_found(&unit.spec));
+        }
+
+        let record = if should_restart(&unit.spec, &record)? {
+            self.restart_record(&unit.spec, record).await?
+        } else {
+            record
+        };
+        let observation = self.observation(&unit.spec, &record, None, None).await?;
+        Ok(RuntimeInspection::Found {
+            schema: RuntimeInspection::SCHEMA.into(),
+            observation: Box::new(observation),
+        })
+    }
+
+    pub(super) async fn stop_unit(
+        &self,
+        unit: &RuntimeUnitRecord,
+        request: &RuntimeActionRequest,
+    ) -> RuntimeResult<RuntimeObservation> {
+        request.validate().map_err(RuntimeError::InvalidRequest)?;
+        validate_action_identity(unit, request)?;
+        if unit.observation.state.is_terminal() {
+            return Ok(unit.observation.clone());
+        }
+
+        let Some(record) = self.find_generation(&unit.spec).await? else {
+            return unknown_observation(&unit.observation);
+        };
+        provider_identity_matches(&unit.observation, &record)?;
+        let before = local_identity(&record)?.2;
+        let mut record = self.refresh_record(&unit.spec, record).await?;
+        if provider_was_lost(before, &record)? {
+            return unknown_observation(&unit.observation);
+        }
+
+        let (_, generation, state) = local_identity(&record)?;
+        if !state.is_terminal() {
+            let execution_id = a3s_box_core::ExecutionId::new(record.id.clone())
+                .map_err(|error| RuntimeError::Protocol(error.to_string()))?;
+            self.manager
+                .kill(&execution_id, generation)
+                .await
+                .map_err(|error| map_execution_error(&unit.spec.unit_id, error))?;
+            record = self.load_record(&unit.spec, &execution_id).await?;
+        }
+
+        self.observation(
+            &unit.spec,
+            &record,
+            Some(RuntimeUnitState::Stopped),
+            None,
+        )
+        .await
+    }
+
+    pub(super) async fn remove_unit(
+        &self,
+        unit: &RuntimeUnitRecord,
+        request: &RuntimeActionRequest,
+    ) -> RuntimeResult<RuntimeRemoval> {
+        request.validate().map_err(RuntimeError::InvalidRequest)?;
+        validate_action_identity(unit, request)?;
+        let record = self.find_generation(&unit.spec).await?;
+        let already_absent = record.is_none();
+        if let Some(record) = record {
+            provider_identity_matches(&unit.observation, &record)?;
+            self.retire_record(record, &unit.spec.unit_id).await?;
+        }
+        let removal = RuntimeRemoval {
+            schema: RuntimeRemoval::SCHEMA.into(),
+            request_id: request.request_id.clone(),
+            unit_id: request.unit_id.clone(),
+            generation: request.generation,
+            removed_at_ms: now_ms(),
+            already_absent,
+        };
+        removal.validate().map_err(RuntimeError::Protocol)?;
+        Ok(removal)
+    }
+
+    async fn ensure_started(
+        &self,
+        spec: &RuntimeUnitSpec,
+        record: BoxRecord,
+    ) -> RuntimeResult<BoxRecord> {
+        validate_record_for_spec(&record, spec)?;
+        let (execution_id, generation, state) = local_identity(&record)?;
+        match state {
+            ManagedExecutionState::Creating
+            | ManagedExecutionState::Created
+            | ManagedExecutionState::Starting => {
+                let result = self
+                    .bounded("startup", async {
+                        self.manager
+                            .start(&execution_id, generation)
+                            .await
+                            .map_err(|error| map_execution_error(&spec.unit_id, error))
+                    })
+                    .await;
+                if let Err(error) = result {
+                    let current = self.load_record(spec, &execution_id).await?;
+                    if local_identity(&current)?.2.is_terminal() {
+                        return Ok(current);
+                    }
+                    return Err(error);
+                }
+                self.load_record(spec, &execution_id).await
+            }
+            ManagedExecutionState::Running => Ok(record),
+            ManagedExecutionState::Stopped | ManagedExecutionState::Failed => {
+                if should_restart(spec, &record)? {
+                    self.restart_record(spec, record).await
+                } else {
+                    Ok(record)
+                }
+            }
+            ManagedExecutionState::Removing => Err(RuntimeError::ProviderUnavailable(format!(
+                "Box execution {} is still being removed",
+                record.id
+            ))),
+            state => Err(RuntimeError::ProviderUnavailable(format!(
+                "Box execution {} cannot be applied while in state {state}",
+                record.id
+            ))),
+        }
+    }
+
+    async fn wait_for_task(
+        &self,
+        spec: &RuntimeUnitSpec,
+        mut record: BoxRecord,
+    ) -> RuntimeResult<RuntimeObservation> {
+        let timeout_ms = spec.resources.execution_timeout_ms.ok_or_else(|| {
+            RuntimeError::InvalidRequest("Runtime Task has no execution timeout".into())
+        })?;
+        let timeout = Duration::from_millis(timeout_ms);
+        let deadline = tokio::time::Instant::now() + timeout;
+
+        loop {
+            let before = local_identity(&record)?.2;
+            record = self.refresh_record(spec, record).await?;
+            let state = local_identity(&record)?.2;
+            if state.is_terminal() {
+                if provider_was_lost(before, &record)? {
+                    return self
+                        .observation(
+                            spec,
+                            &record,
+                            Some(RuntimeUnitState::Failed),
+                            Some(RuntimeFailure {
+                                code: "provider_lost".into(),
+                                message: "Box lost the Sandbox provider resource".into(),
+                                retryable: true,
+                            }),
+                        )
+                        .await;
+                }
+                if should_restart(spec, &record)? {
+                    record = self.restart_record(spec, record).await?;
+                    continue;
+                }
+                return self.observation(spec, &record, None, None).await;
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                let (execution_id, generation, _) = local_identity(&record)?;
+                self.bounded("Task timeout cleanup", async {
+                    self.manager
+                        .kill(&execution_id, generation)
+                        .await
+                        .map_err(|error| map_execution_error(&spec.unit_id, error))
+                })
+                .await?;
+                record = self.load_record(spec, &execution_id).await?;
+                return self
+                    .observation(
+                        spec,
+                        &record,
+                        Some(RuntimeUnitState::Failed),
+                        Some(RuntimeFailure {
+                            code: "execution_timeout".into(),
+                            message: format!("Box Task exceeded its {timeout_ms} ms timeout"),
+                            retryable: false,
+                        }),
+                    )
+                    .await;
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            tokio::time::sleep(self.config.task_poll_interval.min(remaining)).await;
+        }
+    }
+
+    async fn refresh_record(
+        &self,
+        spec: &RuntimeUnitSpec,
+        record: BoxRecord,
+    ) -> RuntimeResult<BoxRecord> {
+        let (execution_id, _, _) = local_identity(&record)?;
+        self.bounded("inspection", async {
+            self.manager
+                .inspect(&execution_id)
+                .await
+                .map_err(|error| map_execution_error(&spec.unit_id, error))
+        })
+        .await?;
+        self.load_record(spec, &execution_id).await
+    }
+
+    async fn load_record(
+        &self,
+        spec: &RuntimeUnitSpec,
+        execution_id: &a3s_box_core::ExecutionId,
+    ) -> RuntimeResult<BoxRecord> {
+        let record = self
+            .manager
+            .managed_record(execution_id)
+            .await
+            .map_err(|error| map_execution_error(&spec.unit_id, error))?
+            .ok_or_else(|| RuntimeError::NotFound {
+                unit_id: spec.unit_id.clone(),
+            })?;
+        validate_record_for_spec(&record, spec)?;
+        Ok(record)
+    }
+
+    async fn restart_record(
+        &self,
+        spec: &RuntimeUnitSpec,
+        record: BoxRecord,
+    ) -> RuntimeResult<BoxRecord> {
+        let (execution_id, generation, _) = local_identity(&record)?;
+        let operation_id = restart_operation(spec, generation)?;
+        self.bounded("restart", async {
+            self.manager
+                .restart(&execution_id, generation, &operation_id)
+                .await
+                .map_err(|error| map_execution_error(&spec.unit_id, error))
+        })
+        .await?;
+        self.load_record(spec, &execution_id).await
+    }
+
+    async fn retire_stale_generations(
+        &self,
+        spec: &RuntimeUnitSpec,
+        current_id: &str,
+    ) -> RuntimeResult<()> {
+        let records = self.unit_records(&spec.unit_id).await?;
+        if !records.iter().any(|record| record.id == current_id) {
+            return Err(RuntimeError::ProviderUnavailable(
+                "Box lost the current execution during generation reconciliation".into(),
+            ));
+        }
+        for record in records {
+            if record.id != current_id {
+                self.retire_record(record, &spec.unit_id).await?;
+            }
+        }
+
+        let remaining = self.unit_records(&spec.unit_id).await?;
+        if remaining.len() != 1 || remaining[0].id != current_id {
+            return Err(RuntimeError::Protocol(format!(
+                "Box generation reconciliation for unit {:?} left {} executions",
+                spec.unit_id,
+                remaining.len()
+            )));
+        }
+        validate_record_for_spec(&remaining[0], spec)
+    }
+
+    async fn retire_record(
+        &self,
+        mut record: BoxRecord,
+        unit_id: &str,
+    ) -> RuntimeResult<()> {
+        let (execution_id, mut generation, mut state) = local_identity(&record)?;
+        if matches!(
+            state,
+            ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting
+        ) {
+            let create_operation = record
+                .managed_execution
+                .as_ref()
+                .ok_or_else(|| RuntimeError::Protocol("Box execution lost metadata".into()))?
+                .operation_id
+                .clone();
+            match self
+                .bounded("restart reconciliation", async {
+                    self.manager
+                        .reconcile(&create_operation)
+                        .await
+                        .map_err(|error| map_execution_error(unit_id, error))
+                })
+                .await
+            {
+                Ok(ReconcileOutcome::Absent) => return Ok(()),
+                Ok(_) => {}
+                Err(error) => return Err(error),
+            }
+            record = self
+                .manager
+                .managed_record(&execution_id)
+                .await
+                .map_err(|error| map_execution_error(unit_id, error))?
+                .ok_or_else(|| RuntimeError::NotFound {
+                    unit_id: unit_id.into(),
+                })?;
+            (_, generation, state) = local_identity(&record)?;
+        }
+
+        if !matches!(
+            state,
+            ManagedExecutionState::Created
+                | ManagedExecutionState::Stopped
+                | ManagedExecutionState::Failed
+                | ManagedExecutionState::Removing
+        ) {
+            match self
+                .bounded("generation retirement stop", async {
+                    self.manager
+                        .kill(&execution_id, generation)
+                        .await
+                        .map_err(|error| map_execution_error(unit_id, error))
+                })
+                .await
+            {
+                Ok(KillOutcome::Killed | KillOutcome::AlreadyStopped) => {}
+                Err(error) => return Err(error),
+            }
+            record = self
+                .manager
+                .managed_record(&execution_id)
+                .await
+                .map_err(|error| map_execution_error(unit_id, error))?
+                .ok_or_else(|| RuntimeError::NotFound {
+                    unit_id: unit_id.into(),
+                })?;
+            generation = local_identity(&record)?.1;
+        }
+
+        self.bounded("generation retirement removal", async {
+            self.manager
+                .remove_execution(&execution_id, generation)
+                .await
+                .map_err(|error| map_execution_error(unit_id, error))
+        })
+        .await?;
+        if self
+            .manager
+            .managed_record(&execution_id)
+            .await
+            .map_err(|error| map_execution_error(unit_id, error))?
+            .is_some()
+        {
+            return Err(RuntimeError::Protocol(format!(
+                "Box removal left execution {} in durable inventory",
+                execution_id
+            )));
+        }
+        Ok(())
+    }
+
+    pub(super) async fn observation(
+        &self,
+        spec: &RuntimeUnitSpec,
+        record: &BoxRecord,
+        state_override: Option<RuntimeUnitState>,
+        failure_override: Option<RuntimeFailure>,
+    ) -> RuntimeResult<RuntimeObservation> {
+        validate_record_for_spec(record, spec)?;
+        let state = state_override.unwrap_or(runtime_state(spec, record)?);
+        let terminal = state.is_terminal();
+        let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+            RuntimeError::Protocol(format!("Box execution {} lost metadata", record.id))
+        })?;
+        let started_at_ms = record.started_at.map(timestamp_ms).transpose()?;
+        let finished_at_ms = if terminal {
+            Some(
+                metadata
+                    .finished_at
+                    .map(timestamp_ms)
+                    .transpose()?
+                    .unwrap_or_else(now_ms),
+            )
+        } else {
+            None
+        };
+        let mut observed_at_ms = now_ms();
+        if let Some(started) = started_at_ms {
+            observed_at_ms = observed_at_ms.max(started);
+        }
+        if let Some(finished) = finished_at_ms {
+            observed_at_ms = observed_at_ms.max(finished);
+        }
+        let failure = if state == RuntimeUnitState::Failed {
+            Some(failure_override.unwrap_or_else(|| exit_failure(record)))
+        } else {
+            None
+        };
+        let observation = RuntimeObservation {
+            schema: RuntimeObservation::SCHEMA.into(),
+            unit_id: spec.unit_id.clone(),
+            generation: spec.generation,
+            spec_digest: spec.digest().map_err(RuntimeError::Protocol)?,
+            class: spec.class,
+            state,
+            provider_resource_id: Some(record.id.clone()),
+            provider_build: Some(self.provider_build().await?),
+            observed_at_ms,
+            started_at_ms,
+            finished_at_ms,
+            health: None,
+            outputs: Vec::new(),
+            usage: None,
+            evidence: None,
+            provider_attestation: None,
+            failure,
+        };
+        observation
+            .validate_against(spec)
+            .map_err(RuntimeError::Protocol)?;
+        Ok(observation)
+    }
+}
+
+fn runtime_state(spec: &RuntimeUnitSpec, record: &BoxRecord) -> RuntimeResult<RuntimeUnitState> {
+    let state = local_identity(record)?.2;
+    match state {
+        ManagedExecutionState::Creating => Ok(RuntimeUnitState::Preparing),
+        ManagedExecutionState::Created
+        | ManagedExecutionState::Starting
+        | ManagedExecutionState::RestartStarting => Ok(RuntimeUnitState::Starting),
+        ManagedExecutionState::Running
+        | ManagedExecutionState::Pausing
+        | ManagedExecutionState::Paused
+        | ManagedExecutionState::Resuming
+        | ManagedExecutionState::Snapshotting
+        | ManagedExecutionState::RestartStopping => Ok(RuntimeUnitState::Running),
+        ManagedExecutionState::Killing | ManagedExecutionState::Removing => {
+            Ok(RuntimeUnitState::Stopping)
+        }
+        ManagedExecutionState::Stopped | ManagedExecutionState::Failed => match spec.class {
+            RuntimeUnitClass::Task if record.exit_code == Some(0) => {
+                Ok(RuntimeUnitState::Succeeded)
+            }
+            RuntimeUnitClass::Task => Ok(RuntimeUnitState::Failed),
+            RuntimeUnitClass::Service if record.exit_code.unwrap_or_default() == 0 => {
+                Ok(RuntimeUnitState::Stopped)
+            }
+            RuntimeUnitClass::Service => Ok(RuntimeUnitState::Failed),
+        },
+    }
+}
+
+fn exit_failure(record: &BoxRecord) -> RuntimeFailure {
+    let message = match record.exit_code {
+        Some(code) => format!("Box Sandbox exited with code {code}"),
+        None => "Box Sandbox exited without a recoverable exit code".into(),
+    };
+    RuntimeFailure {
+        code: "sandbox_exit".into(),
+        message,
+        retryable: false,
+    }
+}
+
+fn should_replace_confirmed_loss(
+    record: &BoxRecord,
+    current: &RuntimeObservation,
+) -> RuntimeResult<bool> {
+    Ok(current.state == RuntimeUnitState::Unknown
+        && local_identity(record)?.2.is_terminal()
+        && record.exit_code.is_none())
+}
+
+fn provider_was_lost(before: ManagedExecutionState, after: &BoxRecord) -> RuntimeResult<bool> {
+    Ok(before.keeps_resources()
+        && local_identity(after)?.2 == ManagedExecutionState::Failed
+        && after.exit_code.is_none())
+}
+
+fn should_restart(spec: &RuntimeUnitSpec, record: &BoxRecord) -> RuntimeResult<bool> {
+    if !local_identity(record)?.2.is_terminal() || record.exit_code.is_none() {
+        return Ok(false);
+    }
+    let attempts = local_identity(record)?.1.get().saturating_sub(1);
+    Ok(match &spec.restart {
+        RestartPolicy::Never => false,
+        RestartPolicy::Always => spec.class == RuntimeUnitClass::Service,
+        RestartPolicy::OnFailure { max_retries } => {
+            record.exit_code != Some(0) && attempts < u64::from(*max_retries)
+        }
+    })
+}
+
+fn restart_operation(
+    spec: &RuntimeUnitSpec,
+    generation: a3s_box_core::ExecutionGeneration,
+) -> RuntimeResult<a3s_box_core::OperationId> {
+    let mut digest = Sha256::new();
+    digest.update(b"a3s-box-runtime-restart-v1\0");
+    digest.update(spec.unit_id.as_bytes());
+    digest.update(spec.generation.to_be_bytes());
+    digest.update(spec.digest().map_err(RuntimeError::Protocol)?.as_bytes());
+    digest.update(generation.get().to_be_bytes());
+    a3s_box_core::OperationId::new(format!("a3s-runtime-restart-v1:{:x}", digest.finalize()))
+        .map_err(|error| RuntimeError::InvalidRequest(error.to_string()))
+}
+
+fn validate_action_identity(
+    unit: &RuntimeUnitRecord,
+    request: &RuntimeActionRequest,
+) -> RuntimeResult<()> {
+    if request.unit_id != unit.spec.unit_id || request.generation != unit.spec.generation {
+        return Err(RuntimeError::InvalidRequest(
+            "Runtime action identity does not match its unit record".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn unknown_observation(current: &RuntimeObservation) -> RuntimeResult<RuntimeObservation> {
+    let mut unknown = current.clone();
+    unknown.state = RuntimeUnitState::Unknown;
+    unknown.observed_at_ms = unknown.observed_at_ms.max(now_ms());
+    unknown.finished_at_ms = None;
+    unknown.health = None;
+    unknown.outputs.clear();
+    unknown.failure = None;
+    unknown.validate().map_err(RuntimeError::Protocol)?;
+    Ok(unknown)
+}
+
+fn not_found(spec: &RuntimeUnitSpec) -> RuntimeInspection {
+    RuntimeInspection::NotFound {
+        schema: RuntimeInspection::SCHEMA.into(),
+        unit_id: spec.unit_id.clone(),
+        last_generation: Some(spec.generation),
+    }
+}

--- a/src/runtime/src/a3s_runtime_driver/lifecycle.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle.rs
@@ -134,13 +134,8 @@ impl BoxRuntimeDriver {
             record = self.load_record(&unit.spec, &execution_id).await?;
         }
 
-        self.observation(
-            &unit.spec,
-            &record,
-            Some(RuntimeUnitState::Stopped),
-            None,
-        )
-        .await
+        self.observation(&unit.spec, &record, Some(RuntimeUnitState::Stopped), None)
+            .await
     }
 
     pub(super) async fn remove_unit(
@@ -359,11 +354,7 @@ impl BoxRuntimeDriver {
         validate_record_for_spec(&remaining[0], spec)
     }
 
-    async fn retire_record(
-        &self,
-        mut record: BoxRecord,
-        unit_id: &str,
-    ) -> RuntimeResult<()> {
+    async fn retire_record(&self, mut record: BoxRecord, unit_id: &str) -> RuntimeResult<()> {
         let (execution_id, mut generation, mut state) = local_identity(&record)?;
         if matches!(
             state,

--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -1,0 +1,206 @@
+use a3s_box_core::ExecutionManager;
+use a3s_runtime::contract::{
+    RuntimeInspection, RuntimeUnitClass, RuntimeUnitState,
+};
+use a3s_runtime::RuntimeDriver;
+
+use super::metadata::GENERATION_LABEL;
+use super::test_support::{
+    accepted, action, fake_driver, fake_driver_with_backend, runtime_spec, unit, unknown,
+};
+
+#[tokio::test]
+async fn service_replay_reopens_the_same_identity_and_stop_remove_are_idempotent() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, backend) = fake_driver(&directory);
+    let spec = runtime_spec("service-replay", 1, RuntimeUnitClass::Service);
+
+    let running = driver.apply(&spec, &accepted(&spec)).await.unwrap();
+    assert_eq!(running.state, RuntimeUnitState::Running);
+    assert_eq!(backend.starts(), 1);
+    let provider_id = running.provider_resource_id.clone().unwrap();
+
+    let reopened = fake_driver_with_backend(&directory, backend.clone());
+    let replayed = reopened.apply(&spec, &running).await.unwrap();
+    assert_eq!(replayed.provider_resource_id.as_deref(), Some(provider_id.as_str()));
+    assert_eq!(backend.starts(), 1);
+    assert_eq!(reopened.manager.managed_records().await.unwrap().len(), 1);
+
+    let running_unit = unit(spec.clone(), replayed);
+    let stopped = reopened
+        .stop(&running_unit, &action("service-stop", &spec))
+        .await
+        .unwrap();
+    assert_eq!(stopped.state, RuntimeUnitState::Stopped);
+    assert_eq!(backend.kills(), 1);
+
+    let stopped_unit = unit(spec.clone(), stopped.clone());
+    let stop_replay = reopened
+        .stop(&stopped_unit, &action("service-stop-replay", &spec))
+        .await
+        .unwrap();
+    assert_eq!(stop_replay, stopped);
+    assert_eq!(backend.kills(), 1);
+
+    let removal = reopened
+        .remove(&stopped_unit, &action("service-remove", &spec))
+        .await
+        .unwrap();
+    assert!(!removal.already_absent);
+    let replayed_removal = reopened
+        .remove(&stopped_unit, &action("service-remove-replay", &spec))
+        .await
+        .unwrap();
+    assert!(replayed_removal.already_absent);
+    assert!(reopened.manager.managed_records().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn generation_handoff_leaves_exactly_one_current_execution() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, backend) = fake_driver(&directory);
+    let first = runtime_spec("generation-handoff", 1, RuntimeUnitClass::Service);
+    let first_running = driver.apply(&first, &accepted(&first)).await.unwrap();
+    let first_provider_id = first_running.provider_resource_id.unwrap();
+
+    let mut second = runtime_spec("generation-handoff", 2, RuntimeUnitClass::Service);
+    second.process.args = vec!["-c".into(), "echo generation-2".into()];
+    let second_running = driver.apply(&second, &accepted(&second)).await.unwrap();
+    let second_provider_id = second_running.provider_resource_id.clone().unwrap();
+    assert_ne!(second_provider_id, first_provider_id);
+    assert_eq!(backend.starts(), 2);
+
+    let records = driver.manager.managed_records().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].id, second_provider_id);
+    assert_eq!(
+        records[0].labels.get(GENERATION_LABEL).map(String::as_str),
+        Some("2")
+    );
+
+    let replayed = driver.apply(&second, &second_running).await.unwrap();
+    assert_eq!(replayed.provider_resource_id, second_running.provider_resource_id);
+    assert_eq!(backend.starts(), 2);
+    assert_eq!(driver.manager.managed_records().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn tasks_report_success_failure_and_timeout_with_terminal_evidence() {
+    let success_directory = tempfile::tempdir().unwrap();
+    let (success_driver, success_backend) = fake_driver(&success_directory);
+    let success_spec = runtime_spec("task-success", 1, RuntimeUnitClass::Task);
+    success_backend.finish_next_start(0);
+    let succeeded = success_driver
+        .apply(&success_spec, &accepted(&success_spec))
+        .await
+        .unwrap();
+    assert_eq!(succeeded.state, RuntimeUnitState::Succeeded);
+    assert!(succeeded.finished_at_ms.is_some());
+    assert!(succeeded.failure.is_none());
+
+    let failure_directory = tempfile::tempdir().unwrap();
+    let (failure_driver, failure_backend) = fake_driver(&failure_directory);
+    let failure_spec = runtime_spec("task-failure", 1, RuntimeUnitClass::Task);
+    failure_backend.finish_next_start(17);
+    let failed = failure_driver
+        .apply(&failure_spec, &accepted(&failure_spec))
+        .await
+        .unwrap();
+    assert_eq!(failed.state, RuntimeUnitState::Failed);
+    assert_eq!(failed.failure.as_ref().unwrap().code, "sandbox_exit");
+    assert!(failed.failure.as_ref().unwrap().message.contains("17"));
+
+    let timeout_directory = tempfile::tempdir().unwrap();
+    let (timeout_driver, timeout_backend) = fake_driver(&timeout_directory);
+    let mut timeout_spec = runtime_spec("task-timeout", 1, RuntimeUnitClass::Task);
+    timeout_spec.resources.execution_timeout_ms = Some(25);
+    let timed_out = timeout_driver
+        .apply(&timeout_spec, &accepted(&timeout_spec))
+        .await
+        .unwrap();
+    assert_eq!(timed_out.state, RuntimeUnitState::Failed);
+    assert_eq!(
+        timed_out.failure.as_ref().unwrap().code,
+        "execution_timeout"
+    );
+    assert!(!timed_out.failure.as_ref().unwrap().retryable);
+    assert_eq!(timeout_backend.kills(), 1);
+}
+
+#[tokio::test]
+async fn service_failure_restarts_the_same_durable_execution() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, backend) = fake_driver(&directory);
+    let spec = runtime_spec("service-restart", 1, RuntimeUnitClass::Service);
+    let running = driver.apply(&spec, &accepted(&spec)).await.unwrap();
+    let provider_id = running.provider_resource_id.clone().unwrap();
+    backend.finish(&provider_id, 9);
+
+    let inspection = driver
+        .inspect(&unit(spec.clone(), running))
+        .await
+        .unwrap();
+    let RuntimeInspection::Found { observation, .. } = inspection else {
+        panic!("restartable Service disappeared")
+    };
+    assert_eq!(observation.state, RuntimeUnitState::Running);
+    assert_eq!(observation.provider_resource_id.as_deref(), Some(provider_id.as_str()));
+    assert_eq!(backend.starts(), 2);
+    assert_eq!(driver.manager.managed_records().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn response_loss_reattaches_and_confirmed_provider_loss_replaces_once() {
+    let response_loss_directory = tempfile::tempdir().unwrap();
+    let (response_loss_driver, response_loss_backend) = fake_driver(&response_loss_directory);
+    let response_loss_spec =
+        runtime_spec("start-response-loss", 1, RuntimeUnitClass::Service);
+    response_loss_backend.fail_next_start_response();
+    let recovered = response_loss_driver
+        .apply(&response_loss_spec, &accepted(&response_loss_spec))
+        .await
+        .unwrap();
+    assert_eq!(recovered.state, RuntimeUnitState::Running);
+    assert_eq!(response_loss_backend.starts(), 1);
+    assert_eq!(
+        response_loss_driver
+            .manager
+            .managed_records()
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let loss_directory = tempfile::tempdir().unwrap();
+    let (loss_driver, loss_backend) = fake_driver(&loss_directory);
+    let loss_spec = runtime_spec("confirmed-provider-loss", 1, RuntimeUnitClass::Service);
+    let running = loss_driver
+        .apply(&loss_spec, &accepted(&loss_spec))
+        .await
+        .unwrap();
+    let lost_provider_id = running.provider_resource_id.clone().unwrap();
+    loss_backend.lose(&lost_provider_id);
+    let inspection = loss_driver
+        .inspect(&unit(loss_spec.clone(), running.clone()))
+        .await
+        .unwrap();
+    assert!(matches!(inspection, RuntimeInspection::NotFound { .. }));
+
+    let replacement = loss_driver
+        .apply(&loss_spec, &unknown(&running))
+        .await
+        .unwrap();
+    assert_eq!(replacement.state, RuntimeUnitState::Running);
+    assert_ne!(
+        replacement.provider_resource_id.as_deref(),
+        Some(lost_provider_id.as_str())
+    );
+    assert_eq!(loss_backend.starts(), 2);
+    assert_eq!(loss_driver.manager.managed_records().await.unwrap().len(), 1);
+
+    let replayed = loss_driver.apply(&loss_spec, &replacement).await.unwrap();
+    assert_eq!(replayed.provider_resource_id, replacement.provider_resource_id);
+    assert_eq!(loss_backend.starts(), 2);
+    assert_eq!(loss_driver.manager.managed_records().await.unwrap().len(), 1);
+}

--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -1,4 +1,3 @@
-use a3s_box_core::ExecutionManager;
 use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitClass, RuntimeUnitState};
 use a3s_runtime::RuntimeDriver;
 

--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -1,7 +1,5 @@
 use a3s_box_core::ExecutionManager;
-use a3s_runtime::contract::{
-    RuntimeInspection, RuntimeUnitClass, RuntimeUnitState,
-};
+use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitClass, RuntimeUnitState};
 use a3s_runtime::RuntimeDriver;
 
 use super::metadata::GENERATION_LABEL;
@@ -22,7 +20,10 @@ async fn service_replay_reopens_the_same_identity_and_stop_remove_are_idempotent
 
     let reopened = fake_driver_with_backend(&directory, backend.clone());
     let replayed = reopened.apply(&spec, &running).await.unwrap();
-    assert_eq!(replayed.provider_resource_id.as_deref(), Some(provider_id.as_str()));
+    assert_eq!(
+        replayed.provider_resource_id.as_deref(),
+        Some(provider_id.as_str())
+    );
     assert_eq!(backend.starts(), 1);
     assert_eq!(reopened.manager.managed_records().await.unwrap().len(), 1);
 
@@ -79,7 +80,10 @@ async fn generation_handoff_leaves_exactly_one_current_execution() {
     );
 
     let replayed = driver.apply(&second, &second_running).await.unwrap();
-    assert_eq!(replayed.provider_resource_id, second_running.provider_resource_id);
+    assert_eq!(
+        replayed.provider_resource_id,
+        second_running.provider_resource_id
+    );
     assert_eq!(backend.starts(), 2);
     assert_eq!(driver.manager.managed_records().await.unwrap().len(), 1);
 }
@@ -136,15 +140,15 @@ async fn service_failure_restarts_the_same_durable_execution() {
     let provider_id = running.provider_resource_id.clone().unwrap();
     backend.finish(&provider_id, 9);
 
-    let inspection = driver
-        .inspect(&unit(spec.clone(), running))
-        .await
-        .unwrap();
+    let inspection = driver.inspect(&unit(spec.clone(), running)).await.unwrap();
     let RuntimeInspection::Found { observation, .. } = inspection else {
         panic!("restartable Service disappeared")
     };
     assert_eq!(observation.state, RuntimeUnitState::Running);
-    assert_eq!(observation.provider_resource_id.as_deref(), Some(provider_id.as_str()));
+    assert_eq!(
+        observation.provider_resource_id.as_deref(),
+        Some(provider_id.as_str())
+    );
     assert_eq!(backend.starts(), 2);
     assert_eq!(driver.manager.managed_records().await.unwrap().len(), 1);
 }
@@ -153,8 +157,7 @@ async fn service_failure_restarts_the_same_durable_execution() {
 async fn response_loss_reattaches_and_confirmed_provider_loss_replaces_once() {
     let response_loss_directory = tempfile::tempdir().unwrap();
     let (response_loss_driver, response_loss_backend) = fake_driver(&response_loss_directory);
-    let response_loss_spec =
-        runtime_spec("start-response-loss", 1, RuntimeUnitClass::Service);
+    let response_loss_spec = runtime_spec("start-response-loss", 1, RuntimeUnitClass::Service);
     response_loss_backend.fail_next_start_response();
     let recovered = response_loss_driver
         .apply(&response_loss_spec, &accepted(&response_loss_spec))
@@ -197,10 +200,19 @@ async fn response_loss_reattaches_and_confirmed_provider_loss_replaces_once() {
         Some(lost_provider_id.as_str())
     );
     assert_eq!(loss_backend.starts(), 2);
-    assert_eq!(loss_driver.manager.managed_records().await.unwrap().len(), 1);
+    assert_eq!(
+        loss_driver.manager.managed_records().await.unwrap().len(),
+        1
+    );
 
     let replayed = loss_driver.apply(&loss_spec, &replacement).await.unwrap();
-    assert_eq!(replayed.provider_resource_id, replacement.provider_resource_id);
+    assert_eq!(
+        replayed.provider_resource_id,
+        replacement.provider_resource_id
+    );
     assert_eq!(loss_backend.starts(), 2);
-    assert_eq!(loss_driver.manager.managed_records().await.unwrap().len(), 1);
+    assert_eq!(
+        loss_driver.manager.managed_records().await.unwrap().len(),
+        1
+    );
 }

--- a/src/runtime/src/a3s_runtime_driver/logs.rs
+++ b/src/runtime/src/a3s_runtime_driver/logs.rs
@@ -1,9 +1,7 @@
 //! Ordered Runtime log cursors over Box's structured json-file projection.
 
 use a3s_box_core::ExecutionManager;
-use a3s_runtime::contract::{
-    RuntimeLogChunk, RuntimeLogQuery, RuntimeLogStream,
-};
+use a3s_runtime::contract::{RuntimeLogChunk, RuntimeLogQuery, RuntimeLogStream};
 use a3s_runtime::{RuntimeError, RuntimeResult, RuntimeUnitRecord};
 use chrono::DateTime;
 use sha2::{Digest, Sha256};
@@ -25,12 +23,12 @@ impl BoxRuntimeDriver {
                 "Runtime log query identity does not match its unit record".into(),
             ));
         }
-        let record = self
-            .find_generation(&unit.spec)
-            .await?
-            .ok_or_else(|| RuntimeError::NotFound {
-                unit_id: unit.spec.unit_id.clone(),
-            })?;
+        let record =
+            self.find_generation(&unit.spec)
+                .await?
+                .ok_or_else(|| RuntimeError::NotFound {
+                    unit_id: unit.spec.unit_id.clone(),
+                })?;
         provider_identity_matches(&unit.observation, &record)?;
         let (execution_id, local_generation, _) = local_identity(&record)?;
         let entries = self
@@ -46,11 +44,7 @@ fn project_logs(
     entries: Vec<a3s_box_core::log::LogEntry>,
     query: &RuntimeLogQuery,
 ) -> RuntimeResult<Vec<RuntimeLogChunk>> {
-    let requested_cursor = query
-        .cursor
-        .as_deref()
-        .map(LogCursor::parse)
-        .transpose()?;
+    let requested_cursor = query.cursor.as_deref().map(LogCursor::parse).transpose()?;
     if requested_cursor
         .as_ref()
         .is_some_and(|cursor| cursor.generation != query.generation)

--- a/src/runtime/src/a3s_runtime_driver/logs.rs
+++ b/src/runtime/src/a3s_runtime_driver/logs.rs
@@ -1,0 +1,325 @@
+//! Ordered Runtime log cursors over Box's structured json-file projection.
+
+use a3s_box_core::ExecutionManager;
+use a3s_runtime::contract::{
+    RuntimeLogChunk, RuntimeLogQuery, RuntimeLogStream,
+};
+use a3s_runtime::{RuntimeError, RuntimeResult, RuntimeUnitRecord};
+use chrono::DateTime;
+use sha2::{Digest, Sha256};
+
+use super::metadata::{local_identity, map_execution_error, provider_identity_matches};
+use super::BoxRuntimeDriver;
+
+const RECORDS_PER_SECOND: u64 = 1_000_000;
+
+impl BoxRuntimeDriver {
+    pub(super) async fn read_runtime_logs(
+        &self,
+        unit: &RuntimeUnitRecord,
+        query: &RuntimeLogQuery,
+    ) -> RuntimeResult<Vec<RuntimeLogChunk>> {
+        query.validate().map_err(RuntimeError::InvalidRequest)?;
+        if query.unit_id != unit.spec.unit_id || query.generation != unit.spec.generation {
+            return Err(RuntimeError::InvalidRequest(
+                "Runtime log query identity does not match its unit record".into(),
+            ));
+        }
+        let record = self
+            .find_generation(&unit.spec)
+            .await?
+            .ok_or_else(|| RuntimeError::NotFound {
+                unit_id: unit.spec.unit_id.clone(),
+            })?;
+        provider_identity_matches(&unit.observation, &record)?;
+        let (execution_id, local_generation, _) = local_identity(&record)?;
+        let entries = self
+            .manager
+            .read_logs(&execution_id, local_generation)
+            .await
+            .map_err(|error| map_execution_error(&unit.spec.unit_id, error))?;
+        project_logs(entries, query)
+    }
+}
+
+fn project_logs(
+    entries: Vec<a3s_box_core::log::LogEntry>,
+    query: &RuntimeLogQuery,
+) -> RuntimeResult<Vec<RuntimeLogChunk>> {
+    let requested_cursor = query
+        .cursor
+        .as_deref()
+        .map(LogCursor::parse)
+        .transpose()?;
+    if requested_cursor
+        .as_ref()
+        .is_some_and(|cursor| cursor.generation != query.generation)
+    {
+        return Err(RuntimeError::InvalidRequest(
+            "Box log cursor belongs to another Runtime generation".into(),
+        ));
+    }
+    let target = requested_cursor.as_ref().map(LogCursor::encode);
+    let mut cursor_found = target.is_none();
+    let mut chunks = Vec::with_capacity(query.limit as usize);
+    let mut prior_timestamp = None;
+    let mut current_second = None;
+    let mut ordinal = 0_u64;
+
+    for entry in entries {
+        let stream = match entry.stream.as_str() {
+            "stdout" => RuntimeLogStream::Stdout,
+            "stderr" => RuntimeLogStream::Stderr,
+            value => {
+                return Err(RuntimeError::Protocol(format!(
+                    "Box structured log contains unsupported stream {value:?}"
+                )))
+            }
+        };
+        if entry.log.len() > 1024 * 1024 {
+            return Err(RuntimeError::Protocol(
+                "Box log record exceeds the Runtime one-MiB chunk bound".into(),
+            ));
+        }
+        let timestamp_ns = DateTime::parse_from_rfc3339(&entry.time)
+            .map_err(|_| RuntimeError::Protocol("Box log timestamp is invalid".into()))?
+            .timestamp_nanos_opt()
+            .ok_or_else(|| RuntimeError::Protocol("Box log timestamp is out of range".into()))?;
+        if prior_timestamp.is_some_and(|prior| timestamp_ns < prior) {
+            return Err(RuntimeError::Protocol(
+                "Box log records are not ordered by provider timestamp".into(),
+            ));
+        }
+        prior_timestamp = Some(timestamp_ns);
+        let second = timestamp_ns.div_euclid(1_000_000_000);
+        if current_second != Some(second) {
+            current_second = Some(second);
+            ordinal = 0;
+        }
+        if ordinal >= RECORDS_PER_SECOND {
+            return Err(RuntimeError::Protocol(
+                "Box emitted more than one million log records in one second".into(),
+            ));
+        }
+        let raw = RawLogRecord {
+            generation: query.generation,
+            timestamp_ns,
+            ordinal,
+            stream,
+            data: entry.log,
+        };
+        ordinal += 1;
+        let cursor = LogCursor::new(&raw).encode();
+        let sequence = log_sequence(second, ordinal)?;
+
+        if !cursor_found {
+            if target.as_deref() == Some(cursor.as_str()) {
+                cursor_found = true;
+            }
+            continue;
+        }
+        if query.stream.is_some_and(|requested| requested != stream) {
+            continue;
+        }
+        let observed_at_ms = u64::try_from(timestamp_ns.div_euclid(1_000_000))
+            .map_err(|_| RuntimeError::Protocol("Box log timestamp precedes the epoch".into()))?;
+        let chunk = RuntimeLogChunk {
+            schema: RuntimeLogChunk::SCHEMA.into(),
+            cursor,
+            sequence,
+            observed_at_ms,
+            stream,
+            data: raw.data,
+        };
+        chunk.validate().map_err(RuntimeError::Protocol)?;
+        chunks.push(chunk);
+        if chunks.len() == query.limit as usize {
+            break;
+        }
+    }
+
+    if !cursor_found {
+        return Err(RuntimeError::Protocol(
+            "Box log cursor is no longer available; the stream contains an explicit rotation gap"
+                .into(),
+        ));
+    }
+    if chunks
+        .windows(2)
+        .any(|pair| pair[0].sequence >= pair[1].sequence)
+    {
+        return Err(RuntimeError::Protocol(
+            "Box log projection produced unordered Runtime chunks".into(),
+        ));
+    }
+    Ok(chunks)
+}
+
+struct RawLogRecord {
+    generation: u64,
+    timestamp_ns: i64,
+    ordinal: u64,
+    stream: RuntimeLogStream,
+    data: String,
+}
+
+struct LogCursor {
+    generation: u64,
+    timestamp_ns: i64,
+    ordinal: u64,
+    stream: RuntimeLogStream,
+    digest: String,
+}
+
+impl LogCursor {
+    fn new(record: &RawLogRecord) -> Self {
+        let mut hash = Sha256::new();
+        hash.update(b"a3s-box-log-cursor-v1\0");
+        hash.update(record.generation.to_be_bytes());
+        hash.update(record.timestamp_ns.to_be_bytes());
+        hash.update(record.ordinal.to_be_bytes());
+        hash.update(match record.stream {
+            RuntimeLogStream::Stdout => b"stdout".as_slice(),
+            RuntimeLogStream::Stderr => b"stderr".as_slice(),
+        });
+        hash.update(record.data.as_bytes());
+        let digest = format!("{:x}", hash.finalize());
+        Self {
+            generation: record.generation,
+            timestamp_ns: record.timestamp_ns,
+            ordinal: record.ordinal,
+            stream: record.stream,
+            digest: digest[..16].into(),
+        }
+    }
+
+    fn parse(value: &str) -> RuntimeResult<Self> {
+        let fields = value.split(':').collect::<Vec<_>>();
+        if fields.len() != 6 || fields[0] != "v1" {
+            return Err(RuntimeError::InvalidRequest(
+                "invalid Box log cursor".into(),
+            ));
+        }
+        let generation = fields[1]
+            .parse::<u64>()
+            .ok()
+            .filter(|value| *value > 0)
+            .ok_or_else(|| RuntimeError::InvalidRequest("invalid Box log cursor".into()))?;
+        let timestamp_ns = fields[2]
+            .parse::<i64>()
+            .map_err(|_| RuntimeError::InvalidRequest("invalid Box log cursor".into()))?;
+        let ordinal = fields[3]
+            .parse::<u64>()
+            .map_err(|_| RuntimeError::InvalidRequest("invalid Box log cursor".into()))?;
+        if ordinal >= RECORDS_PER_SECOND {
+            return Err(RuntimeError::InvalidRequest(
+                "invalid Box log cursor".into(),
+            ));
+        }
+        let stream = match fields[4] {
+            "o" => RuntimeLogStream::Stdout,
+            "e" => RuntimeLogStream::Stderr,
+            _ => {
+                return Err(RuntimeError::InvalidRequest(
+                    "invalid Box log cursor".into(),
+                ))
+            }
+        };
+        let digest = fields[5];
+        if digest.len() != 16 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(RuntimeError::InvalidRequest(
+                "invalid Box log cursor".into(),
+            ));
+        }
+        Ok(Self {
+            generation,
+            timestamp_ns,
+            ordinal,
+            stream,
+            digest: digest.into(),
+        })
+    }
+
+    fn encode(&self) -> String {
+        let stream = match self.stream {
+            RuntimeLogStream::Stdout => "o",
+            RuntimeLogStream::Stderr => "e",
+        };
+        format!(
+            "v1:{}:{}:{}:{stream}:{}",
+            self.generation, self.timestamp_ns, self.ordinal, self.digest
+        )
+    }
+}
+
+fn log_sequence(second: i64, ordinal_after_increment: u64) -> RuntimeResult<u64> {
+    u64::try_from(second)
+        .ok()
+        .and_then(|second| second.checked_mul(RECORDS_PER_SECOND))
+        .and_then(|base| base.checked_add(ordinal_after_increment))
+        .ok_or_else(|| RuntimeError::Protocol("Box log sequence overflowed".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use a3s_box_core::log::LogEntry;
+
+    use super::*;
+
+    fn query(cursor: Option<String>, stream: Option<RuntimeLogStream>) -> RuntimeLogQuery {
+        RuntimeLogQuery {
+            schema: RuntimeLogQuery::SCHEMA.into(),
+            unit_id: "unit-1".into(),
+            generation: 7,
+            cursor,
+            limit: 10,
+            stream,
+        }
+    }
+
+    #[test]
+    fn cursor_resume_preserves_same_timestamp_total_order_and_filtering() {
+        let entries = vec![
+            LogEntry {
+                log: "first\n".into(),
+                stream: "stdout".into(),
+                time: "2026-07-17T00:00:00.123456789Z".into(),
+            },
+            LogEntry {
+                log: "second\n".into(),
+                stream: "stderr".into(),
+                time: "2026-07-17T00:00:00.123456789Z".into(),
+            },
+            LogEntry {
+                log: "third\n".into(),
+                stream: "stdout".into(),
+                time: "2026-07-17T00:00:01Z".into(),
+            },
+        ];
+        let all = project_logs(entries.clone(), &query(None, None)).unwrap();
+        assert_eq!(all.len(), 3);
+        assert!(all[0].sequence < all[1].sequence && all[1].sequence < all[2].sequence);
+
+        let resumed = project_logs(
+            entries,
+            &query(Some(all[0].cursor.clone()), Some(RuntimeLogStream::Stdout)),
+        )
+        .unwrap();
+        assert_eq!(resumed.len(), 1);
+        assert_eq!(resumed[0].data, "third\n");
+    }
+
+    #[test]
+    fn missing_valid_cursor_reports_an_explicit_gap() {
+        let cursor = LogCursor {
+            generation: 7,
+            timestamp_ns: 1,
+            ordinal: 0,
+            stream: RuntimeLogStream::Stdout,
+            digest: "0123456789abcdef".into(),
+        }
+        .encode();
+        let error = project_logs(Vec::new(), &query(Some(cursor), None)).unwrap_err();
+        assert!(error.to_string().contains("rotation gap"));
+    }
+}

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -2,9 +2,10 @@
 
 use std::collections::BTreeMap;
 
+use a3s_box_core::log::LogConfig;
 use a3s_box_core::{
     BoxConfig, CreateExecutionRequest, ExecutionIsolation, ExecutionRecordPolicy,
-    ExecutionRestartPolicy, LogConfig, NetworkMode, ResourceConfig, ResourceLimits,
+    ExecutionRestartPolicy, NetworkMode, ResourceConfig, ResourceLimits,
 };
 use a3s_runtime::contract::{ArtifactRef, RestartPolicy, RuntimeUnitClass, RuntimeUnitSpec};
 use a3s_runtime::{RuntimeError, RuntimeResult};

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -1,0 +1,201 @@
+//! Lossless Runtime protocol to Box Sandbox creation mapping.
+
+use std::collections::BTreeMap;
+
+use a3s_box_core::{
+    BoxConfig, CreateExecutionRequest, ExecutionIsolation, ExecutionRecordPolicy,
+    ExecutionRestartPolicy, LogConfig, NetworkMode, ResourceConfig, ResourceLimits,
+};
+use a3s_runtime::contract::{
+    ArtifactRef, RestartPolicy, RuntimeUnitClass, RuntimeUnitSpec,
+};
+use a3s_runtime::{RuntimeError, RuntimeResult};
+use url::Position;
+
+use super::metadata::{managed_labels, operation_id};
+use super::{DOCKER_IMAGE_MANIFEST, OCI_IMAGE_MANIFEST};
+
+const CPU_PERIOD_US: u64 = 100_000;
+const BYTES_PER_MIB: u64 = 1024 * 1024;
+
+pub(super) fn creation_request(spec: &RuntimeUnitSpec) -> RuntimeResult<CreateExecutionRequest> {
+    spec.validate().map_err(RuntimeError::InvalidRequest)?;
+    validate_supported_shape(spec)?;
+    let spec_digest = spec.digest().map_err(RuntimeError::InvalidRequest)?;
+    let memory_mb = spec.resources.memory_bytes.div_ceil(BYTES_PER_MIB);
+    let memory_mb = u32::try_from(memory_mb).map_err(|_| {
+        RuntimeError::InvalidRequest("Box Sandbox memory limit exceeds u32 MiB metadata".into())
+    })?;
+    let vcpus = u32::try_from(spec.resources.cpu_millis.div_ceil(1_000)).map_err(|_| {
+        RuntimeError::InvalidRequest("Box Sandbox CPU limit exceeds u32 vCPUs".into())
+    })?;
+    let cpu_quota = spec
+        .resources
+        .cpu_millis
+        .checked_mul(CPU_PERIOD_US / 1_000)
+        .and_then(|value| i64::try_from(value).ok())
+        .ok_or_else(|| RuntimeError::InvalidRequest("Box Sandbox CPU quota overflows i64".into()))?;
+    let memory_swap = i64::try_from(spec.resources.memory_bytes).map_err(|_| {
+        RuntimeError::InvalidRequest("Box Sandbox memory limit overflows i64".into())
+    })?;
+    let task_timeout_secs = spec
+        .resources
+        .execution_timeout_ms
+        .map(|milliseconds| milliseconds.div_ceil(1_000));
+    let (entrypoint_override, cmd) = if spec.process.command.is_empty() {
+        (None, spec.process.args.clone())
+    } else {
+        (Some(spec.process.command.clone()), spec.process.args.clone())
+    };
+
+    let config = BoxConfig {
+        image: image_reference(&spec.artifact)?,
+        isolation: ExecutionIsolation::Sandbox,
+        resources: ResourceConfig {
+            vcpus,
+            memory_mb,
+            disk_mb: BoxConfig::default().resources.disk_mb,
+            timeout: task_timeout_secs.unwrap_or(0),
+        },
+        cmd,
+        entrypoint_override,
+        workdir: spec.process.working_directory.clone(),
+        extra_env: spec
+            .process
+            .environment
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+        network: NetworkMode::None,
+        resource_limits: ResourceLimits {
+            pids_limit: Some(u64::from(spec.resources.pids)),
+            cpu_quota: Some(cpu_quota),
+            cpu_period: Some(CPU_PERIOD_US),
+            memory_swap: Some(memory_swap),
+            sandbox_memory_limit_bytes: Some(spec.resources.memory_bytes),
+            ..Default::default()
+        },
+        persistent: true,
+        cap_drop: vec!["ALL".into()],
+        security_opt: vec!["no-new-privileges".into()],
+        ..Default::default()
+    };
+
+    Ok(CreateExecutionRequest {
+        external_sandbox_id: format!("{}:{}", spec.unit_id, spec.generation),
+        config,
+        labels: managed_labels(spec, &spec_digest),
+        policy: ExecutionRecordPolicy {
+            auto_remove: false,
+            restart_policy: ExecutionRestartPolicy::No,
+            log_config: LogConfig::default(),
+            init: true,
+            ..Default::default()
+        },
+        rootfs_snapshot_id: None,
+    })
+}
+
+pub(super) fn operation(spec: &RuntimeUnitSpec) -> RuntimeResult<a3s_box_core::OperationId> {
+    operation_id(
+        &spec.unit_id,
+        spec.generation,
+        &spec.digest().map_err(RuntimeError::InvalidRequest)?,
+    )
+}
+
+fn validate_supported_shape(spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+    if !matches!(
+        spec.artifact.media_type.as_str(),
+        OCI_IMAGE_MANIFEST | DOCKER_IMAGE_MANIFEST
+    ) {
+        return Err(RuntimeError::UnsupportedCapabilities(vec![format!(
+            "artifact_media_type:{}",
+            spec.artifact.media_type
+        )]));
+    }
+    if spec.isolation != a3s_runtime::contract::IsolationLevel::Sandbox {
+        return Err(RuntimeError::UnsupportedCapabilities(vec![format!(
+            "isolation:{:?}",
+            spec.isolation
+        )]));
+    }
+    if spec.network.mode != a3s_runtime::contract::NetworkMode::None {
+        return Err(RuntimeError::UnsupportedCapabilities(vec![format!(
+            "network_mode:{:?}",
+            spec.network.mode
+        )]));
+    }
+    if !spec.mounts.is_empty() {
+        return Err(RuntimeError::UnsupportedCapabilities(vec![
+            "mounts are not supported by the Box Runtime driver".into(),
+        ]));
+    }
+    if spec.health.is_some() {
+        return Err(RuntimeError::UnsupportedCapabilities(vec![
+            "health checks are not supported by the Box Runtime driver".into(),
+        ]));
+    }
+    if !spec.secrets.is_empty() {
+        return Err(RuntimeError::UnsupportedCapabilities(vec![
+            "feature:SecretReferences".into(),
+        ]));
+    }
+    if !spec.outputs.is_empty() {
+        return Err(RuntimeError::UnsupportedCapabilities(vec![
+            "feature:OutputArtifacts".into(),
+        ]));
+    }
+    if spec.resources.ephemeral_storage_bytes.is_some() {
+        return Err(RuntimeError::UnsupportedCapabilities(vec![
+            "resource_control:EphemeralStorage".into(),
+        ]));
+    }
+    match (&spec.class, &spec.restart) {
+        (RuntimeUnitClass::Task, RestartPolicy::Never | RestartPolicy::OnFailure { .. })
+        | (RuntimeUnitClass::Service, _) => Ok(()),
+        (RuntimeUnitClass::Task, RestartPolicy::Always) => Err(RuntimeError::InvalidRequest(
+            "Runtime Tasks cannot use an always restart policy".into(),
+        )),
+    }
+}
+
+fn image_reference(artifact: &ArtifactRef) -> RuntimeResult<String> {
+    artifact.validate().map_err(RuntimeError::InvalidRequest)?;
+    let parsed = url::Url::parse(&artifact.uri)
+        .map_err(|error| RuntimeError::InvalidRequest(error.to_string()))?;
+    if parsed.scheme() != "oci"
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || parsed.path().contains('%')
+    {
+        return Err(RuntimeError::InvalidRequest(
+            "Box artifacts require a credential-free canonical oci:// URI".into(),
+        ));
+    }
+    let authority = &parsed[Position::BeforeHost..Position::AfterPort];
+    if authority.is_empty() || parsed.path() == "/" {
+        return Err(RuntimeError::InvalidRequest(
+            "Box artifact URI requires a registry and repository path".into(),
+        ));
+    }
+    let image = format!("{authority}{}", parsed.path());
+    let expected_suffix = format!("@{}", artifact.digest);
+    if !image.ends_with(&expected_suffix) || image.matches('@').count() != 1 {
+        return Err(RuntimeError::InvalidRequest(
+            "Box artifact URI must end with its authoritative digest".into(),
+        ));
+    }
+    Ok(image)
+}
+
+pub(super) fn labels_as_hash_map(
+    labels: &BTreeMap<String, String>,
+) -> std::collections::HashMap<String, String> {
+    labels
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -6,9 +6,7 @@ use a3s_box_core::{
     BoxConfig, CreateExecutionRequest, ExecutionIsolation, ExecutionRecordPolicy,
     ExecutionRestartPolicy, LogConfig, NetworkMode, ResourceConfig, ResourceLimits,
 };
-use a3s_runtime::contract::{
-    ArtifactRef, RestartPolicy, RuntimeUnitClass, RuntimeUnitSpec,
-};
+use a3s_runtime::contract::{ArtifactRef, RestartPolicy, RuntimeUnitClass, RuntimeUnitSpec};
 use a3s_runtime::{RuntimeError, RuntimeResult};
 use url::Position;
 
@@ -34,7 +32,9 @@ pub(super) fn creation_request(spec: &RuntimeUnitSpec) -> RuntimeResult<CreateEx
         .cpu_millis
         .checked_mul(CPU_PERIOD_US / 1_000)
         .and_then(|value| i64::try_from(value).ok())
-        .ok_or_else(|| RuntimeError::InvalidRequest("Box Sandbox CPU quota overflows i64".into()))?;
+        .ok_or_else(|| {
+            RuntimeError::InvalidRequest("Box Sandbox CPU quota overflows i64".into())
+        })?;
     let memory_swap = i64::try_from(spec.resources.memory_bytes).map_err(|_| {
         RuntimeError::InvalidRequest("Box Sandbox memory limit overflows i64".into())
     })?;
@@ -45,7 +45,10 @@ pub(super) fn creation_request(spec: &RuntimeUnitSpec) -> RuntimeResult<CreateEx
     let (entrypoint_override, cmd) = if spec.process.command.is_empty() {
         (None, spec.process.args.clone())
     } else {
-        (Some(spec.process.command.clone()), spec.process.args.clone())
+        (
+            Some(spec.process.command.clone()),
+            spec.process.args.clone(),
+        )
     };
 
     let config = BoxConfig {

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -1,13 +1,16 @@
 //! Lossless Runtime protocol to Box Sandbox creation mapping.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use a3s_box_core::log::LogConfig;
 use a3s_box_core::{
     BoxConfig, CreateExecutionRequest, ExecutionIsolation, ExecutionRecordPolicy,
     ExecutionRestartPolicy, NetworkMode, ResourceConfig, ResourceLimits,
 };
-use a3s_runtime::contract::{ArtifactRef, RestartPolicy, RuntimeUnitClass, RuntimeUnitSpec};
+use a3s_runtime::contract::{
+    ArtifactRef, MountKind, RestartPolicy, RuntimeMountSource, RuntimeUnitClass, RuntimeUnitSpec,
+};
 use a3s_runtime::{RuntimeError, RuntimeResult};
 use url::Position;
 
@@ -19,6 +22,7 @@ const BYTES_PER_MIB: u64 = 1024 * 1024;
 
 pub(super) fn creation_request(spec: &RuntimeUnitSpec) -> RuntimeResult<CreateExecutionRequest> {
     spec.validate().map_err(RuntimeError::InvalidRequest)?;
+    validate_provider_unit_id(&spec.unit_id)?;
     validate_supported_shape(spec)?;
     let spec_digest = spec.digest().map_err(RuntimeError::InvalidRequest)?;
     let memory_mb = spec.resources.memory_bytes.div_ceil(BYTES_PER_MIB);
@@ -51,6 +55,7 @@ pub(super) fn creation_request(spec: &RuntimeUnitSpec) -> RuntimeResult<CreateEx
             spec.process.args.clone(),
         )
     };
+    let tmpfs = compile_tmpfs_mounts(spec)?;
 
     let config = BoxConfig {
         image: image_reference(&spec.artifact)?,
@@ -71,6 +76,7 @@ pub(super) fn creation_request(spec: &RuntimeUnitSpec) -> RuntimeResult<CreateEx
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect(),
         network: NetworkMode::None,
+        tmpfs,
         resource_limits: ResourceLimits {
             pids_limit: Some(u64::from(spec.resources.pids)),
             cpu_quota: Some(cpu_quota),
@@ -130,10 +136,19 @@ fn validate_supported_shape(spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
             spec.network.mode
         )]));
     }
-    if !spec.mounts.is_empty() {
-        return Err(RuntimeError::UnsupportedCapabilities(vec![
-            "mounts are not supported by the Box Runtime driver".into(),
-        ]));
+    let unsupported_mount_kinds = spec
+        .mounts
+        .iter()
+        .map(|mount| mount.source.kind())
+        .filter(|kind| *kind != MountKind::Tmpfs)
+        .collect::<std::collections::BTreeSet<_>>();
+    if !unsupported_mount_kinds.is_empty() {
+        return Err(RuntimeError::UnsupportedCapabilities(
+            unsupported_mount_kinds
+                .into_iter()
+                .map(|kind| format!("mount_kind:{kind:?}"))
+                .collect(),
+        ));
     }
     if spec.health.is_some() {
         return Err(RuntimeError::UnsupportedCapabilities(vec![
@@ -162,6 +177,69 @@ fn validate_supported_shape(spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
             "Runtime Tasks cannot use an always restart policy".into(),
         )),
     }
+}
+
+fn validate_provider_unit_id(unit_id: &str) -> RuntimeResult<()> {
+    if unit_id
+        .split(['/', '\\'])
+        .any(|segment| segment.is_empty() || matches!(segment, "." | ".."))
+    {
+        return Err(RuntimeError::InvalidRequest(format!(
+            "Box Runtime unit identity must not contain path traversal: {unit_id:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn compile_tmpfs_mounts(spec: &RuntimeUnitSpec) -> RuntimeResult<Vec<String>> {
+    spec.mounts
+        .iter()
+        .map(|mount| {
+            let RuntimeMountSource::Tmpfs { size_bytes } = &mount.source else {
+                return Err(RuntimeError::Protocol(
+                    "Box tmpfs compilation received an unsupported mount kind".into(),
+                ));
+            };
+            validate_tmpfs_target(&mount.target)?;
+            Ok(format!(
+                "{}:size={size_bytes},{}",
+                mount.target,
+                if mount.read_only { "ro" } else { "rw" }
+            ))
+        })
+        .collect()
+}
+
+fn validate_tmpfs_target(target: &str) -> RuntimeResult<()> {
+    let path = Path::new(target);
+    let normalized = target.strip_prefix('/').is_some_and(|relative| {
+        !relative.is_empty()
+            && relative
+                .split('/')
+                .all(|segment| !segment.is_empty() && !matches!(segment, "." | ".."))
+    });
+    if !normalized || target.contains(':') {
+        return Err(RuntimeError::InvalidRequest(format!(
+            "Box Sandbox tmpfs target must be an encodable normalized absolute path: {target:?}"
+        )));
+    }
+    let is_or_below = |root: &Path| {
+        path == root
+            || path
+                .strip_prefix(root)
+                .is_ok_and(|suffix| !suffix.as_os_str().is_empty())
+    };
+    let protected = path == Path::new("/")
+        || is_or_below(Path::new("/proc"))
+        || is_or_below(Path::new("/sys"))
+        || (is_or_below(Path::new("/dev")) && path != Path::new("/dev/shm"))
+        || is_or_below(Path::new("/run/a3s-box"));
+    if protected {
+        return Err(RuntimeError::InvalidRequest(format!(
+            "Box Sandbox tmpfs target is protected: {target:?}"
+        )));
+    }
+    Ok(())
 }
 
 fn image_reference(artifact: &ArtifactRef) -> RuntimeResult<String> {

--- a/src/runtime/src/a3s_runtime_driver/metadata.rs
+++ b/src/runtime/src/a3s_runtime_driver/metadata.rs
@@ -62,8 +62,7 @@ impl BoxRuntimeDriver {
             .into_iter()
             .filter(|record| {
                 record.labels.get(UNIT_LABEL) == Some(&spec.unit_id)
-                    && record.labels.get(GENERATION_LABEL)
-                        == Some(&spec.generation.to_string())
+                    && record.labels.get(GENERATION_LABEL) == Some(&spec.generation.to_string())
             })
             .collect::<Vec<_>>();
         if matches.len() > 1 {
@@ -87,7 +86,12 @@ impl BoxRuntimeDriver {
             .map_err(|error| map_execution_error(unit_id, error))?;
         let mut matches = records
             .into_iter()
-            .filter(|record| record.labels.get(UNIT_LABEL).is_some_and(|value| value == unit_id))
+            .filter(|record| {
+                record
+                    .labels
+                    .get(UNIT_LABEL)
+                    .is_some_and(|value| value == unit_id)
+            })
             .collect::<Vec<_>>();
         for record in &matches {
             validate_owned_record(record, unit_id)?;
@@ -185,7 +189,9 @@ pub(super) fn local_identity(
     let state = record
         .managed_state()
         .map_err(|error| RuntimeError::Protocol(error.to_string()))?
-        .ok_or_else(|| RuntimeError::Protocol(format!("Box execution {} is unmanaged", record.id)))?;
+        .ok_or_else(|| {
+            RuntimeError::Protocol(format!("Box execution {} is unmanaged", record.id))
+        })?;
     Ok((execution_id, metadata.generation, state))
 }
 

--- a/src/runtime/src/a3s_runtime_driver/metadata.rs
+++ b/src/runtime/src/a3s_runtime_driver/metadata.rs
@@ -1,0 +1,243 @@
+//! Stable provider ownership metadata and fail-closed record discovery.
+
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use a3s_box_core::{ExecutionGeneration, ExecutionId, OperationId};
+use a3s_runtime::contract::{RuntimeObservation, RuntimeUnitSpec, RuntimeUnitState};
+use a3s_runtime::{RuntimeError, RuntimeResult};
+use sha2::{Digest, Sha256};
+
+use crate::{BoxRecord, ManagedExecutionState};
+
+use super::mapping::{creation_request, labels_as_hash_map};
+use super::BoxRuntimeDriver;
+
+pub(super) const MANAGED_LABEL: &str = "a3s.runtime.managed";
+pub(super) const PROVIDER_LABEL: &str = "a3s.runtime.provider";
+pub(super) const UNIT_LABEL: &str = "a3s.runtime.unit-id";
+pub(super) const GENERATION_LABEL: &str = "a3s.runtime.generation";
+pub(super) const SPEC_DIGEST_LABEL: &str = "a3s.runtime.spec-digest";
+const PROVIDER_VALUE: &str = "a3s-box";
+
+pub(super) fn managed_labels(
+    spec: &RuntimeUnitSpec,
+    spec_digest: &str,
+) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (MANAGED_LABEL.into(), "true".into()),
+        (PROVIDER_LABEL.into(), PROVIDER_VALUE.into()),
+        (UNIT_LABEL.into(), spec.unit_id.clone()),
+        (GENERATION_LABEL.into(), spec.generation.to_string()),
+        (SPEC_DIGEST_LABEL.into(), spec_digest.into()),
+    ])
+}
+
+pub(super) fn operation_id(
+    unit_id: &str,
+    generation: u64,
+    spec_digest: &str,
+) -> RuntimeResult<OperationId> {
+    let mut digest = Sha256::new();
+    digest.update(b"a3s-box-runtime-operation-v1\0");
+    digest.update((unit_id.len() as u64).to_be_bytes());
+    digest.update(unit_id.as_bytes());
+    digest.update(generation.to_be_bytes());
+    digest.update(spec_digest.as_bytes());
+    OperationId::new(format!("a3s-runtime-box-v1:{:x}", digest.finalize()))
+        .map_err(|error| RuntimeError::InvalidRequest(error.to_string()))
+}
+
+impl BoxRuntimeDriver {
+    pub(super) async fn find_generation(
+        &self,
+        spec: &RuntimeUnitSpec,
+    ) -> RuntimeResult<Option<BoxRecord>> {
+        let records = self
+            .manager
+            .managed_records()
+            .await
+            .map_err(|error| map_execution_error(&spec.unit_id, error))?;
+        let matches = records
+            .into_iter()
+            .filter(|record| {
+                record.labels.get(UNIT_LABEL) == Some(&spec.unit_id)
+                    && record.labels.get(GENERATION_LABEL)
+                        == Some(&spec.generation.to_string())
+            })
+            .collect::<Vec<_>>();
+        if matches.len() > 1 {
+            return Err(RuntimeError::Protocol(format!(
+                "Box has multiple managed executions for unit {:?} generation {}",
+                spec.unit_id, spec.generation
+            )));
+        }
+        let Some(record) = matches.into_iter().next() else {
+            return Ok(None);
+        };
+        validate_record_for_spec(&record, spec)?;
+        Ok(Some(record))
+    }
+
+    pub(super) async fn unit_records(&self, unit_id: &str) -> RuntimeResult<Vec<BoxRecord>> {
+        let records = self
+            .manager
+            .managed_records()
+            .await
+            .map_err(|error| map_execution_error(unit_id, error))?;
+        let mut matches = records
+            .into_iter()
+            .filter(|record| record.labels.get(UNIT_LABEL).is_some_and(|value| value == unit_id))
+            .collect::<Vec<_>>();
+        for record in &matches {
+            validate_owned_record(record, unit_id)?;
+        }
+        matches.sort_by(|left, right| left.id.cmp(&right.id));
+        Ok(matches)
+    }
+}
+
+pub(super) fn validate_record_for_spec(
+    record: &BoxRecord,
+    spec: &RuntimeUnitSpec,
+) -> RuntimeResult<()> {
+    validate_owned_record(record, &spec.unit_id)?;
+    let expected_request = creation_request(spec)?;
+    let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+        RuntimeError::Protocol(format!("Box execution {} lost managed metadata", record.id))
+    })?;
+    let actual_request = serde_json::to_value(&metadata.request)
+        .map_err(|error| RuntimeError::Protocol(error.to_string()))?;
+    let expected_request = serde_json::to_value(&expected_request)
+        .map_err(|error| RuntimeError::Protocol(error.to_string()))?;
+    if actual_request != expected_request {
+        return Err(RuntimeError::Protocol(format!(
+            "Box execution {} creation intent does not match the Runtime specification",
+            record.id
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_owned_record(record: &BoxRecord, unit_id: &str) -> RuntimeResult<()> {
+    let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+        RuntimeError::Protocol(format!("Box execution {} is not managed", record.id))
+    })?;
+    metadata
+        .validate()
+        .map_err(|error| RuntimeError::Protocol(error.to_string()))?;
+    let expected = [
+        (MANAGED_LABEL, "true"),
+        (PROVIDER_LABEL, PROVIDER_VALUE),
+        (UNIT_LABEL, unit_id),
+    ];
+    for (key, value) in expected {
+        if record.labels.get(key).map(String::as_str) != Some(value)
+            || metadata.request.labels.get(key).map(String::as_str) != Some(value)
+        {
+            return Err(RuntimeError::Protocol(format!(
+                "Box execution {} metadata {key:?} does not match Runtime ownership",
+                record.id
+            )));
+        }
+    }
+    let generation = label_generation(record)?;
+    let spec_digest = record.labels.get(SPEC_DIGEST_LABEL).ok_or_else(|| {
+        RuntimeError::Protocol(format!(
+            "Box execution {} has no Runtime specification digest",
+            record.id
+        ))
+    })?;
+    let expected_operation = operation_id(unit_id, generation, spec_digest)?;
+    if metadata.operation_id != expected_operation
+        || labels_as_hash_map(&metadata.request.labels) != record.labels
+    {
+        return Err(RuntimeError::Protocol(format!(
+            "Box execution {} has inconsistent managed identity",
+            record.id
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn label_generation(record: &BoxRecord) -> RuntimeResult<u64> {
+    record
+        .labels
+        .get(GENERATION_LABEL)
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .ok_or_else(|| {
+            RuntimeError::Protocol(format!(
+                "Box execution {} has an invalid Runtime generation",
+                record.id
+            ))
+        })
+}
+
+pub(super) fn local_identity(
+    record: &BoxRecord,
+) -> RuntimeResult<(ExecutionId, ExecutionGeneration, ManagedExecutionState)> {
+    let execution_id = ExecutionId::new(record.id.clone())
+        .map_err(|error| RuntimeError::Protocol(error.to_string()))?;
+    let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+        RuntimeError::Protocol(format!("Box execution {} lost managed metadata", record.id))
+    })?;
+    let state = record
+        .managed_state()
+        .map_err(|error| RuntimeError::Protocol(error.to_string()))?
+        .ok_or_else(|| RuntimeError::Protocol(format!("Box execution {} is unmanaged", record.id)))?;
+    Ok((execution_id, metadata.generation, state))
+}
+
+pub(super) fn provider_identity_matches(
+    current: &RuntimeObservation,
+    record: &BoxRecord,
+) -> RuntimeResult<()> {
+    if current.state != RuntimeUnitState::Unknown
+        && current
+            .provider_resource_id
+            .as_deref()
+            .is_some_and(|provider_id| provider_id != record.id)
+    {
+        return Err(RuntimeError::Protocol(format!(
+            "Runtime observation for {:?} is bound to a different Box execution",
+            current.unit_id
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+}
+
+pub(super) fn timestamp_ms(value: chrono::DateTime<chrono::Utc>) -> RuntimeResult<u64> {
+    u64::try_from(value.timestamp_millis()).map_err(|_| {
+        RuntimeError::Protocol("Box execution timestamp precedes the Unix epoch".into())
+    })
+}
+
+pub(super) fn map_execution_error(
+    unit_id: &str,
+    error: a3s_box_core::ExecutionManagerError,
+) -> RuntimeError {
+    match error {
+        a3s_box_core::ExecutionManagerError::InvalidRequest(message) => {
+            RuntimeError::InvalidRequest(message)
+        }
+        a3s_box_core::ExecutionManagerError::NotFound(_) => RuntimeError::NotFound {
+            unit_id: unit_id.into(),
+        },
+        a3s_box_core::ExecutionManagerError::Conflict { message, .. } => {
+            RuntimeError::ProviderUnavailable(format!("Box execution conflict: {message}"))
+        }
+        a3s_box_core::ExecutionManagerError::Unavailable(message) => {
+            RuntimeError::ProviderUnavailable(message)
+        }
+        a3s_box_core::ExecutionManagerError::Internal(message) => RuntimeError::Protocol(message),
+    }
+}

--- a/src/runtime/src/a3s_runtime_driver/metadata.rs
+++ b/src/runtime/src/a3s_runtime_driver/metadata.rs
@@ -19,6 +19,14 @@ pub(super) const UNIT_LABEL: &str = "a3s.runtime.unit-id";
 pub(super) const GENERATION_LABEL: &str = "a3s.runtime.generation";
 pub(super) const SPEC_DIGEST_LABEL: &str = "a3s.runtime.spec-digest";
 const PROVIDER_VALUE: &str = "a3s-box";
+const OPERATION_PREFIX: &str = "a3s-runtime-box-v1:";
+const RUNTIME_LABELS: [&str; 5] = [
+    MANAGED_LABEL,
+    PROVIDER_LABEL,
+    UNIT_LABEL,
+    GENERATION_LABEL,
+    SPEC_DIGEST_LABEL,
+];
 
 pub(super) fn managed_labels(
     spec: &RuntimeUnitSpec,
@@ -44,7 +52,7 @@ pub(super) fn operation_id(
     digest.update(unit_id.as_bytes());
     digest.update(generation.to_be_bytes());
     digest.update(spec_digest.as_bytes());
-    OperationId::new(format!("a3s-runtime-box-v1:{:x}", digest.finalize()))
+    OperationId::new(format!("{OPERATION_PREFIX}{:x}", digest.finalize()))
         .map_err(|error| RuntimeError::InvalidRequest(error.to_string()))
 }
 
@@ -58,7 +66,7 @@ impl BoxRuntimeDriver {
             .managed_records()
             .await
             .map_err(|error| map_execution_error(&spec.unit_id, error))?;
-        let matches = records
+        let matches = runtime_owned_records(records)?
             .into_iter()
             .filter(|record| {
                 record.labels.get(UNIT_LABEL) == Some(&spec.unit_id)
@@ -84,7 +92,7 @@ impl BoxRuntimeDriver {
             .managed_records()
             .await
             .map_err(|error| map_execution_error(unit_id, error))?;
-        let mut matches = records
+        let mut matches = runtime_owned_records(records)?
             .into_iter()
             .filter(|record| {
                 record
@@ -93,12 +101,49 @@ impl BoxRuntimeDriver {
                     .is_some_and(|value| value == unit_id)
             })
             .collect::<Vec<_>>();
-        for record in &matches {
-            validate_owned_record(record, unit_id)?;
-        }
         matches.sort_by(|left, right| left.id.cmp(&right.id));
         Ok(matches)
     }
+}
+
+fn runtime_owned_records(records: Vec<BoxRecord>) -> RuntimeResult<Vec<BoxRecord>> {
+    let mut owned = Vec::new();
+    for record in records {
+        if !has_runtime_ownership_marker(&record) {
+            continue;
+        }
+        let unit_id = record
+            .labels
+            .get(UNIT_LABEL)
+            .or_else(|| {
+                record
+                    .managed_execution
+                    .as_ref()
+                    .and_then(|metadata| metadata.request.labels.get(UNIT_LABEL))
+            })
+            .cloned()
+            .ok_or_else(|| {
+                RuntimeError::Protocol(format!(
+                    "Box execution {} has Runtime ownership markers but no unit identity",
+                    record.id
+                ))
+            })?;
+        validate_owned_record(&record, &unit_id)?;
+        owned.push(record);
+    }
+    Ok(owned)
+}
+
+fn has_runtime_ownership_marker(record: &BoxRecord) -> bool {
+    let Some(metadata) = record.managed_execution.as_ref() else {
+        return RUNTIME_LABELS
+            .iter()
+            .any(|key| record.labels.contains_key(*key));
+    };
+    metadata.operation_id.as_str().starts_with(OPERATION_PREFIX)
+        || RUNTIME_LABELS.iter().any(|key| {
+            record.labels.contains_key(*key) || metadata.request.labels.contains_key(*key)
+        })
 }
 
 pub(super) fn validate_record_for_spec(
@@ -146,6 +191,13 @@ pub(super) fn validate_owned_record(record: &BoxRecord, unit_id: &str) -> Runtim
         }
     }
     let generation = label_generation(record)?;
+    let expected_external_id = format!("{unit_id}:{generation}");
+    if metadata.request.external_sandbox_id != expected_external_id {
+        return Err(RuntimeError::Protocol(format!(
+            "Box execution {} external identity does not match Runtime ownership",
+            record.id
+        )));
+    }
     let spec_digest = record.labels.get(SPEC_DIGEST_LABEL).ok_or_else(|| {
         RuntimeError::Protocol(format!(
             "Box execution {} has no Runtime specification digest",

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -228,6 +228,8 @@ impl RuntimeDriver for BoxRuntimeDriver {
 }
 
 #[cfg(test)]
+mod exec_integration_tests;
+#[cfg(test)]
 mod lifecycle_tests;
 #[cfg(test)]
 mod test_support;

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -228,6 +228,8 @@ impl RuntimeDriver for BoxRuntimeDriver {
 }
 
 #[cfg(test)]
+mod conformance_tests;
+#[cfg(test)]
 mod exec_integration_tests;
 #[cfg(test)]
 mod lifecycle_tests;

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -228,4 +228,8 @@ impl RuntimeDriver for BoxRuntimeDriver {
 }
 
 #[cfg(test)]
+mod lifecycle_tests;
+#[cfg(test)]
+mod test_support;
+#[cfg(test)]
 mod tests;

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -11,9 +11,10 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use a3s_runtime::contract::{
-    IsolationLevel, NetworkMode, ResourceControl, RuntimeActionRequest, RuntimeCapabilities,
-    RuntimeExecRequest, RuntimeExecResult, RuntimeFeature, RuntimeInspection, RuntimeLogChunk,
-    RuntimeLogQuery, RuntimeObservation, RuntimeRemoval, RuntimeUnitClass, RuntimeUnitSpec,
+    IsolationLevel, MountKind, NetworkMode, ResourceControl, RuntimeActionRequest,
+    RuntimeCapabilities, RuntimeExecRequest, RuntimeExecResult, RuntimeFeature, RuntimeInspection,
+    RuntimeLogChunk, RuntimeLogQuery, RuntimeObservation, RuntimeRemoval, RuntimeUnitClass,
+    RuntimeUnitSpec,
 };
 use a3s_runtime::{ProviderId, RuntimeDriver, RuntimeError, RuntimeResult, RuntimeUnitRecord};
 use async_trait::async_trait;
@@ -160,7 +161,7 @@ impl RuntimeDriver for BoxRuntimeDriver {
             artifact_media_types: vec![OCI_IMAGE_MANIFEST.into(), DOCKER_IMAGE_MANIFEST.into()],
             isolation_levels: vec![IsolationLevel::Sandbox],
             network_modes: vec![NetworkMode::None],
-            mount_kinds: Vec::new(),
+            mount_kinds: vec![MountKind::Tmpfs],
             health_check_kinds: Vec::new(),
             resource_controls: vec![
                 ResourceControl::Cpu,

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -15,9 +15,7 @@ use a3s_runtime::contract::{
     RuntimeExecRequest, RuntimeExecResult, RuntimeFeature, RuntimeInspection, RuntimeLogChunk,
     RuntimeLogQuery, RuntimeObservation, RuntimeRemoval, RuntimeUnitClass, RuntimeUnitSpec,
 };
-use a3s_runtime::{
-    ProviderId, RuntimeDriver, RuntimeError, RuntimeResult, RuntimeUnitRecord,
-};
+use a3s_runtime::{ProviderId, RuntimeDriver, RuntimeError, RuntimeResult, RuntimeUnitRecord};
 use async_trait::async_trait;
 use tokio::sync::OnceCell;
 
@@ -119,11 +117,7 @@ impl BoxRuntimeDriver {
             .cloned()
     }
 
-    pub(super) async fn bounded<T, F>(
-        &self,
-        operation: &'static str,
-        future: F,
-    ) -> RuntimeResult<T>
+    pub(super) async fn bounded<T, F>(&self, operation: &'static str, future: F) -> RuntimeResult<T>
     where
         F: Future<Output = RuntimeResult<T>>,
     {
@@ -211,7 +205,8 @@ impl RuntimeDriver for BoxRuntimeDriver {
         unit: &RuntimeUnitRecord,
         request: &RuntimeActionRequest,
     ) -> RuntimeResult<RuntimeRemoval> {
-        self.bounded("remove", self.remove_unit(unit, request)).await
+        self.bounded("remove", self.remove_unit(unit, request))
+            .await
     }
 
     async fn logs(

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -1,0 +1,236 @@
+//! A3S Runtime provider adapter for the certified Box Sandbox backend.
+
+mod exec;
+mod lifecycle;
+mod logs;
+mod mapping;
+mod metadata;
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use a3s_runtime::contract::{
+    IsolationLevel, NetworkMode, ResourceControl, RuntimeActionRequest, RuntimeCapabilities,
+    RuntimeExecRequest, RuntimeExecResult, RuntimeFeature, RuntimeInspection, RuntimeLogChunk,
+    RuntimeLogQuery, RuntimeObservation, RuntimeRemoval, RuntimeUnitClass, RuntimeUnitSpec,
+};
+use a3s_runtime::{
+    ProviderId, RuntimeDriver, RuntimeError, RuntimeResult, RuntimeUnitRecord,
+};
+use async_trait::async_trait;
+use tokio::sync::OnceCell;
+
+use crate::LocalExecutionManager;
+
+pub(super) const OCI_IMAGE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
+pub(super) const DOCKER_IMAGE_MANIFEST: &str =
+    "application/vnd.docker.distribution.manifest.v2+json";
+
+/// Host paths and bounds for one Box Runtime provider instance.
+#[derive(Debug, Clone)]
+pub struct BoxRuntimeDriverConfig {
+    /// Private A3S Box state root. Runtime records share its canonical
+    /// `boxes.json` store with CLI-created records but never adopt them.
+    pub home_dir: PathBuf,
+    /// Independent bound for one provider control-plane operation.
+    pub control_timeout: Duration,
+    /// Poll cadence while waiting for a finite Task to reach a terminal state.
+    pub task_poll_interval: Duration,
+}
+
+impl Default for BoxRuntimeDriverConfig {
+    fn default() -> Self {
+        Self {
+            home_dir: a3s_box_core::dirs_home(),
+            control_timeout: Duration::from_secs(60),
+            task_poll_interval: Duration::from_millis(50),
+        }
+    }
+}
+
+/// Concrete A3S Runtime driver backed only by Box's shared-kernel Sandbox.
+pub struct BoxRuntimeDriver {
+    provider_id: ProviderId,
+    pub(super) config: BoxRuntimeDriverConfig,
+    pub(super) manager: LocalExecutionManager,
+    provider_build: OnceCell<String>,
+}
+
+impl BoxRuntimeDriver {
+    pub fn new(config: BoxRuntimeDriverConfig) -> RuntimeResult<Self> {
+        validate_config(&config)?;
+        let manager = LocalExecutionManager::with_vm_backend(
+            config.home_dir.join("boxes.json"),
+            &config.home_dir,
+        );
+        Self::with_manager(config, manager)
+    }
+
+    fn with_manager(
+        config: BoxRuntimeDriverConfig,
+        manager: LocalExecutionManager,
+    ) -> RuntimeResult<Self> {
+        validate_config(&config)?;
+        Ok(Self {
+            provider_id: ProviderId::parse("a3s-box")?,
+            config,
+            manager,
+            provider_build: OnceCell::new(),
+        })
+    }
+
+    pub(super) async fn provider_build(&self) -> RuntimeResult<String> {
+        self.provider_build
+            .get_or_try_init(|| async {
+                let snapshot = tokio::time::timeout(
+                    self.config.control_timeout,
+                    tokio::task::spawn_blocking(|| {
+                        crate::sandbox::probe_sandbox_capabilities(None)
+                    }),
+                )
+                .await
+                .map_err(|_| {
+                    RuntimeError::ProviderUnavailable(
+                        "Box Sandbox capability probe exceeded the control timeout".into(),
+                    )
+                })?
+                .map_err(|error| {
+                    RuntimeError::ProviderUnavailable(format!(
+                        "Box Sandbox capability probe failed: {error}"
+                    ))
+                })?;
+                snapshot
+                    .require_ready()
+                    .map_err(|error| RuntimeError::ProviderUnavailable(error.to_string()))?;
+                let runtime = snapshot.runtime.ok_or_else(|| {
+                    RuntimeError::ProviderUnavailable(
+                        "Box Sandbox capability probe returned no certified crun runtime".into(),
+                    )
+                })?;
+                Ok::<String, RuntimeError>(format!(
+                    "a3s-box/{} crun/{} sha256:{}",
+                    env!("CARGO_PKG_VERSION"),
+                    runtime.version,
+                    &runtime.sha256[..16]
+                ))
+            })
+            .await
+            .cloned()
+    }
+
+    pub(super) async fn bounded<T, F>(
+        &self,
+        operation: &'static str,
+        future: F,
+    ) -> RuntimeResult<T>
+    where
+        F: Future<Output = RuntimeResult<T>>,
+    {
+        tokio::time::timeout(self.config.control_timeout, future)
+            .await
+            .map_err(|_| {
+                RuntimeError::ProviderUnavailable(format!(
+                    "Box {operation} exceeded the configured control timeout"
+                ))
+            })?
+    }
+}
+
+fn validate_config(config: &BoxRuntimeDriverConfig) -> RuntimeResult<()> {
+    if !config.home_dir.is_absolute() {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Runtime home directory must be absolute".into(),
+        ));
+    }
+    if config.control_timeout.is_zero() || config.task_poll_interval.is_zero() {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Runtime timeout and poll interval must be positive".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl RuntimeDriver for BoxRuntimeDriver {
+    fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    async fn capabilities(&self) -> RuntimeResult<RuntimeCapabilities> {
+        let capabilities = RuntimeCapabilities {
+            schema: RuntimeCapabilities::SCHEMA.into(),
+            provider_id: self.provider_id.clone(),
+            provider_build: self.provider_build().await?,
+            unit_classes: vec![RuntimeUnitClass::Task, RuntimeUnitClass::Service],
+            artifact_media_types: vec![OCI_IMAGE_MANIFEST.into(), DOCKER_IMAGE_MANIFEST.into()],
+            isolation_levels: vec![IsolationLevel::Sandbox],
+            network_modes: vec![NetworkMode::None],
+            mount_kinds: Vec::new(),
+            health_check_kinds: Vec::new(),
+            resource_controls: vec![
+                ResourceControl::Cpu,
+                ResourceControl::Memory,
+                ResourceControl::Pids,
+                ResourceControl::ExecutionTimeout,
+            ],
+            features: vec![
+                RuntimeFeature::DurableIdentity,
+                RuntimeFeature::Stop,
+                RuntimeFeature::Remove,
+                RuntimeFeature::Logs,
+                RuntimeFeature::Exec,
+            ],
+        };
+        capabilities.validate().map_err(RuntimeError::Protocol)?;
+        Ok(capabilities)
+    }
+
+    async fn apply(
+        &self,
+        spec: &RuntimeUnitSpec,
+        current: &RuntimeObservation,
+    ) -> RuntimeResult<RuntimeObservation> {
+        self.apply_unit(spec, current).await
+    }
+
+    async fn inspect(&self, unit: &RuntimeUnitRecord) -> RuntimeResult<RuntimeInspection> {
+        self.bounded("inspection", self.inspect_unit(unit)).await
+    }
+
+    async fn stop(
+        &self,
+        unit: &RuntimeUnitRecord,
+        request: &RuntimeActionRequest,
+    ) -> RuntimeResult<RuntimeObservation> {
+        self.bounded("stop", self.stop_unit(unit, request)).await
+    }
+
+    async fn remove(
+        &self,
+        unit: &RuntimeUnitRecord,
+        request: &RuntimeActionRequest,
+    ) -> RuntimeResult<RuntimeRemoval> {
+        self.bounded("remove", self.remove_unit(unit, request)).await
+    }
+
+    async fn logs(
+        &self,
+        unit: &RuntimeUnitRecord,
+        query: &RuntimeLogQuery,
+    ) -> RuntimeResult<Vec<RuntimeLogChunk>> {
+        self.bounded("log read", self.read_runtime_logs(unit, query))
+            .await
+    }
+
+    async fn exec(
+        &self,
+        unit: &RuntimeUnitRecord,
+        request: &RuntimeExecRequest,
+    ) -> RuntimeResult<RuntimeExecResult> {
+        self.execute_runtime_command(unit, request).await
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/runtime/src/a3s_runtime_driver/test_support.rs
+++ b/src/runtime/src/a3s_runtime_driver/test_support.rs
@@ -7,9 +7,9 @@ use a3s_box_core::{
     ExecutionId, ExecutionManagerError, ExecutionManagerResult, ExecutionState, KillOutcome,
 };
 use a3s_runtime::contract::{
-    ArtifactRef, IsolationLevel, NetworkMode, ResourceLimits, RestartPolicy,
-    RuntimeActionRequest, RuntimeNetworkSpec, RuntimeObservation, RuntimeProcessSpec,
-    RuntimeUnitClass, RuntimeUnitSpec, RuntimeUnitState,
+    ArtifactRef, IsolationLevel, NetworkMode, ResourceLimits, RestartPolicy, RuntimeActionRequest,
+    RuntimeNetworkSpec, RuntimeObservation, RuntimeProcessSpec, RuntimeUnitClass, RuntimeUnitSpec,
+    RuntimeUnitState,
 };
 use a3s_runtime::RuntimeUnitRecord;
 use async_trait::async_trait;
@@ -111,7 +111,10 @@ impl LocalExecutionBackend for DriverFakeBackend {
         let handle = Self::handle(record)?;
         let mut executions = self.executions.lock().unwrap();
         if let Some(execution) = executions.get(&record.id) {
-            if matches!(execution.state, ExecutionState::Running | ExecutionState::Paused) {
+            if matches!(
+                execution.state,
+                ExecutionState::Running | ExecutionState::Paused
+            ) {
                 return Ok(execution.handle.clone());
             }
         }
@@ -146,8 +149,11 @@ impl LocalExecutionBackend for DriverFakeBackend {
             .ok_or_else(|| ExecutionManagerError::NotFound(Self::execution_id(record)))?;
         Ok(LocalExecutionObservation {
             state: execution.state,
-            handle: matches!(execution.state, ExecutionState::Running | ExecutionState::Paused)
-                .then(|| execution.handle.clone()),
+            handle: matches!(
+                execution.state,
+                ExecutionState::Running | ExecutionState::Paused
+            )
+            .then(|| execution.handle.clone()),
             exit_code: execution.exit_code,
         })
     }
@@ -175,7 +181,10 @@ impl LocalExecutionBackend for DriverFakeBackend {
         let Some(execution) = self.executions.lock().unwrap().remove(&record.id) else {
             return Err(ExecutionManagerError::NotFound(Self::execution_id(record)));
         };
-        if matches!(execution.state, ExecutionState::Stopped | ExecutionState::Failed) {
+        if matches!(
+            execution.state,
+            ExecutionState::Stopped | ExecutionState::Failed
+        ) {
             Ok(KillOutcome::AlreadyStopped)
         } else {
             Ok(KillOutcome::Killed)
@@ -196,11 +205,8 @@ pub(super) fn fake_driver_with_backend(
     backend: Arc<DriverFakeBackend>,
 ) -> BoxRuntimeDriver {
     let home_dir = directory.path().join("home");
-    let manager = LocalExecutionManager::new(
-        home_dir.join("boxes.json"),
-        &home_dir,
-        backend.clone(),
-    );
+    let manager =
+        LocalExecutionManager::new(home_dir.join("boxes.json"), &home_dir, backend.clone());
     let driver = BoxRuntimeDriver::with_manager(
         BoxRuntimeDriverConfig {
             home_dir,

--- a/src/runtime/src/a3s_runtime_driver/test_support.rs
+++ b/src/runtime/src/a3s_runtime_driver/test_support.rs
@@ -1,0 +1,314 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use a3s_box_core::{
+    ExecutionId, ExecutionManagerError, ExecutionManagerResult, ExecutionState, KillOutcome,
+};
+use a3s_runtime::contract::{
+    ArtifactRef, IsolationLevel, NetworkMode, ResourceLimits, RestartPolicy,
+    RuntimeActionRequest, RuntimeNetworkSpec, RuntimeObservation, RuntimeProcessSpec,
+    RuntimeUnitClass, RuntimeUnitSpec, RuntimeUnitState,
+};
+use a3s_runtime::RuntimeUnitRecord;
+use async_trait::async_trait;
+
+use crate::{
+    BoxRecord, LocalExecutionBackend, LocalExecutionHandle, LocalExecutionManager,
+    LocalExecutionObservation,
+};
+
+use super::{BoxRuntimeDriver, BoxRuntimeDriverConfig, OCI_IMAGE_MANIFEST};
+
+#[derive(Clone)]
+struct FakeExecution {
+    state: ExecutionState,
+    handle: LocalExecutionHandle,
+    exit_code: Option<i32>,
+}
+
+#[derive(Default)]
+pub(super) struct DriverFakeBackend {
+    executions: Mutex<HashMap<String, FakeExecution>>,
+    starts: AtomicUsize,
+    kills: AtomicUsize,
+    fail_start_after_effect: AtomicBool,
+    next_start_terminal: Mutex<Option<(ExecutionState, i32)>>,
+}
+
+impl DriverFakeBackend {
+    fn execution_id(record: &BoxRecord) -> ExecutionId {
+        ExecutionId::new(record.id.clone()).unwrap()
+    }
+
+    fn handle(record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
+        if let Some(parent) = record.console_log.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                ExecutionManagerError::Internal(format!(
+                    "failed to create fake execution log directory: {error}"
+                ))
+            })?;
+        }
+        if !record.console_log.exists() {
+            std::fs::write(&record.console_log, []).map_err(|error| {
+                ExecutionManagerError::Internal(format!(
+                    "failed to create fake execution log: {error}"
+                ))
+            })?;
+        }
+        let pid = std::process::id();
+        Ok(LocalExecutionHandle {
+            started_at: chrono::Utc::now(),
+            pid: Some(pid),
+            pid_start_time: crate::process::pid_start_time(pid),
+            exec_socket_path: record.box_dir.join("sockets/exec.sock"),
+            console_log: record.console_log.clone(),
+            anonymous_volumes: Vec::new(),
+        })
+    }
+
+    pub(super) fn fail_next_start_response(&self) {
+        self.fail_start_after_effect.store(true, Ordering::SeqCst);
+    }
+
+    pub(super) fn finish_next_start(&self, exit_code: i32) {
+        let state = if exit_code == 0 {
+            ExecutionState::Stopped
+        } else {
+            ExecutionState::Failed
+        };
+        *self.next_start_terminal.lock().unwrap() = Some((state, exit_code));
+    }
+
+    pub(super) fn finish(&self, execution_id: &str, exit_code: i32) {
+        let mut executions = self.executions.lock().unwrap();
+        let execution = executions.get_mut(execution_id).unwrap();
+        execution.state = if exit_code == 0 {
+            ExecutionState::Stopped
+        } else {
+            ExecutionState::Failed
+        };
+        execution.exit_code = Some(exit_code);
+    }
+
+    pub(super) fn lose(&self, execution_id: &str) {
+        self.executions.lock().unwrap().remove(execution_id);
+    }
+
+    pub(super) fn starts(&self) -> usize {
+        self.starts.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn kills(&self) -> usize {
+        self.kills.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl LocalExecutionBackend for DriverFakeBackend {
+    async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
+        let handle = Self::handle(record)?;
+        let mut executions = self.executions.lock().unwrap();
+        if let Some(execution) = executions.get(&record.id) {
+            if matches!(execution.state, ExecutionState::Running | ExecutionState::Paused) {
+                return Ok(execution.handle.clone());
+            }
+        }
+        self.starts.fetch_add(1, Ordering::SeqCst);
+        let terminal = self.next_start_terminal.lock().unwrap().take();
+        let (state, exit_code) = terminal
+            .map(|(state, exit_code)| (state, Some(exit_code)))
+            .unwrap_or((ExecutionState::Running, None));
+        executions.insert(
+            record.id.clone(),
+            FakeExecution {
+                state,
+                handle: handle.clone(),
+                exit_code,
+            },
+        );
+        if self.fail_start_after_effect.swap(false, Ordering::SeqCst) {
+            return Err(ExecutionManagerError::Unavailable(
+                "fake start response was lost".into(),
+            ));
+        }
+        Ok(handle)
+    }
+
+    async fn inspect(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionObservation> {
+        let executions = self.executions.lock().unwrap();
+        let execution = executions
+            .get(&record.id)
+            .ok_or_else(|| ExecutionManagerError::NotFound(Self::execution_id(record)))?;
+        Ok(LocalExecutionObservation {
+            state: execution.state,
+            handle: matches!(execution.state, ExecutionState::Running | ExecutionState::Paused)
+                .then(|| execution.handle.clone()),
+            exit_code: execution.exit_code,
+        })
+    }
+
+    async fn pause(
+        &self,
+        record: &BoxRecord,
+        _keep_memory: bool,
+    ) -> ExecutionManagerResult<LocalExecutionHandle> {
+        Err(ExecutionManagerError::Unavailable(format!(
+            "fake pause is unavailable for {}",
+            record.id
+        )))
+    }
+
+    async fn resume(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
+        Err(ExecutionManagerError::Unavailable(format!(
+            "fake resume is unavailable for {}",
+            record.id
+        )))
+    }
+
+    async fn kill(&self, record: &BoxRecord) -> ExecutionManagerResult<KillOutcome> {
+        self.kills.fetch_add(1, Ordering::SeqCst);
+        let Some(execution) = self.executions.lock().unwrap().remove(&record.id) else {
+            return Err(ExecutionManagerError::NotFound(Self::execution_id(record)));
+        };
+        if matches!(execution.state, ExecutionState::Stopped | ExecutionState::Failed) {
+            Ok(KillOutcome::AlreadyStopped)
+        } else {
+            Ok(KillOutcome::Killed)
+        }
+    }
+}
+
+pub(super) fn fake_driver(
+    directory: &tempfile::TempDir,
+) -> (BoxRuntimeDriver, Arc<DriverFakeBackend>) {
+    let backend = Arc::new(DriverFakeBackend::default());
+    let driver = fake_driver_with_backend(directory, backend.clone());
+    (driver, backend)
+}
+
+pub(super) fn fake_driver_with_backend(
+    directory: &tempfile::TempDir,
+    backend: Arc<DriverFakeBackend>,
+) -> BoxRuntimeDriver {
+    let home_dir = directory.path().join("home");
+    let manager = LocalExecutionManager::new(
+        home_dir.join("boxes.json"),
+        &home_dir,
+        backend.clone(),
+    );
+    let driver = BoxRuntimeDriver::with_manager(
+        BoxRuntimeDriverConfig {
+            home_dir,
+            control_timeout: Duration::from_secs(2),
+            task_poll_interval: Duration::from_millis(5),
+        },
+        manager,
+    )
+    .unwrap();
+    driver
+        .provider_build
+        .set("a3s-box/test crun/test sha256:0123456789abcdef".into())
+        .unwrap();
+    driver
+}
+
+pub(super) fn runtime_spec(
+    unit_id: &str,
+    generation: u64,
+    class: RuntimeUnitClass,
+) -> RuntimeUnitSpec {
+    let digest = format!("sha256:{}", "a".repeat(64));
+    RuntimeUnitSpec {
+        schema: RuntimeUnitSpec::SCHEMA.into(),
+        unit_id: unit_id.into(),
+        generation,
+        class,
+        artifact: ArtifactRef {
+            uri: format!("oci://registry.example/a3s/runtime@{digest}"),
+            digest,
+            media_type: OCI_IMAGE_MANIFEST.into(),
+        },
+        process: RuntimeProcessSpec {
+            command: vec!["/bin/sh".into()],
+            args: vec!["-c".into(), "echo ready".into()],
+            working_directory: Some("/work".into()),
+            environment: BTreeMap::new(),
+        },
+        mounts: Vec::new(),
+        secrets: Vec::new(),
+        network: RuntimeNetworkSpec {
+            mode: NetworkMode::None,
+            ports: Vec::new(),
+        },
+        resources: ResourceLimits {
+            cpu_millis: 500,
+            memory_bytes: 64 * 1024 * 1024,
+            pids: 32,
+            ephemeral_storage_bytes: None,
+            execution_timeout_ms: (class == RuntimeUnitClass::Task).then_some(200),
+        },
+        isolation: IsolationLevel::Sandbox,
+        health: None,
+        restart: if class == RuntimeUnitClass::Service {
+            RestartPolicy::Always
+        } else {
+            RestartPolicy::Never
+        },
+        outputs: Vec::new(),
+        semantics_profile_digest: None,
+    }
+}
+
+pub(super) fn accepted(spec: &RuntimeUnitSpec) -> RuntimeObservation {
+    RuntimeObservation {
+        schema: RuntimeObservation::SCHEMA.into(),
+        unit_id: spec.unit_id.clone(),
+        generation: spec.generation,
+        spec_digest: spec.digest().unwrap(),
+        class: spec.class,
+        state: RuntimeUnitState::Accepted,
+        provider_resource_id: None,
+        provider_build: None,
+        observed_at_ms: 1,
+        started_at_ms: None,
+        finished_at_ms: None,
+        health: None,
+        outputs: Vec::new(),
+        usage: None,
+        evidence: None,
+        provider_attestation: None,
+        failure: None,
+    }
+}
+
+pub(super) fn unknown(previous: &RuntimeObservation) -> RuntimeObservation {
+    let mut observation = previous.clone();
+    observation.state = RuntimeUnitState::Unknown;
+    observation.finished_at_ms = None;
+    observation.failure = None;
+    observation
+}
+
+pub(super) fn unit(spec: RuntimeUnitSpec, observation: RuntimeObservation) -> RuntimeUnitRecord {
+    RuntimeUnitRecord {
+        schema: RuntimeUnitRecord::SCHEMA.into(),
+        spec,
+        observation,
+        removed_at_ms: None,
+    }
+}
+
+pub(super) fn action(request_id: &str, spec: &RuntimeUnitSpec) -> RuntimeActionRequest {
+    RuntimeActionRequest {
+        schema: RuntimeActionRequest::SCHEMA.into(),
+        request_id: request_id.into(),
+        unit_id: spec.unit_id.clone(),
+        generation: spec.generation,
+        deadline_at_ms: None,
+    }
+}

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -3,8 +3,9 @@ use std::time::Duration;
 
 use a3s_box_core::ExecutionManager;
 use a3s_runtime::contract::{
-    ArtifactRef, IsolationLevel, NetworkMode, ResourceControl, ResourceLimits, RestartPolicy,
-    RuntimeFeature, RuntimeNetworkSpec, RuntimeProcessSpec, RuntimeUnitClass, RuntimeUnitSpec,
+    ArtifactRef, IsolationLevel, MountKind, NetworkMode, ResourceControl, ResourceLimits,
+    RestartPolicy, RuntimeFeature, RuntimeMount, RuntimeMountSource, RuntimeNetworkSpec,
+    RuntimeProcessSpec, RuntimeUnitClass, RuntimeUnitSpec,
 };
 use a3s_runtime::RuntimeDriver;
 
@@ -101,7 +102,7 @@ async fn capabilities_claim_only_the_mapped_box_surface() {
     );
     assert_eq!(capabilities.isolation_levels, vec![IsolationLevel::Sandbox]);
     assert_eq!(capabilities.network_modes, vec![NetworkMode::None]);
-    assert!(capabilities.mount_kinds.is_empty());
+    assert_eq!(capabilities.mount_kinds, vec![MountKind::Tmpfs]);
     assert!(capabilities.health_check_kinds.is_empty());
     assert_eq!(
         capabilities.resource_controls,
@@ -149,6 +150,118 @@ fn mapping_preserves_digest_resources_timeout_and_hardening() {
     assert!(request.config.persistent);
     assert_eq!(request.config.cap_drop, vec!["ALL"]);
     assert_eq!(request.config.security_opt, vec!["no-new-privileges"]);
+}
+
+#[test]
+fn mapping_rejects_path_like_unit_identity_before_mutation() {
+    for unit_id in [
+        "../provider-escape",
+        "/absolute-provider-id",
+        "tenant/../provider-escape",
+        "tenant//provider-id",
+    ] {
+        let mut spec = spec(RuntimeUnitClass::Service);
+        spec.unit_id = unit_id.into();
+        assert!(matches!(
+            creation_request(&spec),
+            Err(RuntimeError::InvalidRequest(message))
+                if message.contains("path traversal")
+        ));
+    }
+
+    let mut namespaced = spec(RuntimeUnitClass::Service);
+    namespaced.unit_id = "tenant/provider-id".into();
+    assert!(creation_request(&namespaced).is_ok());
+}
+
+#[test]
+fn mapping_compiles_bounded_tmpfs_mounts_and_read_only_intent() {
+    let mut spec = spec(RuntimeUnitClass::Service);
+    spec.mounts = vec![
+        RuntimeMount {
+            name: "scratch".into(),
+            source: RuntimeMountSource::Tmpfs {
+                size_bytes: 8 * 1024 * 1024,
+            },
+            target: "/runtime/scratch".into(),
+            read_only: false,
+        },
+        RuntimeMount {
+            name: "sealed".into(),
+            source: RuntimeMountSource::Tmpfs {
+                size_bytes: 4 * 1024 * 1024,
+            },
+            target: "/runtime/sealed".into(),
+            read_only: true,
+        },
+    ];
+
+    let request = creation_request(&spec).unwrap();
+
+    assert_eq!(
+        request.config.tmpfs,
+        vec![
+            "/runtime/scratch:size=8388608,rw",
+            "/runtime/sealed:size=4194304,ro",
+        ]
+    );
+    assert!(request.config.volumes.is_empty());
+    assert!(request.policy.volume_names.is_empty());
+}
+
+#[test]
+fn mapping_rejects_unadvertised_mount_kinds_before_mutation() {
+    let mut spec = spec(RuntimeUnitClass::Service);
+    spec.mounts.push(RuntimeMount {
+        name: "data".into(),
+        source: RuntimeMountSource::Volume {
+            volume_id: "runtime-data".into(),
+        },
+        target: "/data".into(),
+        read_only: false,
+    });
+
+    assert!(matches!(
+        creation_request(&spec),
+        Err(RuntimeError::UnsupportedCapabilities(missing))
+            if missing == vec!["mount_kind:Volume"]
+    ));
+}
+
+#[test]
+fn mapping_rejects_protected_or_unencodable_tmpfs_targets() {
+    for target in ["/proc/runtime", "/dev/shm/nested", "/run/a3s-box/data"] {
+        let mut spec = spec(RuntimeUnitClass::Service);
+        spec.mounts.push(RuntimeMount {
+            name: "scratch".into(),
+            source: RuntimeMountSource::Tmpfs { size_bytes: 4096 },
+            target: target.into(),
+            read_only: false,
+        });
+        assert!(matches!(
+            creation_request(&spec),
+            Err(RuntimeError::InvalidRequest(message)) if message.contains("protected")
+        ));
+    }
+
+    for target in [
+        "/runtime/ambiguous:target",
+        "/runtime/./scratch",
+        "/runtime//scratch",
+        "/runtime/scratch/",
+    ] {
+        let mut spec = spec(RuntimeUnitClass::Service);
+        spec.mounts.push(RuntimeMount {
+            name: "scratch".into(),
+            source: RuntimeMountSource::Tmpfs { size_bytes: 4096 },
+            target: target.into(),
+            read_only: false,
+        });
+        assert!(matches!(
+            creation_request(&spec),
+            Err(RuntimeError::InvalidRequest(message)) if message.contains("encodable")
+        ));
+    }
 }
 
 #[test]

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -66,6 +66,24 @@ fn driver(directory: &tempfile::TempDir) -> BoxRuntimeDriver {
     .unwrap()
 }
 
+fn mutate_record(
+    driver: &BoxRuntimeDriver,
+    execution_id: &str,
+    mutation: impl FnOnce(&mut crate::BoxRecord),
+) {
+    crate::BoxStateStore::modify(driver.manager.state_path(), move |store| {
+        let record = store.find_by_id_mut(execution_id).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("missing managed execution {execution_id}"),
+            )
+        })?;
+        mutation(record);
+        Ok(())
+    })
+    .unwrap();
+}
+
 #[tokio::test]
 async fn capabilities_claim_only_the_mapped_box_surface() {
     let directory = tempfile::tempdir().unwrap();
@@ -203,5 +221,56 @@ async fn metadata_tamper_is_rejected_fail_closed() {
     assert!(matches!(
         validate_record_for_spec(&record, &spec),
         Err(RuntimeError::Protocol(message)) if message.contains("identity") || message.contains("intent")
+    ));
+}
+
+#[tokio::test]
+async fn discovery_rejects_a_runtime_record_hidden_by_unit_label_tamper() {
+    let directory = tempfile::tempdir().unwrap();
+    let driver = driver(&directory);
+    let spec = spec(RuntimeUnitClass::Service);
+    let reservation = driver
+        .manager
+        .create(creation_request(&spec).unwrap(), &operation(&spec).unwrap())
+        .await
+        .unwrap();
+
+    mutate_record(&driver, reservation.execution_id.as_str(), |record| {
+        record
+            .labels
+            .insert(super::metadata::UNIT_LABEL.into(), "hidden-unit".into());
+    });
+
+    assert!(matches!(
+        driver.find_generation(&spec).await,
+        Err(RuntimeError::Protocol(message)) if message.contains("ownership")
+    ));
+}
+
+#[tokio::test]
+async fn discovery_rejects_a_runtime_operation_that_lost_all_labels() {
+    let directory = tempfile::tempdir().unwrap();
+    let driver = driver(&directory);
+    let spec = spec(RuntimeUnitClass::Service);
+    let reservation = driver
+        .manager
+        .create(creation_request(&spec).unwrap(), &operation(&spec).unwrap())
+        .await
+        .unwrap();
+
+    mutate_record(&driver, reservation.execution_id.as_str(), |record| {
+        record.labels.clear();
+        record
+            .managed_execution
+            .as_mut()
+            .unwrap()
+            .request
+            .labels
+            .clear();
+    });
+
+    assert!(matches!(
+        driver.find_generation(&spec).await,
+        Err(RuntimeError::Protocol(message)) if message.contains("no unit identity")
     ));
 }

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -73,7 +73,6 @@ async fn capabilities_claim_only_the_mapped_box_surface() {
     driver
         .provider_build
         .set("a3s-box/test crun/test sha256:0123456789abcdef".into())
-        .await
         .unwrap();
 
     let capabilities = driver.capabilities().await.unwrap();

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -174,7 +174,7 @@ fn mapping_rejects_numeric_overflow_before_mutation() {
     value.resources.cpu_millis = u64::MAX;
     assert!(matches!(
         creation_request(&value),
-        Err(RuntimeError::InvalidRequest(message)) if message.contains("CPU quota")
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("CPU")
     ));
 }
 

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -1,0 +1,208 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use a3s_box_core::ExecutionManager;
+use a3s_runtime::contract::{
+    ArtifactRef, IsolationLevel, NetworkMode, ResourceControl, ResourceLimits, RestartPolicy,
+    RuntimeFeature, RuntimeNetworkSpec, RuntimeProcessSpec, RuntimeUnitClass, RuntimeUnitSpec,
+};
+use a3s_runtime::RuntimeDriver;
+
+use super::mapping::{creation_request, operation};
+use super::metadata::validate_record_for_spec;
+use super::*;
+
+fn spec(class: RuntimeUnitClass) -> RuntimeUnitSpec {
+    RuntimeUnitSpec {
+        schema: RuntimeUnitSpec::SCHEMA.into(),
+        unit_id: "box-runtime-test".into(),
+        generation: 7,
+        class,
+        artifact: ArtifactRef {
+            uri: format!(
+                "oci://registry.example/a3s/runtime@sha256:{}",
+                "a".repeat(64)
+            ),
+            digest: format!("sha256:{}", "a".repeat(64)),
+            media_type: OCI_IMAGE_MANIFEST.into(),
+        },
+        process: RuntimeProcessSpec {
+            command: vec!["/bin/sh".into(), "-c".into()],
+            args: vec!["echo ready".into()],
+            working_directory: Some("/work".into()),
+            environment: BTreeMap::from([("LANG".into(), "C.UTF-8".into())]),
+        },
+        mounts: Vec::new(),
+        secrets: Vec::new(),
+        network: RuntimeNetworkSpec {
+            mode: NetworkMode::None,
+            ports: Vec::new(),
+        },
+        resources: ResourceLimits {
+            cpu_millis: 1_501,
+            memory_bytes: 65 * 1024 * 1024 + 17,
+            pids: 37,
+            ephemeral_storage_bytes: None,
+            execution_timeout_ms: (class == RuntimeUnitClass::Task).then_some(2_500),
+        },
+        isolation: IsolationLevel::Sandbox,
+        health: None,
+        restart: if class == RuntimeUnitClass::Task {
+            RestartPolicy::Never
+        } else {
+            RestartPolicy::Always
+        },
+        outputs: Vec::new(),
+        semantics_profile_digest: None,
+    }
+}
+
+fn driver(directory: &tempfile::TempDir) -> BoxRuntimeDriver {
+    BoxRuntimeDriver::new(BoxRuntimeDriverConfig {
+        home_dir: directory.path().join("home"),
+        control_timeout: Duration::from_secs(2),
+        task_poll_interval: Duration::from_millis(5),
+    })
+    .unwrap()
+}
+
+#[tokio::test]
+async fn capabilities_claim_only_the_mapped_box_surface() {
+    let directory = tempfile::tempdir().unwrap();
+    let driver = driver(&directory);
+    driver
+        .provider_build
+        .set("a3s-box/test crun/test sha256:0123456789abcdef".into())
+        .await
+        .unwrap();
+
+    let capabilities = driver.capabilities().await.unwrap();
+    assert_eq!(capabilities.provider_id.as_str(), "a3s-box");
+    assert_eq!(
+        capabilities.unit_classes,
+        vec![RuntimeUnitClass::Task, RuntimeUnitClass::Service]
+    );
+    assert_eq!(capabilities.isolation_levels, vec![IsolationLevel::Sandbox]);
+    assert_eq!(capabilities.network_modes, vec![NetworkMode::None]);
+    assert!(capabilities.mount_kinds.is_empty());
+    assert!(capabilities.health_check_kinds.is_empty());
+    assert_eq!(
+        capabilities.resource_controls,
+        vec![
+            ResourceControl::Cpu,
+            ResourceControl::Memory,
+            ResourceControl::Pids,
+            ResourceControl::ExecutionTimeout,
+        ]
+    );
+    assert_eq!(
+        capabilities.features,
+        vec![
+            RuntimeFeature::DurableIdentity,
+            RuntimeFeature::Stop,
+            RuntimeFeature::Remove,
+            RuntimeFeature::Logs,
+            RuntimeFeature::Exec,
+        ]
+    );
+}
+
+#[test]
+fn mapping_preserves_digest_resources_timeout_and_hardening() {
+    let spec = spec(RuntimeUnitClass::Task);
+    let request = creation_request(&spec).unwrap();
+    assert_eq!(
+        request.config.image,
+        format!("registry.example/a3s/runtime@sha256:{}", "a".repeat(64))
+    );
+    assert_eq!(request.config.resources.vcpus, 2);
+    assert_eq!(request.config.resources.memory_mb, 66);
+    assert_eq!(request.config.resources.timeout, 3);
+    assert_eq!(request.config.resource_limits.cpu_period, Some(100_000));
+    assert_eq!(request.config.resource_limits.cpu_quota, Some(150_100));
+    assert_eq!(request.config.resource_limits.pids_limit, Some(37));
+    assert_eq!(
+        request.config.resource_limits.sandbox_memory_limit_bytes,
+        Some(spec.resources.memory_bytes)
+    );
+    assert_eq!(
+        request.config.resource_limits.memory_swap,
+        Some(spec.resources.memory_bytes as i64)
+    );
+    assert!(request.config.persistent);
+    assert_eq!(request.config.cap_drop, vec!["ALL"]);
+    assert_eq!(request.config.security_opt, vec!["no-new-privileges"]);
+}
+
+#[test]
+fn mapping_rejects_unpinned_mismatched_and_unsupported_artifacts() {
+    let mut value = spec(RuntimeUnitClass::Service);
+    value.artifact.uri = "oci://registry.example/a3s/runtime:latest".into();
+    assert!(creation_request(&value).is_err());
+
+    let mut value = spec(RuntimeUnitClass::Service);
+    value.artifact.uri = format!(
+        "oci://registry.example/a3s/runtime@sha256:{}",
+        "b".repeat(64)
+    );
+    assert!(creation_request(&value).is_err());
+
+    let mut value = spec(RuntimeUnitClass::Service);
+    value.artifact.media_type = "application/vnd.oci.image.index.v1+json".into();
+    assert!(matches!(
+        creation_request(&value),
+        Err(RuntimeError::UnsupportedCapabilities(_))
+    ));
+
+    let mut value = spec(RuntimeUnitClass::Service);
+    value.artifact.uri = format!(
+        "oci://user:secret@registry.example/a3s/runtime@sha256:{}",
+        "a".repeat(64)
+    );
+    assert!(creation_request(&value).is_err());
+}
+
+#[test]
+fn mapping_rejects_numeric_overflow_before_mutation() {
+    let mut value = spec(RuntimeUnitClass::Service);
+    value.resources.memory_bytes = i64::MAX as u64 + 1;
+    assert!(matches!(
+        creation_request(&value),
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("memory")
+    ));
+
+    let mut value = spec(RuntimeUnitClass::Service);
+    value.resources.cpu_millis = u64::MAX;
+    assert!(matches!(
+        creation_request(&value),
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("CPU quota")
+    ));
+}
+
+#[tokio::test]
+async fn metadata_tamper_is_rejected_fail_closed() {
+    let directory = tempfile::tempdir().unwrap();
+    let driver = driver(&directory);
+    let spec = spec(RuntimeUnitClass::Service);
+    let operation_id = operation(&spec).unwrap();
+    let reservation = driver
+        .manager
+        .create(creation_request(&spec).unwrap(), &operation_id)
+        .await
+        .unwrap();
+    let mut record = driver
+        .manager
+        .managed_record(&reservation.execution_id)
+        .await
+        .unwrap()
+        .unwrap();
+    validate_record_for_spec(&record, &spec).unwrap();
+
+    record
+        .labels
+        .insert(super::metadata::GENERATION_LABEL.into(), "8".into());
+    assert!(matches!(
+        validate_record_for_spec(&record, &spec),
+        Err(RuntimeError::Protocol(message)) if message.contains("identity") || message.contains("intent")
+    ));
+}

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -259,6 +259,7 @@ pub enum ManagedExecutionState {
     Killing,
     RestartStopping,
     RestartStarting,
+    Removing,
     Stopped,
     Failed,
 }
@@ -278,6 +279,7 @@ impl ManagedExecutionState {
             Self::Killing => "killing",
             Self::RestartStopping => "restart_stopping",
             Self::RestartStarting => "restart_starting",
+            Self::Removing => "removing",
             Self::Stopped => "stopped",
             Self::Failed => "failed",
         }
@@ -297,6 +299,7 @@ impl ManagedExecutionState {
             "killing" => Ok(Self::Killing),
             "restart_stopping" => Ok(Self::RestartStopping),
             "restart_starting" => Ok(Self::RestartStarting),
+            "removing" => Ok(Self::Removing),
             "stopped" => Ok(Self::Stopped),
             "dead" | "failed" => Ok(Self::Failed),
             other => Err(a3s_box_core::BoxError::StateError(format!(
@@ -344,6 +347,9 @@ pub struct ManagedExecutionMetadata {
     /// Most recent completed restart retained for idempotent response replay.
     #[serde(default)]
     pub last_restart: Option<ManagedRestartCompletion>,
+    /// Provider terminal timestamp retained for deterministic observation replay.
+    #[serde(default)]
+    pub finished_at: Option<DateTime<Utc>>,
 }
 
 /// Recoverable backend operation associated with a transitional state.
@@ -360,6 +366,7 @@ pub enum ManagedExecutionOperation {
         source_state: ManagedExecutionState,
     },
     Kill,
+    Remove,
     Restart {
         operation_id: OperationId,
         source_generation: ExecutionGeneration,
@@ -408,6 +415,7 @@ impl ManagedExecutionMetadata {
             plan,
             pending_operation: None,
             last_restart: None,
+            finished_at: None,
         })
     }
 
@@ -460,6 +468,9 @@ fn validate_pending_operation(
         ) | (
             ManagedExecutionState::Killing,
             Some(ManagedExecutionOperation::Kill)
+        ) | (
+            ManagedExecutionState::Removing,
+            Some(ManagedExecutionOperation::Remove)
         ) | (
             ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting,
             Some(ManagedExecutionOperation::Restart { .. })

--- a/src/runtime/src/grpc/exec.rs
+++ b/src/runtime/src/grpc/exec.rs
@@ -640,7 +640,8 @@ impl StreamingExec {
                         a3s_box_core::exec::StreamType::Stdout => &mut stdout,
                         a3s_box_core::exec::StreamType::Stderr => &mut stderr,
                     };
-                    let remaining = a3s_box_core::exec::MAX_OUTPUT_BYTES.saturating_sub(target.len());
+                    let remaining =
+                        a3s_box_core::exec::MAX_OUTPUT_BYTES.saturating_sub(target.len());
                     if chunk.data.len() > remaining {
                         truncated = true;
                     }

--- a/src/runtime/src/grpc/exec.rs
+++ b/src/runtime/src/grpc/exec.rs
@@ -631,13 +631,21 @@ impl StreamingExec {
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let mut exit_code = -1;
+        let mut truncated = false;
 
         while let Some(event) = self.next_event().await? {
             match event {
-                ExecEvent::Chunk(chunk) => match chunk.stream {
-                    a3s_box_core::exec::StreamType::Stdout => stdout.extend_from_slice(&chunk.data),
-                    a3s_box_core::exec::StreamType::Stderr => stderr.extend_from_slice(&chunk.data),
-                },
+                ExecEvent::Chunk(chunk) => {
+                    let target = match chunk.stream {
+                        a3s_box_core::exec::StreamType::Stdout => &mut stdout,
+                        a3s_box_core::exec::StreamType::Stderr => &mut stderr,
+                    };
+                    let remaining = a3s_box_core::exec::MAX_OUTPUT_BYTES.saturating_sub(target.len());
+                    if chunk.data.len() > remaining {
+                        truncated = true;
+                    }
+                    target.extend_from_slice(&chunk.data[..chunk.data.len().min(remaining)]);
+                }
                 ExecEvent::FlushAck => {}
                 ExecEvent::Exit(exit) => {
                     exit_code = exit.exit_code;
@@ -656,6 +664,7 @@ impl StreamingExec {
             stdout,
             stderr,
             exit_code,
+            truncated,
         };
 
         Ok((output, metrics))
@@ -908,6 +917,7 @@ mod tests {
                 stdout: b"hello\n".to_vec(),
                 stderr: vec![],
                 exit_code: 0,
+                truncated: false,
             };
             let payload = serde_json::to_vec(&output).unwrap();
             writer.write_data(&payload).await.unwrap();
@@ -917,6 +927,7 @@ mod tests {
 
         let client = ExecClient::connect(&sock_path).await.unwrap();
         let req = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: vec!["echo".to_string(), "hello".to_string()],
             env: vec![],
             working_dir: None,
@@ -987,6 +998,7 @@ mod tests {
 
         let client = ExecClient::connect(&sock_path).await.unwrap();
         let req = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: vec!["echo".to_string(), "hello".to_string()],
             env: vec![],
             working_dir: None,
@@ -1047,6 +1059,7 @@ mod tests {
 
         let client = ExecClient::connect(&sock_path).await.unwrap();
         let req = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: vec!["sleep".to_string(), "60".to_string()],
             env: vec![],
             working_dir: None,
@@ -1111,6 +1124,7 @@ mod tests {
 
         let client = ExecClient::connect(&sock_path).await.unwrap();
         let req = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: vec!["cat".to_string()],
             env: vec![],
             working_dir: None,
@@ -1180,6 +1194,7 @@ mod tests {
 
         let client = ExecClient::connect(&sock_path).await.unwrap();
         let req = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: vec!["sh".to_string()],
             env: vec![],
             working_dir: None,
@@ -1234,6 +1249,7 @@ mod tests {
 
         let client = ExecClient::connect(&sock_path).await.unwrap();
         let req = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: vec!["test".to_string()],
             env: vec![],
             working_dir: None,

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -15,6 +15,8 @@
 
 // -- Core modules (always compiled) --
 pub mod audit;
+#[cfg(all(feature = "vm", target_os = "linux"))]
+pub mod a3s_runtime_driver;
 pub mod box_record;
 pub mod box_state;
 pub mod cache;
@@ -57,6 +59,9 @@ pub mod scale;
 
 // Audit
 pub use audit::{read_audit_log, AuditLog, AuditQuery};
+
+#[cfg(all(feature = "vm", target_os = "linux"))]
+pub use a3s_runtime_driver::{BoxRuntimeDriver, BoxRuntimeDriverConfig};
 
 // Canonical local execution metadata
 pub use box_record::{

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -14,9 +14,9 @@
 #![allow(clippy::result_large_err)]
 
 // -- Core modules (always compiled) --
-pub mod audit;
 #[cfg(all(feature = "vm", target_os = "linux"))]
 pub mod a3s_runtime_driver;
+pub mod audit;
 pub mod box_record;
 pub mod box_state;
 pub mod cache;

--- a/src/runtime/src/local_execution/api.rs
+++ b/src/runtime/src/local_execution/api.rs
@@ -229,6 +229,10 @@ impl ExecutionManager for LocalExecutionManager {
                 self.finish_kill(record).await?;
                 Ok(ReconcileOutcome::Failed)
             }
+            ManagedExecutionState::Removing => {
+                self.finish_remove(record).await?;
+                Ok(ReconcileOutcome::Absent)
+            }
             ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting => self
                 .resume_restart(record)
                 .await

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -8,6 +8,7 @@ mod operations;
 mod port;
 mod record;
 mod recovery;
+mod remove;
 mod resources;
 mod restart;
 #[cfg(unix)]

--- a/src/runtime/src/local_execution/record.rs
+++ b/src/runtime/src/local_execution/record.rs
@@ -112,6 +112,9 @@ pub(crate) fn apply_handle(record: &mut BoxRecord, handle: &LocalExecutionHandle
     record.started_at = Some(handle.started_at);
     record.anonymous_volumes = handle.anonymous_volumes.clone();
     record.exit_code = None;
+    if let Some(metadata) = record.managed_execution.as_mut() {
+        metadata.finished_at = None;
+    }
 }
 
 pub(crate) fn apply_start_handle(record: &mut BoxRecord, handle: &LocalExecutionHandle) {
@@ -142,6 +145,9 @@ pub(crate) fn clear_live_runtime(record: &mut BoxRecord, exit_code: Option<i32>)
     record.exit_code = exit_code;
     record.health_status = "none".to_string();
     record.health_retries = 0;
+    if let Some(metadata) = record.managed_execution.as_mut() {
+        metadata.finished_at = Some(Utc::now());
+    }
 }
 
 pub(crate) fn reservation_from_record(

--- a/src/runtime/src/local_execution/recovery.rs
+++ b/src/runtime/src/local_execution/recovery.rs
@@ -20,6 +20,12 @@ impl LocalExecutionManager {
             }
             ManagedExecutionState::Stopped => return Ok((record, ExecutionState::Stopped)),
             ManagedExecutionState::Failed => return Ok((record, ExecutionState::Failed)),
+            ManagedExecutionState::Removing => {
+                return Err(ExecutionManagerError::Conflict {
+                    execution_id: execution_id(&record)?,
+                    message: "execution removal is in progress".to_string(),
+                });
+            }
             ManagedExecutionState::RestartStopping => {
                 let id = execution_id(&record)?;
                 if matches!(

--- a/src/runtime/src/local_execution/remove.rs
+++ b/src/runtime/src/local_execution/remove.rs
@@ -39,17 +39,15 @@ impl LocalExecutionManager {
     ) -> ExecutionManagerResult<bool> {
         let store = self.store.clone();
         let claimed_id = execution_id.clone();
-        let claimed = run_store(move || store.begin_remove(&claimed_id, expected_generation)).await?;
+        let claimed =
+            run_store(move || store.begin_remove(&claimed_id, expected_generation)).await?;
         let Some(record) = claimed else {
             return Ok(false);
         };
         self.finish_remove(record).await
     }
 
-    pub(super) async fn finish_remove(
-        &self,
-        record: BoxRecord,
-    ) -> ExecutionManagerResult<bool> {
+    pub(super) async fn finish_remove(&self, record: BoxRecord) -> ExecutionManagerResult<bool> {
         let execution_id = execution_id(&record)?;
         let expected_generation = generation(&record, &execution_id)?;
 
@@ -77,12 +75,8 @@ fn cleanup_execution_paths(home_dir: &Path, record: &BoxRecord) -> ExecutionMana
     validate_owned_paths(home_dir, record)?;
 
     if record.isolation.is_sandbox() {
-        crate::vm::reap::cleanup_recorded_sandbox_runtime_in(
-            home_dir,
-            &record.box_dir,
-            &record.id,
-        )
-        .map_err(|error| cleanup_error(record, "delete the recorded crun runtime", error))?;
+        crate::vm::reap::cleanup_recorded_sandbox_runtime_in(home_dir, &record.box_dir, &record.id)
+            .map_err(|error| cleanup_error(record, "delete the recorded crun runtime", error))?;
     }
 
     remove_anonymous_volumes(home_dir, record)?;
@@ -142,10 +136,7 @@ fn validate_owned_paths(home_dir: &Path, record: &BoxRecord) -> ExecutionManager
     Ok(())
 }
 
-fn remove_anonymous_volumes(
-    home_dir: &Path,
-    record: &BoxRecord,
-) -> ExecutionManagerResult<()> {
+fn remove_anonymous_volumes(home_dir: &Path, record: &BoxRecord) -> ExecutionManagerResult<()> {
     if record.anonymous_volumes.is_empty() {
         return Ok(());
     }
@@ -185,11 +176,7 @@ fn remove_host_cgroup(record: &BoxRecord) -> ExecutionManagerResult<()> {
                     std::thread::sleep(std::time::Duration::from_millis(20));
                 }
                 Err(error) => {
-                    return Err(cleanup_error(
-                        record,
-                        "remove the host cgroup",
-                        error,
-                    ));
+                    return Err(cleanup_error(record, "remove the host cgroup", error));
                 }
             }
         }

--- a/src/runtime/src/local_execution/remove.rs
+++ b/src/runtime/src/local_execution/remove.rs
@@ -1,0 +1,322 @@
+//! Durable removal and complete host-resource cleanup for managed executions.
+
+use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
+
+use a3s_box_core::{
+    ExecutionGeneration, ExecutionId, ExecutionManagerError, ExecutionManagerResult,
+};
+
+use super::record::execution_id;
+use super::store::run_store;
+use super::support::generation;
+use super::{BoxRecord, LocalExecutionManager};
+
+impl LocalExecutionManager {
+    /// Load one managed record without reconciling provider state.
+    pub(crate) async fn managed_record(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> ExecutionManagerResult<Option<BoxRecord>> {
+        self.get(execution_id).await
+    }
+
+    /// Load the complete managed inventory without exposing legacy CLI boxes.
+    pub(crate) async fn managed_records(&self) -> ExecutionManagerResult<Vec<BoxRecord>> {
+        let store = self.store.clone();
+        run_store(move || store.list()).await
+    }
+
+    /// Remove one terminal generation after durably claiming its teardown.
+    ///
+    /// A failed cleanup deliberately leaves the record in `removing`. Retrying
+    /// the same generation resumes cleanup before the record is forgotten.
+    pub(crate) async fn remove_execution(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<bool> {
+        let store = self.store.clone();
+        let claimed_id = execution_id.clone();
+        let claimed = run_store(move || store.begin_remove(&claimed_id, expected_generation)).await?;
+        let Some(record) = claimed else {
+            return Ok(false);
+        };
+        self.finish_remove(record).await
+    }
+
+    pub(super) async fn finish_remove(
+        &self,
+        record: BoxRecord,
+    ) -> ExecutionManagerResult<bool> {
+        let execution_id = execution_id(&record)?;
+        let expected_generation = generation(&record, &execution_id)?;
+
+        // Detach shared stores before deleting execution-owned paths. Both the
+        // detach and the path cleanup are idempotent, so a crash can replay.
+        self.release_execution_resources(&record).await?;
+
+        let home_dir = self.home_dir.clone();
+        let cleanup_record = record.clone();
+        tokio::task::spawn_blocking(move || cleanup_execution_paths(&home_dir, &cleanup_record))
+            .await
+            .map_err(|error| {
+                ExecutionManagerError::Internal(format!(
+                    "managed removal task failed for {execution_id}: {error}"
+                ))
+            })??;
+
+        let store = self.store.clone();
+        let removed_id = execution_id.clone();
+        run_store(move || store.finish_remove(&removed_id, expected_generation)).await
+    }
+}
+
+fn cleanup_execution_paths(home_dir: &Path, record: &BoxRecord) -> ExecutionManagerResult<()> {
+    validate_owned_paths(home_dir, record)?;
+
+    if record.isolation.is_sandbox() {
+        crate::vm::reap::cleanup_recorded_sandbox_runtime_in(
+            home_dir,
+            &record.box_dir,
+            &record.id,
+        )
+        .map_err(|error| cleanup_error(record, "delete the recorded crun runtime", error))?;
+    }
+
+    remove_anonymous_volumes(home_dir, record)?;
+
+    let socket_dir = crate::vm::runtime_socket_dir(home_dir, &record.id);
+    #[cfg(target_os = "linux")]
+    crate::network::terminate_passt(&socket_dir);
+
+    crate::rootfs::unmount_box_overlay(&record.box_dir.join("merged"));
+    crate::rootfs::unmount_box_rootfs(&record.box_dir.join("rootfs"));
+
+    remove_tree_if_present(&record.box_dir)
+        .map_err(|error| cleanup_error(record, "remove the execution directory", error))?;
+    remove_tree_if_present(&socket_dir)
+        .map_err(|error| cleanup_error(record, "remove the runtime socket directory", error))?;
+
+    let runtime_root = home_dir.join("run/crun").join(&record.id);
+    remove_tree_if_present(&runtime_root)
+        .map_err(|error| cleanup_error(record, "remove the crun state directory", error))?;
+
+    let bind_mount_dir = std::env::temp_dir().join(format!("a3s-fs-mount-{}", record.id));
+    remove_tree_if_present(&bind_mount_dir)
+        .map_err(|error| cleanup_error(record, "remove temporary bind-mount staging", error))?;
+
+    remove_host_cgroup(record)?;
+    Ok(())
+}
+
+fn validate_owned_paths(home_dir: &Path, record: &BoxRecord) -> ExecutionManagerResult<()> {
+    uuid::Uuid::parse_str(&record.id).map_err(|error| {
+        ExecutionManagerError::Internal(format!(
+            "managed execution has an invalid internal ID {}: {error}",
+            record.id
+        ))
+    })?;
+    let expected_box_dir = home_dir.join("boxes").join(&record.id);
+    if record.box_dir != expected_box_dir {
+        return Err(ExecutionManagerError::Internal(format!(
+            "managed execution {} has an unexpected host directory {}",
+            record.id,
+            record.box_dir.display()
+        )));
+    }
+
+    let internal_exec = expected_box_dir.join("sockets/exec.sock");
+    let external_exec = crate::vm::runtime_socket_dir(home_dir, &record.id).join("exec.sock");
+    if !record.exec_socket_path.as_os_str().is_empty()
+        && record.exec_socket_path != internal_exec
+        && record.exec_socket_path != external_exec
+    {
+        return Err(ExecutionManagerError::Internal(format!(
+            "managed execution {} has an unexpected exec endpoint {}",
+            record.id,
+            record.exec_socket_path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn remove_anonymous_volumes(
+    home_dir: &Path,
+    record: &BoxRecord,
+) -> ExecutionManagerResult<()> {
+    if record.anonymous_volumes.is_empty() {
+        return Ok(());
+    }
+    let store = crate::VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"));
+    for name in &record.anonymous_volumes {
+        if store
+            .get(name)
+            .map_err(|error| cleanup_error(record, "inspect an anonymous volume", error))?
+            .is_some()
+        {
+            store
+                .remove(name, true)
+                .map_err(|error| cleanup_error(record, "remove an anonymous volume", error))?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_tree_if_present(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_host_cgroup(record: &BoxRecord) -> ExecutionManagerResult<()> {
+    #[cfg(target_os = "linux")]
+    {
+        let path = PathBuf::from("/sys/fs/cgroup/a3s-box").join(&record.id);
+        for attempt in 0..50 {
+            match std::fs::remove_dir(&path) {
+                Ok(()) => return Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) if attempt + 1 < 50 => {
+                    let _ = error;
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                Err(error) => {
+                    return Err(cleanup_error(
+                        record,
+                        "remove the host cgroup",
+                        error,
+                    ));
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = record;
+    Ok(())
+}
+
+fn cleanup_error(
+    record: &BoxRecord,
+    operation: &str,
+    error: impl std::fmt::Display,
+) -> ExecutionManagerError {
+    ExecutionManagerError::Unavailable(format!(
+        "failed to {operation} for execution {}: {error}",
+        record.id
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use a3s_box_core::{
+        BoxConfig, CreateExecutionRequest, ExecutionIsolation, ExecutionManager,
+        ExecutionRecordPolicy, OperationId,
+    };
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::local_execution::{
+        LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation,
+    };
+
+    struct UnusedBackend;
+
+    #[async_trait]
+    impl LocalExecutionBackend for UnusedBackend {
+        async fn start(&self, _record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
+            unreachable!("removal test never starts a backend")
+        }
+
+        async fn inspect(
+            &self,
+            _record: &BoxRecord,
+        ) -> ExecutionManagerResult<LocalExecutionObservation> {
+            unreachable!("removal test never inspects a backend")
+        }
+
+        async fn pause(
+            &self,
+            _record: &BoxRecord,
+            _keep_memory: bool,
+        ) -> ExecutionManagerResult<LocalExecutionHandle> {
+            unreachable!("removal test never pauses a backend")
+        }
+
+        async fn resume(
+            &self,
+            _record: &BoxRecord,
+        ) -> ExecutionManagerResult<LocalExecutionHandle> {
+            unreachable!("removal test never resumes a backend")
+        }
+
+        async fn kill(
+            &self,
+            _record: &BoxRecord,
+        ) -> ExecutionManagerResult<a3s_box_core::KillOutcome> {
+            unreachable!("removal test never kills a backend")
+        }
+    }
+
+    #[tokio::test]
+    async fn removal_claim_cleans_owned_paths_before_forgetting_the_record() {
+        let temporary = tempfile::tempdir().unwrap();
+        let home_dir = temporary.path().join("home");
+        let manager = LocalExecutionManager::new(
+            home_dir.join("boxes.json"),
+            &home_dir,
+            Arc::new(UnusedBackend),
+        );
+        let reservation = manager
+            .create(
+                CreateExecutionRequest {
+                    external_sandbox_id: "runtime-unit-1".to_string(),
+                    config: BoxConfig {
+                        isolation: ExecutionIsolation::Sandbox,
+                        persistent: true,
+                        ..Default::default()
+                    },
+                    labels: Default::default(),
+                    policy: ExecutionRecordPolicy::default(),
+                    rootfs_snapshot_id: None,
+                },
+                &OperationId::new("runtime-create-1").unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let box_dir = home_dir
+            .join("boxes")
+            .join(reservation.execution_id.as_str());
+        std::fs::create_dir_all(box_dir.join("logs")).unwrap();
+        std::fs::write(
+            box_dir.join("logs/container.json"),
+            b"retained until remove\n",
+        )
+        .unwrap();
+        let socket_dir =
+            crate::vm::runtime_socket_dir(&home_dir, reservation.execution_id.as_str());
+        std::fs::create_dir_all(&socket_dir).unwrap();
+
+        assert!(manager
+            .remove_execution(&reservation.execution_id, reservation.generation)
+            .await
+            .unwrap());
+        assert!(!box_dir.exists());
+        assert!(!socket_dir.exists());
+        assert!(manager
+            .managed_record(&reservation.execution_id)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(!manager
+            .remove_execution(&reservation.execution_id, reservation.generation)
+            .await
+            .unwrap());
+    }
+}

--- a/src/runtime/src/local_execution/store.rs
+++ b/src/runtime/src/local_execution/store.rs
@@ -213,7 +213,7 @@ pub(super) enum RuntimeUpdate {
     RestartFailed(Option<i32>),
 }
 
-async fn run_store<T>(
+pub(super) async fn run_store<T>(
     operation: impl FnOnce() -> Result<T, ManagedExecutionStoreError> + Send + 'static,
 ) -> ExecutionManagerResult<T>
 where
@@ -227,7 +227,7 @@ where
         .map_err(map_store_error)
 }
 
-fn map_store_error(error: ManagedExecutionStoreError) -> ExecutionManagerError {
+pub(super) fn map_store_error(error: ManagedExecutionStoreError) -> ExecutionManagerError {
     match error {
         ManagedExecutionStoreError::Io(error) => {
             ExecutionManagerError::Unavailable(error.to_string())

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -454,6 +454,7 @@ async fn process_session_inherits_environment_from_persisted_record() {
             &execution_id,
             record.managed_execution.as_ref().unwrap().generation,
             ExecRequest {
+                request_id: None,
                 cmd: vec!["env".to_string()],
                 timeout_ns: 1_000_000_000,
                 env: vec!["OVERRIDE=request".to_string()],

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -8,6 +8,13 @@ impl VmLocalExecutionBackend {
         record: &BoxRecord,
     ) -> ExecutionManagerResult<LocalExecutionObservation> {
         self.metadata(record)?;
+        // The registered manager owns the live `crun` and log-worker child
+        // handles. Let it observe and reap terminal children so a subsequent
+        // managed restart can claim the same execution ID. Durable inspection
+        // below is only for a control plane that has no in-process owner.
+        if let Some(manager) = self.manager(&record.id) {
+            return self.inspect_registered(record, manager).await;
+        }
         let home_dir = self.home_dir.clone();
         let box_dir = record.box_dir.clone();
         let box_id = record.id.clone();

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -53,11 +53,12 @@ impl VmLocalExecutionBackend {
                 })
             }
             "stopped" => {
+                let exit_code = crate::rootfs::read_persisted_exit_code(&record.box_dir);
                 self.cleanup_detached_sandbox(record).await?;
                 Ok(LocalExecutionObservation {
                     state: ExecutionState::Stopped,
                     handle: None,
-                    exit_code: None,
+                    exit_code,
                 })
             }
             status => Err(ExecutionManagerError::Internal(format!(

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -93,6 +93,22 @@ impl ManagedExecutionStore {
         Ok(Some(record))
     }
 
+    /// Return every managed record without reconciling provider state.
+    ///
+    /// Legacy CLI records share the same state file and are deliberately
+    /// excluded. Loading remains strict: one malformed managed record fails the
+    /// complete snapshot instead of letting provider discovery skip corrupt
+    /// ownership metadata.
+    pub fn list(&self) -> ManagedExecutionStoreResult<Vec<BoxRecord>> {
+        let store = BoxStateStore::load_readonly(&self.path)?;
+        Ok(store
+            .records()
+            .iter()
+            .filter(|record| record.managed_execution.is_some())
+            .cloned()
+            .collect())
+    }
+
     /// Return the record reserved by an idempotent creation operation.
     pub fn get_by_operation_id(
         &self,
@@ -152,6 +168,90 @@ impl ManagedExecutionStore {
 
             store.records_mut().push(record.clone());
             Ok(ManagedExecutionReservation::Reserved(record))
+        })
+    }
+
+    /// Claim terminal-record removal before deleting host resources.
+    ///
+    /// The durable `removing` state prevents another lifecycle operation from
+    /// reviving the execution while cleanup is in progress. A retry observes
+    /// the same claim and can resume cleanup after a process crash.
+    pub fn begin_remove(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+    ) -> ManagedExecutionStoreResult<Option<BoxRecord>> {
+        let execution_id = execution_id.clone();
+        BoxStateStore::transact(&self.path, move |store| {
+            let Some(record) = store.find_by_id_mut(execution_id.as_str()) else {
+                return Ok(None);
+            };
+            let state = record
+                .managed_state()
+                .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+            let metadata = record
+                .managed_execution
+                .as_mut()
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+            if metadata.generation != expected_generation {
+                return Err(ManagedExecutionStoreError::Conflict {
+                    execution_id: execution_id.clone(),
+                    message: format!(
+                        "expected generation {}, found {}",
+                        expected_generation.get(),
+                        metadata.generation.get()
+                    ),
+                });
+            }
+            match state {
+                ManagedExecutionState::Removing => Ok(Some(record.clone())),
+                ManagedExecutionState::Created
+                | ManagedExecutionState::Stopped
+                | ManagedExecutionState::Failed => {
+                    record.status = ManagedExecutionState::Removing.as_status().to_string();
+                    metadata.pending_operation = Some(ManagedExecutionOperation::Remove);
+                    Ok(Some(record.clone()))
+                }
+                _ => Err(ManagedExecutionStoreError::Conflict {
+                    execution_id: execution_id.clone(),
+                    message: format!("cannot remove execution in state {state}"),
+                }),
+            }
+        })
+    }
+
+    /// Forget a generation only after its durable removal claim has completed.
+    pub fn finish_remove(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+    ) -> ManagedExecutionStoreResult<bool> {
+        let execution_id = execution_id.clone();
+        BoxStateStore::transact(&self.path, move |store| {
+            let Some(record) = store.find_by_id(execution_id.as_str()) else {
+                return Ok(false);
+            };
+            let state = record
+                .managed_state()
+                .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+            let metadata = record
+                .managed_execution
+                .as_ref()
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+            if metadata.generation != expected_generation || state != ManagedExecutionState::Removing
+            {
+                return Err(ManagedExecutionStoreError::Conflict {
+                    execution_id: execution_id.clone(),
+                    message: format!(
+                        "expected removing generation {}, found {state} generation {}",
+                        expected_generation.get(),
+                        metadata.generation.get()
+                    ),
+                });
+            }
+            Ok(store.remove_by_id(execution_id.as_str()))
         })
     }
 
@@ -290,6 +390,7 @@ impl ManagedExecutionStore {
                     }
                 },
                 ManagedExecutionState::Killing => Some(ManagedExecutionOperation::Kill),
+                ManagedExecutionState::Removing => Some(ManagedExecutionOperation::Remove),
                 ManagedExecutionState::RestartStopping | ManagedExecutionState::RestartStarting => {
                     match metadata.pending_operation.take() {
                         Some(operation @ ManagedExecutionOperation::Restart { .. }) => {
@@ -506,6 +607,56 @@ mod tests {
             BoxStateStore::load(store.path()).unwrap().records().len(),
             1
         );
+    }
+
+    #[test]
+    fn removal_claim_is_generation_fenced_durable_and_idempotent() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = ManagedExecutionStore::new(directory.path().join("boxes.json"));
+        let id = ExecutionId::new("execution-1").unwrap();
+        store
+            .reserve(managed_record(id.as_str(), "operation-1"))
+            .unwrap();
+
+        let claimed = store
+            .begin_remove(&id, ExecutionGeneration::INITIAL)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            claimed.managed_state().unwrap(),
+            Some(ManagedExecutionState::Removing)
+        );
+        assert!(matches!(
+            claimed
+                .managed_execution
+                .as_ref()
+                .unwrap()
+                .pending_operation,
+            Some(ManagedExecutionOperation::Remove)
+        ));
+
+        let reopened = ManagedExecutionStore::new(store.path().to_path_buf());
+        assert_eq!(
+            reopened
+                .begin_remove(&id, ExecutionGeneration::INITIAL)
+                .unwrap()
+                .unwrap()
+                .managed_state()
+                .unwrap(),
+            Some(ManagedExecutionState::Removing)
+        );
+        assert!(matches!(
+            reopened.begin_remove(&id, ExecutionGeneration::new(2).unwrap()),
+            Err(ManagedExecutionStoreError::Conflict { .. })
+        ));
+
+        assert!(reopened
+            .finish_remove(&id, ExecutionGeneration::INITIAL)
+            .unwrap());
+        assert!(!reopened
+            .finish_remove(&id, ExecutionGeneration::INITIAL)
+            .unwrap());
+        assert!(reopened.get(&id).unwrap().is_none());
     }
 
     #[test]

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -240,7 +240,8 @@ impl ManagedExecutionStore {
                 .managed_execution
                 .as_ref()
                 .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
-            if metadata.generation != expected_generation || state != ManagedExecutionState::Removing
+            if metadata.generation != expected_generation
+                || state != ManagedExecutionState::Removing
             {
                 return Err(ManagedExecutionStoreError::Conflict {
                     execution_id: execution_id.clone(),

--- a/src/runtime/src/process.rs
+++ b/src/runtime/src/process.rs
@@ -93,6 +93,43 @@ pub fn is_process_running_with_identity(pid: u32, expected_start_time: Option<u6
     is_process_alive_with_identity(pid, expected_start_time)
 }
 
+/// Wait for a Linux process identity to disappear, reaping it when it is an
+/// exited child of the current process.
+///
+/// Recovered runtime handles retain only a durable PID/start-time pair. When a
+/// worker was originally spawned by this process, dropping its `Child` handle
+/// does not transfer wait ownership: the completed worker remains a zombie
+/// until an explicit `waitpid`. Workers inherited by another process cannot be
+/// reaped here, so this helper waits for their owner to reap them instead.
+#[cfg(target_os = "linux")]
+pub(crate) fn wait_for_process_exit_with_identity(
+    pid: u32,
+    expected_start_time: u64,
+    timeout: std::time::Duration,
+) -> bool {
+    let Ok(raw_pid) = i32::try_from(pid) else {
+        return false;
+    };
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if !is_process_alive_with_identity(pid, Some(expected_start_time)) {
+            return true;
+        }
+        if !is_process_running_with_identity(pid, Some(expected_start_time)) {
+            let mut status = 0;
+            let waited = unsafe { libc::waitpid(raw_pid, &mut status, libc::WNOHANG) };
+            if waited == raw_pid || !is_process_alive_with_identity(pid, Some(expected_start_time))
+            {
+                return true;
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn linux_process_identity_from_stat(stat: &str) -> Option<(char, u64)> {
     // `comm` may contain spaces and parentheses, so fields begin after the
@@ -152,8 +189,8 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn running_identity_treats_an_unreaped_child_as_finished() {
-        let mut child = std::process::Command::new("true").spawn().unwrap();
+    fn recovered_identity_reaps_an_exited_child() {
+        let child = std::process::Command::new("true").spawn().unwrap();
         let pid = child.id();
         let start_time = pid_start_time(pid).unwrap();
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
@@ -165,6 +202,11 @@ mod tests {
 
         assert!(is_process_alive_with_identity(pid, Some(start_time)));
         assert!(!is_process_running_with_identity(pid, Some(start_time)));
-        child.wait().unwrap();
+        assert!(wait_for_process_exit_with_identity(
+            pid,
+            start_time,
+            std::time::Duration::from_secs(1),
+        ));
+        assert!(!is_process_alive_with_identity(pid, Some(start_time)));
     }
 }

--- a/src/runtime/src/process.rs
+++ b/src/runtime/src/process.rs
@@ -189,6 +189,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    #[allow(clippy::zombie_processes)] // Deliberately drop Child to exercise recovered waitpid.
     fn recovered_identity_reaps_an_exited_child() {
         let child = std::process::Command::new("true").spawn().unwrap();
         let pid = child.id();

--- a/src/runtime/src/sandbox/handler.rs
+++ b/src/runtime/src/sandbox/handler.rs
@@ -424,6 +424,18 @@ impl CrunHandler {
                 }
             }
         }
+        #[cfg(target_os = "linux")]
+        if !crate::process::wait_for_process_exit_with_identity(
+            pid,
+            start_time,
+            LOG_WORKER_EXIT_TIMEOUT,
+        ) {
+            tracing::warn!(
+                container_id = %self.container_id,
+                log_worker_pid = pid,
+                "Recovered Sandbox log worker remained present after cleanup"
+            );
+        }
     }
 
     fn delete_runtime_state(&mut self) -> Result<()> {

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -70,11 +70,21 @@ impl SandboxResources {
             ));
         }
 
-        let memory_limit = i64::from(config.resources.memory_mb)
-            .checked_mul(1024 * 1024)
-            .ok_or_else(|| {
+        let memory_limit = match config.resource_limits.sandbox_memory_limit_bytes {
+            Some(0) => {
+                return Err(BoxError::ConfigError(
+                    "Sandbox memory limit must be greater than zero".to_string(),
+                ))
+            }
+            Some(bytes) => i64::try_from(bytes).map_err(|_| {
                 BoxError::ConfigError("Sandbox memory limit overflows i64".to_string())
-            })?;
+            })?,
+            None => i64::from(config.resources.memory_mb)
+                .checked_mul(1024 * 1024)
+                .ok_or_else(|| {
+                    BoxError::ConfigError("Sandbox memory limit overflows i64".to_string())
+                })?,
+        };
         let memory_reservation = config
             .resource_limits
             .memory_reservation

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -41,6 +41,7 @@ pub struct SandboxMount {
 pub struct SandboxTmpfs {
     pub destination: PathBuf,
     pub size_bytes: u64,
+    pub read_only: bool,
 }
 
 /// Cgroup values compiled from `BoxConfig`.
@@ -625,6 +626,7 @@ fn compile_mounts(user_mounts: &[SandboxMount], user_tmpfs: &[SandboxTmpfs]) -> 
             "nodev".to_string(),
             "mode=1777".to_string(),
             format!("size={}", tmpfs.size_bytes),
+            if tmpfs.read_only { "ro" } else { "rw" }.to_string(),
         ];
         if is_shared_memory {
             options.push("noexec".to_string());
@@ -1364,6 +1366,7 @@ mod tests {
         input.tmpfs.push(SandboxTmpfs {
             destination: PathBuf::from("/dev/shm"),
             size_bytes: 128 * 1024 * 1024,
+            read_only: true,
         });
 
         let value = as_json(&compile_oci_spec(&input).unwrap());
@@ -1377,6 +1380,7 @@ mod tests {
         let options = shared_memory[0]["options"].as_array().unwrap();
         assert!(options.iter().any(|option| option == "size=134217728"));
         assert!(options.iter().any(|option| option == "noexec"));
+        assert!(options.iter().any(|option| option == "ro"));
 
         input.tmpfs[0].destination = PathBuf::from("/dev/shm/nested");
         assert!(compile_oci_spec(&input).is_err());

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -1271,6 +1271,7 @@ mod tests {
         *vm.state.write().await = BoxState::Ready;
 
         let request = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: vec![],
             timeout_ns: 0,
             env: vec!["ENV=test".to_string()],
@@ -1295,6 +1296,7 @@ mod tests {
         *vm.state.write().await = BoxState::Ready;
 
         let request = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd: vec!["printenv".to_string()],
             timeout_ns: 123,
             env: vec!["ENV=test".to_string()],

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -714,10 +714,15 @@ impl VmManager {
         if stderr.is_empty() {
             stderr = Self::read_file_from_offset(&console_err_path, console_err_start);
         }
+        let truncated = stdout.len() > a3s_box_core::exec::MAX_OUTPUT_BYTES
+            || stderr.len() > a3s_box_core::exec::MAX_OUTPUT_BYTES;
+        stdout.truncate(a3s_box_core::exec::MAX_OUTPUT_BYTES);
+        stderr.truncate(a3s_box_core::exec::MAX_OUTPUT_BYTES);
         Ok(a3s_box_core::exec::ExecOutput {
             stdout,
             stderr,
             exit_code,
+            truncated,
         })
     }
 
@@ -828,6 +833,7 @@ impl VmManager {
         timeout_ns: u64,
     ) -> Result<a3s_box_core::exec::ExecOutput> {
         let request = a3s_box_core::exec::ExecRequest {
+            request_id: None,
             cmd,
             timeout_ns,
             env: vec![],

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -328,23 +328,38 @@ fn reap_orphaned_crun(home_dir: &Path, box_dir: &Path, box_id: &str) -> SandboxR
 
 #[cfg(target_os = "linux")]
 fn drain_recorded_log_worker(record: &RecordedSandboxRuntime, box_id: &str) {
-    let (Some(pid), Some(_start_time)) = (record.log_worker_pid, record.log_worker_pid_start_time)
+    const LOG_WORKER_EXIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+    let (Some(pid), Some(start_time)) = (record.log_worker_pid, record.log_worker_pid_start_time)
     else {
         return;
     };
-    if wait_for_log_worker_identity(record, std::time::Duration::from_secs(2)) {
-        return;
-    }
-
-    tracing::warn!(
-        box_id,
-        log_worker_pid = pid,
-        "Recovered Sandbox log worker did not drain after crun cleanup; terminating it"
-    );
-    if let Ok(pid) = i32::try_from(pid) {
-        unsafe {
-            libc::kill(pid, libc::SIGKILL);
+    if !wait_for_log_worker_identity(record, LOG_WORKER_EXIT_TIMEOUT) {
+        tracing::warn!(
+            box_id,
+            log_worker_pid = pid,
+            "Recovered Sandbox log worker did not drain after crun cleanup; terminating it"
+        );
+        // Revalidate the stable identity immediately before signalling so a
+        // PID reused during cleanup cannot be targeted.
+        if crate::process::is_process_running_with_identity(pid, Some(start_time)) {
+            if let Ok(pid) = i32::try_from(pid) {
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                }
+            }
         }
+    }
+    if !crate::process::wait_for_process_exit_with_identity(
+        pid,
+        start_time,
+        LOG_WORKER_EXIT_TIMEOUT,
+    ) {
+        tracing::warn!(
+            box_id,
+            log_worker_pid = pid,
+            "Recovered Sandbox log worker remained present after cleanup"
+        );
     }
 }
 
@@ -572,5 +587,28 @@ mod tests {
         assert!(error
             .to_string()
             .contains("Cannot verify the recorded Sandbox runtime"));
+    }
+
+    #[test]
+    fn cleanup_reaps_a_terminal_recovered_log_worker() {
+        let worker = std::process::Command::new("true").spawn().unwrap();
+        let pid = worker.id();
+        let start_time = crate::process::pid_start_time(pid).unwrap();
+        drop(worker);
+        let record = RecordedSandboxRuntime {
+            runtime_path: Path::new("/bin/true").to_path_buf(),
+            runtime_root: Path::new("/tmp/recovered-runtime").to_path_buf(),
+            bundle_dir: Path::new("/tmp/recovered-bundle").to_path_buf(),
+            init_pid: 42,
+            log_worker_pid: Some(pid),
+            log_worker_pid_start_time: Some(start_time),
+        };
+
+        drain_recorded_log_worker(&record, "terminal-recovered-worker");
+
+        assert!(
+            !crate::process::is_process_alive_with_identity(pid, Some(start_time)),
+            "cleanup must not leave its completed child as a zombie"
+        );
     }
 }

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -427,20 +427,43 @@ fn parse_sandbox_tmpfs(value: &str) -> Result<SandboxTmpfs> {
     let (destination, options) = value
         .split_once(':')
         .map_or((value, None), |(path, options)| (path, Some(options)));
-    let size_bytes = match options {
-        None | Some("") => DEFAULT_SIZE,
-        Some(option) => option
-            .strip_prefix("size=")
-            .ok_or_else(|| {
-                BoxError::ConfigError(format!(
-                    "Invalid Sandbox tmpfs option {option:?}; only size=<bytes> is supported"
-                ))
-            })
-            .and_then(parse_byte_size)?,
-    };
+    let mut size_bytes = DEFAULT_SIZE;
+    let mut size_seen = false;
+    let mut read_only = None;
+    for option in options
+        .into_iter()
+        .flat_map(|options| options.split(','))
+        .filter(|option| !option.is_empty())
+    {
+        match option {
+            "ro" | "rw" => {
+                let requested = option == "ro";
+                if read_only.replace(requested).is_some() {
+                    return Err(BoxError::ConfigError(format!(
+                        "Sandbox tmpfs has duplicate or conflicting access modes: {value:?}"
+                    )));
+                }
+            }
+            _ if option.starts_with("size=") => {
+                if size_seen {
+                    return Err(BoxError::ConfigError(format!(
+                        "Sandbox tmpfs has duplicate size options: {value:?}"
+                    )));
+                }
+                size_seen = true;
+                size_bytes = parse_byte_size(&option["size=".len()..])?;
+            }
+            _ => {
+                return Err(BoxError::ConfigError(format!(
+                    "Invalid Sandbox tmpfs option {option:?}; only size=<bytes>, ro, and rw are supported"
+                )));
+            }
+        }
+    }
     Ok(SandboxTmpfs {
         destination: normalized_container_path(destination, "tmpfs destination")?,
         size_bytes,
+        read_only: read_only.unwrap_or(false),
     })
 }
 
@@ -645,6 +668,14 @@ mod tests {
 
         let tmpfs = parse_sandbox_tmpfs("/scratch:size=128m").unwrap();
         assert_eq!(tmpfs.size_bytes, 128 * 1024 * 1024);
+        assert!(!tmpfs.read_only);
+
+        let read_only = parse_sandbox_tmpfs("/sealed:size=4m,ro").unwrap();
+        assert_eq!(read_only.size_bytes, 4 * 1024 * 1024);
+        assert!(read_only.read_only);
+
+        assert!(parse_sandbox_tmpfs("/scratch:size=1m,ro,rw").is_err());
+        assert!(parse_sandbox_tmpfs("/scratch:exec").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a production A3S Runtime driver backed by Box Sandbox lifecycle, execution, logs, metadata, recovery, and durable operation state
- harden guest exec framing, bounded output, timeouts, process reaping, ownership checks, cleanup fencing, and portable guest-init networking
- certify all advertised Runtime profiles against real crun, including cancellation replay, partial-creation adoption, provider/client restart recovery, external deletion, and duplicate-resource detection
- prove unadvertised outbound networking, volume mounts, health checks, and secret references fail before provider mutation
- make the opt-in R17 gate self-contained with bounded runner and Tokio worker stacks
- document the provider contract and certified tmpfs/mount boundary

This is the Runtime-provider portion of #124. Compose normalization remains in #125; this PR does not close the issue.

## Validation

- exact HEAD `ab75e7c5aa5b916011284b9c13b37c1e02079d6d`: real R17 suite passed all 8 capability-activated profiles on Ubuntu 24.04 with certified crun 1.28 in 53.35s
- R17 image: `public.ecr.aws/docker/library/alpine@sha256:c64c687cbea9300178b30c95835354e34c4e4febc4badfe27102879de0483b5e` (`application/vnd.oci.image.manifest.v1+json`)
- CI run 29663872305: Format, Clippy, Test, E2B Contract, E2B Official Clients, SDK Packages, Linux x86_64/arm64, macOS arm64, and Windows WHPX all passed
- combined #125 + #126 merge-tree validation: Core 444, normalization 6, Runtime Compose 37, CLI Compose 26, and command coverage 13 tests passed; only `CHANGELOG.md` needs mechanical entry concatenation
- static PIE musl guest init and native shim built successfully on the R17 host
- `cargo fmt --all -- --check`
- `git diff --check`