### PR TITLE
chore(release): prepare Box 3.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+## [3.0.12] — 2026-07-23
+
 ### Added
 
 - **Zero-configuration local Rust, Python, and TypeScript SDKs.** Native

--- a/deploy/scripts/install-runtimeclass.sh
+++ b/deploy/scripts/install-runtimeclass.sh
@@ -16,7 +16,7 @@
 # Usage:
 #   install-runtimeclass.sh [--version vX.Y.Z] [--repo OWNER/REPO] [--from-dir DIR]
 #
-#   --version   release tag to install                 (default: v3.0.11)
+#   --version   release tag to install                 (default: v3.0.12)
 #   --repo      GitHub repo to download artifacts from (default: A3S-Lab/Box)
 #   --from-dir  install from a local directory instead of downloading; the dir must
 #               contain a3s-box-<version>-linux-<arch>.tar.gz, its .sha256 file,
@@ -28,7 +28,7 @@
 # Idempotent: safe to re-run (re-installs binaries, rewrites the containerd drop-in).
 set -euo pipefail
 
-VERSION="v3.0.11"
+VERSION="v3.0.12"
 REPO="A3S-Lab/Box"
 FROM_DIR=""
 WARMUP_IMAGE="busybox:latest"   # first box on a fresh node builds a one-time cache

--- a/deploy/scripts/test-install-runtimeclass.sh
+++ b/deploy/scripts/test-install-runtimeclass.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALLER="$SCRIPT_DIR/install-runtimeclass.sh"
-VERSION="v3.0.11"
+VERSION="v3.0.12"
 ARCH="x86_64"
 PACKAGE_DIR="a3s-box-${VERSION}-linux-${ARCH}"
 TARBALL="${PACKAGE_DIR}.tar.gz"
@@ -35,7 +35,7 @@ make_assets() {
 
   cat > "$fixture/a3s-box" <<'SCRIPT'
 #!/usr/bin/env bash
-echo "a3s-box 3.0.11"
+echo "a3s-box 3.0.12"
 SCRIPT
   cat > "$fixture/a3s-box-cri" <<'SCRIPT'
 #!/usr/bin/env bash

--- a/docs/production-cluster-tests.md
+++ b/docs/production-cluster-tests.md
@@ -98,7 +98,7 @@ directory must contain the platform tarball, the matching standalone
 
 ```bash
 sudo deploy/scripts/install-runtimeclass.sh \
-  --version v3.0.11 \
+  --version v3.0.12 \
   --from-dir /opt/a3s-box-artifacts \
   --warmup-image docker.m.daocloud.io/library/busybox:latest
 ```

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "a3s-box"
-version = "3.0.11"
+version = "3.0.12"
 description = "Local-first Python SDK for A3S Box with E2B-like APIs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/box",
-      "version": "3.0.11",
+      "version": "3.0.12",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "20.19.9",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "Local-first TypeScript SDK for A3S Box with E2B-like APIs",
   "type": "module",
   "sideEffects": false,

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -9,7 +9,7 @@ source = "git+https://github.com/A3S-Lab/ACL.git?rev=fc041758758eba89dd5d22a3414
 
 [[package]]
 name = "a3s-box-cli"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-compat"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-acl",
  "a3s-box-core",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-core"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-acl",
  "a3s-common",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cri"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-guest-init"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-box-core",
  "a3s-common",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-lambda"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-netproxy"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-box-core",
  "libc",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-runtime"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-sdk"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-shim"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-libkrun-sys"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "libc",
  "num_cpus",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -24,7 +24,7 @@ resolver = "2"
 h2 = { path = "third_party/h2" }
 
 [workspace.package]
-version = "3.0.11"
+version = "3.0.12"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump the Rust workspace, Python SDK, and TypeScript SDK to 3.0.12
- update the RuntimeClass installer defaults and production-cluster example
- archive the zero-configuration local SDK work in the 3.0.12 changelog section

## Validation
- `cargo fmt --all -- --check`
- `A3S_DEPS_STUB=1 cargo check --locked -p a3s-box-sdk`
- `bash deploy/scripts/test-install-runtimeclass.sh`
- Python 3.12 sdist/wheel build, isolated wheel install, and 8 unit tests
- `npm run build`
- `npm test`
- `npm pack --dry-run`
- `git diff --check`