### PR TITLE
feat(sdk): add zero-credential local Sandbox facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential musl-tools protobuf-compiler
           rustup target add x86_64-unknown-linux-musl
+          echo "void krun_stub(void) {}" > /tmp/krun_stub.c
+          gcc -shared -o /tmp/libkrun.so /tmp/krun_stub.c
+          sudo cp /tmp/libkrun.so /usr/lib/
+          sudo ldconfig
       - name: Build local SDK runtime artifacts
         run: |
           cd src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         with:
           workspaces: src
       - run: cd src && cargo test --locked --workspace --lib
+      - name: Compile local SDK real-runtime smoke
+        run: cd src && cargo test --locked -p a3s-box-sdk --test local_sandbox --no-run
 
   # The RuntimeClass shim is an intentionally standalone Cargo workspace, so
   # none of the src workspace gates above compile or test it.
@@ -170,10 +172,80 @@ jobs:
           npm test
           npm pack --dry-run
 
+  # ── Real shared-kernel local SDK gate ──────────────────────────
+  sdk-local-sandbox:
+    name: SDK Local Sandbox (real crun)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      A3S_HOME: /tmp/a3s-local-sdk-smoke-sandbox
+      A3S_BOX_CRUN_PATH: /tmp/a3s-local-sdk-smoke-sandbox/bin/crun
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - name: Init submodules
+        run: git -c http.extraheader= submodule update --init --recursive
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential musl-tools protobuf-compiler
+          rustup target add x86_64-unknown-linux-musl
+      - name: Build local SDK runtime artifacts
+        run: |
+          cd src
+          cargo build --locked -p a3s-box-cli -p a3s-box-shim
+          cargo build --locked --release -p a3s-box-guest-init \
+            --target x86_64-unknown-linux-musl
+      - name: Install certified crun and host identity ranges
+        run: |
+          curl --fail --location --silent --show-error \
+            https://github.com/containers/crun/releases/download/1.28/crun-1.28-linux-amd64 \
+            --output /tmp/crun-1.28-linux-amd64
+          echo '2aa6b7024a9c9f153895c0d11ae233d3758f54844011c3a039e3e89048d01d42  /tmp/crun-1.28-linux-amd64' \
+            | sha256sum --check
+          sudo install -d -m 755 "$A3S_HOME/bin"
+          sudo install -m 755 /tmp/crun-1.28-linux-amd64 "$A3S_BOX_CRUN_PATH"
+          grep -q '^root:' /etc/subuid ||
+            echo 'root:100000:65536' | sudo tee -a /etc/subuid
+          grep -q '^root:' /etc/subgid ||
+            echo 'root:100000:65536' | sudo tee -a /etc/subgid
+      - name: Test Rust, Python, and TypeScript SDKs without credentials
+        run: |
+          sudo env \
+              PATH="$PATH" \
+              HOME="$HOME" \
+              RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}" \
+              CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" \
+              A3S_DEPS_STUB=1 \
+              A3S_HOME="$A3S_HOME" \
+              A3S_BOX_CRUN_PATH="$A3S_BOX_CRUN_PATH" \
+              A3S_BOX_BINARY="$GITHUB_WORKSPACE/src/target/debug/a3s-box" \
+              A3S_BOX_SHIM_BINARY="$GITHUB_WORKSPACE/src/target/debug/a3s-box-shim" \
+              A3S_BOX_GUEST_INIT_BINARY="$GITHUB_WORKSPACE/src/target/x86_64-unknown-linux-musl/release/a3s-box-guest-init" \
+              RUST_MIN_STACK=16777216 \
+              PYTHON=python3 \
+              scripts/local-sdk-smoke.sh sandbox
+      - name: Verify cleanup
+        if: always()
+        run: |
+          if pgrep -f 'a3s-box-shim|crun.*a3s-local-sdk' >/dev/null; then
+            ps aux | grep -E 'a3s-box-shim|crun.*a3s-local-sdk' | grep -v grep
+            exit 1
+          fi
+          sudo rm -rf "$A3S_HOME"
+
   # ── Build check (compile only, no artifacts) ────────────────────
   build-check:
     name: Build Check (${{ matrix.target }})
-    needs: [fmt, clippy, test, e2b-contract, e2b-official-clients, sdk-packages]
+    needs: [fmt, clippy, test, e2b-contract, e2b-official-clients, sdk-packages, sdk-local-sandbox]
     strategy:
       matrix:
         include:
@@ -302,7 +374,7 @@ jobs:
   # Until both are done this job is SKIPPED (inert) and never blocks a PR.
   integration-kvm:
     name: Integration (real microVM, KVM)
-    needs: [fmt, clippy, test, e2b-contract, e2b-official-clients, sdk-packages]
+    needs: [fmt, clippy, test, e2b-contract, e2b-official-clients, sdk-packages, sdk-local-sandbox]
     # Never execute arbitrary pull-request code on a persistent self-hosted
     # runner. After review, maintainers can dispatch this workflow against the
     # PR branch explicitly.
@@ -353,6 +425,26 @@ jobs:
           unset A3S_DEPS_STUB
           cd src
           cargo test --locked --release -p a3s-box-cli --test core_smoke -- --ignored --nocapture --test-threads=1
+      - name: Rust local SDK — zero credentials + real MicroVM
+        run: |
+          unset A3S_DEPS_STUB
+          unset E2B_API_KEY E2B_API_URL E2B_DOMAIN
+          unset A3S_BOX_API_KEY A3S_BOX_ENDPOINT A3S_BOX_DOMAIN A3S_BOX_SANDBOX_URL
+          export A3S_HOME
+          A3S_HOME="$(mktemp -d /tmp/a3s-local-sdk-smoke.XXXXXX)"
+          trap 'rm -rf "$A3S_HOME"' EXIT
+          mkdir -p "$A3S_HOME/bin"
+          install -m 755 src/target/release/a3s-box-shim \
+            "$A3S_HOME/bin/a3s-box-shim"
+          install -m 755 \
+            src/target/x86_64-unknown-linux-musl/release/a3s-box-guest-init \
+            "$A3S_HOME/bin/a3s-box-guest-init"
+          cd src
+          A3S_BOX_SDK_LOCAL_SMOKE=1 \
+            A3S_BOX_SDK_SMOKE_ISOLATION=microvm \
+            cargo test --locked --release -p a3s-box-sdk --test local_sandbox \
+              e2b_style_local_sandbox_runs_without_remote_credentials \
+              -- --ignored --nocapture --test-threads=1
       # Keep the cached foreground no-op inside a bounded production envelope.
       # Docker is intentionally unavailable on this runner; the original
       # macOS/HVF Docker ratio remains a separate hardware-specific comparison.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential musl-tools protobuf-compiler
           rustup target add x86_64-unknown-linux-musl
-          echo "void krun_stub(void) {}" > /tmp/krun_stub.c
+          sed -nE \
+            's/^[[:space:]]*pub fn (krun_[A-Za-z0-9_]+).*/long \1(void) { return -1; }/p' \
+            src/deps/libkrun-sys/src/lib.rs \
+            | sort -u > /tmp/krun_stub.c
+          test -s /tmp/krun_stub.c
           gcc -shared -o /tmp/libkrun.so /tmp/krun_stub.c
           sudo cp /tmp/libkrun.so /usr/lib/
           sudo ldconfig

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ coverage/
 htmlcov/
 *.egg-info/
 /dist/
+/sdk/python/dist/
+/sdk/typescript/dist/
 /build/
 
 # Node.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
-- **Zero-configuration local Python and TypeScript SDKs.** Native `Sandbox`,
-  commands, files, lifecycle, and a small Python Code Interpreter facade now
-  call the installed `a3s-box` runtime through a versioned structured bridge.
-  Local use has no endpoint or API key, and the packages no longer depend on,
-  wrap, or re-export official E2B SDKs.
+- **Zero-configuration local Rust, Python, and TypeScript SDKs.** Native
+  `Sandbox`, commands, files, lifecycle, and a small Python Code Interpreter
+  facade now share the direct Rust runtime implementation through a versioned
+  structured bridge. Local use has no endpoint or API key, supports the
+  default MicroVM and explicit shared-kernel Sandbox isolation levels, and the
+  packages do not depend on, wrap, or re-export official E2B SDKs.
 - **Runnable native Windows WHPX path.** Windows packages now include the
   `libkrunfw.dll` companion kernel alongside `krun.dll`, and the native path is
   documented and validated with Alpine foreground/detached workloads, separated

--- a/README.md
+++ b/README.md
@@ -55,14 +55,32 @@ a3s-box run --rm --isolation sandbox alpine:latest -- id
 
 ### Local SDKs with E2B-like APIs
 
-The A3S Python and TypeScript packages expose familiar `Sandbox`, `commands`,
-and `files` namespaces while executing through the A3S Box runtime installed
-on the same machine. They do not wrap, import, depend on, or contact the
-official E2B SDK.
+The A3S Rust, Python, and TypeScript packages expose familiar `Sandbox`,
+`commands`, and `files` namespaces while executing through the A3S Box runtime
+installed on the same machine. They do not wrap, import, depend on, or contact
+the official E2B SDK.
 
 Local SDK use is zero-configuration: do not set an endpoint, domain, or API
-key. The package finds `a3s-box` on `PATH` and talks to its versioned,
-machine-only bridge instead of parsing human CLI output.
+key. The Rust SDK calls the runtime directly. Python and TypeScript find
+`a3s-box` on `PATH` and talk to its versioned, machine-only bridge instead of
+parsing human CLI output.
+
+Rust:
+
+```rust
+use a3s_box_sdk::Sandbox;
+
+# async fn example() -> Result<(), a3s_box_sdk::ClientError> {
+let sandbox = Sandbox::create("python:3.12-alpine").await?;
+let result = sandbox
+    .commands
+    .run("python -c 'print(6 * 7)'")
+    .await?;
+println!("{}", result.stdout);
+sandbox.files.write("/workspace/note.txt", "hello").await?;
+sandbox.kill().await?;
+# Ok(()) }
+```
 
 Python:
 
