### PR TITLE
fix(ci): install musl target for Windows libkrun builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
         run: git -c http.extraheader= submodule update --init --recursive
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
         with:
-          targets: x86_64-pc-windows-msvc
+          targets: x86_64-pc-windows-msvc,x86_64-unknown-linux-musl
       - name: Verify bundled libkrun source archive
         shell: pwsh
         run: powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/package-libkrun-source.ps1 -Check

--- a/.github/workflows/publish-libkrun-sys.yml
+++ b/.github/workflows/publish-libkrun-sys.yml
@@ -42,7 +42,7 @@ jobs:
       # dtolnay/rust-toolchain stable (2026-07-16)
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
-          targets: x86_64-pc-windows-msvc
+          targets: x86_64-pc-windows-msvc,x86_64-unknown-linux-musl
 
       - name: Validate requested package version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,7 +476,7 @@ jobs:
       # dtolnay/rust-toolchain stable (2026-07-16)
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
-          targets: x86_64-pc-windows-msvc
+          targets: x86_64-pc-windows-msvc,x86_64-unknown-linux-musl
       - name: Verify bundled libkrun source archive
         shell: pwsh
         run: powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/package-libkrun-source.ps1 -Check


### PR DESCRIPTION
## Summary

- install x86_64-unknown-linux-musl alongside the Windows Rust target
- cover CI, Box release, and libkrun-sys publishing workflows
- unblock the Windows init wrapper compiled by the libkrun devices build script

## Validation

- parsed all three modified workflow files as YAML
- verified all three Windows jobs declare both required Rust targets
- git diff --check