### PR TITLE
chore(release): v3.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+## [3.0.11] — 2026-07-19
+
 ### Added
 
 - **A3S Runtime recovery fault fixtures.** The real-provider R17 Recovery

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "a3s-box"
-version = "3.0.10"
+version = "3.0.11"
 description = "Typed Python convenience package for the A3S Box E2B-compatible endpoint"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/box",
-      "version": "3.0.10",
+      "version": "3.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@e2b/code-interpreter": "2.6.1",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "Typed TypeScript convenience package for the A3S Box E2B-compatible endpoint",
   "type": "module",
   "sideEffects": false,

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -9,7 +9,7 @@ source = "git+https://github.com/A3S-Lab/ACL.git?rev=fc041758758eba89dd5d22a3414
 
 [[package]]
 name = "a3s-box-cli"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-compat"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-acl",
  "a3s-box-core",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-core"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-acl",
  "a3s-common",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cri"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-guest-init"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-box-core",
  "a3s-common",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-lambda"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-netproxy"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-box-core",
  "libc",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-runtime"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-sdk"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-shim"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-libkrun-sys"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "libc",
  "num_cpus",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -24,7 +24,7 @@ resolver = "2"
 h2 = { path = "third_party/h2" }
 
 [workspace.package]
-version = "3.0.10"
+version = "3.0.11"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- cut 3.0.11 for Runtime recovery, tmpfs conformance, deterministic Compose normalization, resilient registry pulls, and multi-platform OCI loading
- align Rust workspace, Python SDK, and TypeScript SDK versions
- move the current Unreleased notes into the 3.0.11 section

## Validation

- locked Cargo metadata and `cargo fmt --all -- --check`
- TypeScript `npm ci`, build, and tests
- Python 3.12 clean-venv package install and tests
- merged #127 CI is green; this PR CI re-runs the Linux workspace test gate

Local macOS all-workspace library compilation still encounters the pre-existing Linux-specific `a3s-box-compat` filesystem implementation; the release matrix only builds that compatibility binary on Linux.