@@ -92,9 +110,12 @@ try {
 }
 ```
 
-`Sandbox.create()` defaults to `alpine:3.20` and MicroVM isolation. Its first
-argument is a local OCI image reference. Set `A3S_BOX_BINARY` only when the
-installed executable is not on `PATH`.
+All three constructors default to `alpine:3.20` and MicroVM isolation. Their
+image argument is a local OCI image reference. Set `A3S_BOX_BINARY` only for
+Python or TypeScript when the installed executable is not on `PATH`. Select
+`ExecutionIsolation::Sandbox`, `isolation="sandbox"`, or
+`isolation: 'sandbox'` respectively to opt into the shared-kernel backend on a
+certified Linux host.
 
 `A3S_BOX_ENDPOINT`, `A3S_BOX_API_KEY`, `A3S_BOX_DOMAIN`, and
 `A3S_BOX_SANDBOX_URL` are exclusively for an explicitly remote, self-hosted
@@ -144,8 +165,8 @@ E2B client used to validate it.
 | Storage | Bind mounts, named volumes, tmpfs, `cp`, `diff`, `export`, `commit`, filesystem snapshots, and CoW restore | Implemented. Filesystem snapshots do not contain live VM RAM or device state. |
 | Networking and Compose | TSI, bridge networks, TCP publishing, peer discovery, and Compose lifecycle/config/logs | Implemented subset for MicroVM workloads. UDP publishing, host-IP binds, ranges, and live network hot-plug are not implemented. |
 | Warm pool and snapshot-fork | Pre-booted MicroVMs, one-shot runs, build leases, metrics, and CoW memory restore | Implemented. Native snapshot-fork is Linux/KVM-only and disabled by default. |
-| Rust SDK | Typed, direct runtime-backed management and guest-control APIs | Implemented in `a3s-box-sdk`. The optional `pipeline-cli` feature retains the CLI-driven programmable pipeline. |
-| Local Python and TypeScript SDKs | E2B-like `Sandbox`, commands, files, lifecycle, and a small Python Code Interpreter facade over the installed local runtime | The packages have no official E2B runtime dependency and require no endpoint or API key. Their versioned bridge, request mapping, package builds, language-level API tests, and real macOS MicroVM create/command/file/cleanup smokes pass; a broader release-host MicroVM/Sandbox matrix remains a publication gate. |
+| Rust SDK | Typed, direct runtime-backed management and guest-control APIs plus an E2B-like local `Sandbox`, commands, files, and lifecycle facade | Implemented in `a3s-box-sdk`. Local use requires no endpoint or API key, defaults to MicroVM, and explicitly accepts the shared-kernel Sandbox isolation level. The optional `pipeline-cli` feature retains the CLI-driven programmable pipeline. |
+| Local Python and TypeScript SDKs | E2B-like `Sandbox`, commands, files, lifecycle, and a small Python Code Interpreter facade over the installed local runtime | The packages share the Rust Sandbox implementation through the versioned bridge, have no official E2B runtime dependency, and require no endpoint or API key. Package builds, language-level API tests for both isolation selectors, and real macOS MicroVM create/command/file/cleanup smokes pass; a broader release-host MicroVM/Sandbox matrix remains a publication gate. |
 | Remote E2B protocol service | Pinned contracts, durable lifecycle, memory-preserving and filesystem-only pause/resume, owner-scoped filesystem Snapshots and Volumes, v1/v2 listing and runtime-backed structured logs, current metrics, TLS routing, envd file/environment operations, Filesystem, Process, PTY, and Python Code Interpreter contexts | The certified A3S OS evidence uses unchanged official Python sync/async and TypeScript clients. Templates/builds, historical metrics, signed files, public-port breadth, MCP, cancellation/backpressure, deeper Snapshot/Volume failure recovery, and the rest of the pinned contract remain gates; `full_compatibility=false`. |
 | TEE | SEV-SNP-oriented attestation, RA-TLS, sealing, secret injection, and simulation | Host-specific. Hardware claims require a supported SEV-SNP host and real attestation evidence. Simulation is development-only; TDX is not productized. |
 | Kubernetes | CRI server plus a containerd runtime-v2 shim and `runtimeClassName: a3s-box` | Preview. Core lifecycle, streaming, logs, resources, and RuntimeClass paths exist; complete CRI conformance is not claimed. |
@@ -1051,7 +1072,7 @@ Main components:
 | `src/netproxy` | macOS user-space bridge, DNS, inbound TCP, and outbound TCP |
 | `src/cri` | Kubernetes CRI server |
 | `containerd-shim` | containerd runtime-v2 adapter for RuntimeClass |
-| `src/sdk` | Direct runtime-backed Rust SDK and optional pipeline runner |
+| `src/sdk` | Direct runtime-backed Rust SDK, E2B-style local Sandbox facade, and optional pipeline runner |
 | `src/lambda` | Workload-execution integration retained for higher-level runtimes |
 | `sdk/python`, `sdk/typescript` | Production-tested A3S language SDK packages; public registry publication pending |
 
@@ -1093,6 +1114,8 @@ entry points are:
 
 - [`scripts/host-integration-smoke.sh`](scripts/host-integration-smoke.sh) for
   macOS/HVF and Linux/KVM;
+- [`scripts/local-sdk-smoke.sh`](scripts/local-sdk-smoke.sh) for the
+  zero-credential Rust/Python/TypeScript MicroVM and Sandbox API matrix;
 - [`scripts/e2b-production-smoke.sh`](scripts/e2b-production-smoke.sh) for the
   destructive A3S OS Sandbox compatibility gate;
 - [Production Cluster Tests](docs/production-cluster-tests.md) for enrolled

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -10,6 +10,7 @@ root.
 | --- | --- | --- |
 | Stub baseline | macOS or Linux with Rust, C compiler, and protoc | `scripts/host-integration-smoke.sh` |
 | Core MicroVM smoke | macOS Apple Silicon/HVF or Linux KVM, libkrun, Linux guest init, runnable image | `scripts/host-integration-smoke.sh --core` |
+| Native local SDK smoke | Same as the selected MicroVM or certified Linux Sandbox backend, plus Python 3.10+ and Node.js 20+ | `scripts/local-sdk-smoke.sh microvm` or `scripts/local-sdk-smoke.sh sandbox` |
 | Host command and warm-pool smoke | Same as core smoke; optional registry credentials for push coverage | `scripts/host-integration-smoke.sh --host` |
 | Linux Dockerfile `RUN` | Linux, root, chroot-capable filesystem, local Alpine OCI archive | `sudo -E scripts/host-integration-smoke.sh --linux-run --no-pure` |
 | CRI smoke | macOS or Linux MicroVM host, `crictl`, CRI images | `scripts/host-integration-smoke.sh --cri` |
@@ -85,6 +86,40 @@ new login session:
 ```bash
 sudo usermod -aG kvm "$USER"
 ```
+
+## Native local SDK matrix
+
+The native Rust, Python, and TypeScript SDK smoke exercises the same E2B-style
+`Sandbox`, commands, files, pause/resume, kill, and cleanup behavior against a
+real local backend. It fails if any remote endpoint, domain, or API-key
+variable is present.
+
+Build the host binary, shim, and matching Linux guest init first. Then use a
+dedicated state directory:
+
+```bash
+export A3S_HOME=/var/tmp/a3s-local-sdk-smoke
+unset E2B_API_KEY E2B_API_URL E2B_DOMAIN
+unset A3S_BOX_API_KEY A3S_BOX_ENDPOINT A3S_BOX_DOMAIN A3S_BOX_SANDBOX_URL
+
+# Development-tree override only; installed packages normally find a3s-box on PATH.
+export A3S_BOX_BINARY="$PWD/src/target/debug/a3s-box"
+
+scripts/local-sdk-smoke.sh microvm
+```
+
+On a certified Linux shared-kernel host, install `crun 1.28` at the normal A3S
+Box runtime location or select the verified artifact, then run the second
+isolation row:
+
+```bash
+export A3S_BOX_CRUN_PATH="$A3S_HOME/bin/crun"
+scripts/local-sdk-smoke.sh sandbox
+```
+
+`A3S_BOX_BINARY` is only an optional executable-path override for development;
+it is not a service endpoint or credential. Normal local SDK consumers set
+none of these variables.
 
 ## Resilient registry pull validation
 

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Exercise the zero-configuration Rust, Python, and TypeScript local SDKs
+# against one real A3S Box isolation backend.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE="$REPO_ROOT/src"
+ISOLATION="${1:-microvm}"
+PYTHON="${PYTHON:-python3}"
+A3S_BOX_BINARY="${A3S_BOX_BINARY:-$WORKSPACE/target/debug/a3s-box}"
+CARGO_PROFILE="${A3S_BOX_SDK_CARGO_PROFILE:-debug}"
+BINARY_DIR="$(cd "$(dirname "$A3S_BOX_BINARY")" && pwd)"
+RUST_MIN_STACK="${RUST_MIN_STACK:-16777216}"
+
+case "$ISOLATION" in
+    microvm|sandbox) ;;
+    *)
+        echo "usage: scripts/local-sdk-smoke.sh [microvm|sandbox]" >&2
+        exit 2
+        ;;
+esac
+
+case "$CARGO_PROFILE" in
+    debug)
+        cargo_release=0
+        ;;
+    release)
+        cargo_release=1
+        ;;
+    *)
+        echo "A3S_BOX_SDK_CARGO_PROFILE must be debug or release" >&2
+        exit 2
+        ;;
+esac
+
+if [ ! -x "$A3S_BOX_BINARY" ]; then
+    echo "A3S Box binary is not executable: $A3S_BOX_BINARY" >&2
+    exit 1
+fi
+
+case "$(uname -m)" in
+    arm64|aarch64)
+        guest_target="aarch64-unknown-linux-musl"
+        ;;
+    x86_64|amd64)
+        guest_target="x86_64-unknown-linux-musl"
+        ;;
+    *)
+        echo "unsupported host architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+A3S_BOX_SHIM_BINARY="${A3S_BOX_SHIM_BINARY:-$BINARY_DIR/a3s-box-shim}"
+if [ -n "${A3S_BOX_GUEST_INIT_BINARY:-}" ]; then
+    guest_init="$A3S_BOX_GUEST_INIT_BINARY"
+elif [ -x "$BINARY_DIR/a3s-box-guest-init" ]; then
+    guest_init="$BINARY_DIR/a3s-box-guest-init"
+elif [ -x "$WORKSPACE/target/$guest_target/release/a3s-box-guest-init" ]; then
+    guest_init="$WORKSPACE/target/$guest_target/release/a3s-box-guest-init"
+else
+    guest_init="$WORKSPACE/target/$guest_target/debug/a3s-box-guest-init"
+fi
+
+if [ ! -x "$A3S_BOX_SHIM_BINARY" ]; then
+    echo "matching A3S Box shim is not executable: $A3S_BOX_SHIM_BINARY" >&2
+    exit 1
+fi
+if [ ! -x "$guest_init" ]; then
+    echo "matching Linux guest init is not executable: $guest_init" >&2
+    exit 1
+fi
+
+if [ -z "${A3S_HOME:-}" ] ||
+    [[ "$(basename "$A3S_HOME")" != *local-sdk-smoke* ]]; then
+    echo "A3S_HOME must point to a dedicated directory whose name contains local-sdk-smoke" >&2
+    exit 1
+fi
+
+mkdir -p "$A3S_HOME/bin"
+install -m 755 "$A3S_BOX_SHIM_BINARY" "$A3S_HOME/bin/a3s-box-shim"
+install -m 755 "$guest_init" "$A3S_HOME/bin/a3s-box-guest-init"
+
+remote_variables=(
+    E2B_API_KEY
+    E2B_API_URL
+    E2B_DOMAIN
+    A3S_BOX_API_KEY
+    A3S_BOX_ENDPOINT
+    A3S_BOX_DOMAIN
+    A3S_BOX_SANDBOX_URL
+)
+clean_env=(env)
+for variable in "${remote_variables[@]}"; do
+    clean_env+=(-u "$variable")
+done
+
+echo "==> Rust SDK ($ISOLATION)"
+(
+    cd "$WORKSPACE"
+    if [ "$cargo_release" -eq 1 ]; then
+        "${clean_env[@]}" \
+            A3S_BOX_SDK_LOCAL_SMOKE=1 \
+            A3S_BOX_SDK_SMOKE_ISOLATION="$ISOLATION" \
+            RUST_MIN_STACK="$RUST_MIN_STACK" \
+            cargo test --locked --release -p a3s-box-sdk --test local_sandbox \
+            e2b_style_local_sandbox_runs_without_remote_credentials \
+            -- --ignored --nocapture --test-threads=1
+    else
+        "${clean_env[@]}" \
+            A3S_BOX_SDK_LOCAL_SMOKE=1 \
+            A3S_BOX_SDK_SMOKE_ISOLATION="$ISOLATION" \
+            RUST_MIN_STACK="$RUST_MIN_STACK" \
+            cargo test --locked -p a3s-box-sdk --test local_sandbox \
+            e2b_style_local_sandbox_runs_without_remote_credentials \
+            -- --ignored --nocapture --test-threads=1
+    fi
+)
+
+echo "==> Python SDK ($ISOLATION)"
+"${clean_env[@]}" \
+    A3S_BOX_BINARY="$A3S_BOX_BINARY" \
+    A3S_BOX_SDK_SMOKE_ISOLATION="$ISOLATION" \
+    PYTHONPATH="$REPO_ROOT/sdk/python/src" \
+    "$PYTHON" - <<'PY'
+import os
+
+from a3s_box import Sandbox
+
+for name in (
+    "E2B_API_KEY",
+    "E2B_API_URL",
+    "E2B_DOMAIN",
+    "A3S_BOX_API_KEY",
+    "A3S_BOX_ENDPOINT",
+    "A3S_BOX_DOMAIN",
+    "A3S_BOX_SANDBOX_URL",
+):
+    assert name not in os.environ
+
+with Sandbox.create(
+    "alpine:3.20",
+    isolation=os.environ["A3S_BOX_SDK_SMOKE_ISOLATION"],
+) as sandbox:
+    result = sandbox.commands.run("printf 'python-sdk-ok'")
+    assert result.exit_code == 0
+    assert result.stdout == "python-sdk-ok"
+    sandbox.files.write("/tmp/a3s-python-sdk-smoke.txt", "hello")
+    assert sandbox.files.read("/tmp/a3s-python-sdk-smoke.txt") == "hello"
+    sandbox.files.remove("/tmp/a3s-python-sdk-smoke.txt")
+PY
+
+echo "==> TypeScript SDK ($ISOLATION)"
+npm --prefix "$REPO_ROOT/sdk/typescript" ci
+npm --prefix "$REPO_ROOT/sdk/typescript" run build
+"${clean_env[@]}" \
+    A3S_BOX_BINARY="$A3S_BOX_BINARY" \
+    A3S_BOX_SDK_SMOKE_ISOLATION="$ISOLATION" \
+    node --input-type=module <<'JS'
+import { Sandbox } from './sdk/typescript/dist/index.js'
+
+for (const name of [
+  'E2B_API_KEY',
+  'E2B_API_URL',
+  'E2B_DOMAIN',
+  'A3S_BOX_API_KEY',
+  'A3S_BOX_ENDPOINT',
+  'A3S_BOX_DOMAIN',
+  'A3S_BOX_SANDBOX_URL',
+]) {
+  if (name in process.env) throw new Error(`${name} must be unset`)
+}
+
+const sandbox = await Sandbox.create('alpine:3.20', {
+  isolation: process.env.A3S_BOX_SDK_SMOKE_ISOLATION,
+})
+try {
+  const result = await sandbox.commands.run("printf 'typescript-sdk-ok'")
+  if (result.exitCode !== 0 || result.stdout !== 'typescript-sdk-ok') {
+    throw new Error('TypeScript SDK command returned an unexpected result')
+  }
+  await sandbox.files.write('/tmp/a3s-typescript-sdk-smoke.txt', 'hello')
+  if (await sandbox.files.read('/tmp/a3s-typescript-sdk-smoke.txt') !== 'hello') {
+    throw new Error('TypeScript SDK file read returned unexpected data')
+  }
+  await sandbox.files.remove('/tmp/a3s-typescript-sdk-smoke.txt')
+} finally {
+  await sandbox.kill()
+}
+JS
+
+echo "All local SDK smokes passed for isolation=$ISOLATION"

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import os
 import unittest
 from collections.abc import Mapping
 from typing import Any
+from unittest.mock import patch
 
 import a3s_box
 from a3s_box import (
@@ -13,6 +15,7 @@ from a3s_box import (
     Sandbox,
 )
 from a3s_box.code_interpreter import Sandbox as CodeInterpreter
+from a3s_box.runtime import _resolve_binary
 
 
 class FakeRuntime:
@@ -133,12 +136,34 @@ class SdkTests(unittest.TestCase):
         self.assertEqual(create["timeout_seconds"], 120)
         self.assertEqual(create["env"], {"MODE": "test"})
         self.assertEqual(create["labels"], {"suite": "sdk"})
+        self.assertEqual(create["isolation"], "microvm")
         self.assertEqual(command["argv"], ["/bin/sh", "-lc", "python -c 'print(6 * 7)'"])
         self.assertEqual(command["generation"], 1)
         self.assertEqual(write["data_base64"], base64.b64encode(b"hello").decode())
         self.assertEqual(read["path"], "/workspace/notes.txt")
         self.assertEqual(stat["operation"], "filesystem_stat")
         self.assertEqual(kill["operation"], "sandbox_kill")
+
+    def test_create_explicitly_selects_shared_kernel_sandbox_isolation(self) -> None:
+        runtime = FakeRuntime()
+
+        sandbox = Sandbox.create(isolation="sandbox", runtime=runtime)
+        sandbox.kill()
+
+        self.assertEqual(runtime.requests[0]["isolation"], "sandbox")
+
+    def test_local_binary_resolution_ignores_remote_credentials(self) -> None:
+        environment = {
+            "E2B_API_KEY": "must-not-be-read",
+            "A3S_BOX_API_KEY": "must-not-be-read",
+            "A3S_BOX_ENDPOINT": "https://must-not-be-read.invalid",
+        }
+        with (
+            patch.dict(os.environ, environment, clear=True),
+            patch("a3s_box.runtime.shutil.which", return_value="/usr/local/bin/a3s-box") as which,
+        ):
+            self.assertEqual(_resolve_binary(None), "/usr/local/bin/a3s-box")
+            which.assert_called_once_with("a3s-box")
 
     def test_connect_recovers_a_local_handle_without_credentials(self) -> None:
         runtime = FakeRuntime()

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 
 import SandboxDefault, {
+  A3SLocalRuntime,
   A3SRemoteConnection,
   DEFAULT_IMAGE,
   Sandbox,
@@ -106,6 +107,7 @@ assert.equal(create.image, 'python:3.12-alpine')
 assert.equal(create.timeout_seconds, 120)
 assert.deepEqual(create.env, { MODE: 'test' })
 assert.deepEqual(create.labels, { suite: 'sdk' })
+assert.equal(create.isolation, 'microvm')
 assert.deepEqual(command.argv, [
   '/bin/sh',
   '-lc',
@@ -116,6 +118,30 @@ assert.equal(writeRequest.data_base64, Buffer.from('hello').toString('base64'))
 assert.equal(read.path, '/workspace/notes.txt')
 assert.equal(stat.operation, 'filesystem_stat')
 assert.equal(kill.operation, 'sandbox_kill')
+
+const sandboxIsolationRuntime = new FakeRuntime()
+const sharedKernelSandbox = await Sandbox.create(undefined, {
+  isolation: 'sandbox',
+  runtime: sandboxIsolationRuntime,
+})
+await sharedKernelSandbox.kill()
+assert.equal(sandboxIsolationRuntime.requests[0].isolation, 'sandbox')
+
+const savedEnvironment = {
+  E2B_API_KEY: process.env.E2B_API_KEY,
+  A3S_BOX_API_KEY: process.env.A3S_BOX_API_KEY,
+  A3S_BOX_ENDPOINT: process.env.A3S_BOX_ENDPOINT,
+  A3S_BOX_BINARY: process.env.A3S_BOX_BINARY,
+}
+process.env.E2B_API_KEY = 'must-not-be-read'
+process.env.A3S_BOX_API_KEY = 'must-not-be-read'
+process.env.A3S_BOX_ENDPOINT = 'https://must-not-be-read.invalid'
+delete process.env.A3S_BOX_BINARY
+assert.equal(new A3SLocalRuntime().binaryPath, 'a3s-box')
+for (const [key, value] of Object.entries(savedEnvironment)) {
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+}
 
 const connected = await Sandbox.connect('existing-local', { runtime })
 assert.equal(connected.sandboxId, 'existing-local')

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -6,6 +6,53 @@ By default, the SDK does not spawn the `a3s-box` CLI. `A3sBoxClient` calls
 `a3s-box-runtime` stores and socket clients directly, returning typed Rust data
 for management apps, automation, and tests.
 
+## E2B-Style Local Sandbox
+
+The high-level `Sandbox` API is local and zero-configuration. It does not read
+`E2B_API_KEY`, `A3S_BOX_API_KEY`, an endpoint, or a domain:
+
+```rust
+use a3s_box_sdk::Sandbox;
+
+# async fn example() -> Result<(), a3s_box_sdk::ClientError> {
+let sandbox = Sandbox::create("python:3.12-alpine").await?;
+let result = sandbox
+    .commands
+    .run("python -c 'print(6 * 7)'")
+    .await?;
+println!("{}", result.stdout);
+
+sandbox.files.write("/workspace/note.txt", "hello").await?;
+assert_eq!(
+    sandbox.files.read_text("/workspace/note.txt").await?,
+    "hello"
+);
+sandbox.kill().await?;
+# Ok(()) }
+```
+
+MicroVM isolation is the default. Shared-kernel Sandbox isolation is an
+explicit opt-in and requires a certified Linux host:
+
+```rust
+use a3s_box_sdk::{ExecutionIsolation, Sandbox, SandboxCreateOptions};
+
+# async fn example() -> Result<(), a3s_box_sdk::ClientError> {
+let sandbox = Sandbox::create_with_options(
+    SandboxCreateOptions::new("python:3.12-alpine")
+        .isolation(ExecutionIsolation::Sandbox)
+        .cpus(2)
+        .memory_mb(1024),
+)
+.await?;
+sandbox.kill().await?;
+# Ok(()) }
+```
+
+The facade also provides `connect`, `pause`, `resume`, `is_running`, command
+environment/working-directory/stdin options, and file metadata and mutation
+operations. `A3sBoxClient` remains available for lower-level management APIs.
+
 ## Runtime-Backed Client
 
 ```rust
