### PR TITLE
fix(cli): retain wait status after auto-removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ transitions, idempotent operation IDs, and restart reconciliation. The runtime
 persists caller policy instead of rebuilding it from defaults during a retry.
 Health checks and restart policies are owned by generation-fenced background
 workers, and structured `json-file` logging keeps stdout and stderr distinct.
+Auto-removed boxes retain terminal exit metadata, plus logs when enabled and
+available, under the removed-box retention limits. Both `wait` and `logs` can
+therefore resolve a removed box by name or ID after its live state is gone.
 
 Common runtime controls include:
 

--- a/src/cli/src/commands/logs.rs
+++ b/src/cli/src/commands/logs.rs
@@ -324,7 +324,11 @@ fn resolve_archived_log_source(
     archive: &crate::log_archive::RemovedLogArchive,
 ) -> Option<LogSource> {
     let log_dir = archive.log_dir();
-    let json_log = a3s_box_runtime::log::json_log_path(&log_dir);
+    resolve_archived_log_source_in(&log_dir)
+}
+
+fn resolve_archived_log_source_in(log_dir: &Path) -> Option<LogSource> {
+    let json_log = a3s_box_runtime::log::json_log_path(log_dir);
     if json_log.exists() {
         return Some(LogSource {
             path: json_log,
@@ -332,7 +336,7 @@ fn resolve_archived_log_source(
         });
     }
 
-    let console_log = archive.console_log();
+    let console_log = log_dir.join("console.log");
     if console_log.exists() {
         return Some(LogSource {
             path: console_log,
@@ -488,36 +492,6 @@ fn extract_line_timestamp(line: &str) -> Option<DateTime<Utc>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    struct EnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        key: &'static str,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &Path) -> Self {
-            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-            let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
-            Self {
-                _lock: lock,
-                key,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
 
     #[test]
     #[cfg(unix)]
@@ -694,24 +668,13 @@ mod tests {
     #[test]
     fn test_resolve_archived_log_source_prefers_structured_json() {
         let tmp = tempfile::tempdir().unwrap();
-        let _guard = EnvGuard::set("A3S_HOME", tmp.path());
-        let archive = crate::log_archive::RemovedLogArchive {
-            id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
-            short_id: "550e8400e29b".to_string(),
-            name: "web".to_string(),
-            image: "alpine:latest".to_string(),
-            removed_at: Utc::now(),
-            created_at: Utc::now(),
-            started_at: None,
-            exit_code: Some(1),
-            log_config: a3s_box_core::log::LogConfig::default(),
-        };
-        std::fs::create_dir_all(archive.log_dir()).unwrap();
-        let json_log = a3s_box_runtime::log::json_log_path(&archive.log_dir());
+        let log_dir = tmp.path().join("logs");
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let json_log = a3s_box_runtime::log::json_log_path(&log_dir);
         std::fs::write(&json_log, "{}\n").unwrap();
-        std::fs::write(archive.console_log(), "console\n").unwrap();
+        std::fs::write(log_dir.join("console.log"), "console\n").unwrap();
 
-        let source = resolve_archived_log_source(&archive).unwrap();
+        let source = resolve_archived_log_source_in(&log_dir).unwrap();
         assert!(source.structured);
         assert_eq!(source.path, json_log);
     }

--- a/src/cli/src/commands/wait.rs
+++ b/src/cli/src/commands/wait.rs
@@ -39,7 +39,17 @@ async fn wait_one(
     let mut heartbeat = WaitHeartbeat::new(heartbeat_interval);
     loop {
         let state = StateFile::load_default()?;
-        let record = resolve::resolve(&state, query)?;
+        let record = match resolve::resolve(&state, query) {
+            Ok(record) => record,
+            Err(error @ resolve::ResolveError::NotFound(_)) => {
+                if let Some(exit_code) = archived_wait_exit_code(query)? {
+                    println!("{exit_code}");
+                    return Ok(());
+                }
+                return Err(error.into());
+            }
+            Err(error) => return Err(error.into()),
+        };
 
         match wait_poll_action(record) {
             WaitPollAction::Finish(exit_code) => {
@@ -52,6 +62,10 @@ async fn wait_one(
             }
         }
     }
+}
+
+fn archived_wait_exit_code(query: &str) -> Result<Option<i32>, String> {
+    Ok(crate::log_archive::resolve_archive(query)?.map(|archive| archive.exit_code.unwrap_or(0)))
 }
 
 fn wait_heartbeat_interval(args: &WaitArgs) -> Option<std::time::Duration> {

--- a/src/cli/src/log_archive.rs
+++ b/src/cli/src/log_archive.rs
@@ -1,4 +1,4 @@
-//! Archived logs for auto-removed boxes.
+//! Archived terminal metadata and logs for auto-removed boxes.
 
 use std::path::{Path, PathBuf};
 
@@ -45,38 +45,29 @@ pub(crate) struct RemovedLogArchive {
 
 impl RemovedLogArchive {
     pub(crate) fn log_dir(&self) -> PathBuf {
-        archive_dir(&self.id).join("logs")
-    }
-
-    pub(crate) fn console_log(&self) -> PathBuf {
-        self.log_dir().join("console.log")
+        archive_dir(&archive_root(), &self.id).join("logs")
     }
 }
 
+/// Persist terminal metadata and copy any available logs.
+///
+/// `Some` means at least one log file was retained. Terminal metadata is still
+/// persisted when this returns `None`, so callers can avoid advertising logs
+/// that do not exist without losing the removed box's final status.
 pub(crate) fn archive_removed_logs(record: &BoxRecord) -> std::io::Result<Option<PathBuf>> {
-    if record.log_config.driver == a3s_box_core::log::LogDriver::None {
-        return Ok(None);
-    }
+    archive_removed_logs_in(record, &archive_root())
+}
 
+fn archive_removed_logs_in(
+    record: &BoxRecord,
+    archive_root: &Path,
+) -> std::io::Result<Option<PathBuf>> {
     let source_log_dir = record.box_dir.join("logs");
-    if !source_log_dir.exists() && !record.console_log.exists() {
-        return Ok(None);
-    }
-
-    let archive_dir = archive_dir(&record.id);
+    let archive_dir = archive_dir(archive_root, &record.id);
     if archive_dir.exists() {
         std::fs::remove_dir_all(&archive_dir)?;
     }
-    std::fs::create_dir_all(archive_dir.join("logs"))?;
-
-    if source_log_dir.exists() {
-        copy_dir_contents(&source_log_dir, &archive_dir.join("logs"))?;
-    } else if record.console_log.exists() {
-        std::fs::copy(
-            &record.console_log,
-            archive_dir.join("logs").join("console.log"),
-        )?;
-    }
+    std::fs::create_dir_all(&archive_dir)?;
 
     let metadata = RemovedLogArchive {
         id: record.id.clone(),
@@ -92,18 +83,39 @@ pub(crate) fn archive_removed_logs(record: &BoxRecord) -> std::io::Result<Option
     let data = serde_json::to_vec_pretty(&metadata).map_err(std::io::Error::other)?;
     std::fs::write(archive_dir.join(METADATA_FILE), data)?;
 
-    if let Err(error) = prune_archives(LogArchiveRetention::default()) {
+    let mut archived_logs = false;
+    if record.log_config.driver != a3s_box_core::log::LogDriver::None {
+        let archived_log_dir = archive_dir.join("logs");
+        if source_log_dir.is_dir() {
+            archived_logs = copy_dir_contents(&source_log_dir, &archived_log_dir)?;
+        }
+        if !archived_logs && record.console_log.is_file() {
+            std::fs::create_dir_all(&archived_log_dir)?;
+            std::fs::copy(&record.console_log, archived_log_dir.join("console.log"))?;
+            archived_logs = true;
+        }
+    }
+
+    if let Err(error) = prune_archives(archive_root, LogArchiveRetention::default()) {
         tracing::debug!(
             error = %error,
             "Failed to prune removed-log archives after archiving logs"
         );
     }
 
-    Ok(Some(archive_dir))
+    Ok(archived_logs.then_some(archive_dir))
 }
 
 pub(crate) fn resolve_archive(query: &str) -> Result<Option<RemovedLogArchive>, String> {
-    let archives = load_archives().map_err(|e| format!("Failed to read removed logs: {e}"))?;
+    resolve_archive_in(query, &archive_root())
+}
+
+fn resolve_archive_in(
+    query: &str,
+    archive_root: &Path,
+) -> Result<Option<RemovedLogArchive>, String> {
+    let archives =
+        load_archives(archive_root).map_err(|e| format!("Failed to read removed logs: {e}"))?;
 
     if let Some(archive) = archives.iter().find(|archive| archive.id == query) {
         return Ok(Some(archive.clone()));
@@ -135,8 +147,8 @@ pub(crate) fn resolve_archive(query: &str) -> Result<Option<RemovedLogArchive>, 
     }
 }
 
-fn load_archives() -> std::io::Result<Vec<RemovedLogArchive>> {
-    Ok(load_archive_entries()?
+fn load_archives(archive_root: &Path) -> std::io::Result<Vec<RemovedLogArchive>> {
+    Ok(load_archive_entries(archive_root)?
         .into_iter()
         .map(|entry| entry.archive)
         .collect())
@@ -148,14 +160,13 @@ struct ArchiveEntry {
     size_bytes: u64,
 }
 
-fn load_archive_entries() -> std::io::Result<Vec<ArchiveEntry>> {
-    let root = archive_root();
-    if !root.exists() {
+fn load_archive_entries(archive_root: &Path) -> std::io::Result<Vec<ArchiveEntry>> {
+    if !archive_root.exists() {
         return Ok(Vec::new());
     }
 
     let mut archives = Vec::new();
-    for entry in std::fs::read_dir(root)? {
+    for entry in std::fs::read_dir(archive_root)? {
         let entry = entry?;
         let path = entry.path().join(METADATA_FILE);
         if !path.exists() {
@@ -177,8 +188,8 @@ fn load_archive_entries() -> std::io::Result<Vec<ArchiveEntry>> {
     Ok(archives)
 }
 
-pub(crate) fn prune_archives(retention: LogArchiveRetention) -> std::io::Result<usize> {
-    let mut entries = load_archive_entries()?;
+fn prune_archives(archive_root: &Path, retention: LogArchiveRetention) -> std::io::Result<usize> {
+    let mut entries = load_archive_entries(archive_root)?;
     let now = Utc::now();
     let mut removed = 0;
 
@@ -246,68 +257,40 @@ fn dir_size(path: &Path) -> std::io::Result<u64> {
     Ok(size)
 }
 
-fn copy_dir_contents(src: &Path, dst: &Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dst)?;
+fn copy_dir_contents(src: &Path, dst: &Path) -> std::io::Result<bool> {
+    let mut copied_file = false;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
         let file_type = entry.file_type()?;
         let from = entry.path();
         let to = dst.join(entry.file_name());
         if file_type.is_dir() {
-            copy_dir_contents(&from, &to)?;
+            copied_file |= copy_dir_contents(&from, &to)?;
         } else if file_type.is_file() {
+            std::fs::create_dir_all(dst)?;
             std::fs::copy(from, to)?;
+            copied_file = true;
         }
     }
-    Ok(())
+    Ok(copied_file)
 }
 
 fn archive_root() -> PathBuf {
     a3s_box_core::dirs_home().join(ARCHIVE_DIR)
 }
 
-fn archive_dir(id: &str) -> PathBuf {
-    archive_root().join(id)
+fn archive_dir(archive_root: &Path, id: &str) -> PathBuf {
+    archive_root.join(id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    struct EnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        key: &'static str,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &Path) -> Self {
-            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-            let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
-            Self {
-                _lock: lock,
-                key,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
 
     #[test]
     fn archives_and_resolves_auto_removed_logs_by_name() {
         let tmp = tempfile::tempdir().unwrap();
-        let _guard = EnvGuard::set("A3S_HOME", tmp.path());
+        let archive_root = tmp.path().join(ARCHIVE_DIR);
         let box_dir = tmp.path().join("box");
         std::fs::create_dir_all(box_dir.join("logs")).unwrap();
         std::fs::write(box_dir.join("logs").join("container.json"), "{}\n").unwrap();
@@ -322,63 +305,165 @@ mod tests {
         record.box_dir = box_dir;
         record.console_log = record.box_dir.join("logs").join("console.log");
 
-        let archive_path = archive_removed_logs(&record).unwrap().unwrap();
+        let archive_path = archive_removed_logs_in(&record, &archive_root)
+            .unwrap()
+            .unwrap();
         assert!(archive_path.join("logs").join("container.json").exists());
 
-        let archive = resolve_archive("web").unwrap().unwrap();
+        let archive = resolve_archive_in("web", &archive_root).unwrap().unwrap();
         assert_eq!(archive.id, record.id);
-        assert!(archive.log_dir().join("container.json").exists());
+        assert!(archive_dir(&archive_root, &archive.id)
+            .join("logs")
+            .join("container.json")
+            .exists());
+    }
+
+    #[test]
+    fn archives_terminal_metadata_without_log_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let archive_root = tmp.path().join(ARCHIVE_DIR);
+
+        for (id, name, driver, exit_code) in [
+            (
+                "550e8400-e29b-41d4-a716-446655440001",
+                "logging-disabled",
+                a3s_box_core::log::LogDriver::None,
+                17,
+            ),
+            (
+                "550e8400-e29b-41d4-a716-446655440002",
+                "logs-missing",
+                a3s_box_core::log::LogDriver::JsonFile,
+                23,
+            ),
+        ] {
+            let mut record = crate::test_helpers::fixtures::make_record(id, name, "dead", None);
+            record.auto_remove = true;
+            record.exit_code = Some(exit_code);
+            record.log_config.driver = driver;
+            record.box_dir = tmp.path().join(name);
+            record.console_log = record.box_dir.join("logs").join("console.log");
+
+            assert!(archive_removed_logs_in(&record, &archive_root)
+                .unwrap()
+                .is_none());
+
+            let archive = resolve_archive_in(name, &archive_root).unwrap().unwrap();
+            assert_eq!(archive.id, record.id);
+            assert_eq!(archive.exit_code, Some(exit_code));
+            assert!(!archive_dir(&archive_root, &archive.id)
+                .join("logs")
+                .exists());
+        }
     }
 
     #[test]
     fn prunes_archives_by_age_and_count() {
         let tmp = tempfile::tempdir().unwrap();
-        let _guard = EnvGuard::set("A3S_HOME", tmp.path());
+        let archive_root = tmp.path().join(ARCHIVE_DIR);
 
-        write_archive("old", Utc::now() - chrono::Duration::days(30), 8);
-        write_archive("keep-1", Utc::now() - chrono::Duration::days(3), 8);
-        write_archive("keep-2", Utc::now() - chrono::Duration::days(2), 8);
-        write_archive("keep-3", Utc::now() - chrono::Duration::days(1), 8);
+        write_archive(
+            &archive_root,
+            "old",
+            Utc::now() - chrono::Duration::days(30),
+            8,
+        );
+        write_archive(
+            &archive_root,
+            "keep-1",
+            Utc::now() - chrono::Duration::days(3),
+            8,
+        );
+        write_archive(
+            &archive_root,
+            "keep-2",
+            Utc::now() - chrono::Duration::days(2),
+            8,
+        );
+        write_archive(
+            &archive_root,
+            "keep-3",
+            Utc::now() - chrono::Duration::days(1),
+            8,
+        );
 
-        let removed = prune_archives(LogArchiveRetention {
-            max_age_days: 7,
-            max_archives: 2,
-            max_total_bytes: u64::MAX,
-        })
+        let removed = prune_archives(
+            &archive_root,
+            LogArchiveRetention {
+                max_age_days: 7,
+                max_archives: 2,
+                max_total_bytes: u64::MAX,
+            },
+        )
         .unwrap();
 
         assert_eq!(removed, 2);
-        assert!(resolve_archive("old").unwrap().is_none());
-        assert!(resolve_archive("keep-1").unwrap().is_none());
-        assert!(resolve_archive("keep-2").unwrap().is_some());
-        assert!(resolve_archive("keep-3").unwrap().is_some());
+        assert!(resolve_archive_in("old", &archive_root).unwrap().is_none());
+        assert!(resolve_archive_in("keep-1", &archive_root)
+            .unwrap()
+            .is_none());
+        assert!(resolve_archive_in("keep-2", &archive_root)
+            .unwrap()
+            .is_some());
+        assert!(resolve_archive_in("keep-3", &archive_root)
+            .unwrap()
+            .is_some());
     }
 
     #[test]
     fn prunes_archives_by_total_size() {
         let tmp = tempfile::tempdir().unwrap();
-        let _guard = EnvGuard::set("A3S_HOME", tmp.path());
+        let archive_root = tmp.path().join(ARCHIVE_DIR);
 
-        write_archive("large-1", Utc::now() - chrono::Duration::days(3), 128);
-        write_archive("large-2", Utc::now() - chrono::Duration::days(2), 128);
-        write_archive("large-3", Utc::now() - chrono::Duration::days(1), 128);
+        write_archive(
+            &archive_root,
+            "large-1",
+            Utc::now() - chrono::Duration::days(3),
+            128,
+        );
+        write_archive(
+            &archive_root,
+            "large-2",
+            Utc::now() - chrono::Duration::days(2),
+            128,
+        );
+        write_archive(
+            &archive_root,
+            "large-3",
+            Utc::now() - chrono::Duration::days(1),
+            128,
+        );
 
-        let before = dir_size(&archive_root()).unwrap();
-        let removed = prune_archives(LogArchiveRetention {
-            max_age_days: 7,
-            max_archives: 10,
-            max_total_bytes: before.saturating_sub(1),
-        })
+        let before = dir_size(&archive_root).unwrap();
+        let removed = prune_archives(
+            &archive_root,
+            LogArchiveRetention {
+                max_age_days: 7,
+                max_archives: 10,
+                max_total_bytes: before.saturating_sub(1),
+            },
+        )
         .unwrap();
 
         assert_eq!(removed, 1);
-        assert!(resolve_archive("large-1").unwrap().is_none());
-        assert!(resolve_archive("large-2").unwrap().is_some());
-        assert!(resolve_archive("large-3").unwrap().is_some());
+        assert!(resolve_archive_in("large-1", &archive_root)
+            .unwrap()
+            .is_none());
+        assert!(resolve_archive_in("large-2", &archive_root)
+            .unwrap()
+            .is_some());
+        assert!(resolve_archive_in("large-3", &archive_root)
+            .unwrap()
+            .is_some());
     }
 
-    fn write_archive(id: &str, removed_at: DateTime<Utc>, payload_bytes: usize) {
-        let dir = archive_dir(id);
+    fn write_archive(
+        archive_root: &Path,
+        id: &str,
+        removed_at: DateTime<Utc>,
+        payload_bytes: usize,
+    ) {
+        let dir = archive_dir(archive_root, id);
         std::fs::create_dir_all(dir.join("logs")).unwrap();
         std::fs::write(
             dir.join("logs").join("console.log"),

--- a/src/cli/tests/wait_integration.rs
+++ b/src/cli/tests/wait_integration.rs
@@ -1,0 +1,53 @@
+//! Integration coverage for terminal status retained after auto-removal.
+
+mod support;
+use support::CliTest;
+
+fn write_removed_terminal_archive(cli: &CliTest, id: &str, name: &str, exit_code: Option<i32>) {
+    let archive_dir = cli.home_path().join("removed-logs").join(id);
+    std::fs::create_dir_all(&archive_dir).expect("create removed terminal archive");
+    let metadata = serde_json::json!({
+        "id": id,
+        "short_id": id.replace('-', "").chars().take(12).collect::<String>(),
+        "name": name,
+        "image": "alpine:latest",
+        "removed_at": "2026-07-18T00:00:00Z",
+        "created_at": "2026-07-18T00:00:00Z",
+        "started_at": "2026-07-18T00:00:01Z",
+        "exit_code": exit_code,
+        "log_config": {
+            "driver": "none",
+            "options": {}
+        }
+    });
+    std::fs::write(
+        archive_dir.join("metadata.json"),
+        serde_json::to_vec_pretty(&metadata).expect("serialize removed terminal archive"),
+    )
+    .expect("write removed terminal archive");
+}
+
+#[test]
+fn wait_reads_auto_removed_terminal_archive() {
+    let cli = CliTest::new();
+    write_removed_terminal_archive(
+        &cli,
+        "550e8400-e29b-41d4-a716-446655440010",
+        "failed-removed-job",
+        Some(23),
+    );
+    write_removed_terminal_archive(
+        &cli,
+        "550e8400-e29b-41d4-a716-446655440011",
+        "successful-removed-job",
+        None,
+    );
+
+    let output = cli.ok(&[
+        "wait",
+        "failed-removed-job",
+        "successful-removed-job",
+        "--no-heartbeat",
+    ]);
+    assert_eq!(output, "23\n0\n");
+}


### PR DESCRIPTION
## Summary

- persist terminal metadata for auto-removed boxes even when logging is disabled or no log file exists
- make `a3s-box wait` fall back to the removed-box archive after live state disappears
- retain the existing `0` default when no exit code was recorded, without advertising logs unless files were actually copied
- isolate archive tests from process-global `A3S_HOME` state and add CLI integration coverage

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p a3s-box-cli` (753 unit tests plus default integration suites)
- `cargo clippy -p a3s-box-cli --all-targets --no-deps -- -D warnings`
- `cargo check --release -p a3s-box-cli`

## Context

Related to A3S-Lab/Box#167. Current `main` already handles foreground `run --rm` interruption cleanup; this PR addresses the remaining `wait`/auto-removal status race. It intentionally does not use an auto-closing keyword so both reported behaviors can be verified together after merge.