@@ -128,6 +175,9 @@ embedding or tests without changing request semantics.
   volumes, snapshots, state files, and other local data.
 - Running boxes on Unix: exec, file transfer, heartbeat, main-process signal,
   deferred-main spawn, PTY client, and attestation report through runtime sockets.
+- E2B-style local use: zero-configuration `Sandbox`, `commands`, `files`,
+  lifecycle, explicit MicroVM/shared-kernel isolation, and typed client
+  injection for embedding and tests.
 
 The client reads the shared `boxes.json` state format through an SDK-local model
 so it does not depend on the CLI crate. Image, volume, network, snapshot, build,

--- a/src/sdk/src/bridge.rs
+++ b/src/sdk/src/bridge.rs
@@ -5,24 +5,23 @@
 //! the direct Rust SDK and never parses human-facing CLI output.
 
 use std::collections::BTreeMap;
+use std::time::Duration;
 
-use a3s_box_core::config::ResourceConfig;
 use a3s_box_core::{
-    BoxConfig, CreateExecutionRequest, ExecRequest, ExecutionGeneration, ExecutionId,
-    ExecutionIsolation, ExecutionRecordPolicy, ExecutionState, FileOp, FileRequest,
-    FilesystemEntry, FilesystemEntryKind, FilesystemOp, FilesystemRequest, OperationId,
+    ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionState, FilesystemEntry,
+    FilesystemEntryKind,
 };
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::{A3sBoxClient, ClientError};
+use crate::{
+    A3sBoxClient, ClientError, CommandRunOptions, FilesystemOptions, Sandbox, SandboxCommand,
+    SandboxCreateOptions, DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_TIMEOUT_SECONDS,
+};
 
 pub const BRIDGE_PROTOCOL_VERSION: u8 = 1;
-const DEFAULT_IMAGE: &str = "alpine:3.20";
-const DEFAULT_TIMEOUT_SECONDS: u64 = 3600;
-const KEEPALIVE_COMMAND: &[&str] = &["/bin/sh", "-c", "while :; do sleep 3600; done"];
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(tag = "operation", rename_all = "snake_case")]
@@ -213,74 +212,50 @@ async fn execute_request(
             memory_mb,
             isolation,
         } => {
-            let (request, operation) = create_request(
-                image,
-                timeout_seconds,
-                env,
-                labels,
-                name,
-                cpus,
-                memory_mb,
-                isolation,
-            )?;
-            let lease = client.run_box(request, &operation).await?;
-            Ok(sandbox_value(
-                &lease.execution_id,
-                lease.generation,
-                ExecutionState::Running,
-            ))
+            let sandbox = Sandbox::create_with_client(
+                client.clone(),
+                SandboxCreateOptions {
+                    image,
+                    timeout_seconds,
+                    envs: env,
+                    metadata: labels,
+                    name,
+                    cpus,
+                    memory_mb,
+                    isolation,
+                },
+            )
+            .await?;
+            Ok(sandbox_info_value(&sandbox))
         }
         BridgeRequest::SandboxInspect { sandbox_id } => {
-            let execution_id = execution_id(sandbox_id)?;
-            let status = client.inspect_execution(&execution_id).await?;
-            Ok(sandbox_value(
-                &status.execution_id,
-                status.generation,
-                status.state,
-            ))
+            let sandbox = Sandbox::connect_with_client(client.clone(), sandbox_id).await?;
+            Ok(sandbox_info_value(&sandbox))
         }
         BridgeRequest::SandboxKill {
             sandbox_id,
             generation,
         } => {
-            let execution_id = execution_id(sandbox_id)?;
-            let generation = parse_generation(generation)?;
-            client.kill_execution(&execution_id, generation).await?;
-            client.remove_execution(&execution_id, generation).await?;
-            Ok(sandbox_value(
-                &execution_id,
-                generation,
-                ExecutionState::Stopped,
-            ))
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            sandbox.kill().await?;
+            Ok(sandbox_info_value(&sandbox))
         }
         BridgeRequest::SandboxPause {
             sandbox_id,
             generation,
             keep_memory,
         } => {
-            let execution_id = execution_id(sandbox_id)?;
-            let lease = client
-                .pause_execution(&execution_id, parse_generation(generation)?, keep_memory)
-                .await?;
-            Ok(sandbox_value(
-                &lease.execution_id,
-                lease.generation,
-                ExecutionState::Paused,
-            ))
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            sandbox.pause(keep_memory).await?;
+            Ok(sandbox_info_value(&sandbox))
         }
         BridgeRequest::SandboxResume {
             sandbox_id,
             generation,
         } => {
-            let execution_id = execution_id(sandbox_id)?;
-            let lease = client
-                .resume_execution(&execution_id, parse_generation(generation)?)
-                .await?;
-            Ok(sandbox_value(
-                &lease.execution_id,
-                lease.generation,
-                ExecutionState::Running,
-            ))
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Paused)?;
+            sandbox.resume().await?;
+            Ok(sandbox_info_value(&sandbox))
         }
         BridgeRequest::CommandRun {
             sandbox_id,
@@ -292,9 +267,6 @@ async fn execute_request(
             user,
             stdin_base64,
         } => {
-            if argv.is_empty() {
-                return Err(invalid("command argv cannot be empty"));
-            }
             let stdin = stdin_base64
                 .map(|encoded| {
                     STANDARD
@@ -302,44 +274,26 @@ async fn execute_request(
                         .map_err(|error| invalid(format!("stdin_base64 is invalid: {error}")))
                 })
                 .transpose()?;
-            let request = ExecRequest {
-                request_id: Some(format!("sdk-command-{}", uuid::Uuid::new_v4())),
-                cmd: argv,
-                timeout_ns: timeout_ms.unwrap_or_default().saturating_mul(1_000_000),
-                env: env
-                    .into_iter()
-                    .map(|(key, value)| format!("{key}={value}"))
-                    .collect(),
-                working_dir: cwd,
-                rootfs: None,
-                stdin,
-                stdin_streaming: false,
-                user,
-                streaming: false,
-            };
-            #[cfg(unix)]
-            {
-                let output = client
-                    .execute_execution(
-                        &execution_id(sandbox_id)?,
-                        parse_generation(generation)?,
-                        request,
-                    )
-                    .await?;
-                Ok(json!({
-                    "stdout_base64": STANDARD.encode(output.stdout),
-                    "stderr_base64": STANDARD.encode(output.stderr),
-                    "exit_code": output.exit_code,
-                    "truncated": output.truncated,
-                }))
-            }
-            #[cfg(not(unix))]
-            {
-                let _ = (client, sandbox_id, generation, request);
-                Err(unavailable(
-                    "local command sessions are not available on this host",
-                ))
-            }
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            let output = sandbox
+                .commands
+                .run_with_options(
+                    SandboxCommand::Argv(argv),
+                    CommandRunOptions {
+                        timeout: timeout_ms.map(Duration::from_millis),
+                        envs: env,
+                        cwd,
+                        user,
+                        stdin,
+                    },
+                )
+                .await?;
+            Ok(json!({
+                "stdout_base64": STANDARD.encode(output.stdout_bytes),
+                "stderr_base64": STANDARD.encode(output.stderr_bytes),
+                "exit_code": output.exit_code,
+                "truncated": output.truncated,
+            }))
         }
         BridgeRequest::FileWrite {
             sandbox_id,
@@ -348,19 +302,18 @@ async fn execute_request(
             data_base64,
             user,
         } => {
-            STANDARD
+            let data = STANDARD
                 .decode(&data_base64)
                 .map_err(|error| invalid(format!("data_base64 is invalid: {error}")))?;
-            transfer_file(
-                client,
-                sandbox_id,
-                generation,
-                path,
-                FileOp::Upload,
-                Some(data_base64),
-                user,
-            )
-            .await
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            let result = sandbox
+                .files
+                .write_with_options(&path, data, FilesystemOptions { user })
+                .await?;
+            Ok(json!({
+                "path": result.path,
+                "size": result.size,
+            }))
         }
         BridgeRequest::FileRead {
             sandbox_id,
@@ -368,16 +321,16 @@ async fn execute_request(
             path,
             user,
         } => {
-            transfer_file(
-                client,
-                sandbox_id,
-                generation,
-                path,
-                FileOp::Download,
-                None,
-                user,
-            )
-            .await
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            let data = sandbox
+                .files
+                .read_with_options(&path, FilesystemOptions { user })
+                .await?;
+            Ok(json!({
+                "path": path,
+                "data_base64": STANDARD.encode(&data),
+                "size": data.len(),
+            }))
         }
         BridgeRequest::FilesystemStat {
             sandbox_id,
@@ -385,19 +338,12 @@ async fn execute_request(
             path,
             user,
         } => {
-            filesystem(
-                client,
-                sandbox_id,
-                generation,
-                FilesystemRequest {
-                    op: FilesystemOp::Stat,
-                    path,
-                    destination: None,
-                    depth: 0,
-                    user,
-                },
-            )
-            .await
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            let entry = sandbox
+                .files
+                .stat_with_options(path, FilesystemOptions { user })
+                .await?;
+            Ok(json!({ "entry": entry_value(&entry) }))
         }
         BridgeRequest::FilesystemList {
             sandbox_id,
@@ -406,19 +352,14 @@ async fn execute_request(
             depth,
             user,
         } => {
-            filesystem(
-                client,
-                sandbox_id,
-                generation,
-                FilesystemRequest {
-                    op: FilesystemOp::ListDir,
-                    path,
-                    destination: None,
-                    depth,
-                    user,
-                },
-            )
-            .await
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            let entries = sandbox
+                .files
+                .list_with_options(path, depth, FilesystemOptions { user })
+                .await?;
+            Ok(json!({
+                "entries": entries.iter().map(entry_value).collect::<Vec<_>>(),
+            }))
         }
         BridgeRequest::FilesystemMakeDir {
             sandbox_id,
@@ -426,19 +367,12 @@ async fn execute_request(
             path,
             user,
         } => {
-            filesystem(
-                client,
-                sandbox_id,
-                generation,
-                FilesystemRequest {
-                    op: FilesystemOp::MakeDir,
-                    path,
-                    destination: None,
-                    depth: 0,
-                    user,
-                },
-            )
-            .await
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            sandbox
+                .files
+                .make_dir_with_options(path, FilesystemOptions { user })
+                .await?;
+            Ok(json!({ "ok": true }))
         }
         BridgeRequest::FilesystemMove {
             sandbox_id,
@@ -447,19 +381,12 @@ async fn execute_request(
             destination,
             user,
         } => {
-            filesystem(
-                client,
-                sandbox_id,
-                generation,
-                FilesystemRequest {
-                    op: FilesystemOp::Move,
-                    path,
-                    destination: Some(destination),
-                    depth: 0,
-                    user,
-                },
-            )
-            .await
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            sandbox
+                .files
+                .move_path_with_options(path, destination, FilesystemOptions { user })
+                .await?;
+            Ok(json!({ "ok": true }))
         }
         BridgeRequest::FilesystemRemove {
             sandbox_id,
@@ -467,183 +394,37 @@ async fn execute_request(
             path,
             user,
         } => {
-            filesystem(
-                client,
-                sandbox_id,
-                generation,
-                FilesystemRequest {
-                    op: FilesystemOp::Remove,
-                    path,
-                    destination: None,
-                    depth: 0,
-                    user,
-                },
-            )
-            .await
+            let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Running)?;
+            sandbox
+                .files
+                .remove_with_options(path, FilesystemOptions { user })
+                .await?;
+            Ok(json!({ "ok": true }))
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn create_request(
-    image: String,
-    timeout_seconds: u64,
-    env: BTreeMap<String, String>,
-    labels: BTreeMap<String, String>,
-    name: Option<String>,
-    cpus: Option<u32>,
-    memory_mb: Option<u32>,
-    isolation: ExecutionIsolation,
-) -> Result<(CreateExecutionRequest, OperationId), BridgeFailure> {
-    if image.trim().is_empty() {
-        return Err(invalid("image cannot be empty"));
-    }
-    if timeout_seconds == 0 {
-        return Err(invalid("timeout_seconds must be greater than zero"));
-    }
-    if cpus == Some(0) {
-        return Err(invalid("cpus must be greater than zero"));
-    }
-    if memory_mb == Some(0) {
-        return Err(invalid("memory_mb must be greater than zero"));
-    }
-
-    let identity = uuid::Uuid::new_v4();
-    let mut resources = ResourceConfig {
-        timeout: timeout_seconds,
-        ..ResourceConfig::default()
-    };
-    if let Some(cpus) = cpus {
-        resources.vcpus = cpus;
-    }
-    if let Some(memory_mb) = memory_mb {
-        resources.memory_mb = memory_mb;
-    }
-    let config = BoxConfig {
-        isolation,
-        image,
-        resources,
-        cmd: KEEPALIVE_COMMAND
-            .iter()
-            .map(|part| (*part).to_string())
-            .collect(),
-        extra_env: env.into_iter().collect(),
-        ..BoxConfig::default()
-    };
-    let operation = OperationId::new(format!("sdk-create-{identity}"))
-        .map_err(|error| invalid(error.to_string()))?;
-    Ok((
-        CreateExecutionRequest {
-            external_sandbox_id: format!("local-{identity}"),
-            config,
-            labels,
-            policy: ExecutionRecordPolicy {
-                name,
-                auto_remove: true,
-                ..ExecutionRecordPolicy::default()
-            },
-            rootfs_snapshot_id: None,
-        },
-        operation,
+fn bridge_sandbox(
+    client: &A3sBoxClient,
+    sandbox_id: String,
+    generation: u64,
+    state: ExecutionState,
+) -> Result<Sandbox, BridgeFailure> {
+    Ok(Sandbox::from_known_state(
+        client.clone(),
+        execution_id(sandbox_id)?,
+        parse_generation(generation)?,
+        state,
+        ExecutionIsolation::Microvm,
     ))
 }
 
-async fn transfer_file(
-    client: &A3sBoxClient,
-    sandbox_id: String,
-    raw_generation: u64,
-    path: String,
-    op: FileOp,
-    data: Option<String>,
-    user: Option<String>,
-) -> Result<Value, BridgeFailure> {
-    #[cfg(unix)]
-    {
-        let response = client
-            .transfer_execution_file(
-                &execution_id(sandbox_id)?,
-                parse_generation(raw_generation)?,
-                FileRequest {
-                    op,
-                    guest_path: path.clone(),
-                    data,
-                    user,
-                },
-            )
-            .await?;
-        if !response.success {
-            return Err(guest_failure(
-                response
-                    .error
-                    .unwrap_or_else(|| "file operation failed".to_string()),
-            ));
-        }
-        match op {
-            FileOp::Upload => Ok(json!({
-                "path": path,
-                "size": response.size,
-            })),
-            FileOp::Download => Ok(json!({
-                "path": path,
-                "data_base64": response.data.unwrap_or_default(),
-                "size": response.size,
-            })),
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = (client, sandbox_id, raw_generation, path, op, data, user);
-        Err(unavailable(
-            "local file sessions are not available on this host",
-        ))
-    }
-}
-
-async fn filesystem(
-    client: &A3sBoxClient,
-    sandbox_id: String,
-    raw_generation: u64,
-    request: FilesystemRequest,
-) -> Result<Value, BridgeFailure> {
-    #[cfg(unix)]
-    {
-        let response = client
-            .filesystem_execution(
-                &execution_id(sandbox_id)?,
-                parse_generation(raw_generation)?,
-                request,
-            )
-            .await?;
-        if !response.success {
-            return Err(guest_failure(
-                response
-                    .error
-                    .unwrap_or_else(|| "filesystem operation failed".to_string()),
-            ));
-        }
-        Ok(json!({
-            "entry": response.entry.as_ref().map(entry_value),
-            "entries": response.entries.iter().map(entry_value).collect::<Vec<_>>(),
-        }))
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = (client, sandbox_id, raw_generation, request);
-        Err(unavailable(
-            "local filesystem sessions are not available on this host",
-        ))
-    }
-}
-
-fn sandbox_value(
-    execution_id: &ExecutionId,
-    generation: ExecutionGeneration,
-    state: ExecutionState,
-) -> Value {
+fn sandbox_info_value(sandbox: &Sandbox) -> Value {
+    let info = sandbox.info();
     json!({
-        "sandbox_id": execution_id.as_str(),
-        "generation": generation.get(),
-        "state": state_name(state),
+        "sandbox_id": info.sandbox_id,
+        "generation": info.generation,
+        "state": state_name(info.state),
     })
 }
 
@@ -687,11 +468,11 @@ fn parse_generation(value: u64) -> Result<ExecutionGeneration, BridgeFailure> {
 }
 
 fn default_image() -> String {
-    DEFAULT_IMAGE.to_string()
+    DEFAULT_SANDBOX_IMAGE.to_string()
 }
 
 const fn default_timeout_seconds() -> u64 {
-    DEFAULT_TIMEOUT_SECONDS
+    DEFAULT_SANDBOX_TIMEOUT_SECONDS
 }
 
 const fn default_depth() -> u32 {
@@ -709,23 +490,6 @@ fn invalid(message: impl Into<String>) -> BridgeFailure {
     }
 }
 
-#[cfg(not(unix))]
-fn unavailable(message: impl Into<String>) -> BridgeFailure {
-    BridgeFailure {
-        code: "unavailable",
-        message: message.into(),
-    }
-}
-
-fn guest_failure(message: String) -> BridgeFailure {
-    let code = if message.to_ascii_lowercase().contains("not found") {
-        "not_found"
-    } else {
-        "runtime_error"
-    };
-    BridgeFailure { code, message }
-}
-
 impl From<ClientError> for BridgeFailure {
     fn from(error: ClientError) -> Self {
         let code = match &error {
@@ -740,6 +504,13 @@ impl From<ClientError> for BridgeFailure {
             }
             ClientError::Execution(a3s_box_core::ExecutionManagerError::Unavailable(_)) => {
                 "unavailable"
+            }
+            ClientError::Guest(message) => {
+                if message.to_ascii_lowercase().contains("not found") {
+                    "not_found"
+                } else {
+                    "runtime_error"
+                }
             }
             ClientError::State(_)
             | ClientError::Runtime(_)
@@ -771,23 +542,24 @@ mod tests {
         else {
             panic!("expected create request");
         };
-        assert_eq!(image, DEFAULT_IMAGE);
-        assert_eq!(timeout_seconds, DEFAULT_TIMEOUT_SECONDS);
+        assert_eq!(image, DEFAULT_SANDBOX_IMAGE);
+        assert_eq!(timeout_seconds, DEFAULT_SANDBOX_TIMEOUT_SECONDS);
         assert_eq!(isolation, ExecutionIsolation::Microvm);
     }
 
     #[test]
     fn create_request_maps_language_options_to_the_runtime_facade() {
-        let (request, _) = create_request(
-            "python:3.12-alpine".to_string(),
-            120,
-            BTreeMap::from([("MODE".to_string(), "test".to_string())]),
-            BTreeMap::from([("suite".to_string(), "sdk".to_string())]),
-            Some("local-sdk".to_string()),
-            Some(4),
-            Some(2048),
-            ExecutionIsolation::Sandbox,
-        )
+        let (request, _) = SandboxCreateOptions {
+            image: "python:3.12-alpine".to_string(),
+            timeout_seconds: 120,
+            envs: BTreeMap::from([("MODE".to_string(), "test".to_string())]),
+            metadata: BTreeMap::from([("suite".to_string(), "sdk".to_string())]),
+            name: Some("local-sdk".to_string()),
+            cpus: Some(4),
+            memory_mb: Some(2048),
+            isolation: ExecutionIsolation::Sandbox,
+        }
+        .into_runtime_request()
         .unwrap();
 
         assert_eq!(request.config.image, "python:3.12-alpine");

--- a/src/sdk/src/client/core.rs
+++ b/src/sdk/src/client/core.rs
@@ -64,6 +64,24 @@ impl A3sBoxClient {
         }
     }
 
+    /// Create a client with explicit typed lifecycle and session managers.
+    ///
+    /// This is useful for embedding the E2B-style [`crate::Sandbox`] facade in
+    /// another local process without selecting backends by string.
+    pub fn with_execution_services(
+        paths: A3sBoxPaths,
+        execution_manager: Arc<dyn ExecutionManager>,
+        execution_session_manager: Arc<dyn ExecutionSessionManager>,
+    ) -> Self {
+        Self {
+            paths,
+            image_cache_size: a3s_box_runtime::DEFAULT_IMAGE_CACHE_SIZE,
+            execution_manager,
+            execution_session_manager: Some(execution_session_manager),
+            local_execution_manager: None,
+        }
+    }
+
     /// Override the image cache size used when opening the runtime image store.
     pub fn with_image_cache_size(mut self, image_cache_size: u64) -> Self {
         self.image_cache_size = image_cache_size;

--- a/src/sdk/src/client/lifecycle.rs
+++ b/src/sdk/src/client/lifecycle.rs
@@ -89,17 +89,15 @@ impl A3sBoxClient {
     }
 
     /// Remove one terminal local execution and all runtime-owned paths.
-    pub(crate) async fn remove_execution(
+    pub(crate) async fn remove_local_execution_if_present(
         &self,
         execution_id: &ExecutionId,
         generation: ExecutionGeneration,
     ) -> Result<bool> {
-        let manager = self.local_execution_manager.as_ref().ok_or_else(|| {
-            ClientError::Validation(
-                "this client was constructed without a local execution manager".to_string(),
-            )
-        })?;
-        Ok(manager.remove_execution(execution_id, generation).await?)
+        match self.local_execution_manager.as_ref() {
+            Some(manager) => Ok(manager.remove_execution(execution_id, generation).await?),
+            None => Ok(false),
+        }
     }
 
     /// Reconcile one idempotent create operation after caller or service restart.

--- a/src/sdk/src/client/types.rs
+++ b/src/sdk/src/client/types.rs
@@ -12,6 +12,8 @@ pub enum ClientError {
     Execution(#[from] a3s_box_core::ExecutionManagerError),
     #[error("validation error: {0}")]
     Validation(String),
+    #[error("guest operation failed: {0}")]
+    Guest(String),
     #[error("box not found: {0}")]
     BoxNotFound(String),
     #[error("box query {query:?} matched multiple boxes: {matches:?}")]

--- a/src/sdk/src/lib.rs
+++ b/src/sdk/src/lib.rs
@@ -9,6 +9,7 @@ mod box_state;
 
 pub mod bridge;
 pub mod client;
+pub mod sandbox;
 
 #[cfg(feature = "pipeline-cli")]
 pub mod pipeline;
@@ -21,6 +22,11 @@ pub use client::{
     PushImageSummary, ReadBoxLogsOptions, RegistryCredentials, RemoveBox, RemoveBoxSummary,
     RestoreSnapshot, Result, RuntimeDiagnostics, RuntimeDiskUsage, RuntimeVirtualizationSummary,
     SnapshotSummary, StopBox, StopBoxSummary, StopOutcome, TagImage, VolumeSummary,
+};
+pub use sandbox::{
+    CommandResult, CommandRunOptions, Commands, Filesystem, FilesystemOptions, Sandbox,
+    SandboxCommand, SandboxCreateOptions, SandboxInfo, WriteInfo, DEFAULT_SANDBOX_IMAGE,
+    DEFAULT_SANDBOX_TIMEOUT_SECONDS,
 };
 
 pub use a3s_box_core::{

--- a/src/sdk/src/sandbox/commands.rs
+++ b/src/sdk/src/sandbox/commands.rs
@@ -163,30 +163,32 @@ impl Commands {
             streaming: false,
         };
 
-        #[cfg(unix)]
-        let output = self
-            .inner
-            .client
-            .execute_execution(&self.inner.execution_id, generation, request)
-            .await?;
-
         #[cfg(not(unix))]
-        let output = {
+        {
             let _ = (generation, request);
             return Err(ClientError::Execution(
                 a3s_box_core::ExecutionManagerError::Unavailable(
                     "local command sessions are not available on this host".to_string(),
                 ),
             ));
-        };
+        }
 
-        Ok(CommandResult {
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            exit_code: output.exit_code,
-            truncated: output.truncated,
-            stdout_bytes: output.stdout,
-            stderr_bytes: output.stderr,
-        })
+        #[cfg(unix)]
+        {
+            let output = self
+                .inner
+                .client
+                .execute_execution(&self.inner.execution_id, generation, request)
+                .await?;
+
+            Ok(CommandResult {
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                exit_code: output.exit_code,
+                truncated: output.truncated,
+                stdout_bytes: output.stdout,
+                stderr_bytes: output.stderr,
+            })
+        }
     }
 }

--- a/src/sdk/src/sandbox/commands.rs
+++ b/src/sdk/src/sandbox/commands.rs
@@ -1,0 +1,192 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use a3s_box_core::ExecRequest;
+
+use super::SandboxInner;
+use crate::{ClientError, Result};
+
+/// A shell command or an explicit argument vector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SandboxCommand {
+    Shell(String),
+    Argv(Vec<String>),
+}
+
+impl SandboxCommand {
+    pub fn shell(command: impl Into<String>) -> Self {
+        Self::Shell(command.into())
+    }
+
+    pub fn argv(command: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self::Argv(command.into_iter().map(Into::into).collect())
+    }
+
+    fn into_argv(self) -> Result<Vec<String>> {
+        let argv = match self {
+            Self::Shell(command) => {
+                if command.trim().is_empty() {
+                    return Err(ClientError::Validation(
+                        "sandbox command cannot be empty".to_string(),
+                    ));
+                }
+                vec!["/bin/sh".to_string(), "-lc".to_string(), command]
+            }
+            Self::Argv(argv) => argv,
+        };
+        if argv.is_empty() {
+            return Err(ClientError::Validation(
+                "sandbox command cannot be empty".to_string(),
+            ));
+        }
+        Ok(argv)
+    }
+}
+
+impl From<String> for SandboxCommand {
+    fn from(command: String) -> Self {
+        Self::Shell(command)
+    }
+}
+
+impl From<&str> for SandboxCommand {
+    fn from(command: &str) -> Self {
+        Self::Shell(command.to_string())
+    }
+}
+
+impl From<Vec<String>> for SandboxCommand {
+    fn from(command: Vec<String>) -> Self {
+        Self::Argv(command)
+    }
+}
+
+/// Optional controls for one Sandbox command.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CommandRunOptions {
+    pub timeout: Option<Duration>,
+    pub envs: BTreeMap<String, String>,
+    pub cwd: Option<String>,
+    pub user: Option<String>,
+    pub stdin: Option<Vec<u8>>,
+}
+
+impl CommandRunOptions {
+    pub const fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.envs.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn cwd(mut self, cwd: impl Into<String>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    pub fn user(mut self, user: impl Into<String>) -> Self {
+        self.user = Some(user.into());
+        self
+    }
+
+    pub fn stdin(mut self, stdin: impl Into<Vec<u8>>) -> Self {
+        self.stdin = Some(stdin.into());
+        self
+    }
+}
+
+/// Captured result of one E2B-style command execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub truncated: bool,
+    pub(crate) stdout_bytes: Vec<u8>,
+    pub(crate) stderr_bytes: Vec<u8>,
+}
+
+/// E2B-style command namespace attached to a local [`super::Sandbox`].
+#[derive(Clone)]
+pub struct Commands {
+    pub(crate) inner: Arc<SandboxInner>,
+}
+
+impl std::fmt::Debug for Commands {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Commands")
+            .field("sandbox_id", &self.inner.execution_id)
+            .finish()
+    }
+}
+
+impl Commands {
+    pub async fn run(&self, command: impl Into<SandboxCommand>) -> Result<CommandResult> {
+        self.run_with_options(command, CommandRunOptions::default())
+            .await
+    }
+
+    pub async fn run_with_options(
+        &self,
+        command: impl Into<SandboxCommand>,
+        options: CommandRunOptions,
+    ) -> Result<CommandResult> {
+        let timeout_ns = match options.timeout {
+            Some(timeout) if timeout.is_zero() => {
+                return Err(ClientError::Validation(
+                    "sandbox command timeout must be greater than zero".to_string(),
+                ))
+            }
+            Some(timeout) => u64::try_from(timeout.as_nanos()).unwrap_or(u64::MAX),
+            None => 0,
+        };
+        let (_, generation) = self.inner.active_execution()?;
+        let request = ExecRequest {
+            request_id: Some(format!("sdk-command-{}", uuid::Uuid::new_v4())),
+            cmd: command.into().into_argv()?,
+            timeout_ns,
+            env: options
+                .envs
+                .into_iter()
+                .map(|(key, value)| format!("{key}={value}"))
+                .collect(),
+            working_dir: options.cwd,
+            rootfs: None,
+            stdin: options.stdin,
+            stdin_streaming: false,
+            user: options.user,
+            streaming: false,
+        };
+
+        #[cfg(unix)]
+        let output = self
+            .inner
+            .client
+            .execute_execution(&self.inner.execution_id, generation, request)
+            .await?;
+
+        #[cfg(not(unix))]
+        let output = {
+            let _ = (generation, request);
+            return Err(ClientError::Execution(
+                a3s_box_core::ExecutionManagerError::Unavailable(
+                    "local command sessions are not available on this host".to_string(),
+                ),
+            ));
+        };
+
+        Ok(CommandResult {
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            exit_code: output.exit_code,
+            truncated: output.truncated,
+            stdout_bytes: output.stdout,
+            stderr_bytes: output.stderr,
+        })
+    }
+}

--- a/src/sdk/src/sandbox/filesystem.rs
+++ b/src/sdk/src/sandbox/filesystem.rs
@@ -1,0 +1,298 @@
+use std::sync::Arc;
+
+use a3s_box_core::{
+    FileOp, FileRequest, FileResponse, FilesystemEntry, FilesystemOp, FilesystemRequest,
+    FilesystemResponse,
+};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+
+use super::SandboxInner;
+use crate::{ClientError, Result};
+
+/// Metadata returned after a successful file write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteInfo {
+    pub path: String,
+    pub size: u64,
+}
+
+/// Optional guest identity for a filesystem operation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FilesystemOptions {
+    pub user: Option<String>,
+}
+
+impl FilesystemOptions {
+    pub fn user(mut self, user: impl Into<String>) -> Self {
+        self.user = Some(user.into());
+        self
+    }
+}
+
+/// E2B-style file namespace attached to a local [`super::Sandbox`].
+#[derive(Clone)]
+pub struct Filesystem {
+    pub(crate) inner: Arc<SandboxInner>,
+}
+
+impl std::fmt::Debug for Filesystem {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Filesystem")
+            .field("sandbox_id", &self.inner.execution_id)
+            .finish()
+    }
+}
+
+impl Filesystem {
+    pub async fn write(
+        &self,
+        path: impl Into<String>,
+        data: impl AsRef<[u8]>,
+    ) -> Result<WriteInfo> {
+        self.write_with_options(path, data, FilesystemOptions::default())
+            .await
+    }
+
+    pub async fn write_with_options(
+        &self,
+        path: impl Into<String>,
+        data: impl AsRef<[u8]>,
+        options: FilesystemOptions,
+    ) -> Result<WriteInfo> {
+        let path = path.into();
+        let response = self
+            .transfer(FileRequest {
+                op: FileOp::Upload,
+                guest_path: path.clone(),
+                data: Some(STANDARD.encode(data.as_ref())),
+                user: options.user,
+            })
+            .await?;
+        require_file_success(response).map(|response| WriteInfo {
+            path,
+            size: response.size,
+        })
+    }
+
+    pub async fn read(&self, path: impl Into<String>) -> Result<Vec<u8>> {
+        self.read_with_options(path, FilesystemOptions::default())
+            .await
+    }
+
+    pub async fn read_with_options(
+        &self,
+        path: impl Into<String>,
+        options: FilesystemOptions,
+    ) -> Result<Vec<u8>> {
+        let response = self
+            .transfer(FileRequest {
+                op: FileOp::Download,
+                guest_path: path.into(),
+                data: None,
+                user: options.user,
+            })
+            .await?;
+        let response = require_file_success(response)?;
+        STANDARD
+            .decode(response.data.unwrap_or_default())
+            .map_err(|error| {
+                ClientError::Guest(format!("guest returned invalid file data: {error}"))
+            })
+    }
+
+    pub async fn read_text(&self, path: impl Into<String>) -> Result<String> {
+        String::from_utf8(self.read(path).await?)
+            .map_err(|error| ClientError::Guest(format!("guest file is not valid UTF-8: {error}")))
+    }
+
+    pub async fn stat(&self, path: impl Into<String>) -> Result<FilesystemEntry> {
+        self.stat_with_options(path, FilesystemOptions::default())
+            .await
+    }
+
+    pub async fn stat_with_options(
+        &self,
+        path: impl Into<String>,
+        options: FilesystemOptions,
+    ) -> Result<FilesystemEntry> {
+        let response = self
+            .filesystem(FilesystemRequest {
+                op: FilesystemOp::Stat,
+                path: path.into(),
+                destination: None,
+                depth: 0,
+                user: options.user,
+            })
+            .await?;
+        let mut response = require_filesystem_success(response)?;
+        response.entry.take().ok_or_else(|| {
+            ClientError::Guest("guest stat response did not include an entry".to_string())
+        })
+    }
+
+    pub async fn exists(&self, path: impl Into<String>) -> Result<bool> {
+        match self.stat(path).await {
+            Ok(_) => Ok(true),
+            Err(ClientError::Guest(message))
+                if message.to_ascii_lowercase().contains("not found") =>
+            {
+                Ok(false)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub async fn list(&self, path: impl Into<String>, depth: u32) -> Result<Vec<FilesystemEntry>> {
+        self.list_with_options(path, depth, FilesystemOptions::default())
+            .await
+    }
+
+    pub async fn list_with_options(
+        &self,
+        path: impl Into<String>,
+        depth: u32,
+        options: FilesystemOptions,
+    ) -> Result<Vec<FilesystemEntry>> {
+        let response = self
+            .filesystem(FilesystemRequest {
+                op: FilesystemOp::ListDir,
+                path: path.into(),
+                destination: None,
+                depth,
+                user: options.user,
+            })
+            .await?;
+        Ok(require_filesystem_success(response)?.entries)
+    }
+
+    pub async fn make_dir(&self, path: impl Into<String>) -> Result<()> {
+        self.make_dir_with_options(path, FilesystemOptions::default())
+            .await
+    }
+
+    pub async fn make_dir_with_options(
+        &self,
+        path: impl Into<String>,
+        options: FilesystemOptions,
+    ) -> Result<()> {
+        self.mutate(FilesystemRequest {
+            op: FilesystemOp::MakeDir,
+            path: path.into(),
+            destination: None,
+            depth: 0,
+            user: options.user,
+        })
+        .await
+    }
+
+    pub async fn move_path(
+        &self,
+        source: impl Into<String>,
+        destination: impl Into<String>,
+    ) -> Result<()> {
+        self.move_path_with_options(source, destination, FilesystemOptions::default())
+            .await
+    }
+
+    pub async fn move_path_with_options(
+        &self,
+        source: impl Into<String>,
+        destination: impl Into<String>,
+        options: FilesystemOptions,
+    ) -> Result<()> {
+        self.mutate(FilesystemRequest {
+            op: FilesystemOp::Move,
+            path: source.into(),
+            destination: Some(destination.into()),
+            depth: 0,
+            user: options.user,
+        })
+        .await
+    }
+
+    pub async fn remove(&self, path: impl Into<String>) -> Result<()> {
+        self.remove_with_options(path, FilesystemOptions::default())
+            .await
+    }
+
+    pub async fn remove_with_options(
+        &self,
+        path: impl Into<String>,
+        options: FilesystemOptions,
+    ) -> Result<()> {
+        self.mutate(FilesystemRequest {
+            op: FilesystemOp::Remove,
+            path: path.into(),
+            destination: None,
+            depth: 0,
+            user: options.user,
+        })
+        .await
+    }
+
+    async fn mutate(&self, request: FilesystemRequest) -> Result<()> {
+        require_filesystem_success(self.filesystem(request).await?).map(|_| ())
+    }
+
+    async fn transfer(&self, request: FileRequest) -> Result<FileResponse> {
+        let (_, generation) = self.inner.active_execution()?;
+        #[cfg(unix)]
+        {
+            self.inner
+                .client
+                .transfer_execution_file(&self.inner.execution_id, generation, request)
+                .await
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (generation, request);
+            Err(ClientError::Execution(
+                a3s_box_core::ExecutionManagerError::Unavailable(
+                    "local file sessions are not available on this host".to_string(),
+                ),
+            ))
+        }
+    }
+
+    async fn filesystem(&self, request: FilesystemRequest) -> Result<FilesystemResponse> {
+        let (_, generation) = self.inner.active_execution()?;
+        #[cfg(unix)]
+        {
+            self.inner
+                .client
+                .filesystem_execution(&self.inner.execution_id, generation, request)
+                .await
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (generation, request);
+            Err(ClientError::Execution(
+                a3s_box_core::ExecutionManagerError::Unavailable(
+                    "local filesystem sessions are not available on this host".to_string(),
+                ),
+            ))
+        }
+    }
+}
+
+fn require_file_success(response: FileResponse) -> Result<FileResponse> {
+    if response.success {
+        Ok(response)
+    } else {
+        Err(ClientError::Guest(response.error.unwrap_or_else(|| {
+            "guest file operation failed".to_string()
+        })))
+    }
+}
+
+fn require_filesystem_success(response: FilesystemResponse) -> Result<FilesystemResponse> {
+    if response.success {
+        Ok(response)
+    } else {
+        Err(ClientError::Guest(response.error.unwrap_or_else(|| {
+            "guest filesystem operation failed".to_string()
+        })))
+    }
+}

--- a/src/sdk/src/sandbox/mod.rs
+++ b/src/sdk/src/sandbox/mod.rs
@@ -1,0 +1,273 @@
+//! E2B-style local Sandbox API backed directly by the A3S Box runtime.
+//!
+//! This module never reads endpoint or API-key environment variables. The
+//! default constructor opens the installed local runtime state directly.
+
+mod commands;
+mod filesystem;
+mod options;
+
+use std::sync::{Arc, RwLock};
+
+use a3s_box_core::{
+    ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionState, ExecutionStatus,
+};
+
+pub use commands::{CommandResult, CommandRunOptions, Commands, SandboxCommand};
+pub use filesystem::{Filesystem, FilesystemOptions, WriteInfo};
+pub use options::{SandboxCreateOptions, DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_TIMEOUT_SECONDS};
+
+use crate::{A3sBoxClient, ClientError, Result};
+
+#[derive(Debug, Clone, Copy)]
+struct SandboxState {
+    generation: ExecutionGeneration,
+    state: ExecutionState,
+    closed: bool,
+}
+
+pub(crate) struct SandboxInner {
+    client: A3sBoxClient,
+    execution_id: ExecutionId,
+    isolation: ExecutionIsolation,
+    state: RwLock<SandboxState>,
+}
+
+impl SandboxInner {
+    fn state(&self) -> SandboxState {
+        *self
+            .state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn update(&self, generation: ExecutionGeneration, state: ExecutionState) {
+        let mut current = self
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        current.generation = generation;
+        current.state = state;
+    }
+
+    fn close(&self, generation: ExecutionGeneration) {
+        let mut current = self
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        current.generation = generation;
+        current.state = ExecutionState::Stopped;
+        current.closed = true;
+    }
+
+    pub(crate) fn active_execution(&self) -> Result<(ExecutionId, ExecutionGeneration)> {
+        let state = self.state();
+        if state.closed || state.state != ExecutionState::Running {
+            return Err(ClientError::Validation(format!(
+                "sandbox {} is not running",
+                self.execution_id
+            )));
+        }
+        Ok((self.execution_id.clone(), state.generation))
+    }
+}
+
+/// Current local Sandbox identity and runtime state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxInfo {
+    pub sandbox_id: String,
+    pub generation: u64,
+    pub state: ExecutionState,
+    pub isolation: ExecutionIsolation,
+}
+
+/// A zero-configuration local A3S Box handle with an E2B-style surface.
+///
+/// `Sandbox::create` uses MicroVM isolation by default. Pass
+/// [`ExecutionIsolation::Sandbox`] through [`SandboxCreateOptions`] to opt into
+/// the lower-overhead shared-kernel backend on a certified Linux host.
+#[derive(Clone)]
+pub struct Sandbox {
+    inner: Arc<SandboxInner>,
+    pub commands: Commands,
+    pub files: Filesystem,
+}
+
+impl std::fmt::Debug for Sandbox {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Sandbox")
+            .field("info", &self.info())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Sandbox {
+    /// Create a local MicroVM Sandbox from an OCI image.
+    pub async fn create(image: impl Into<String>) -> Result<Self> {
+        Self::create_with_options(SandboxCreateOptions::new(image)).await
+    }
+
+    /// Create a local Sandbox with explicit runtime and isolation options.
+    pub async fn create_with_options(options: SandboxCreateOptions) -> Result<Self> {
+        Self::create_with_client(A3sBoxClient::new(), options).await
+    }
+
+    /// Create a local Sandbox through an explicitly supplied typed client.
+    pub async fn create_with_client(
+        client: A3sBoxClient,
+        options: SandboxCreateOptions,
+    ) -> Result<Self> {
+        let isolation = options.isolation;
+        let (request, operation) = options.into_runtime_request()?;
+        let lease = client.run_box(request, &operation).await?;
+        Ok(Self::from_known_state(
+            client,
+            lease.execution_id,
+            lease.generation,
+            ExecutionState::Running,
+            isolation,
+        ))
+    }
+
+    /// Reconnect to an existing local Sandbox without credentials.
+    pub async fn connect(sandbox_id: impl Into<String>) -> Result<Self> {
+        Self::connect_with_client(A3sBoxClient::new(), sandbox_id).await
+    }
+
+    /// Reconnect through an explicitly supplied typed client.
+    pub async fn connect_with_client(
+        client: A3sBoxClient,
+        sandbox_id: impl Into<String>,
+    ) -> Result<Self> {
+        let execution_id = ExecutionId::new(sandbox_id.into())
+            .map_err(|error| ClientError::Validation(error.to_string()))?;
+        let status = client.inspect_execution(&execution_id).await?;
+        Ok(Self::from_status(client, status))
+    }
+
+    fn from_status(client: A3sBoxClient, status: ExecutionStatus) -> Self {
+        Self::from_known_state(
+            client,
+            status.execution_id,
+            status.generation,
+            status.state,
+            status.plan.requested_isolation,
+        )
+    }
+
+    pub(crate) fn from_known_state(
+        client: A3sBoxClient,
+        execution_id: ExecutionId,
+        generation: ExecutionGeneration,
+        state: ExecutionState,
+        isolation: ExecutionIsolation,
+    ) -> Self {
+        let inner = Arc::new(SandboxInner {
+            client,
+            execution_id,
+            isolation,
+            state: RwLock::new(SandboxState {
+                generation,
+                state,
+                closed: false,
+            }),
+        });
+        Self {
+            commands: Commands {
+                inner: Arc::clone(&inner),
+            },
+            files: Filesystem {
+                inner: Arc::clone(&inner),
+            },
+            inner,
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        self.inner.execution_id.as_str()
+    }
+
+    pub fn info(&self) -> SandboxInfo {
+        let state = self.inner.state();
+        SandboxInfo {
+            sandbox_id: self.id().to_string(),
+            generation: state.generation.get(),
+            state: state.state,
+            isolation: self.inner.isolation,
+        }
+    }
+
+    pub fn isolation(&self) -> ExecutionIsolation {
+        self.inner.isolation
+    }
+
+    pub async fn pause(&self, keep_memory: bool) -> Result<()> {
+        let (_, generation) = self.inner.active_execution()?;
+        let lease = self
+            .inner
+            .client
+            .pause_execution(&self.inner.execution_id, generation, keep_memory)
+            .await?;
+        self.inner.update(lease.generation, ExecutionState::Paused);
+        Ok(())
+    }
+
+    pub async fn resume(&self) -> Result<()> {
+        let state = self.inner.state();
+        if state.closed {
+            return Err(ClientError::Validation(format!(
+                "sandbox {} has been killed",
+                self.id()
+            )));
+        }
+        let lease = self
+            .inner
+            .client
+            .resume_execution(&self.inner.execution_id, state.generation)
+            .await?;
+        self.inner.update(lease.generation, ExecutionState::Running);
+        Ok(())
+    }
+
+    pub async fn is_running(&self) -> Result<bool> {
+        if self.inner.state().closed {
+            return Ok(false);
+        }
+        match self
+            .inner
+            .client
+            .inspect_execution(&self.inner.execution_id)
+            .await
+        {
+            Ok(status) => {
+                self.inner.update(status.generation, status.state);
+                Ok(status.state == ExecutionState::Running)
+            }
+            Err(ClientError::Execution(a3s_box_core::ExecutionManagerError::NotFound(_)))
+            | Err(ClientError::BoxNotFound(_)) => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Kill the local execution and remove its runtime-owned record/resources.
+    pub async fn kill(&self) -> Result<()> {
+        let state = self.inner.state();
+        if state.closed {
+            return Ok(());
+        }
+        self.inner
+            .client
+            .kill_execution(&self.inner.execution_id, state.generation)
+            .await?;
+        self.inner
+            .client
+            .remove_local_execution_if_present(&self.inner.execution_id, state.generation)
+            .await?;
+        self.inner.close(state.generation);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/sdk/src/sandbox/options.rs
+++ b/src/sdk/src/sandbox/options.rs
@@ -1,0 +1,157 @@
+use std::collections::BTreeMap;
+
+use a3s_box_core::config::ResourceConfig;
+use a3s_box_core::{
+    resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionIsolation,
+    ExecutionRecordPolicy, OperationId,
+};
+
+use crate::{ClientError, Result};
+
+/// Default OCI image used by all native local SDKs.
+pub const DEFAULT_SANDBOX_IMAGE: &str = "alpine:3.20";
+
+/// Default lifetime of a locally created Sandbox.
+pub const DEFAULT_SANDBOX_TIMEOUT_SECONDS: u64 = 3_600;
+
+const KEEPALIVE_COMMAND: &[&str] = &["/bin/sh", "-c", "while :; do sleep 3600; done"];
+
+/// Options for [`super::Sandbox::create_with_options`].
+///
+/// MicroVM isolation is the default. Shared-kernel Sandbox isolation must be
+/// selected explicitly with [`SandboxCreateOptions::isolation`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxCreateOptions {
+    pub image: String,
+    pub timeout_seconds: u64,
+    pub envs: BTreeMap<String, String>,
+    pub metadata: BTreeMap<String, String>,
+    pub name: Option<String>,
+    pub cpus: Option<u32>,
+    pub memory_mb: Option<u32>,
+    pub isolation: ExecutionIsolation,
+}
+
+impl SandboxCreateOptions {
+    pub fn new(image: impl Into<String>) -> Self {
+        Self {
+            image: image.into(),
+            ..Self::default()
+        }
+    }
+
+    pub const fn timeout_seconds(mut self, timeout_seconds: u64) -> Self {
+        self.timeout_seconds = timeout_seconds;
+        self
+    }
+
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.envs.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub const fn cpus(mut self, cpus: u32) -> Self {
+        self.cpus = Some(cpus);
+        self
+    }
+
+    pub const fn memory_mb(mut self, memory_mb: u32) -> Self {
+        self.memory_mb = Some(memory_mb);
+        self
+    }
+
+    pub const fn isolation(mut self, isolation: ExecutionIsolation) -> Self {
+        self.isolation = isolation;
+        self
+    }
+
+    pub(crate) fn into_runtime_request(self) -> Result<(CreateExecutionRequest, OperationId)> {
+        if self.image.trim().is_empty() {
+            return Err(ClientError::Validation(
+                "sandbox image cannot be empty".to_string(),
+            ));
+        }
+        if self.timeout_seconds == 0 {
+            return Err(ClientError::Validation(
+                "sandbox timeout must be greater than zero".to_string(),
+            ));
+        }
+        if self.cpus == Some(0) {
+            return Err(ClientError::Validation(
+                "sandbox CPUs must be greater than zero".to_string(),
+            ));
+        }
+        if self.memory_mb == Some(0) {
+            return Err(ClientError::Validation(
+                "sandbox memory must be greater than zero".to_string(),
+            ));
+        }
+
+        let identity = uuid::Uuid::new_v4();
+        let mut resources = ResourceConfig {
+            timeout: self.timeout_seconds,
+            ..ResourceConfig::default()
+        };
+        if let Some(cpus) = self.cpus {
+            resources.vcpus = cpus;
+        }
+        if let Some(memory_mb) = self.memory_mb {
+            resources.memory_mb = memory_mb;
+        }
+
+        let config = BoxConfig {
+            isolation: self.isolation,
+            image: self.image,
+            resources,
+            cmd: KEEPALIVE_COMMAND
+                .iter()
+                .map(|part| (*part).to_string())
+                .collect(),
+            extra_env: self.envs.into_iter().collect(),
+            ..BoxConfig::default()
+        };
+        resolve_execution(&config).map_err(ClientError::Runtime)?;
+
+        let operation = OperationId::new(format!("sdk-create-{identity}"))
+            .map_err(|error| ClientError::Validation(error.to_string()))?;
+        Ok((
+            CreateExecutionRequest {
+                external_sandbox_id: format!("local-{identity}"),
+                config,
+                labels: self.metadata,
+                policy: ExecutionRecordPolicy {
+                    name: self.name,
+                    auto_remove: true,
+                    ..ExecutionRecordPolicy::default()
+                },
+                rootfs_snapshot_id: None,
+            },
+            operation,
+        ))
+    }
+}
+
+impl Default for SandboxCreateOptions {
+    fn default() -> Self {
+        Self {
+            image: DEFAULT_SANDBOX_IMAGE.to_string(),
+            timeout_seconds: DEFAULT_SANDBOX_TIMEOUT_SECONDS,
+            envs: BTreeMap::new(),
+            metadata: BTreeMap::new(),
+            name: None,
+            cpus: None,
+            memory_mb: None,
+            isolation: ExecutionIsolation::Microvm,
+        }
+    }
+}

--- a/src/sdk/src/sandbox/tests.rs
+++ b/src/sdk/src/sandbox/tests.rs
@@ -1,0 +1,318 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use a3s_box_core::pty::PtyRequest;
+use a3s_box_core::{
+    resolve_execution, BoxConfig, CreateExecutionRequest, ExecOutput, ExecRequest,
+    ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionLease, ExecutionManager,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionProcess, ExecutionReservation,
+    ExecutionSessionManager, ExecutionState, ExecutionStatus, FileOp, FileRequest, FileResponse,
+    FilesystemEntry, FilesystemEntryKind, FilesystemOp, FilesystemRequest, FilesystemResponse,
+    KillOutcome, OperationId, ReconcileOutcome,
+};
+use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use chrono::Utc;
+
+use super::{CommandRunOptions, Sandbox, SandboxCreateOptions};
+use crate::{A3sBoxClient, A3sBoxPaths};
+
+#[derive(Debug)]
+struct RecordingRuntime {
+    config: Mutex<Option<BoxConfig>>,
+    state: Mutex<ExecutionState>,
+    create_requests: Mutex<Vec<CreateExecutionRequest>>,
+    exec_requests: Mutex<Vec<ExecRequest>>,
+    file_requests: Mutex<Vec<FileRequest>>,
+    filesystem_requests: Mutex<Vec<FilesystemRequest>>,
+}
+
+impl RecordingRuntime {
+    fn new() -> Self {
+        Self {
+            config: Mutex::new(None),
+            state: Mutex::new(ExecutionState::Created),
+            create_requests: Mutex::new(Vec::new()),
+            exec_requests: Mutex::new(Vec::new()),
+            file_requests: Mutex::new(Vec::new()),
+            filesystem_requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn execution_id() -> ExecutionId {
+        ExecutionId::new("local-rust-sdk-test").unwrap()
+    }
+
+    fn lease(&self) -> ExecutionLease {
+        let config = self.config.lock().unwrap().clone().unwrap();
+        ExecutionLease {
+            execution_id: Self::execution_id(),
+            generation: ExecutionGeneration::INITIAL,
+            plan: resolve_execution(&config).unwrap(),
+            resources: config.resources,
+            started_at: Utc::now(),
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionManager for RecordingRuntime {
+    async fn create(
+        &self,
+        request: CreateExecutionRequest,
+        _operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ExecutionReservation> {
+        let config = request.config.clone();
+        *self.config.lock().unwrap() = Some(config.clone());
+        self.create_requests.lock().unwrap().push(request);
+        Ok(ExecutionReservation {
+            execution_id: Self::execution_id(),
+            generation: ExecutionGeneration::INITIAL,
+            plan: resolve_execution(&config).unwrap(),
+            resources: config.resources,
+            created_at: Utc::now(),
+        })
+    }
+
+    async fn create_and_start(
+        &self,
+        request: CreateExecutionRequest,
+        _operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        *self.config.lock().unwrap() = Some(request.config.clone());
+        self.create_requests.lock().unwrap().push(request);
+        *self.state.lock().unwrap() = ExecutionState::Running;
+        Ok(self.lease())
+    }
+
+    async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
+        if execution_id != &Self::execution_id() {
+            return Err(ExecutionManagerError::NotFound(execution_id.clone()));
+        }
+        let lease = self.lease();
+        Ok(ExecutionStatus {
+            execution_id: lease.execution_id,
+            generation: lease.generation,
+            state: *self.state.lock().unwrap(),
+            plan: lease.plan,
+        })
+    }
+
+    async fn pause(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        _keep_memory: bool,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        *self.state.lock().unwrap() = ExecutionState::Paused;
+        Ok(self.lease())
+    }
+
+    async fn resume(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<ExecutionLease> {
+        *self.state.lock().unwrap() = ExecutionState::Running;
+        Ok(self.lease())
+    }
+
+    async fn kill(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+    ) -> ExecutionManagerResult<KillOutcome> {
+        *self.state.lock().unwrap() = ExecutionState::Stopped;
+        Ok(KillOutcome::Killed)
+    }
+
+    async fn reconcile(
+        &self,
+        _operation_id: &OperationId,
+    ) -> ExecutionManagerResult<ReconcileOutcome> {
+        Ok(ReconcileOutcome::Absent)
+    }
+}
+
+#[async_trait]
+impl ExecutionSessionManager for RecordingRuntime {
+    async fn execute(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        request: ExecRequest,
+    ) -> ExecutionManagerResult<ExecOutput> {
+        self.exec_requests.lock().unwrap().push(request);
+        Ok(ExecOutput {
+            stdout: b"42\n".to_vec(),
+            stderr: Vec::new(),
+            exit_code: 0,
+            truncated: false,
+        })
+    }
+
+    async fn start_process(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        _request: ExecRequest,
+    ) -> ExecutionManagerResult<ExecutionProcess> {
+        Err(ExecutionManagerError::Unavailable(
+            "streaming process is outside this test".to_string(),
+        ))
+    }
+
+    async fn start_pty(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        _request: PtyRequest,
+    ) -> ExecutionManagerResult<ExecutionProcess> {
+        Err(ExecutionManagerError::Unavailable(
+            "PTY is outside this test".to_string(),
+        ))
+    }
+
+    async fn transfer_file(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        request: FileRequest,
+    ) -> ExecutionManagerResult<FileResponse> {
+        let response = match request.op {
+            FileOp::Upload => FileResponse {
+                success: true,
+                data: None,
+                size: request
+                    .data
+                    .as_deref()
+                    .and_then(|data| STANDARD.decode(data).ok())
+                    .map_or(0, |data| data.len() as u64),
+                error: None,
+            },
+            FileOp::Download => FileResponse {
+                success: true,
+                data: Some(STANDARD.encode(b"hello")),
+                size: 5,
+                error: None,
+            },
+        };
+        self.file_requests.lock().unwrap().push(request);
+        Ok(response)
+    }
+
+    async fn filesystem(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        request: FilesystemRequest,
+    ) -> ExecutionManagerResult<FilesystemResponse> {
+        let entry = (request.op == FilesystemOp::Stat).then(|| FilesystemEntry {
+            name: "note.txt".to_string(),
+            kind: FilesystemEntryKind::File,
+            path: request.path.clone(),
+            size: 5,
+            mode: 0o644,
+            permissions: "-rw-r--r--".to_string(),
+            owner: "root".to_string(),
+            group: "root".to_string(),
+            modified_seconds: 1,
+            modified_nanos: 0,
+            symlink_target: None,
+            metadata: BTreeMap::new(),
+        });
+        self.filesystem_requests.lock().unwrap().push(request);
+        Ok(FilesystemResponse {
+            success: true,
+            entry,
+            entries: Vec::new(),
+            error: None,
+        })
+    }
+}
+
+fn test_client(runtime: Arc<RecordingRuntime>, home: &std::path::Path) -> A3sBoxClient {
+    A3sBoxClient::with_execution_services(A3sBoxPaths::from_home(home), runtime.clone(), runtime)
+}
+
+#[tokio::test]
+async fn e2b_style_rust_surface_supports_both_local_isolation_levels() {
+    for isolation in [ExecutionIsolation::Microvm, ExecutionIsolation::Sandbox] {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = Arc::new(RecordingRuntime::new());
+        let sandbox = Sandbox::create_with_client(
+            test_client(Arc::clone(&runtime), temp.path()),
+            SandboxCreateOptions::new("python:3.12-alpine")
+                .timeout_seconds(120)
+                .env("MODE", "test")
+                .metadata("suite", "rust-sdk")
+                .isolation(isolation),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(sandbox.id(), "local-rust-sdk-test");
+        assert_eq!(sandbox.isolation(), isolation);
+        assert_eq!(sandbox.info().state, ExecutionState::Running);
+
+        let output = sandbox
+            .commands
+            .run_with_options(
+                "python -c 'print(6 * 7)'",
+                CommandRunOptions::default().cwd("/workspace"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(output.stdout, "42\n");
+        assert_eq!(output.exit_code, 0);
+
+        let write = sandbox
+            .files
+            .write("/workspace/note.txt", b"hello")
+            .await
+            .unwrap();
+        assert_eq!(write.size, 5);
+        assert_eq!(
+            sandbox
+                .files
+                .read_text("/workspace/note.txt")
+                .await
+                .unwrap(),
+            "hello"
+        );
+        assert!(sandbox.files.exists("/workspace/note.txt").await.unwrap());
+
+        sandbox.pause(true).await.unwrap();
+        assert_eq!(sandbox.info().state, ExecutionState::Paused);
+        sandbox.resume().await.unwrap();
+        assert!(sandbox.is_running().await.unwrap());
+        sandbox.kill().await.unwrap();
+        assert!(!sandbox.is_running().await.unwrap());
+        sandbox.kill().await.unwrap();
+
+        let requests = runtime.create_requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].config.isolation, isolation);
+        assert_eq!(requests[0].config.image, "python:3.12-alpine");
+        assert_eq!(requests[0].config.resources.timeout, 120);
+        assert_eq!(
+            requests[0].config.extra_env,
+            [("MODE".to_string(), "test".to_string())]
+        );
+        assert_eq!(
+            requests[0].labels.get("suite").map(String::as_str),
+            Some("rust-sdk")
+        );
+        drop(requests);
+
+        let exec = runtime.exec_requests.lock().unwrap();
+        assert_eq!(exec[0].cmd, ["/bin/sh", "-lc", "python -c 'print(6 * 7)'"]);
+    }
+}
+
+#[test]
+fn local_sandbox_handle_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Sandbox>();
+}

--- a/src/sdk/tests/local_sandbox.rs
+++ b/src/sdk/tests/local_sandbox.rs
@@ -1,0 +1,173 @@
+//! Opt-in real-runtime proof for the zero-configuration E2B-style Rust API.
+
+use std::error::Error;
+use std::path::PathBuf;
+
+use a3s_box_sdk::{A3sBoxClient, ClientError, ExecutionIsolation, Sandbox, SandboxCreateOptions};
+
+type AnyError = Box<dyn Error + Send + Sync>;
+
+#[tokio::test]
+#[ignore = "requires a real local A3S Box runtime and runnable OCI image"]
+async fn e2b_style_local_sandbox_runs_without_remote_credentials() -> Result<(), AnyError> {
+    require(
+        std::env::var("A3S_BOX_SDK_LOCAL_SMOKE").as_deref() == Ok("1"),
+        "set A3S_BOX_SDK_LOCAL_SMOKE=1 to acknowledge the destructive smoke test",
+    )?;
+    for variable in [
+        "E2B_API_KEY",
+        "E2B_API_URL",
+        "E2B_DOMAIN",
+        "A3S_BOX_API_KEY",
+        "A3S_BOX_ENDPOINT",
+        "A3S_BOX_DOMAIN",
+        "A3S_BOX_SANDBOX_URL",
+    ] {
+        require(
+            std::env::var_os(variable).is_none(),
+            format!("{variable} must be unset for the zero-configuration local SDK smoke"),
+        )?;
+    }
+
+    let home = validated_home()?;
+    let isolation = requested_isolation()?;
+    let image =
+        std::env::var("A3S_BOX_SDK_SMOKE_IMAGE").unwrap_or_else(|_| "alpine:3.20".to_string());
+    let sandbox = Sandbox::create_with_client(
+        A3sBoxClient::from_home(&home),
+        SandboxCreateOptions::new(image)
+            .timeout_seconds(300)
+            .metadata("purpose", "local-sdk-smoke")
+            .isolation(isolation),
+    )
+    .await?;
+    let sandbox_id = sandbox.id().to_string();
+
+    let exercise_result = exercise(&sandbox, isolation).await;
+    let cleanup_result = sandbox.kill().await;
+    if let Err(error) = exercise_result {
+        if let Err(cleanup_error) = cleanup_result {
+            eprintln!("local SDK cleanup also failed: {cleanup_error}");
+        }
+        return Err(error);
+    }
+    cleanup_result?;
+
+    require(
+        !sandbox.is_running().await?,
+        "killed Sandbox still reports itself running",
+    )?;
+    require(
+        !home.join("boxes").join(&sandbox_id).exists(),
+        "Sandbox runtime directory remained after kill",
+    )?;
+    require(
+        Sandbox::connect_with_client(A3sBoxClient::from_home(&home), sandbox_id)
+            .await
+            .is_err(),
+        "Sandbox execution record remained connectable after kill",
+    )?;
+    Ok(())
+}
+
+async fn exercise(
+    sandbox: &Sandbox,
+    expected_isolation: ExecutionIsolation,
+) -> Result<(), AnyError> {
+    require(
+        sandbox.isolation() == expected_isolation,
+        "created Sandbox reports the wrong isolation level",
+    )?;
+    require(sandbox.is_running().await?, "Sandbox is not running")?;
+
+    let command = sandbox.commands.run("printf 'rust-sdk-ok'").await?;
+    require(command.exit_code == 0, "Rust SDK command failed")?;
+    require(
+        command.stdout == "rust-sdk-ok",
+        "Rust SDK command returned unexpected stdout",
+    )?;
+
+    let directory = "/tmp/a3s-local-sdk-smoke";
+    let source = format!("{directory}/source.txt");
+    let destination = format!("{directory}/moved.txt");
+    sandbox.files.make_dir(directory).await?;
+    let write = sandbox.files.write(&source, "hello").await?;
+    require(
+        write.size == 5,
+        "Rust SDK file write reported the wrong size",
+    )?;
+    require(
+        sandbox.files.read_text(&source).await? == "hello",
+        "Rust SDK file read returned unexpected data",
+    )?;
+    require(
+        sandbox.files.stat(&source).await?.size == 5,
+        "Rust SDK stat returned the wrong size",
+    )?;
+    require(
+        sandbox
+            .files
+            .list(directory, 1)
+            .await?
+            .iter()
+            .any(|entry| entry.path == source),
+        "Rust SDK list did not return the created file",
+    )?;
+    sandbox.files.move_path(&source, &destination).await?;
+    require(
+        sandbox.files.exists(&destination).await?,
+        "Rust SDK move did not publish the destination",
+    )?;
+    sandbox.files.remove(directory).await?;
+
+    sandbox.pause(true).await?;
+    require(
+        !sandbox.is_running().await?,
+        "paused Sandbox reports itself running",
+    )?;
+    sandbox.resume().await?;
+    require(
+        sandbox.is_running().await?,
+        "resumed Sandbox is not running",
+    )?;
+    Ok(())
+}
+
+fn requested_isolation() -> Result<ExecutionIsolation, AnyError> {
+    match std::env::var("A3S_BOX_SDK_SMOKE_ISOLATION")
+        .unwrap_or_else(|_| "microvm".to_string())
+        .as_str()
+    {
+        "microvm" => Ok(ExecutionIsolation::Microvm),
+        "sandbox" => Ok(ExecutionIsolation::Sandbox),
+        value => Err(failure(format!(
+            "A3S_BOX_SDK_SMOKE_ISOLATION must be microvm or sandbox, got {value:?}"
+        ))),
+    }
+}
+
+fn validated_home() -> Result<PathBuf, AnyError> {
+    let home = std::env::var_os("A3S_HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| failure("A3S_HOME must point to a dedicated local-sdk-smoke directory"))?;
+    require(home.is_absolute(), "A3S_HOME must be absolute")?;
+    require(
+        home.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.contains("local-sdk-smoke")),
+        "A3S_HOME must name a dedicated local-sdk-smoke directory",
+    )?;
+    Ok(home)
+}
+
+fn require(condition: bool, message: impl Into<String>) -> Result<(), AnyError> {
+    if condition {
+        Ok(())
+    } else {
+        Err(failure(message))
+    }
+}
+
+fn failure(message: impl Into<String>) -> AnyError {
+    Box::new(ClientError::Validation(message.into()))
+}


### PR DESCRIPTION
## Summary

- add a native Rust `Sandbox` facade with E2B-like commands, files, and lifecycle APIs
- keep Rust, Python, and TypeScript local SDK usage free of API keys, endpoints, and remote domains
- support MicroVM by default and explicit shared-kernel Sandbox isolation
- route the language bridge through the canonical Rust implementation
- add real-runtime zero-credential smoke coverage for all three SDKs

## Validation

- `cargo test --locked -p a3s-box-sdk --lib --tests` (41 passed; real-runtime tests compile and remain opt-in)
- `cargo clippy --locked -p a3s-box-sdk --all-targets --no-deps -- -D warnings`
- Python 3.12 unit tests (8 passed)
- TypeScript build, tests, and package dry run
- real macOS MicroVM smoke for Rust, Python, and TypeScript with all remote credential variables unset
- new Ubuntu CI gate runs the same three-language smoke against certified crun 1.28
