### PR TITLE
feat(sdk): add fluent programmable runtime builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,24 +43,6 @@ execution, the E2B protocol service, Kubernetes CRI/RuntimeClass integration,
 TEE workflows, and Windows support have different maturity and host
 requirements; the capability matrix below states those boundaries explicitly.
 
-### Distribution status
-
-This README describes the current `main` branch, including unreleased work.
-Distribution status was verified on 2026-07-23:
-
-| Surface | Current public distribution | Boundary |
-| --- | --- | --- |
-| CLI and runtime | GitHub Release and Homebrew `v3.0.11` | Stable. It predates the native local SDK bridge and the unreleased Windows packaging work on `main`. |
-| Rust SDK | crates.io `a3s-box-sdk` `3.0.11` | The direct runtime-backed client is published. The high-level local `Sandbox` facade described below was added after `v3.0.11` and is not in the published crate yet. |
-| Python SDK | PyPI `a3s-box` `2.0.0`; GitHub `v3.0.11` also contains a wheel and sdist | Those artifacts expose the earlier remote E2B-oriented wrapper, not the native zero-configuration local API on `main`. |
-| TypeScript SDK | npm `@a3s-lab/box` `2.0.0`; GitHub `v3.0.11` also contains a package tarball | Those artifacts expose the earlier remote E2B-oriented wrapper, not the native zero-configuration local API on `main`. |
-| Windows runtime | Source build from `main` | The WHPX path has real-host validation, but the current `v3.0.11` release has no Windows archive. |
-
-Use the stable release for the published CLI/runtime behavior. Evaluate the
-native local SDKs or Windows path from one consistent `main` source checkout
-until a newer version is tagged and published; do not mix `main` language
-packages with the `v3.0.11` runtime binary.
-
 ### Basic usage
 
 ```bash
@@ -170,8 +152,8 @@ bridge networking and port publication are MicroVM-only in the current
 runtime; the Sandbox backend rejects them rather than silently weakening the
 request.
 
-These native local APIs are currently an unreleased `main` feature; the
-distribution table above identifies which published artifacts predate them.
+Use a runtime and language SDK built from the same release or source revision;
+the machine bridge is versioned and rejects incompatible requests.
 
 Python and TypeScript default to `alpine:3.20`. Rust
 `Sandbox::create(...)` requires an image argument, while
@@ -230,12 +212,12 @@ E2B client used to validate it.
 | Storage | Bind mounts, named volumes, tmpfs, `cp`, `diff`, `export`, `commit`, filesystem snapshots, and CoW restore | Implemented. Filesystem snapshots do not contain live VM RAM or device state. |
 | Networking and Compose | TSI, bridge networks, TCP publishing, peer discovery, and Compose lifecycle/config/logs | Implemented subset for MicroVM workloads. UDP publishing, host-IP binds, ranges, and live network hot-plug are not implemented. |
 | Warm pool and snapshot-fork | Pre-booted MicroVMs, one-shot runs, build leases, metrics, and CoW memory restore | Implemented. Native snapshot-fork is Linux/KVM-only and disabled by default. |
-| Rust SDK | Typed, direct runtime-backed management and guest-control APIs; E2B-like local `Sandbox`, commands, files, and lifecycle; fluent image, volume, network, Sandbox, and script builders | The direct client is published as `a3s-box-sdk` `3.0.11`. The zero-credential local facade and builder-style programmable CI/CD API are implemented and package-tested on `main`, default to MicroVM, and explicitly accept supported shared-kernel Sandbox configurations, but await the next crate release. The optional historical `pipeline-cli` feature remains separate. |
+| Rust SDK | Typed, direct runtime-backed management and guest-control APIs; E2B-like local `Sandbox`, commands, files, and lifecycle; fluent image, volume, network, Sandbox, and script builders | The zero-credential local facade and builder-style programmable CI/CD API are implemented and package-tested, default to MicroVM, and explicitly accept supported shared-kernel Sandbox configurations. The optional historical `pipeline-cli` feature remains separate. |
 | Local Python and TypeScript SDKs | E2B-like `Sandbox`, commands, files, lifecycle, plus fluent image-build, named-volume, bridge-network, typed Sandbox, and stdin-backed script builders over the installed local runtime | Implemented and package-tested on `main`. The packages share the Rust implementation through the versioned bridge, have no official E2B runtime dependency, and require no endpoint or API key. The real macOS/HVF MicroVM three-language builder-to-E2B smoke passes; the expanded Ubuntu/crun 1.28 Sandbox matrix is a blocking CI gate. Linux/KVM MicroVM validation remains host-specific, and the native packages are not yet published to PyPI or npm. |
 | Remote E2B protocol service | Pinned contracts, durable lifecycle, memory-preserving and filesystem-only pause/resume, owner-scoped filesystem Snapshots and Volumes, v1/v2 listing and runtime-backed structured logs, current metrics, TLS routing, envd file/environment operations, Filesystem, Process, PTY, and Python Code Interpreter contexts | The certified A3S OS evidence uses unchanged official Python sync/async and TypeScript clients. Templates/builds, historical metrics, signed files, public-port breadth, MCP, cancellation/backpressure, deeper Snapshot/Volume failure recovery, and the rest of the pinned contract remain gates; `full_compatibility=false`. |
 | TEE | SEV-SNP-oriented attestation, RA-TLS, sealing, secret injection, and simulation | Host-specific. Hardware claims require a supported SEV-SNP host and real attestation evidence. Simulation is development-only; TDX is not productized. |
 | Kubernetes | CRI server plus a containerd runtime-v2 shim and `runtimeClassName: a3s-box` | Preview. Core lifecycle, streaming, logs, resources, and RuntimeClass paths exist; complete CRI conformance is not claimed. |
-| Windows | Native x86_64 WHPX/libkrun MicroVM execution | Implemented and real-host validated on `main`, but not included in the current `v3.0.11` release. Foreground and detached workloads, long arguments staged outside the guest kernel command line, live split logs, exit codes, TCP publishing, bind mounts, named-volume persistence, stats, stopped-box commit, and stopped-box filesystem snapshot flows pass. Running-box commit has no guest archive channel. The reliable path is currently limited to one vCPU; container health checks, bridge networking, interactive execution, TEE, snapshot-fork, and CRI remain unsupported. |
+| Windows | Native x86_64 WHPX/libkrun MicroVM execution | Implemented and real-host validated from source; published Windows archives remain pending. Foreground and detached workloads, long arguments staged outside the guest kernel command line, live split logs, exit codes, TCP publishing, bind mounts, named-volume persistence, stats, stopped-box commit, and stopped-box filesystem snapshot flows pass. Running-box commit has no guest archive channel. The reliable path is currently limited to one vCPU; container health checks, bridge networking, interactive execution, TEE, snapshot-fork, and CRI remain unsupported. |
 
 An implemented API is not automatically a production guarantee for every host
 or threat model. Real-runtime validation evidence and remaining platform gaps
@@ -247,17 +229,15 @@ are maintained in [Host Integration](docs/host-integration.md),
 
 ### Installation
 
-Install the current stable macOS or Linux CLI/runtime (`v3.0.11`) from the
-Homebrew tap:
+Install the current stable macOS or Linux CLI/runtime from the Homebrew tap:
 
 ```bash
 brew install a3s-lab/tap/a3s-box
 a3s-box info
 ```
 
-That release predates the native local SDK bridge described above. To evaluate
-the current `main` implementation, build the runtime and language packages
-from the same source checkout:
+To evaluate the current source implementation, build the runtime and language
+packages from the same checkout:
 
 ```bash
 git clone https://github.com/A3S-Lab/Box.git
@@ -276,7 +256,7 @@ Host requirements:
 | Linux | KVM and libkrun | The current primary production-host path |
 | macOS | Apple Silicon and Hypervisor.framework | Intel macOS is unsupported |
 | Linux Sandbox | Certified `crun 1.28`, user namespaces, subordinate IDs, seccomp, and delegated cgroup v2 | Does not require KVM; explicitly select `--isolation sandbox` |
-| Windows | x86_64, Windows Hypervisor Platform, Developer Mode (or `SeCreateSymbolicLinkPrivilege`), and matching `krun.dll`/`libkrunfw.dll` assets | Source-build path on `main`; no Windows archive exists in `v3.0.11`. Currently one vCPU, with the command boundaries documented below |
+| Windows | x86_64, Windows Hypervisor Platform, Developer Mode (or `SeCreateSymbolicLinkPrivilege`), and matching `krun.dll`/`libkrunfw.dll` assets | Source-build path; published Windows archives remain pending. Currently one vCPU, with the command boundaries documented below |
 
 Linux release archives intentionally contain GNU/glibc host executables because
 the CLI, CRI service, and VM shim dynamically load the bundled `libkrun`. The
@@ -662,11 +642,8 @@ does not spawn the `a3s-box` CLI and uses the same stores, execution manager,
 registry, build, volume, network, snapshot, exec, PTY, and attestation
 implementations as the runtime.
 
-The crates.io dependency below is the published `3.0.x` direct client. It does
-not yet contain the high-level local `Sandbox` facade added after `v3.0.11`.
-Use the workspace crate from a consistent `main` checkout for development, or
-wait for the next published crate before depending on that facade in released
-applications.
+Use matching runtime and SDK minor versions. For source development, use the
+workspace crate and language packages from one checkout.
 
 ```toml
 [dependencies]
@@ -1030,10 +1007,10 @@ The native local Python package under
 runtime dependency. Their bridge mapping, package tests, real macOS MicroVM
 smoke, and real Ubuntu/crun 1.28 Sandbox smoke are separate from the remote
 production compatibility matrix, which uses only unchanged official clients.
-The current PyPI/npm releases and GitHub `v3.0.11` language artifacts still
-contain the earlier remote-oriented wrappers. Passing either tested subset is
-not evidence for unimplemented protocol surfaces, so the generated manifest
-continues to report `full_compatibility=false`.
+The native local packages and remote protocol compatibility surface have
+separate test matrices. Passing either tested subset is not evidence for
+unimplemented protocol surfaces, so the generated manifest continues to
+report `full_compatibility=false`.
 
 See [E2B Protocol Compatibility and SDK Design](docs/e2b-compatible-sdk-design.md)
 for the release definition, architecture, ACL schema, and remaining gates.
@@ -1150,7 +1127,7 @@ Main components:
 | `containerd-shim` | containerd runtime-v2 adapter for RuntimeClass |
 | `src/sdk` | Direct runtime-backed Rust SDK, E2B-style local Sandbox facade, and optional pipeline runner |
 | `src/lambda` | Workload-execution integration retained for higher-level runtimes |
-| `sdk/python`, `sdk/typescript` | Native local A3S language SDK source packages on `main`; their first public-registry release is pending, while existing registry and `v3.0.11` artifacts contain the earlier remote-oriented wrappers |
+| `sdk/python`, `sdk/typescript` | Native local A3S language SDKs using the versioned machine bridge |
 
 MicroVM guest control uses vsock-backed channels for control/health, exec, PTY,
 attestation, and optional sidecars. These are guest-to-host control channels,

--- a/README.md
+++ b/README.md
@@ -128,6 +128,48 @@ try {
 }
 ```
 
+The same packages also expose builder-style programmable CI/CD without
+introducing a separate workflow engine. Builders manage host-level images,
+named volumes, and bridge networks, then create the same E2B-style `Sandbox`
+handle:
+
+```typescript
+import { A3SBoxClient } from '@a3s-lab/box'
+
+const client = new A3SBoxClient()
+const image = await client
+  .image('./ci')
+  .dockerfile('Dockerfile')
+  .tag('local/ci-base:latest')
+  .build()
+const cache = await client.volume('build-cache').create()
+const network = await client.network('ci-net').subnet('10.89.40.0/24').create()
+const sandbox = await client
+  .sandbox(image.reference)
+  .mountNamed(cache.name, '/cache')
+  .network(network.name)
+  .publishTcp(8080, 8080)
+  .start()
+
+try {
+  const result = await sandbox
+    .script('npm ci\nnpm test\n')
+    .interpreter('/bin/sh', '-se')
+    .run()
+  if (result.exitCode !== 0) throw new Error(result.stderr)
+} finally {
+  await sandbox.kill()
+}
+```
+
+Rust, synchronous/asynchronous Python, and TypeScript expose the same builder
+concepts. Script source travels over stdin to an explicit interpreter. Mounts,
+network selection, ports, tmpfs, workdir, persistence, cleanup, and snapshot
+restore remain typed values and are validated before runtime mutation. Named
+bridge networking and port publication are MicroVM-only in the current
+runtime; the Sandbox backend rejects them rather than silently weakening the
+request.
+
 These native local APIs are currently an unreleased `main` feature; the
 distribution table above identifies which published artifacts predate them.
 
@@ -188,8 +230,8 @@ E2B client used to validate it.
 | Storage | Bind mounts, named volumes, tmpfs, `cp`, `diff`, `export`, `commit`, filesystem snapshots, and CoW restore | Implemented. Filesystem snapshots do not contain live VM RAM or device state. |
 | Networking and Compose | TSI, bridge networks, TCP publishing, peer discovery, and Compose lifecycle/config/logs | Implemented subset for MicroVM workloads. UDP publishing, host-IP binds, ranges, and live network hot-plug are not implemented. |
 | Warm pool and snapshot-fork | Pre-booted MicroVMs, one-shot runs, build leases, metrics, and CoW memory restore | Implemented. Native snapshot-fork is Linux/KVM-only and disabled by default. |
-| Rust SDK | Typed, direct runtime-backed management and guest-control APIs plus an E2B-like local `Sandbox`, commands, files, and lifecycle facade | The direct client is published as `a3s-box-sdk` `3.0.11`. The zero-credential local facade is implemented and tested on `main`, defaults to MicroVM, and explicitly accepts shared-kernel Sandbox isolation, but awaits the next crate release. The optional `pipeline-cli` feature retains the CLI-driven programmable pipeline. |
-| Local Python and TypeScript SDKs | E2B-like `Sandbox`, commands, files, lifecycle, and a small Python Code Interpreter facade over the installed local runtime | Implemented on `main`. The packages share the Rust Sandbox implementation through the versioned bridge, have no official E2B runtime dependency, and require no endpoint or API key. Package tests plus real macOS MicroVM and Ubuntu/crun 1.28 Sandbox three-language smokes pass. Linux/KVM MicroVM validation remains host-specific, and the native packages are not yet published to PyPI or npm. |
+| Rust SDK | Typed, direct runtime-backed management and guest-control APIs; E2B-like local `Sandbox`, commands, files, and lifecycle; fluent image, volume, network, Sandbox, and script builders | The direct client is published as `a3s-box-sdk` `3.0.11`. The zero-credential local facade and builder-style programmable CI/CD API are implemented and package-tested on `main`, default to MicroVM, and explicitly accept supported shared-kernel Sandbox configurations, but await the next crate release. The optional historical `pipeline-cli` feature remains separate. |
+| Local Python and TypeScript SDKs | E2B-like `Sandbox`, commands, files, lifecycle, plus fluent image-build, named-volume, bridge-network, typed Sandbox, and stdin-backed script builders over the installed local runtime | Implemented and package-tested on `main`. The packages share the Rust implementation through the versioned bridge, have no official E2B runtime dependency, and require no endpoint or API key. The real macOS/HVF MicroVM three-language builder-to-E2B smoke passes; the expanded Ubuntu/crun 1.28 Sandbox matrix is a blocking CI gate. Linux/KVM MicroVM validation remains host-specific, and the native packages are not yet published to PyPI or npm. |
 | Remote E2B protocol service | Pinned contracts, durable lifecycle, memory-preserving and filesystem-only pause/resume, owner-scoped filesystem Snapshots and Volumes, v1/v2 listing and runtime-backed structured logs, current metrics, TLS routing, envd file/environment operations, Filesystem, Process, PTY, and Python Code Interpreter contexts | The certified A3S OS evidence uses unchanged official Python sync/async and TypeScript clients. Templates/builds, historical metrics, signed files, public-port breadth, MCP, cancellation/backpressure, deeper Snapshot/Volume failure recovery, and the rest of the pinned contract remain gates; `full_compatibility=false`. |
 | TEE | SEV-SNP-oriented attestation, RA-TLS, sealing, secret injection, and simulation | Host-specific. Hardware claims require a supported SEV-SNP host and real attestation evidence. Simulation is development-only; TDX is not productized. |
 | Kubernetes | CRI server plus a containerd runtime-v2 shim and `runtimeClassName: a3s-box` | Preview. Core lifecycle, streaming, logs, resources, and RuntimeClass paths exist; complete CRI conformance is not claimed. |

--- a/docs/sdk-api-and-programmable-cicd.md
+++ b/docs/sdk-api-and-programmable-cicd.md
@@ -1,0 +1,236 @@
+# SDK API and Programmable CI/CD Plan
+
+This document is the authoritative completion plan for the native local A3S
+Box SDKs. It covers Rust, Python, and TypeScript. It does not redefine the
+native SDKs as wrappers around the official E2B clients: local calls remain
+credential-free and execute through the installed A3S Box runtime.
+
+Remote E2B protocol compatibility is a separate product surface. Its pinned
+contract and official-client evidence remain tracked under
+[`compat/e2b`](../compat/e2b/README.md).
+
+## Product Contract
+
+"Programmable CI/CD" means a code-first execution toolbox, similar in spirit
+to BoxLite. A user must be able to build an OCI base image, create reusable
+storage and networks, configure an isolated box, run scripts, capture results,
+and reuse a filesystem snapshot directly from normal Rust, Python, or
+TypeScript code. A separate YAML service or workflow engine is not required.
+
+Rust is the implementation source of truth. Python and TypeScript use the
+versioned machine bridge and never parse human CLI output. Language differences
+are limited to normal conventions such as Python sync/async variants and
+JavaScript promises.
+
+Each language exposes two complementary entry styles over that single
+implementation:
+
+- the familiar E2B-style `Sandbox.create`, `commands`, and `files` surface for
+  low-friction migration and direct execution;
+- a fluent builder surface for image, storage, network, box, and script
+  configuration.
+
+The E2B-style surface remains supported as the builder API grows. Neither entry
+style may maintain a separate lifecycle or transport implementation.
+
+Every public operation must have:
+
+1. a typed request and response;
+2. validation before runtime mutation;
+3. a stable machine error code;
+4. unit or protocol coverage in every language that exposes it;
+5. a real-runtime test for every supported isolation backend;
+6. documentation that distinguishes implemented, tested, and published state.
+
+An API is not complete merely because a method exists. Completion requires the
+matching cross-language and real-runtime evidence.
+
+## Programmable Runtime Toolbox
+
+The primary SDK contract consists of the following layers.
+
+### Runtime and resource management
+
+The runtime client owns host-level resources:
+
+- build an OCI image from a context and Dockerfile;
+- pull, inspect, list, tag, push, and remove images;
+- create, inspect, list, remove, and prune named volumes;
+- create, inspect, list, remove, and prune bridge networks;
+- create, reconnect to, inspect, list, stop, restart, and remove boxes;
+- inspect runtime diagnostics, resource usage, logs, and metrics.
+
+Resource creation is explicit. Passing a named volume or network to a box does
+not silently create it with guessed settings.
+
+### Typed box configuration
+
+A box creation request must support:
+
+- OCI image reference or a previously built image reference;
+- explicit MicroVM or shared-kernel Sandbox isolation;
+- CPU, memory, lifetime, and persistence settings;
+- environment, metadata, hostname, user, and working directory;
+- typed host bind mounts and named-volume mounts with read-only/read-write
+  access;
+- typed tmpfs mounts;
+- TSI, disabled, or named bridge networking;
+- validated TCP port publication, DNS servers, and host aliases;
+- read-only root filesystems and explicit automatic cleanup;
+- restoration from a runtime-managed immutable filesystem snapshot.
+
+The public API uses typed objects for mounts, networking, and published ports.
+Raw runtime strings such as `host:guest:ro` or `bridge:name` remain internal
+serialization details.
+
+### Commands and scripts
+
+The box handle must support:
+
+- argv execution without a shell;
+- shell commands when explicitly selected;
+- script execution by sending source through standard input to an explicit
+  interpreter, avoiding shell-escaping and temporary-host-file problems;
+- environment, working directory, user, standard input, and timeout controls;
+- separated bounded stdout/stderr, exit code, and truncation state;
+- background process handles, output streaming, wait, signal, and PTY controls.
+
+Script steps are composed in the user's programming language. A user can use
+ordinary loops, functions, exceptions, and concurrency rather than translating
+their program into a second workflow language.
+
+### Snapshots, caches, and artifacts
+
+- capture a running or paused box filesystem under a validated snapshot ID;
+- restore independent copy-on-write boxes from that snapshot;
+- query snapshot size and delete snapshots with live-use fencing;
+- mount named volumes as explicit dependency caches;
+- collect artifacts through typed file APIs with path confinement, size limits,
+  hashes, and optional host export;
+- clean up boxes and ephemeral resources on success, failure, cancellation,
+  and context-manager exit.
+
+This is sufficient to implement warm CI bases, test matrices, build caches, and
+artifact collection in application code without a dedicated pipeline engine.
+
+## Cross-Language API Shape
+
+The naming follows each language while preserving the same concepts:
+
+| Concept | Rust | Python | TypeScript |
+| --- | --- | --- | --- |
+| Runtime client | `A3sBoxClient` | `A3SBoxClient` | `A3SBoxClient` |
+| Box handle | `Sandbox` | `Sandbox` / `AsyncSandbox` | `Sandbox` |
+| Build request | `BuildImage` | `BuildImageOptions` | `BuildImageOptions` |
+| Named volume | `CreateVolume` | `CreateVolumeOptions` | `CreateVolumeOptions` |
+| Named network | `CreateNetwork` | `CreateNetworkOptions` | `CreateNetworkOptions` |
+| Mount | `VolumeMount` | `VolumeMount` | `VolumeMount` |
+| Network selection | `SandboxNetwork` | `SandboxNetwork` | `SandboxNetwork` |
+| Published port | `PortMapping` | `PortMapping` | `PortMapping` |
+| Script | `Script` | `Script` | `Script` |
+
+The existing E2B-style `Sandbox` remains the convenient local execution
+facade. It is not overloaded with host-wide image, volume, and network
+management; those operations belong to the runtime client.
+
+The preferred fluent flow is:
+
+1. `client.image(context)...build()`;
+2. `client.volume(name)...create()` and
+   `client.network(name)...create()` where required;
+3. `client.sandbox(image)...mount(...).network(...).start()`;
+4. `box.script(source)...run()` or the E2B-style
+   `box.commands.run(...)`;
+5. deterministic cleanup through `kill`, `close`, or a language context
+   manager.
+
+Typed option values remain public for serialization, testing, and applications
+that construct configuration dynamically. Builders are the ergonomic default,
+not a second contract.
+
+## Optional Composition Layer
+
+Parallel fan-out, matrices, dependency graphs, retries, and reports may be
+provided later as a small library above the runtime toolbox. They are not the
+definition of programmable CI/CD and must not introduce a second lifecycle
+implementation.
+
+If retained, the composition layer must:
+
+- call the typed runtime client instead of assembling CLI strings;
+- represent jobs and results as stable serializable values;
+- use runtime-managed snapshots for warm-base fan-out;
+- use named volumes for declared caches and file APIs for artifacts;
+- preserve exit codes and distinguish command, timeout, cancellation, and
+  infrastructure failures;
+- fence cleanup ownership so crash recovery never removes a live peer's
+  resources.
+
+## Required Native SDK Surface
+
+| Area | Required operations | Current state |
+| --- | --- | --- |
+| Images and builds | list, inspect, history, pull, build, tag, push, remove, cache eviction, platform selection, credentials, and progress | Fluent build plus pull/list have Rust/Python/TypeScript parity. Inspect, history, tag, push, remove, eviction, credentials, and progress remain bridge gaps. |
+| Typed box configuration | image, isolation, CPU/memory/lifetime, environment, workdir/user, mounts, tmpfs, network, ports, DNS/hosts, read-only root, persistence, cleanup, and snapshot restore | Implemented in Rust/Python/TypeScript options and fluent builders. The real macOS/HVF MicroVM builder gate passes; the Ubuntu/crun gate is wired into blocking CI, while Linux/KVM remains host-gated. |
+| Volumes | list, get, create, typed mount, content operations, remove, and prune | Create/get/list/remove and typed bind/named mounts have three-language parity. Prune and direct content helpers remain pending. |
+| Networking | list/create/get/remove/prune, typed attachment, published ports, and resolved endpoint inspection | Create/get/list/remove, typed TSI/disabled/bridge selection, endpoint responses, and TCP publication have three-language parity. Prune remains pending; live hot-plug is intentionally unsupported. |
+| Commands and scripts | foreground argv/shell/script execution, environment, cwd, user, stdin, timeout, binary-safe output, background processes, signals, wait, and streaming | Foreground argv/shell and stdin-backed fluent scripts have three-language parity and pass the real macOS/HVF builder-to-E2B smoke. Process handles, signals, wait, and streaming remain pending. |
+| Files and artifacts | binary/text read/write, stat, exists, list, mkdir, move, remove, streaming, confined export, size limits, and hashes | Core mutations implemented; artifact/export layer and large-file streaming pending. |
+| Filesystem snapshots | capture, size, restore, delete, in-use fencing, and cleanup | Rust and bridge foundations implemented; real-backend release gate pending. |
+| Lifecycle | create, connect, inspect, list, pause, resume, restart, timeout replacement, stop, kill, remove, and deterministic cleanup | Partial high-level parity. |
+| Observability | structured logs, stats, events, health, audit data, and runtime diagnostics | Partial Rust direct-client coverage; language parity pending. |
+| PTY | create, resize, input, output streaming, wait, and cancellation | Rust lower-level primitives only. |
+| Security | typed isolation, resource limits, read-only policy, capabilities, devices, secret injection, and attestation | Partial; unsupported policies must be rejected rather than represented as enforced. |
+
+## Delivery Sequence
+
+### Phase 1: Typed build and runtime primitives
+
+- Keep this plan and the capability matrix current.
+- Expose image build and resource-management operations through the bridge and
+  native Python/TypeScript clients.
+- Add typed volume mounts, network selection, published ports, workdir, and
+  persistence controls to box creation.
+- Add explicit script execution and executable examples in all three languages.
+- Retain and validate runtime-managed filesystem snapshot operations.
+
+### Phase 2: Results, caches, and artifacts
+
+- Complete lifecycle, structured logs, stats, and snapshot inspection parity.
+- Add confined artifact export with hashes and limits.
+- Document named-volume cache patterns and warm-base snapshot patterns.
+- Add a checked API inventory so exported operations cannot drift silently.
+
+### Phase 3: Processes and interactive execution
+
+- Expose background process handles, output streaming, wait, signals, and PTY
+  operations through the same bridge.
+- Add cancellation and cleanup behavior for interrupted language clients.
+
+### Phase 4: Optional composition and release gates
+
+- Refactor any retained matrix or DAG helper onto the typed toolbox.
+- Run every supported operation through Rust, Python, and TypeScript against
+  certified Linux Sandbox execution.
+- Run the supported matrix against Linux/KVM and macOS/HVF MicroVM execution.
+- Build and install clean package artifacts before testing them.
+- Publish Rust, Python, TypeScript, runtime, and documentation from one version
+  and verify the public registries after release.
+
+## Completion Gates
+
+The SDK objective is complete only when all of the following are true:
+
+- the required native SDK surface table has no `Partial` or pending row;
+- the checked Rust/Python/TypeScript inventory reports parity;
+- all bridge operations have success, validation, runtime-error, and malformed
+  response tests;
+- the real Sandbox three-language matrix covers every supported operation;
+- the MicroVM matrix covers every operation supported on Linux/KVM and
+  macOS/HVF;
+- build, volume, network, port, script, cache, snapshot, artifact, cancellation,
+  and cleanup scenarios have end-to-end evidence;
+- release artifacts contain the tested implementation and public registry
+  versions match the runtime release;
+- root and package READMEs contain only commands that work with the currently
+  published versions.

--- a/docs/sdk-api-and-programmable-cicd.md
+++ b/docs/sdk-api-and-programmable-cicd.md
@@ -32,6 +32,9 @@ implementation:
 
 The E2B-style surface remains supported as the builder API grows. Neither entry
 style may maintain a separate lifecycle or transport implementation.
+`SandboxBuilder.start()` returns the same public `Sandbox` type used by
+`Sandbox.create()`, with the same `commands`, `files`, snapshot, and lifecycle
+namespaces.
 
 Every public operation must have:
 

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -189,7 +189,9 @@ try:
         assert sandbox.files.read("/tmp/a3s-python-sdk-smoke.txt") == "hello"
         sandbox.files.remove("/tmp/a3s-python-sdk-smoke.txt")
         if isolation == "sandbox":
-            marker = "/tmp/a3s-python-sdk-snapshot.txt"
+            # `/tmp` is an ephemeral tmpfs and is intentionally excluded from
+            # rootfs snapshots.
+            marker = "/a3s-python-sdk-snapshot.txt"
             snapshot_id = f"python_sdk_{sandbox.id.replace('-', '_')}"
             sandbox.files.write(marker, "snapshot-ok")
             snapshot = sandbox.create_filesystem_snapshot(snapshot_id)
@@ -299,7 +301,9 @@ try {
     }
     await sandbox.files.remove('/tmp/a3s-typescript-sdk-smoke.txt')
     if (isolation === 'sandbox') {
-      const marker = '/tmp/a3s-typescript-sdk-snapshot.txt'
+      // `/tmp` is an ephemeral tmpfs and is intentionally excluded from
+      // rootfs snapshots.
+      const marker = '/a3s-typescript-sdk-snapshot.txt'
       const snapshotId = `typescript_sdk_${sandbox.id.replaceAll('-', '_')}`
       await sandbox.files.write(marker, 'snapshot-ok')
       const snapshot = await sandbox.createFilesystemSnapshot(snapshotId)

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -127,8 +127,10 @@ echo "==> Python SDK ($ISOLATION)"
     PYTHONPATH="$REPO_ROOT/sdk/python/src" \
     "$PYTHON" - <<'PY'
 import os
+import shutil
+from pathlib import Path
 
-from a3s_box import Sandbox
+from a3s_box import A3SBoxClient, Sandbox
 
 for name in (
     "E2B_API_KEY",
@@ -141,16 +143,79 @@ for name in (
 ):
     assert name not in os.environ
 
-with Sandbox.create(
-    "alpine:3.20",
-    isolation=os.environ["A3S_BOX_SDK_SMOKE_ISOLATION"],
-) as sandbox:
-    result = sandbox.commands.run("printf 'python-sdk-ok'")
-    assert result.exit_code == 0
-    assert result.stdout == "python-sdk-ok"
-    sandbox.files.write("/tmp/a3s-python-sdk-smoke.txt", "hello")
-    assert sandbox.files.read("/tmp/a3s-python-sdk-smoke.txt") == "hello"
-    sandbox.files.remove("/tmp/a3s-python-sdk-smoke.txt")
+client = A3SBoxClient()
+isolation = os.environ["A3S_BOX_SDK_SMOKE_ISOLATION"]
+context = Path(os.environ["A3S_HOME"]) / "python-sdk-build-context"
+context.mkdir(parents=True, exist_ok=True)
+(context / "Dockerfile").write_text(
+    "FROM alpine:3.20\nENV A3S_SDK_BASE=ready\nWORKDIR /workspace\n"
+)
+image = None
+volume = None
+network = None
+try:
+    image = (
+        client.image(str(context))
+        .tag("local/a3s-sdk-smoke-python:latest")
+        .build()
+    )
+    volume = client.volume("python-sdk-cache").label("purpose", "sdk-smoke").create()
+    builder = (
+        client.sandbox(image.reference)
+        .isolation(isolation)
+        .mount_named(volume.name, "/cache")
+        .workdir("/workspace")
+    )
+    if isolation == "microvm":
+        network = (
+            client.network("python-sdk-network")
+            .subnet("10.89.92.0/24")
+            .create()
+        )
+        builder = builder.network(network.name).publish_tcp(0, 8080)
+    else:
+        builder = builder.disable_network()
+
+    with builder.start() as sandbox:
+        result = sandbox.commands.run("printf 'python-sdk-ok'")
+        assert result.exit_code == 0
+        assert result.stdout == "python-sdk-ok"
+        script = sandbox.script("printf 'python-script-ok'\n").env("CI", "true").run()
+        assert script.exit_code == 0
+        assert script.stdout == "python-script-ok"
+        sandbox.files.write("/cache/marker.txt", "cache-ok")
+        assert sandbox.files.read("/cache/marker.txt") == "cache-ok"
+        sandbox.files.write("/tmp/a3s-python-sdk-smoke.txt", "hello")
+        assert sandbox.files.read("/tmp/a3s-python-sdk-smoke.txt") == "hello"
+        sandbox.files.remove("/tmp/a3s-python-sdk-smoke.txt")
+        if isolation == "sandbox":
+            marker = "/tmp/a3s-python-sdk-snapshot.txt"
+            snapshot_id = f"python_sdk_{sandbox.id.replace('-', '_')}"
+            sandbox.files.write(marker, "snapshot-ok")
+            snapshot = sandbox.create_filesystem_snapshot(snapshot_id)
+            assert Sandbox.filesystem_snapshot_size(snapshot.snapshot_id) == snapshot.size_bytes
+            with Sandbox.create(
+                image.reference,
+                isolation="sandbox",
+                filesystem_snapshot_id=snapshot.snapshot_id,
+            ) as restored:
+                assert restored.files.read(marker) == "snapshot-ok"
+                try:
+                    Sandbox.delete_filesystem_snapshot(snapshot.snapshot_id)
+                except Exception:
+                    pass
+                else:
+                    raise AssertionError("active restored Sandbox did not fence snapshot deletion")
+            assert Sandbox.delete_filesystem_snapshot(snapshot.snapshot_id)
+            assert Sandbox.filesystem_snapshot_size(snapshot.snapshot_id) is None
+finally:
+    if network is not None:
+        client.remove_network(network.name)
+    if volume is not None:
+        client.remove_volume(volume.name)
+    if image is not None:
+        client.remove_image(image.reference)
+    shutil.rmtree(context, ignore_errors=True)
 PY
 
 echo "==> TypeScript SDK ($ISOLATION)"
@@ -159,8 +224,11 @@ npm --prefix "$REPO_ROOT/sdk/typescript" run build
 "${clean_env[@]}" \
     A3S_BOX_BINARY="$A3S_BOX_BINARY" \
     A3S_BOX_SDK_SMOKE_ISOLATION="$ISOLATION" \
-    node --input-type=module <<'JS'
-import { Sandbox } from './sdk/typescript/dist/index.js'
+node --input-type=module <<'JS'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { A3SBoxClient, Sandbox } from './sdk/typescript/dist/index.js'
 
 for (const name of [
   'E2B_API_KEY',
@@ -174,21 +242,103 @@ for (const name of [
   if (name in process.env) throw new Error(`${name} must be unset`)
 }
 
-const sandbox = await Sandbox.create('alpine:3.20', {
-  isolation: process.env.A3S_BOX_SDK_SMOKE_ISOLATION,
-})
+const client = new A3SBoxClient()
+const isolation = process.env.A3S_BOX_SDK_SMOKE_ISOLATION
+const context = join(process.env.A3S_HOME, 'typescript-sdk-build-context')
+await mkdir(context, { recursive: true })
+await writeFile(
+  join(context, 'Dockerfile'),
+  'FROM alpine:3.20\nENV A3S_SDK_BASE=ready\nWORKDIR /workspace\n'
+)
+let image
+let volume
+let network
 try {
-  const result = await sandbox.commands.run("printf 'typescript-sdk-ok'")
-  if (result.exitCode !== 0 || result.stdout !== 'typescript-sdk-ok') {
-    throw new Error('TypeScript SDK command returned an unexpected result')
+  image = await client
+    .image(context)
+    .tag('local/a3s-sdk-smoke-typescript:latest')
+    .build()
+  volume = await client
+    .volume('typescript-sdk-cache')
+    .label('purpose', 'sdk-smoke')
+    .create()
+  let builder = client
+    .sandbox(image.reference)
+    .isolation(isolation)
+    .mountNamed(volume.name, '/cache')
+    .workdir('/workspace')
+  if (isolation === 'microvm') {
+    network = await client
+      .network('typescript-sdk-network')
+      .subnet('10.89.93.0/24')
+      .create()
+    builder = builder.network(network.name).publishTcp(0, 8080)
+  } else {
+    builder = builder.disableNetwork()
   }
-  await sandbox.files.write('/tmp/a3s-typescript-sdk-smoke.txt', 'hello')
-  if (await sandbox.files.read('/tmp/a3s-typescript-sdk-smoke.txt') !== 'hello') {
-    throw new Error('TypeScript SDK file read returned unexpected data')
+  const sandbox = await builder.start()
+  try {
+    const result = await sandbox.commands.run("printf 'typescript-sdk-ok'")
+    if (result.exitCode !== 0 || result.stdout !== 'typescript-sdk-ok') {
+      throw new Error('TypeScript SDK command returned an unexpected result')
+    }
+    const script = await sandbox
+      .script("printf 'typescript-script-ok'\n")
+      .env('CI', 'true')
+      .run()
+    if (script.exitCode !== 0 || script.stdout !== 'typescript-script-ok') {
+      throw new Error('TypeScript SDK script returned an unexpected result')
+    }
+    await sandbox.files.write('/cache/marker.txt', 'cache-ok')
+    if (await sandbox.files.read('/cache/marker.txt') !== 'cache-ok') {
+      throw new Error('TypeScript SDK named volume returned unexpected data')
+    }
+    await sandbox.files.write('/tmp/a3s-typescript-sdk-smoke.txt', 'hello')
+    if (await sandbox.files.read('/tmp/a3s-typescript-sdk-smoke.txt') !== 'hello') {
+      throw new Error('TypeScript SDK file read returned unexpected data')
+    }
+    await sandbox.files.remove('/tmp/a3s-typescript-sdk-smoke.txt')
+    if (isolation === 'sandbox') {
+      const marker = '/tmp/a3s-typescript-sdk-snapshot.txt'
+      const snapshotId = `typescript_sdk_${sandbox.id.replaceAll('-', '_')}`
+      await sandbox.files.write(marker, 'snapshot-ok')
+      const snapshot = await sandbox.createFilesystemSnapshot(snapshotId)
+      if (await Sandbox.filesystemSnapshotSize(snapshot.snapshotId) !== snapshot.sizeBytes) {
+        throw new Error('snapshot size lookup returned an unexpected value')
+      }
+      const restored = await Sandbox.create(image.reference, {
+        isolation: 'sandbox',
+        filesystemSnapshotId: snapshot.snapshotId,
+      })
+      try {
+        if (await restored.files.read(marker) !== 'snapshot-ok') {
+          throw new Error('restored Sandbox did not contain the captured file')
+        }
+        let fenced = false
+        try {
+          await Sandbox.deleteFilesystemSnapshot(snapshot.snapshotId)
+        } catch {
+          fenced = true
+        }
+        if (!fenced) throw new Error('active restored Sandbox did not fence snapshot deletion')
+      } finally {
+        await restored.kill()
+      }
+      if (!(await Sandbox.deleteFilesystemSnapshot(snapshot.snapshotId))) {
+        throw new Error('snapshot was not deleted after restored Sandbox cleanup')
+      }
+      if (await Sandbox.filesystemSnapshotSize(snapshot.snapshotId) !== undefined) {
+        throw new Error('deleted snapshot still reported a size')
+      }
+    }
+  } finally {
+    await sandbox.kill()
   }
-  await sandbox.files.remove('/tmp/a3s-typescript-sdk-smoke.txt')
 } finally {
-  await sandbox.kill()
+  if (network !== undefined) await client.removeNetwork(network.name)
+  if (volume !== undefined) await client.removeVolume(volume.name)
+  if (image !== undefined) await client.removeImage(image.reference)
+  await rm(context, { recursive: true, force: true })
 }
 JS
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -57,6 +57,63 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Builder-style programmable CI/CD
+
+The E2B-style API remains available for direct execution. For build and CI
+tooling, `A3SBoxClient` adds fluent builders over the same local runtime and
+bridge:
+
+```python
+from a3s_box import A3SBoxClient
+
+client = A3SBoxClient()
+
+image = (
+    client.image("./ci")
+    .dockerfile("Dockerfile")
+    .tag("local/ci-base:latest")
+    .build_arg("NODE_VERSION", "24")
+    .build()
+)
+cache = (
+    client.volume("npm-cache")
+    .label("purpose", "ci-cache")
+    .size_limit(10 * 1024 * 1024 * 1024)
+    .create()
+)
+network = client.network("ci-net").subnet("10.89.40.0/24").create()
+
+with (
+    client.sandbox(image.reference)
+    .cpus(4)
+    .memory_mb(4096)
+    .mount_named(cache.name, "/root/.npm")
+    .network(network.name)
+    .publish_tcp(8080, 8080)
+    .workdir("/workspace")
+    .start()
+) as box:
+    result = (
+        box.script("npm ci\nnpm test\n")
+        .interpreter("/bin/sh", "-se")
+        .env("CI", "true")
+        .run()
+    )
+    if result.exit_code != 0:
+        raise RuntimeError(result.stderr)
+```
+
+`A3SAsyncBoxClient` provides the same builders with asynchronous terminal
+operations. Named volumes and networks must be created explicitly before they
+are mounted or selected. Builder scripts are sent through standard input to
+the selected interpreter, so their contents are not interpolated into a host
+shell command.
+
+Named bridge networks and published ports are currently MicroVM-only. A
+shared-kernel Sandbox request that selects either fails before runtime
+mutation; use `.disable_network()` or the default TSI-compatible configuration
+for supported Sandbox workloads.
+
 The package invokes the versioned machine bridge built into the installed
 `a3s-box` executable. It does not parse human CLI output. Set `A3S_BOX_BINARY`
 only when the executable is not on `PATH`.

--- a/sdk/python/src/a3s_box/__init__.py
+++ b/sdk/python/src/a3s_box/__init__.py
@@ -1,22 +1,77 @@
 """Native local-first SDK for A3S Box."""
 
+from .client import (
+    A3SAsyncBoxClient,
+    A3SBoxClient,
+    AsyncImageBuilder,
+    AsyncNetworkBuilder,
+    AsyncSandboxBuilder,
+    AsyncVolumeBuilder,
+    ImageBuilder,
+    NetworkBuilder,
+    SandboxBuilder,
+    VolumeBuilder,
+)
 from .connection import A3SConnectionConfig, A3SRemoteConnection
 from .exceptions import A3SBoxError, A3SBoxNotInstalledError
-from .models import CommandResult, EntryInfo, WriteInfo
+from .models import (
+    BuildImageInfo,
+    CommandResult,
+    EntryInfo,
+    FilesystemSnapshotInfo,
+    ImageInfo,
+    NetworkEndpointInfo,
+    NetworkInfo,
+    PortMapping,
+    SandboxNetwork,
+    Script,
+    TmpfsMount,
+    VolumeInfo,
+    VolumeMount,
+    WriteInfo,
+)
 from .runtime import A3SAsyncLocalRuntime, A3SLocalRuntime
-from .sandbox import DEFAULT_IMAGE, AsyncSandbox, Sandbox
+from .script import AsyncScriptBuilder, ScriptBuilder
+from .sandbox import (
+    DEFAULT_IMAGE,
+    AsyncSandbox,
+    Sandbox,
+)
 
 __all__ = [
+    "A3SAsyncBoxClient",
     "A3SAsyncLocalRuntime",
+    "A3SBoxClient",
     "A3SBoxError",
     "A3SBoxNotInstalledError",
     "A3SConnectionConfig",
     "A3SLocalRuntime",
     "A3SRemoteConnection",
     "AsyncSandbox",
+    "AsyncImageBuilder",
+    "AsyncNetworkBuilder",
+    "AsyncSandboxBuilder",
+    "AsyncScriptBuilder",
+    "AsyncVolumeBuilder",
+    "BuildImageInfo",
     "CommandResult",
     "DEFAULT_IMAGE",
     "EntryInfo",
+    "FilesystemSnapshotInfo",
+    "ImageBuilder",
+    "ImageInfo",
+    "NetworkBuilder",
+    "NetworkEndpointInfo",
+    "NetworkInfo",
+    "PortMapping",
     "Sandbox",
+    "SandboxBuilder",
+    "SandboxNetwork",
+    "Script",
+    "ScriptBuilder",
+    "TmpfsMount",
+    "VolumeBuilder",
+    "VolumeInfo",
+    "VolumeMount",
     "WriteInfo",
 ]

--- a/sdk/python/src/a3s_box/client.py
+++ b/sdk/python/src/a3s_box/client.py
@@ -1,0 +1,694 @@
+"""Fluent programmable runtime client for local A3S Box."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Literal, TypeVar, cast
+
+from .models import (
+    BuildImageInfo,
+    ImageInfo,
+    NetworkEndpointInfo,
+    NetworkInfo,
+    PortMapping,
+    SandboxNetwork,
+    TmpfsMount,
+    VolumeInfo,
+    VolumeMount,
+)
+from .runtime import (
+    A3SAsyncLocalRuntime,
+    A3SLocalRuntime,
+    AsyncLocalRuntime,
+    LocalRuntime,
+)
+from .sandbox import DEFAULT_IMAGE, AsyncSandbox, Sandbox
+
+LiteralIsolation = Literal["microvm", "sandbox"]
+
+
+class A3SBoxClient:
+    """Synchronous resource client with fluent terminal builders."""
+
+    def __init__(self, runtime: LocalRuntime | None = None) -> None:
+        self._runtime = runtime or A3SLocalRuntime()
+
+    def image(self, context_dir: str) -> ImageBuilder:
+        return ImageBuilder(self._runtime, context_dir)
+
+    def volume(self, name: str) -> VolumeBuilder:
+        return VolumeBuilder(self._runtime, name)
+
+    def network(self, name: str) -> NetworkBuilder:
+        return NetworkBuilder(self._runtime, name)
+
+    def sandbox(self, image: str = DEFAULT_IMAGE) -> SandboxBuilder:
+        return SandboxBuilder(self._runtime, image)
+
+    def pull_image(
+        self,
+        reference: str,
+        *,
+        force: bool = False,
+        platform: str | None = None,
+    ) -> ImageInfo:
+        result = self._runtime.request(
+            {
+                "operation": "image_pull",
+                "reference": reference,
+                "force": force,
+                **({} if platform is None else {"platform": platform}),
+            }
+        )
+        return _image_info(result)
+
+    def list_images(self) -> list[ImageInfo]:
+        result = self._runtime.request({"operation": "image_list"})
+        return [_image_info(item) for item in _mapping_list(result, "images")]
+
+    def remove_image(self, reference: str) -> None:
+        self._runtime.request(
+            {"operation": "image_remove", "reference": reference}
+        )
+
+    def get_volume(self, name: str) -> VolumeInfo | None:
+        result = self._runtime.request({"operation": "volume_get", "name": name})
+        value = result.get("volume")
+        return None if value is None else _volume_info(_mapping(value))
+
+    def list_volumes(self) -> list[VolumeInfo]:
+        result = self._runtime.request({"operation": "volume_list"})
+        return [_volume_info(item) for item in _mapping_list(result, "volumes")]
+
+    def remove_volume(self, name: str, *, force: bool = False) -> VolumeInfo:
+        return _volume_info(
+            self._runtime.request(
+                {
+                    "operation": "volume_remove",
+                    "name": name,
+                    "force": force,
+                }
+            )
+        )
+
+    def get_network(self, name: str) -> NetworkInfo | None:
+        result = self._runtime.request({"operation": "network_get", "name": name})
+        value = result.get("network")
+        return None if value is None else _network_info(_mapping(value))
+
+    def list_networks(self) -> list[NetworkInfo]:
+        result = self._runtime.request({"operation": "network_list"})
+        return [_network_info(item) for item in _mapping_list(result, "networks")]
+
+    def remove_network(self, name: str) -> NetworkInfo:
+        return _network_info(
+            self._runtime.request({"operation": "network_remove", "name": name})
+        )
+
+
+class A3SAsyncBoxClient:
+    """Asynchronous counterpart of :class:`A3SBoxClient`."""
+
+    def __init__(self, runtime: AsyncLocalRuntime | None = None) -> None:
+        self._runtime = runtime or A3SAsyncLocalRuntime()
+
+    def image(self, context_dir: str) -> AsyncImageBuilder:
+        return AsyncImageBuilder(self._runtime, context_dir)
+
+    def volume(self, name: str) -> AsyncVolumeBuilder:
+        return AsyncVolumeBuilder(self._runtime, name)
+
+    def network(self, name: str) -> AsyncNetworkBuilder:
+        return AsyncNetworkBuilder(self._runtime, name)
+
+    def sandbox(self, image: str = DEFAULT_IMAGE) -> AsyncSandboxBuilder:
+        return AsyncSandboxBuilder(self._runtime, image)
+
+    async def pull_image(
+        self,
+        reference: str,
+        *,
+        force: bool = False,
+        platform: str | None = None,
+    ) -> ImageInfo:
+        result = await self._runtime.request(
+            {
+                "operation": "image_pull",
+                "reference": reference,
+                "force": force,
+                **({} if platform is None else {"platform": platform}),
+            }
+        )
+        return _image_info(result)
+
+    async def list_images(self) -> list[ImageInfo]:
+        result = await self._runtime.request({"operation": "image_list"})
+        return [_image_info(item) for item in _mapping_list(result, "images")]
+
+    async def remove_image(self, reference: str) -> None:
+        await self._runtime.request(
+            {"operation": "image_remove", "reference": reference}
+        )
+
+    async def get_volume(self, name: str) -> VolumeInfo | None:
+        result = await self._runtime.request({"operation": "volume_get", "name": name})
+        value = result.get("volume")
+        return None if value is None else _volume_info(_mapping(value))
+
+    async def list_volumes(self) -> list[VolumeInfo]:
+        result = await self._runtime.request({"operation": "volume_list"})
+        return [_volume_info(item) for item in _mapping_list(result, "volumes")]
+
+    async def remove_volume(self, name: str, *, force: bool = False) -> VolumeInfo:
+        return _volume_info(
+            await self._runtime.request(
+                {
+                    "operation": "volume_remove",
+                    "name": name,
+                    "force": force,
+                }
+            )
+        )
+
+    async def get_network(self, name: str) -> NetworkInfo | None:
+        result = await self._runtime.request({"operation": "network_get", "name": name})
+        value = result.get("network")
+        return None if value is None else _network_info(_mapping(value))
+
+    async def list_networks(self) -> list[NetworkInfo]:
+        result = await self._runtime.request({"operation": "network_list"})
+        return [_network_info(item) for item in _mapping_list(result, "networks")]
+
+    async def remove_network(self, name: str) -> NetworkInfo:
+        return _network_info(
+            await self._runtime.request({"operation": "network_remove", "name": name})
+        )
+
+
+_ImageBuilderT = TypeVar("_ImageBuilderT", bound="_ImageBuilderBase")
+
+
+class _ImageBuilderBase:
+    def __init__(self, context_dir: str) -> None:
+        self._context_dir = context_dir
+        self._dockerfile: str | None = None
+        self._tag: str | None = None
+        self._build_args: dict[str, str] = {}
+        self._quiet = True
+        self._platforms: list[str] = []
+        self._target: str | None = None
+        self._no_cache = False
+
+    def dockerfile(self: _ImageBuilderT, path: str) -> _ImageBuilderT:
+        self._dockerfile = path
+        return self
+
+    def tag(self: _ImageBuilderT, tag: str) -> _ImageBuilderT:
+        self._tag = tag
+        return self
+
+    def build_arg(
+        self: _ImageBuilderT,
+        key: str,
+        value: str,
+    ) -> _ImageBuilderT:
+        self._build_args[key] = value
+        return self
+
+    def quiet(self: _ImageBuilderT, enabled: bool = True) -> _ImageBuilderT:
+        self._quiet = enabled
+        return self
+
+    def platform(self: _ImageBuilderT, platform: str) -> _ImageBuilderT:
+        self._platforms.append(platform)
+        return self
+
+    def target(self: _ImageBuilderT, target: str) -> _ImageBuilderT:
+        self._target = target
+        return self
+
+    def no_cache(self: _ImageBuilderT, enabled: bool = True) -> _ImageBuilderT:
+        self._no_cache = enabled
+        return self
+
+    def _request(self) -> dict[str, object]:
+        return {
+            "operation": "image_build",
+            "context_dir": self._context_dir,
+            "build_args": dict(self._build_args),
+            "quiet": self._quiet,
+            "platforms": list(self._platforms),
+            "no_cache": self._no_cache,
+            **({} if self._dockerfile is None else {"dockerfile": self._dockerfile}),
+            **({} if self._tag is None else {"tag": self._tag}),
+            **({} if self._target is None else {"target": self._target}),
+        }
+
+
+class ImageBuilder(_ImageBuilderBase):
+    def __init__(self, runtime: LocalRuntime, context_dir: str) -> None:
+        super().__init__(context_dir)
+        self._runtime = runtime
+
+    def build(self) -> BuildImageInfo:
+        return _build_image_info(self._runtime.request(self._request()))
+
+
+class AsyncImageBuilder(_ImageBuilderBase):
+    def __init__(self, runtime: AsyncLocalRuntime, context_dir: str) -> None:
+        super().__init__(context_dir)
+        self._runtime = runtime
+
+    async def build(self) -> BuildImageInfo:
+        return _build_image_info(await self._runtime.request(self._request()))
+
+
+_VolumeBuilderT = TypeVar("_VolumeBuilderT", bound="_VolumeBuilderBase")
+
+
+class _VolumeBuilderBase:
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._labels: dict[str, str] = {}
+        self._size_limit = 0
+
+    def label(
+        self: _VolumeBuilderT,
+        key: str,
+        value: str,
+    ) -> _VolumeBuilderT:
+        self._labels[key] = value
+        return self
+
+    def size_limit(self: _VolumeBuilderT, size_bytes: int) -> _VolumeBuilderT:
+        self._size_limit = size_bytes
+        return self
+
+    def _request(self) -> dict[str, object]:
+        return {
+            "operation": "volume_create",
+            "name": self._name,
+            "labels": dict(self._labels),
+            "size_limit": self._size_limit,
+        }
+
+
+class VolumeBuilder(_VolumeBuilderBase):
+    def __init__(self, runtime: LocalRuntime, name: str) -> None:
+        super().__init__(name)
+        self._runtime = runtime
+
+    def create(self) -> VolumeInfo:
+        return _volume_info(self._runtime.request(self._request()))
+
+
+class AsyncVolumeBuilder(_VolumeBuilderBase):
+    def __init__(self, runtime: AsyncLocalRuntime, name: str) -> None:
+        super().__init__(name)
+        self._runtime = runtime
+
+    async def create(self) -> VolumeInfo:
+        return _volume_info(await self._runtime.request(self._request()))
+
+
+_NetworkBuilderT = TypeVar("_NetworkBuilderT", bound="_NetworkBuilderBase")
+
+
+class _NetworkBuilderBase:
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._subnet = "10.89.0.0/24"
+        self._labels: dict[str, str] = {}
+
+    def subnet(self: _NetworkBuilderT, subnet: str) -> _NetworkBuilderT:
+        self._subnet = subnet
+        return self
+
+    def label(
+        self: _NetworkBuilderT,
+        key: str,
+        value: str,
+    ) -> _NetworkBuilderT:
+        self._labels[key] = value
+        return self
+
+    def _request(self) -> dict[str, object]:
+        return {
+            "operation": "network_create",
+            "name": self._name,
+            "subnet": self._subnet,
+            "labels": dict(self._labels),
+        }
+
+
+class NetworkBuilder(_NetworkBuilderBase):
+    def __init__(self, runtime: LocalRuntime, name: str) -> None:
+        super().__init__(name)
+        self._runtime = runtime
+
+    def create(self) -> NetworkInfo:
+        return _network_info(self._runtime.request(self._request()))
+
+
+class AsyncNetworkBuilder(_NetworkBuilderBase):
+    def __init__(self, runtime: AsyncLocalRuntime, name: str) -> None:
+        super().__init__(name)
+        self._runtime = runtime
+
+    async def create(self) -> NetworkInfo:
+        return _network_info(await self._runtime.request(self._request()))
+
+
+_SandboxBuilderT = TypeVar("_SandboxBuilderT", bound="_SandboxBuilderBase")
+
+
+class _SandboxBuilderBase:
+    def __init__(self, image: str) -> None:
+        self._image = image
+        self._timeout = 3600
+        self._envs: dict[str, str] = {}
+        self._metadata: dict[str, str] = {}
+        self._name: str | None = None
+        self._cpus: int | None = None
+        self._memory_mb: int | None = None
+        self._isolation: LiteralIsolation = "microvm"
+        self._snapshot: str | None = None
+        self._workspace: str | None = None
+        self._workdir: str | None = None
+        self._user: str | None = None
+        self._hostname: str | None = None
+        self._mounts: list[VolumeMount] = []
+        self._tmpfs: list[TmpfsMount] = []
+        self._network = SandboxNetwork.tsi()
+        self._ports: list[PortMapping] = []
+        self._dns: list[str] = []
+        self._host_aliases: dict[str, str] = {}
+        self._read_only = False
+        self._persistent = False
+        self._auto_remove = True
+
+    def timeout(self: _SandboxBuilderT, seconds: int) -> _SandboxBuilderT:
+        self._timeout = seconds
+        return self
+
+    def env(
+        self: _SandboxBuilderT,
+        key: str,
+        value: str,
+    ) -> _SandboxBuilderT:
+        self._envs[key] = value
+        return self
+
+    def metadata(
+        self: _SandboxBuilderT,
+        key: str,
+        value: str,
+    ) -> _SandboxBuilderT:
+        self._metadata[key] = value
+        return self
+
+    def name(self: _SandboxBuilderT, name: str) -> _SandboxBuilderT:
+        self._name = name
+        return self
+
+    def cpus(self: _SandboxBuilderT, cpus: int) -> _SandboxBuilderT:
+        self._cpus = cpus
+        return self
+
+    def memory_mb(self: _SandboxBuilderT, memory_mb: int) -> _SandboxBuilderT:
+        self._memory_mb = memory_mb
+        return self
+
+    def isolation(
+        self: _SandboxBuilderT,
+        isolation: LiteralIsolation,
+    ) -> _SandboxBuilderT:
+        self._isolation = isolation
+        return self
+
+    def filesystem_snapshot(
+        self: _SandboxBuilderT,
+        snapshot_id: str,
+    ) -> _SandboxBuilderT:
+        self._snapshot = snapshot_id
+        return self
+
+    def workspace(self: _SandboxBuilderT, path: str) -> _SandboxBuilderT:
+        self._workspace = path
+        return self
+
+    def workdir(self: _SandboxBuilderT, path: str) -> _SandboxBuilderT:
+        self._workdir = path
+        return self
+
+    def user(self: _SandboxBuilderT, user: str) -> _SandboxBuilderT:
+        self._user = user
+        return self
+
+    def hostname(self: _SandboxBuilderT, hostname: str) -> _SandboxBuilderT:
+        self._hostname = hostname
+        return self
+
+    def mount(
+        self: _SandboxBuilderT,
+        mount: VolumeMount,
+    ) -> _SandboxBuilderT:
+        self._mounts.append(mount)
+        return self
+
+    def mount_bind(
+        self: _SandboxBuilderT,
+        source: str,
+        target: str,
+        *,
+        read_only: bool = False,
+    ) -> _SandboxBuilderT:
+        return self.mount(VolumeMount.bind(source, target, read_only=read_only))
+
+    def mount_named(
+        self: _SandboxBuilderT,
+        name: str,
+        target: str,
+        *,
+        read_only: bool = False,
+    ) -> _SandboxBuilderT:
+        return self.mount(VolumeMount.named(name, target, read_only=read_only))
+
+    def tmpfs(
+        self: _SandboxBuilderT,
+        target: str,
+        *,
+        size_bytes: int | None = None,
+        read_only: bool = False,
+    ) -> _SandboxBuilderT:
+        self._tmpfs.append(TmpfsMount(target, size_bytes, read_only))
+        return self
+
+    def network(
+        self: _SandboxBuilderT,
+        network: str | SandboxNetwork,
+    ) -> _SandboxBuilderT:
+        self._network = (
+            SandboxNetwork.bridge(network)
+            if isinstance(network, str)
+            else network
+        )
+        return self
+
+    def disable_network(self: _SandboxBuilderT) -> _SandboxBuilderT:
+        self._network = SandboxNetwork.disabled()
+        return self
+
+    def publish_tcp(
+        self: _SandboxBuilderT,
+        host_port: int,
+        guest_port: int,
+    ) -> _SandboxBuilderT:
+        self._ports.append(PortMapping.tcp(host_port, guest_port))
+        return self
+
+    def dns_server(self: _SandboxBuilderT, address: str) -> _SandboxBuilderT:
+        self._dns.append(address)
+        return self
+
+    def host_alias(
+        self: _SandboxBuilderT,
+        host: str,
+        address: str,
+    ) -> _SandboxBuilderT:
+        self._host_aliases[host] = address
+        return self
+
+    def read_only(
+        self: _SandboxBuilderT,
+        enabled: bool = True,
+    ) -> _SandboxBuilderT:
+        self._read_only = enabled
+        return self
+
+    def persistent(
+        self: _SandboxBuilderT,
+        enabled: bool = True,
+    ) -> _SandboxBuilderT:
+        self._persistent = enabled
+        return self
+
+    def auto_remove(
+        self: _SandboxBuilderT,
+        enabled: bool = True,
+    ) -> _SandboxBuilderT:
+        self._auto_remove = enabled
+        return self
+
+
+class SandboxBuilder(_SandboxBuilderBase):
+    def __init__(self, runtime: LocalRuntime, image: str) -> None:
+        super().__init__(image)
+        self._runtime = runtime
+
+    def start(self) -> Sandbox:
+        return Sandbox.create(
+            self._image,
+            timeout=self._timeout,
+            envs=self._envs,
+            metadata=self._metadata,
+            name=self._name,
+            cpus=self._cpus,
+            memory_mb=self._memory_mb,
+            isolation=self._isolation,
+            filesystem_snapshot_id=self._snapshot,
+            workspace=self._workspace,
+            workdir=self._workdir,
+            user=self._user,
+            hostname=self._hostname,
+            mounts=self._mounts,
+            tmpfs=self._tmpfs,
+            network=self._network,
+            ports=self._ports,
+            dns=self._dns,
+            host_aliases=self._host_aliases,
+            read_only=self._read_only,
+            persistent=self._persistent,
+            auto_remove=self._auto_remove,
+            runtime=self._runtime,
+        )
+
+
+class AsyncSandboxBuilder(_SandboxBuilderBase):
+    def __init__(self, runtime: AsyncLocalRuntime, image: str) -> None:
+        super().__init__(image)
+        self._runtime = runtime
+
+    async def start(self) -> AsyncSandbox:
+        return await AsyncSandbox.create(
+            self._image,
+            timeout=self._timeout,
+            envs=self._envs,
+            metadata=self._metadata,
+            name=self._name,
+            cpus=self._cpus,
+            memory_mb=self._memory_mb,
+            isolation=self._isolation,
+            filesystem_snapshot_id=self._snapshot,
+            workspace=self._workspace,
+            workdir=self._workdir,
+            user=self._user,
+            hostname=self._hostname,
+            mounts=self._mounts,
+            tmpfs=self._tmpfs,
+            network=self._network,
+            ports=self._ports,
+            dns=self._dns,
+            host_aliases=self._host_aliases,
+            read_only=self._read_only,
+            persistent=self._persistent,
+            auto_remove=self._auto_remove,
+            runtime=self._runtime,
+        )
+
+
+def _build_image_info(result: Mapping[str, object]) -> BuildImageInfo:
+    return BuildImageInfo(
+        reference=str(result["reference"]),
+        digest=str(result["digest"]),
+        size_bytes=int(cast(int, result["size_bytes"])),
+        layer_count=int(cast(int, result["layer_count"])),
+    )
+
+
+def _image_info(result: Mapping[str, object]) -> ImageInfo:
+    return ImageInfo(
+        reference=str(result["reference"]),
+        digest=str(result["digest"]),
+        size_bytes=int(cast(int, result["size_bytes"])),
+        pulled_at=str(result["pulled_at"]),
+        last_used=str(result["last_used"]),
+        path=str(result["path"]),
+    )
+
+
+def _volume_info(result: Mapping[str, object]) -> VolumeInfo:
+    return VolumeInfo(
+        name=str(result["name"]),
+        driver=str(result["driver"]),
+        mount_point=str(result["mount_point"]),
+        labels=_string_mapping(result["labels"]),
+        in_use_by=tuple(str(value) for value in _sequence(result["in_use_by"])),
+        in_use=bool(result["in_use"]),
+        size_limit=int(cast(int, result["size_limit"])),
+        created_at=str(result["created_at"]),
+    )
+
+
+def _network_info(result: Mapping[str, object]) -> NetworkInfo:
+    return NetworkInfo(
+        name=str(result["name"]),
+        driver=str(result["driver"]),
+        subnet=str(result["subnet"]),
+        gateway=str(result["gateway"]),
+        labels=_string_mapping(result["labels"]),
+        endpoints=tuple(
+            _network_endpoint(item)
+            for item in _mapping_sequence(result["endpoints"])
+        ),
+        endpoint_count=int(cast(int, result["endpoint_count"])),
+        isolation=str(result["isolation"]),
+        created_at=str(result["created_at"]),
+    )
+
+
+def _network_endpoint(result: Mapping[str, object]) -> NetworkEndpointInfo:
+    return NetworkEndpointInfo(
+        box_id=str(result["box_id"]),
+        box_name=str(result["box_name"]),
+        aliases=tuple(str(value) for value in _sequence(result["aliases"])),
+        ip_address=str(result["ip_address"]),
+        mac_address=str(result["mac_address"]),
+    )
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError("A3S Box bridge returned a non-object value")
+    return cast(Mapping[str, object], value)
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise TypeError("A3S Box bridge returned a non-array value")
+    return cast(Sequence[object], value)
+
+
+def _mapping_sequence(value: object) -> list[Mapping[str, object]]:
+    return [_mapping(item) for item in _sequence(value)]
+
+
+def _mapping_list(
+    result: Mapping[str, object],
+    key: str,
+) -> list[Mapping[str, object]]:
+    return _mapping_sequence(result[key])
+
+
+def _string_mapping(value: object) -> dict[str, str]:
+    return {str(key): str(item) for key, item in _mapping(value).items()}

--- a/sdk/python/src/a3s_box/models.py
+++ b/sdk/python/src/a3s_box/models.py
@@ -21,6 +21,165 @@ class WriteInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class FilesystemSnapshotInfo:
+    snapshot_id: str
+    size_bytes: int
+    state: str
+    generation: int
+
+
+@dataclass(frozen=True, slots=True)
+class BuildImageInfo:
+    reference: str
+    digest: str
+    size_bytes: int
+    layer_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ImageInfo:
+    reference: str
+    digest: str
+    size_bytes: int
+    pulled_at: str
+    last_used: str
+    path: str
+
+
+@dataclass(frozen=True, slots=True)
+class VolumeInfo:
+    name: str
+    driver: str
+    mount_point: str
+    labels: dict[str, str]
+    in_use_by: tuple[str, ...]
+    in_use: bool
+    size_limit: int
+    created_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class NetworkEndpointInfo:
+    box_id: str
+    box_name: str
+    aliases: tuple[str, ...]
+    ip_address: str
+    mac_address: str
+
+
+@dataclass(frozen=True, slots=True)
+class NetworkInfo:
+    name: str
+    driver: str
+    subnet: str
+    gateway: str
+    labels: dict[str, str]
+    endpoints: tuple[NetworkEndpointInfo, ...]
+    endpoint_count: int
+    isolation: str
+    created_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class VolumeMount:
+    kind: Literal["bind", "named"]
+    source: str
+    target: str
+    read_only: bool = False
+
+    @classmethod
+    def bind(
+        cls,
+        source: str,
+        target: str,
+        *,
+        read_only: bool = False,
+    ) -> VolumeMount:
+        return cls("bind", source, target, read_only)
+
+    @classmethod
+    def named(
+        cls,
+        name: str,
+        target: str,
+        *,
+        read_only: bool = False,
+    ) -> VolumeMount:
+        return cls("named", name, target, read_only)
+
+    def bridge_value(self) -> dict[str, object]:
+        source_key = "source" if self.kind == "bind" else "name"
+        return {
+            "kind": self.kind,
+            source_key: self.source,
+            "target": self.target,
+            "read_only": self.read_only,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TmpfsMount:
+    target: str
+    size_bytes: int | None = None
+    read_only: bool = False
+
+    def bridge_value(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "target": self.target,
+            "read_only": self.read_only,
+        }
+        if self.size_bytes is not None:
+            result["size_bytes"] = self.size_bytes
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxNetwork:
+    mode: Literal["tsi", "none", "bridge"]
+    name: str | None = None
+
+    @classmethod
+    def tsi(cls) -> SandboxNetwork:
+        return cls("tsi")
+
+    @classmethod
+    def disabled(cls) -> SandboxNetwork:
+        return cls("none")
+
+    @classmethod
+    def bridge(cls, name: str) -> SandboxNetwork:
+        return cls("bridge", name)
+
+    def bridge_value(self) -> dict[str, str]:
+        result = {"mode": self.mode}
+        if self.name is not None:
+            result["name"] = self.name
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class PortMapping:
+    host_port: int
+    guest_port: int
+
+    @classmethod
+    def tcp(cls, host_port: int, guest_port: int) -> PortMapping:
+        return cls(host_port, guest_port)
+
+    def bridge_value(self) -> dict[str, int]:
+        return {
+            "host_port": self.host_port,
+            "guest_port": self.guest_port,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Script:
+    source: str | bytes
+    interpreter: tuple[str, ...] = ("/bin/sh", "-se")
+
+
+@dataclass(frozen=True, slots=True)
 class EntryInfo:
     name: str
     type: Literal["file", "directory", "unspecified"]

--- a/sdk/python/src/a3s_box/sandbox.py
+++ b/sdk/python/src/a3s_box/sandbox.py
@@ -7,13 +7,24 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Literal, cast
 
 from .exceptions import A3SBoxError
-from .models import CommandResult, EntryInfo, WriteInfo
+from .models import (
+    CommandResult,
+    EntryInfo,
+    FilesystemSnapshotInfo,
+    PortMapping,
+    SandboxNetwork,
+    Script,
+    TmpfsMount,
+    VolumeMount,
+    WriteInfo,
+)
 from .runtime import (
     A3SAsyncLocalRuntime,
     A3SLocalRuntime,
     AsyncLocalRuntime,
     LocalRuntime,
 )
+from .script import AsyncScriptBuilder, ScriptBuilder
 
 DEFAULT_IMAGE = "alpine:3.20"
 
@@ -51,6 +62,20 @@ class Sandbox:
         cpus: int | None = None,
         memory_mb: int | None = None,
         isolation: Literal["microvm", "sandbox"] = "microvm",
+        filesystem_snapshot_id: str | None = None,
+        workspace: str | None = None,
+        workdir: str | None = None,
+        user: str | None = None,
+        hostname: str | None = None,
+        mounts: Sequence[VolumeMount] | None = None,
+        tmpfs: Sequence[TmpfsMount] | None = None,
+        network: SandboxNetwork | None = None,
+        ports: Sequence[PortMapping] | None = None,
+        dns: Sequence[str] | None = None,
+        host_aliases: Mapping[str, str] | None = None,
+        read_only: bool = False,
+        persistent: bool = False,
+        auto_remove: bool = True,
         runtime: LocalRuntime | None = None,
     ) -> Sandbox:
         local_runtime = runtime or A3SLocalRuntime()
@@ -64,6 +89,20 @@ class Sandbox:
                 cpus,
                 memory_mb,
                 isolation,
+                filesystem_snapshot_id,
+                workspace,
+                workdir,
+                user,
+                hostname,
+                mounts,
+                tmpfs,
+                network,
+                ports,
+                dns,
+                host_aliases,
+                read_only,
+                persistent,
+                auto_remove,
             )
         )
         return cls._from_result(result, local_runtime)
@@ -128,6 +167,53 @@ class Sandbox:
         self._update_lifecycle(result, fallback_state=self.state)
         return self.state == "running"
 
+    def create_filesystem_snapshot(
+        self,
+        snapshot_id: str,
+    ) -> FilesystemSnapshotInfo:
+        result = self._runtime.request(
+            {
+                **self._lifecycle_request("sandbox_snapshot_create"),
+                "snapshot_id": snapshot_id,
+            }
+        )
+        self._update_lifecycle(result, fallback_state=self.state)
+        return _snapshot_info(result)
+
+    def script(self, source: str | bytes | Script) -> ScriptBuilder:
+        return self.commands.script(source)
+
+    @classmethod
+    def filesystem_snapshot_size(
+        cls,
+        snapshot_id: str,
+        *,
+        runtime: LocalRuntime | None = None,
+    ) -> int | None:
+        result = (runtime or A3SLocalRuntime()).request(
+            {
+                "operation": "filesystem_snapshot_size",
+                "snapshot_id": snapshot_id,
+            }
+        )
+        size = result.get("size_bytes")
+        return None if size is None else int(size)
+
+    @classmethod
+    def delete_filesystem_snapshot(
+        cls,
+        snapshot_id: str,
+        *,
+        runtime: LocalRuntime | None = None,
+    ) -> bool:
+        result = (runtime or A3SLocalRuntime()).request(
+            {
+                "operation": "filesystem_snapshot_delete",
+                "snapshot_id": snapshot_id,
+            }
+        )
+        return bool(result["deleted"])
+
     def _lifecycle_request(self, operation: str) -> dict[str, object]:
         return {
             "operation": operation,
@@ -178,6 +264,29 @@ class Commands:
             )
         )
         return _command_result(result)
+
+    def script(self, source: str | bytes | Script) -> ScriptBuilder:
+        return ScriptBuilder(self, source)
+
+    def run_script(
+        self,
+        source: str | bytes | Script,
+        *,
+        timeout: float | None = None,
+        envs: Mapping[str, str] | None = None,
+        cwd: str | None = None,
+        user: str | None = None,
+    ) -> CommandResult:
+        script = self.script(source)
+        if timeout is not None:
+            script.timeout(timeout)
+        for key, value in (envs or {}).items():
+            script.env(key, value)
+        if cwd is not None:
+            script.cwd(cwd)
+        if user is not None:
+            script.user(user)
+        return script.run()
 
 
 class Filesystem:
@@ -325,6 +434,20 @@ class AsyncSandbox:
         cpus: int | None = None,
         memory_mb: int | None = None,
         isolation: Literal["microvm", "sandbox"] = "microvm",
+        filesystem_snapshot_id: str | None = None,
+        workspace: str | None = None,
+        workdir: str | None = None,
+        user: str | None = None,
+        hostname: str | None = None,
+        mounts: Sequence[VolumeMount] | None = None,
+        tmpfs: Sequence[TmpfsMount] | None = None,
+        network: SandboxNetwork | None = None,
+        ports: Sequence[PortMapping] | None = None,
+        dns: Sequence[str] | None = None,
+        host_aliases: Mapping[str, str] | None = None,
+        read_only: bool = False,
+        persistent: bool = False,
+        auto_remove: bool = True,
         runtime: AsyncLocalRuntime | None = None,
     ) -> AsyncSandbox:
         local_runtime = runtime or A3SAsyncLocalRuntime()
@@ -338,6 +461,20 @@ class AsyncSandbox:
                 cpus,
                 memory_mb,
                 isolation,
+                filesystem_snapshot_id,
+                workspace,
+                workdir,
+                user,
+                hostname,
+                mounts,
+                tmpfs,
+                network,
+                ports,
+                dns,
+                host_aliases,
+                read_only,
+                persistent,
+                auto_remove,
             )
         )
         return cls._from_result(result, local_runtime)
@@ -404,6 +541,53 @@ class AsyncSandbox:
         self._update_lifecycle(result, fallback_state=self.state)
         return self.state == "running"
 
+    async def create_filesystem_snapshot(
+        self,
+        snapshot_id: str,
+    ) -> FilesystemSnapshotInfo:
+        result = await self._runtime.request(
+            {
+                **self._lifecycle_request("sandbox_snapshot_create"),
+                "snapshot_id": snapshot_id,
+            }
+        )
+        self._update_lifecycle(result, fallback_state=self.state)
+        return _snapshot_info(result)
+
+    def script(self, source: str | bytes | Script) -> AsyncScriptBuilder:
+        return self.commands.script(source)
+
+    @classmethod
+    async def filesystem_snapshot_size(
+        cls,
+        snapshot_id: str,
+        *,
+        runtime: AsyncLocalRuntime | None = None,
+    ) -> int | None:
+        result = await (runtime or A3SAsyncLocalRuntime()).request(
+            {
+                "operation": "filesystem_snapshot_size",
+                "snapshot_id": snapshot_id,
+            }
+        )
+        size = result.get("size_bytes")
+        return None if size is None else int(size)
+
+    @classmethod
+    async def delete_filesystem_snapshot(
+        cls,
+        snapshot_id: str,
+        *,
+        runtime: AsyncLocalRuntime | None = None,
+    ) -> bool:
+        result = await (runtime or A3SAsyncLocalRuntime()).request(
+            {
+                "operation": "filesystem_snapshot_delete",
+                "snapshot_id": snapshot_id,
+            }
+        )
+        return bool(result["deleted"])
+
     def _lifecycle_request(self, operation: str) -> dict[str, object]:
         return {
             "operation": operation,
@@ -454,6 +638,29 @@ class AsyncCommands:
             )
         )
         return _command_result(result)
+
+    def script(self, source: str | bytes | Script) -> AsyncScriptBuilder:
+        return AsyncScriptBuilder(self, source)
+
+    async def run_script(
+        self,
+        source: str | bytes | Script,
+        *,
+        timeout: float | None = None,
+        envs: Mapping[str, str] | None = None,
+        cwd: str | None = None,
+        user: str | None = None,
+    ) -> CommandResult:
+        script = self.script(source)
+        if timeout is not None:
+            script.timeout(timeout)
+        for key, value in (envs or {}).items():
+            script.env(key, value)
+        if cwd is not None:
+            script.cwd(cwd)
+        if user is not None:
+            script.user(user)
+        return await script.run()
 
 
 class AsyncFilesystem:
@@ -582,6 +789,20 @@ def _create_request(
     cpus: int | None,
     memory_mb: int | None,
     isolation: str,
+    filesystem_snapshot_id: str | None,
+    workspace: str | None,
+    workdir: str | None,
+    user: str | None,
+    hostname: str | None,
+    mounts: Sequence[VolumeMount] | None,
+    tmpfs: Sequence[TmpfsMount] | None,
+    network: SandboxNetwork | None,
+    ports: Sequence[PortMapping] | None,
+    dns: Sequence[str] | None,
+    host_aliases: Mapping[str, str] | None,
+    read_only: bool,
+    persistent: bool,
+    auto_remove: bool,
 ) -> dict[str, object]:
     if timeout <= 0:
         raise ValueError("timeout must be greater than zero")
@@ -592,6 +813,15 @@ def _create_request(
         "env": dict(envs or {}),
         "labels": dict(metadata or {}),
         "isolation": isolation,
+        "mounts": [mount.bridge_value() for mount in mounts or ()],
+        "tmpfs": [mount.bridge_value() for mount in tmpfs or ()],
+        "network": (network or SandboxNetwork.tsi()).bridge_value(),
+        "ports": [port.bridge_value() for port in ports or ()],
+        "dns": list(dns or ()),
+        "host_aliases": dict(host_aliases or {}),
+        "read_only": read_only,
+        "persistent": persistent,
+        "auto_remove": auto_remove,
     }
     if name is not None:
         request["name"] = name
@@ -599,7 +829,26 @@ def _create_request(
         request["cpus"] = cpus
     if memory_mb is not None:
         request["memory_mb"] = memory_mb
+    if filesystem_snapshot_id is not None:
+        request["filesystem_snapshot_id"] = filesystem_snapshot_id
+    if workspace is not None:
+        request["workspace"] = workspace
+    if workdir is not None:
+        request["workdir"] = workdir
+    if user is not None:
+        request["user"] = user
+    if hostname is not None:
+        request["hostname"] = hostname
     return request
+
+
+def _snapshot_info(result: Mapping[str, Any]) -> FilesystemSnapshotInfo:
+    return FilesystemSnapshotInfo(
+        snapshot_id=str(result["snapshot_id"]),
+        size_bytes=int(result["size_bytes"]),
+        state=str(result["state"]),
+        generation=int(result["generation"]),
+    )
 
 
 def _command_request(

--- a/sdk/python/src/a3s_box/script.py
+++ b/sdk/python/src/a3s_box/script.py
@@ -1,0 +1,147 @@
+"""Fluent stdin-backed script builders."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Protocol
+
+from .models import CommandResult, Script
+
+
+class _SyncCommands(Protocol):
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        timeout: float | None = None,
+        envs: Mapping[str, str] | None = None,
+        cwd: str | None = None,
+        user: str | None = None,
+        stdin: str | bytes | None = None,
+    ) -> CommandResult:
+        ...
+
+
+class _AsyncCommands(Protocol):
+    async def run(
+        self,
+        command: Sequence[str],
+        *,
+        timeout: float | None = None,
+        envs: Mapping[str, str] | None = None,
+        cwd: str | None = None,
+        user: str | None = None,
+        stdin: str | bytes | None = None,
+    ) -> CommandResult:
+        ...
+
+
+class ScriptBuilder:
+    """Fluent, stdin-backed script execution builder."""
+
+    def __init__(
+        self,
+        commands: _SyncCommands,
+        script: str | bytes | Script,
+    ) -> None:
+        self._commands = commands
+        if isinstance(script, Script):
+            self._source = script.source
+            self._interpreter = list(script.interpreter)
+        else:
+            self._source = script
+            self._interpreter = ["/bin/sh", "-se"]
+        self._timeout: float | None = None
+        self._envs: dict[str, str] = {}
+        self._cwd: str | None = None
+        self._user: str | None = None
+
+    def interpreter(self, executable: str, *args: str) -> ScriptBuilder:
+        self._interpreter = [executable, *args]
+        return self
+
+    def timeout(self, seconds: float) -> ScriptBuilder:
+        self._timeout = seconds
+        return self
+
+    def env(self, key: str, value: str) -> ScriptBuilder:
+        self._envs[key] = value
+        return self
+
+    def cwd(self, path: str) -> ScriptBuilder:
+        self._cwd = path
+        return self
+
+    def user(self, user: str) -> ScriptBuilder:
+        self._user = user
+        return self
+
+    def run(self) -> CommandResult:
+        _validate_script(self._source, self._interpreter)
+        return self._commands.run(
+            self._interpreter,
+            timeout=self._timeout,
+            envs=self._envs,
+            cwd=self._cwd,
+            user=self._user,
+            stdin=self._source,
+        )
+
+
+class AsyncScriptBuilder:
+    """Async counterpart of :class:`ScriptBuilder`."""
+
+    def __init__(
+        self,
+        commands: _AsyncCommands,
+        script: str | bytes | Script,
+    ) -> None:
+        self._commands = commands
+        if isinstance(script, Script):
+            self._source = script.source
+            self._interpreter = list(script.interpreter)
+        else:
+            self._source = script
+            self._interpreter = ["/bin/sh", "-se"]
+        self._timeout: float | None = None
+        self._envs: dict[str, str] = {}
+        self._cwd: str | None = None
+        self._user: str | None = None
+
+    def interpreter(self, executable: str, *args: str) -> AsyncScriptBuilder:
+        self._interpreter = [executable, *args]
+        return self
+
+    def timeout(self, seconds: float) -> AsyncScriptBuilder:
+        self._timeout = seconds
+        return self
+
+    def env(self, key: str, value: str) -> AsyncScriptBuilder:
+        self._envs[key] = value
+        return self
+
+    def cwd(self, path: str) -> AsyncScriptBuilder:
+        self._cwd = path
+        return self
+
+    def user(self, user: str) -> AsyncScriptBuilder:
+        self._user = user
+        return self
+
+    async def run(self) -> CommandResult:
+        _validate_script(self._source, self._interpreter)
+        return await self._commands.run(
+            self._interpreter,
+            timeout=self._timeout,
+            envs=self._envs,
+            cwd=self._cwd,
+            user=self._user,
+            stdin=self._source,
+        )
+
+
+def _validate_script(source: str | bytes, interpreter: Sequence[str]) -> None:
+    if not source:
+        raise ValueError("script source cannot be empty")
+    if not interpreter:
+        raise ValueError("script interpreter cannot be empty")

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -10,6 +10,8 @@ from unittest.mock import patch
 
 import a3s_box
 from a3s_box import (
+    A3SAsyncBoxClient,
+    A3SBoxClient,
     A3SRemoteConnection,
     AsyncSandbox,
     Sandbox,
@@ -41,6 +43,37 @@ class AsyncFakeRuntime:
 
 def response_for(request: Mapping[str, object]) -> dict[str, Any]:
     operation = request["operation"]
+    if operation == "image_build":
+        return {
+            "reference": request.get("tag", "local/build:latest"),
+            "digest": "sha256:build",
+            "size_bytes": 8192,
+            "layer_count": 3,
+        }
+    if operation == "image_pull":
+        return image_response(str(request["reference"]))
+    if operation == "image_list":
+        return {"images": [image_response("alpine:3.20")]}
+    if operation == "image_remove":
+        return {"reference": request["reference"], "removed": True}
+    if operation == "volume_create":
+        return volume_response(str(request["name"]))
+    if operation == "volume_get":
+        return {"volume": volume_response(str(request["name"]))}
+    if operation == "volume_list":
+        return {"volumes": [volume_response("ci-cache")]}
+    if operation == "volume_remove":
+        return volume_response(str(request["name"]))
+    if operation == "network_create":
+        return network_response(str(request["name"]), str(request["subnet"]))
+    if operation == "network_get":
+        return {
+            "network": network_response(str(request["name"]), "10.89.0.0/24")
+        }
+    if operation == "network_list":
+        return {"networks": [network_response("ci-net", "10.89.0.0/24")]}
+    if operation == "network_remove":
+        return network_response(str(request["name"]), "10.89.0.0/24")
     if operation == "sandbox_create":
         return {
             "sandbox_id": "sandbox-local-1",
@@ -52,6 +85,23 @@ def response_for(request: Mapping[str, object]) -> dict[str, Any]:
             "sandbox_id": request["sandbox_id"],
             "generation": 2,
             "state": "paused",
+        }
+    if operation == "sandbox_snapshot_create":
+        return {
+            "snapshot_id": request["snapshot_id"],
+            "size_bytes": 4096,
+            "state": "running",
+            "generation": request["generation"],
+        }
+    if operation == "filesystem_snapshot_size":
+        return {
+            "snapshot_id": request["snapshot_id"],
+            "size_bytes": 4096,
+        }
+    if operation == "filesystem_snapshot_delete":
+        return {
+            "snapshot_id": request["snapshot_id"],
+            "deleted": True,
         }
     if operation == "command_run":
         return {
@@ -96,6 +146,44 @@ def response_for(request: Mapping[str, object]) -> dict[str, Any]:
     }:
         return {"ok": True}
     raise AssertionError(f"unexpected operation: {operation}")
+
+
+def image_response(reference: str) -> dict[str, Any]:
+    return {
+        "reference": reference,
+        "digest": "sha256:image",
+        "size_bytes": 4096,
+        "pulled_at": "2026-07-23T00:00:00Z",
+        "last_used": "2026-07-23T00:00:00Z",
+        "path": "/tmp/image",
+    }
+
+
+def volume_response(name: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "driver": "local",
+        "mount_point": f"/tmp/volumes/{name}",
+        "labels": {"purpose": "ci"},
+        "in_use_by": [],
+        "in_use": False,
+        "size_limit": 4096,
+        "created_at": "2026-07-23T00:00:00Z",
+    }
+
+
+def network_response(name: str, subnet: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "driver": "bridge",
+        "subnet": subnet,
+        "gateway": "10.89.0.1",
+        "labels": {"purpose": "ci"},
+        "endpoints": [],
+        "endpoint_count": 0,
+        "isolation": "none",
+        "created_at": "2026-07-23T00:00:00Z",
+    }
 
 
 class SdkTests(unittest.TestCase):
@@ -144,6 +232,83 @@ class SdkTests(unittest.TestCase):
         self.assertEqual(stat["operation"], "filesystem_stat")
         self.assertEqual(kill["operation"], "sandbox_kill")
 
+    def test_fluent_programmable_cicd_builders_share_the_e2b_sandbox(self) -> None:
+        runtime = FakeRuntime()
+        client = A3SBoxClient(runtime)
+
+        image = (
+            client.image("./ci")
+            .dockerfile("Dockerfile.ci")
+            .tag("local/ci-base:latest")
+            .build_arg("NODE_VERSION", "24")
+            .platform("linux/arm64")
+            .build()
+        )
+        volume = (
+            client.volume("ci-cache")
+            .label("purpose", "ci")
+            .size_limit(4096)
+            .create()
+        )
+        network = (
+            client.network("ci-net")
+            .subnet("10.89.55.0/24")
+            .label("purpose", "ci")
+            .create()
+        )
+        sandbox = (
+            client.sandbox(image.reference)
+            .cpus(4)
+            .memory_mb(4096)
+            .mount_named(volume.name, "/cache")
+            .network(network.name)
+            .publish_tcp(8080, 80)
+            .workdir("/workspace")
+            .auto_remove(False)
+            .start()
+        )
+        result = (
+            sandbox.script("print(6 * 7)\n")
+            .interpreter("python", "-")
+            .env("CI", "true")
+            .cwd("/workspace")
+            .run()
+        )
+        sandbox.kill()
+        client.remove_network(network.name)
+        client.remove_volume(volume.name)
+        client.remove_image(image.reference)
+
+        self.assertEqual(result.stdout, "42\n")
+        self.assertEqual(runtime.requests[0]["operation"], "image_build")
+        self.assertEqual(runtime.requests[0]["dockerfile"], "Dockerfile.ci")
+        self.assertEqual(runtime.requests[0]["platforms"], ["linux/arm64"])
+        create = runtime.requests[3]
+        self.assertEqual(create["operation"], "sandbox_create")
+        self.assertEqual(
+            create["mounts"],
+            [
+                {
+                    "kind": "named",
+                    "name": "ci-cache",
+                    "target": "/cache",
+                    "read_only": False,
+                }
+            ],
+        )
+        self.assertEqual(create["network"], {"mode": "bridge", "name": "ci-net"})
+        self.assertEqual(
+            create["ports"],
+            [{"host_port": 8080, "guest_port": 80}],
+        )
+        self.assertFalse(create["auto_remove"])
+        command = runtime.requests[4]
+        self.assertEqual(command["argv"], ["python", "-"])
+        self.assertEqual(
+            base64.b64decode(str(command["stdin_base64"])),
+            b"print(6 * 7)\n",
+        )
+
     def test_create_explicitly_selects_shared_kernel_sandbox_isolation(self) -> None:
         runtime = FakeRuntime()
 
@@ -174,6 +339,39 @@ class SdkTests(unittest.TestCase):
         self.assertEqual(sandbox.generation, 2)
         self.assertEqual(sandbox.state, "paused")
         self.assertEqual(runtime.requests[0]["operation"], "sandbox_inspect")
+
+    def test_runtime_managed_filesystem_snapshot_lifecycle(self) -> None:
+        runtime = FakeRuntime()
+
+        sandbox = Sandbox.create(
+            isolation="sandbox",
+            filesystem_snapshot_id="ci-base-source",
+            runtime=runtime,
+        )
+        snapshot = sandbox.create_filesystem_snapshot("ci-base-captured")
+        size = Sandbox.filesystem_snapshot_size(snapshot.snapshot_id, runtime=runtime)
+        deleted = Sandbox.delete_filesystem_snapshot(snapshot.snapshot_id, runtime=runtime)
+        sandbox.kill()
+
+        self.assertEqual(snapshot.snapshot_id, "ci-base-captured")
+        self.assertEqual(snapshot.size_bytes, 4096)
+        self.assertEqual(snapshot.state, "running")
+        self.assertEqual(size, 4096)
+        self.assertTrue(deleted)
+        self.assertEqual(
+            [request["operation"] for request in runtime.requests],
+            [
+                "sandbox_create",
+                "sandbox_snapshot_create",
+                "filesystem_snapshot_size",
+                "filesystem_snapshot_delete",
+                "sandbox_kill",
+            ],
+        )
+        self.assertEqual(
+            runtime.requests[0]["filesystem_snapshot_id"],
+            "ci-base-source",
+        )
 
     def test_code_interpreter_uses_the_native_local_sandbox(self) -> None:
         runtime = FakeRuntime()
@@ -224,6 +422,46 @@ class AsyncSdkTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(runtime.requests[0]["image"], "alpine:3.20")
         self.assertEqual(runtime.requests[1]["argv"], ["printf", "42"])
         self.assertEqual(runtime.requests[-1]["operation"], "sandbox_kill")
+
+    async def test_async_fluent_builders_have_resource_and_script_parity(self) -> None:
+        runtime = AsyncFakeRuntime()
+        client = A3SAsyncBoxClient(runtime)
+        image = await client.image("./ci").tag("local/async-ci:latest").build()
+        await client.volume("async-cache").create()
+        sandbox = await (
+            client.sandbox(image.reference)
+            .mount_named("async-cache", "/cache", read_only=True)
+            .disable_network()
+            .start()
+        )
+        result = await sandbox.script("printf '42\\n'\n").run()
+        await sandbox.kill()
+        await client.remove_volume("async-cache")
+        await client.remove_image(image.reference)
+
+        self.assertEqual(result.stdout, "42\n")
+        self.assertEqual(runtime.requests[2]["network"], {"mode": "none"})
+        self.assertTrue(runtime.requests[2]["mounts"][0]["read_only"])
+        self.assertEqual(runtime.requests[3]["argv"], ["/bin/sh", "-se"])
+
+    async def test_async_filesystem_snapshot_lifecycle(self) -> None:
+        runtime = AsyncFakeRuntime()
+        sandbox = await AsyncSandbox.create(isolation="sandbox", runtime=runtime)
+
+        snapshot = await sandbox.create_filesystem_snapshot("ci-async")
+        size = await AsyncSandbox.filesystem_snapshot_size(
+            snapshot.snapshot_id,
+            runtime=runtime,
+        )
+        deleted = await AsyncSandbox.delete_filesystem_snapshot(
+            snapshot.snapshot_id,
+            runtime=runtime,
+        )
+        await sandbox.kill()
+
+        self.assertEqual(snapshot.size_bytes, 4096)
+        self.assertEqual(size, 4096)
+        self.assertTrue(deleted)
 
 
 if __name__ == "__main__":

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -46,6 +46,64 @@ const sandbox = await Sandbox.create('python:3.12-alpine', {
 })
 ```
 
+## Builder-style programmable CI/CD
+
+The E2B-style API remains available for direct execution. For build and CI
+tooling, `A3SBoxClient` adds fluent builders over the same local runtime and
+bridge:
+
+```typescript
+import { A3SBoxClient } from '@a3s-lab/box'
+
+const client = new A3SBoxClient()
+
+const image = await client
+  .image('./ci')
+  .dockerfile('Dockerfile')
+  .tag('local/ci-base:latest')
+  .buildArg('NODE_VERSION', '24')
+  .build()
+const cache = await client
+  .volume('npm-cache')
+  .label('purpose', 'ci-cache')
+  .sizeLimit(10 * 1024 * 1024 * 1024)
+  .create()
+const network = await client
+  .network('ci-net')
+  .subnet('10.89.40.0/24')
+  .create()
+
+const box = await client
+  .sandbox(image.reference)
+  .cpus(4)
+  .memoryMb(4096)
+  .mountNamed(cache.name, '/root/.npm')
+  .network(network.name)
+  .publishTcp(8080, 8080)
+  .workdir('/workspace')
+  .start()
+
+try {
+  const result = await box
+    .script('npm ci\nnpm test\n')
+    .interpreter('/bin/sh', '-se')
+    .env('CI', 'true')
+    .run()
+  if (result.exitCode !== 0) throw new Error(result.stderr)
+} finally {
+  await box.kill()
+}
+```
+
+Named volumes and networks must be created explicitly before they are mounted
+or selected. Builder scripts are sent through standard input to the selected
+interpreter, so their contents are not interpolated into a host shell command.
+
+Named bridge networks and published ports are currently MicroVM-only. A
+shared-kernel Sandbox request that selects either fails before runtime
+mutation; use `.disableNetwork()` or the default TSI-compatible configuration
+for supported Sandbox workloads.
+
 The package invokes the versioned machine bridge built into the installed
 `a3s-box` executable. It does not parse human CLI output. Set `A3S_BOX_BINARY`
 only when the executable is not on `PATH`, or inject a typed

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,556 @@
+import { A3SBoxError } from './errors.js'
+import { A3SLocalRuntime, type BridgeResult, type LocalRuntime } from './runtime.js'
+import {
+  DEFAULT_IMAGE,
+  Sandbox,
+  type Isolation,
+  type PortMapping,
+  type SandboxCreateOptions,
+  type SandboxNetwork,
+  type TmpfsMount,
+  type VolumeMount,
+} from './sandbox.js'
+
+export interface BuildImageInfo {
+  reference: string
+  digest: string
+  sizeBytes: number
+  layerCount: number
+}
+
+export interface ImageInfo {
+  reference: string
+  digest: string
+  sizeBytes: number
+  pulledAt: string
+  lastUsed: string
+  path: string
+}
+
+export interface VolumeInfo {
+  name: string
+  driver: string
+  mountPoint: string
+  labels: Readonly<Record<string, string>>
+  inUseBy: readonly string[]
+  inUse: boolean
+  sizeLimit: number
+  createdAt: string
+}
+
+export interface NetworkEndpointInfo {
+  boxId: string
+  boxName: string
+  aliases: readonly string[]
+  ipAddress: string
+  macAddress: string
+}
+
+export interface NetworkInfo {
+  name: string
+  driver: string
+  subnet: string
+  gateway: string
+  labels: Readonly<Record<string, string>>
+  endpoints: readonly NetworkEndpointInfo[]
+  endpointCount: number
+  isolation: string
+  createdAt: string
+}
+
+/** Host-level resource client and entry point for fluent builders. */
+export class A3SBoxClient {
+  constructor(readonly runtime: LocalRuntime = new A3SLocalRuntime()) {}
+
+  image(contextDir: string): ImageBuilder {
+    return new ImageBuilder(this.runtime, contextDir)
+  }
+
+  volume(name: string): VolumeBuilder {
+    return new VolumeBuilder(this.runtime, name)
+  }
+
+  network(name: string): NetworkBuilder {
+    return new NetworkBuilder(this.runtime, name)
+  }
+
+  sandbox(image = DEFAULT_IMAGE): SandboxBuilder {
+    return new SandboxBuilder(this.runtime, image)
+  }
+
+  async pullImage(
+    reference: string,
+    options: { force?: boolean; platform?: string } = {}
+  ): Promise<ImageInfo> {
+    return imageInfo(
+      await this.runtime.request({
+        operation: 'image_pull',
+        reference,
+        force: options.force ?? false,
+        ...(options.platform === undefined
+          ? {}
+          : { platform: options.platform }),
+      })
+    )
+  }
+
+  async listImages(): Promise<ImageInfo[]> {
+    const result = await this.runtime.request({ operation: 'image_list' })
+    return recordArray(result, 'images').map(imageInfo)
+  }
+
+  async removeImage(reference: string): Promise<void> {
+    await this.runtime.request({ operation: 'image_remove', reference })
+  }
+
+  async getVolume(name: string): Promise<VolumeInfo | undefined> {
+    const result = await this.runtime.request({ operation: 'volume_get', name })
+    return result.volume === null || result.volume === undefined
+      ? undefined
+      : volumeInfo(asRecord(result.volume))
+  }
+
+  async listVolumes(): Promise<VolumeInfo[]> {
+    const result = await this.runtime.request({ operation: 'volume_list' })
+    return recordArray(result, 'volumes').map(volumeInfo)
+  }
+
+  async removeVolume(
+    name: string,
+    options: { force?: boolean } = {}
+  ): Promise<VolumeInfo> {
+    return volumeInfo(
+      await this.runtime.request({
+        operation: 'volume_remove',
+        name,
+        force: options.force ?? false,
+      })
+    )
+  }
+
+  async getNetwork(name: string): Promise<NetworkInfo | undefined> {
+    const result = await this.runtime.request({ operation: 'network_get', name })
+    return result.network === null || result.network === undefined
+      ? undefined
+      : networkInfo(asRecord(result.network))
+  }
+
+  async listNetworks(): Promise<NetworkInfo[]> {
+    const result = await this.runtime.request({ operation: 'network_list' })
+    return recordArray(result, 'networks').map(networkInfo)
+  }
+
+  async removeNetwork(name: string): Promise<NetworkInfo> {
+    return networkInfo(
+      await this.runtime.request({ operation: 'network_remove', name })
+    )
+  }
+}
+
+export class ImageBuilder {
+  private dockerfilePath?: string
+  private imageTag?: string
+  private readonly buildArgs: Record<string, string> = {}
+  private quietBuild = true
+  private readonly platforms: string[] = []
+  private buildTarget?: string
+  private disableCache = false
+
+  constructor(
+    private readonly runtime: LocalRuntime,
+    private readonly contextDir: string
+  ) {}
+
+  dockerfile(path: string): this {
+    this.dockerfilePath = path
+    return this
+  }
+
+  tag(tag: string): this {
+    this.imageTag = tag
+    return this
+  }
+
+  buildArg(key: string, value: string): this {
+    this.buildArgs[key] = value
+    return this
+  }
+
+  quiet(enabled = true): this {
+    this.quietBuild = enabled
+    return this
+  }
+
+  platform(platform: string): this {
+    this.platforms.push(platform)
+    return this
+  }
+
+  target(target: string): this {
+    this.buildTarget = target
+    return this
+  }
+
+  noCache(enabled = true): this {
+    this.disableCache = enabled
+    return this
+  }
+
+  async build(): Promise<BuildImageInfo> {
+    const result = await this.runtime.request({
+      operation: 'image_build',
+      context_dir: this.contextDir,
+      build_args: { ...this.buildArgs },
+      quiet: this.quietBuild,
+      platforms: [...this.platforms],
+      no_cache: this.disableCache,
+      ...(this.dockerfilePath === undefined
+        ? {}
+        : { dockerfile: this.dockerfilePath }),
+      ...(this.imageTag === undefined ? {} : { tag: this.imageTag }),
+      ...(this.buildTarget === undefined ? {} : { target: this.buildTarget }),
+    })
+    return buildImageInfo(result)
+  }
+}
+
+export class VolumeBuilder {
+  private readonly labels: Record<string, string> = {}
+  private sizeLimitBytes = 0
+
+  constructor(
+    private readonly runtime: LocalRuntime,
+    private readonly name: string
+  ) {}
+
+  label(key: string, value: string): this {
+    this.labels[key] = value
+    return this
+  }
+
+  sizeLimit(sizeBytes: number): this {
+    this.sizeLimitBytes = sizeBytes
+    return this
+  }
+
+  async create(): Promise<VolumeInfo> {
+    return volumeInfo(
+      await this.runtime.request({
+        operation: 'volume_create',
+        name: this.name,
+        labels: { ...this.labels },
+        size_limit: this.sizeLimitBytes,
+      })
+    )
+  }
+}
+
+export class NetworkBuilder {
+  private networkSubnet = '10.89.0.0/24'
+  private readonly labels: Record<string, string> = {}
+
+  constructor(
+    private readonly runtime: LocalRuntime,
+    private readonly name: string
+  ) {}
+
+  subnet(subnet: string): this {
+    this.networkSubnet = subnet
+    return this
+  }
+
+  label(key: string, value: string): this {
+    this.labels[key] = value
+    return this
+  }
+
+  async create(): Promise<NetworkInfo> {
+    return networkInfo(
+      await this.runtime.request({
+        operation: 'network_create',
+        name: this.name,
+        subnet: this.networkSubnet,
+        labels: { ...this.labels },
+      })
+    )
+  }
+}
+
+export class SandboxBuilder {
+  private readonly options: SandboxCreateOptions
+
+  constructor(
+    runtime: LocalRuntime,
+    private readonly image: string
+  ) {
+    this.options = { runtime }
+  }
+
+  timeout(timeoutMs: number): this {
+    this.options.timeoutMs = timeoutMs
+    return this
+  }
+
+  env(key: string, value: string): this {
+    this.options.envs = { ...(this.options.envs ?? {}), [key]: value }
+    return this
+  }
+
+  metadata(key: string, value: string): this {
+    this.options.metadata = {
+      ...(this.options.metadata ?? {}),
+      [key]: value,
+    }
+    return this
+  }
+
+  name(name: string): this {
+    this.options.name = name
+    return this
+  }
+
+  cpus(cpus: number): this {
+    this.options.cpus = cpus
+    return this
+  }
+
+  memoryMb(memoryMb: number): this {
+    this.options.memoryMb = memoryMb
+    return this
+  }
+
+  isolation(isolation: Isolation): this {
+    this.options.isolation = isolation
+    return this
+  }
+
+  filesystemSnapshot(snapshotId: string): this {
+    this.options.filesystemSnapshotId = snapshotId
+    return this
+  }
+
+  workspace(path: string): this {
+    this.options.workspace = path
+    return this
+  }
+
+  workdir(path: string): this {
+    this.options.workdir = path
+    return this
+  }
+
+  user(user: string): this {
+    this.options.user = user
+    return this
+  }
+
+  hostname(hostname: string): this {
+    this.options.hostname = hostname
+    return this
+  }
+
+  mount(mount: VolumeMount): this {
+    this.options.mounts = [...(this.options.mounts ?? []), mount]
+    return this
+  }
+
+  mountBind(
+    source: string,
+    target: string,
+    options: { readOnly?: boolean } = {}
+  ): this {
+    return this.mount({
+      kind: 'bind',
+      source,
+      target,
+      readOnly: options.readOnly,
+    })
+  }
+
+  mountNamed(
+    name: string,
+    target: string,
+    options: { readOnly?: boolean } = {}
+  ): this {
+    return this.mount({
+      kind: 'named',
+      name,
+      target,
+      readOnly: options.readOnly,
+    })
+  }
+
+  tmpfs(
+    target: string,
+    options: { sizeBytes?: number; readOnly?: boolean } = {}
+  ): this {
+    const mount: TmpfsMount = {
+      target,
+      sizeBytes: options.sizeBytes,
+      readOnly: options.readOnly,
+    }
+    this.options.tmpfs = [...(this.options.tmpfs ?? []), mount]
+    return this
+  }
+
+  network(network: string | SandboxNetwork): this {
+    this.options.network =
+      typeof network === 'string'
+        ? { mode: 'bridge', name: network }
+        : network
+    return this
+  }
+
+  disableNetwork(): this {
+    this.options.network = { mode: 'none' }
+    return this
+  }
+
+  publishTcp(hostPort: number, guestPort: number): this {
+    const port: PortMapping = { hostPort, guestPort }
+    this.options.ports = [...(this.options.ports ?? []), port]
+    return this
+  }
+
+  dnsServer(address: string): this {
+    this.options.dns = [...(this.options.dns ?? []), address]
+    return this
+  }
+
+  hostAlias(host: string, address: string): this {
+    this.options.hostAliases = {
+      ...(this.options.hostAliases ?? {}),
+      [host]: address,
+    }
+    return this
+  }
+
+  readOnly(enabled = true): this {
+    this.options.readOnly = enabled
+    return this
+  }
+
+  persistent(enabled = true): this {
+    this.options.persistent = enabled
+    return this
+  }
+
+  autoRemove(enabled = true): this {
+    this.options.autoRemove = enabled
+    return this
+  }
+
+  start(): Promise<Sandbox> {
+    return Sandbox.create(this.image, this.options)
+  }
+}
+
+function buildImageInfo(result: BridgeResult): BuildImageInfo {
+  return {
+    reference: requiredString(result, 'reference'),
+    digest: requiredString(result, 'digest'),
+    sizeBytes: requiredNumber(result, 'size_bytes'),
+    layerCount: requiredNumber(result, 'layer_count'),
+  }
+}
+
+function imageInfo(result: BridgeResult): ImageInfo {
+  return {
+    reference: requiredString(result, 'reference'),
+    digest: requiredString(result, 'digest'),
+    sizeBytes: requiredNumber(result, 'size_bytes'),
+    pulledAt: requiredString(result, 'pulled_at'),
+    lastUsed: requiredString(result, 'last_used'),
+    path: requiredString(result, 'path'),
+  }
+}
+
+function volumeInfo(result: BridgeResult): VolumeInfo {
+  return {
+    name: requiredString(result, 'name'),
+    driver: requiredString(result, 'driver'),
+    mountPoint: requiredString(result, 'mount_point'),
+    labels: stringRecord(result.labels),
+    inUseBy: stringArray(result.in_use_by),
+    inUse: requiredBoolean(result, 'in_use'),
+    sizeLimit: requiredNumber(result, 'size_limit'),
+    createdAt: requiredString(result, 'created_at'),
+  }
+}
+
+function networkInfo(result: BridgeResult): NetworkInfo {
+  return {
+    name: requiredString(result, 'name'),
+    driver: requiredString(result, 'driver'),
+    subnet: requiredString(result, 'subnet'),
+    gateway: requiredString(result, 'gateway'),
+    labels: stringRecord(result.labels),
+    endpoints: recordArray(result, 'endpoints').map(networkEndpointInfo),
+    endpointCount: requiredNumber(result, 'endpoint_count'),
+    isolation: requiredString(result, 'isolation'),
+    createdAt: requiredString(result, 'created_at'),
+  }
+}
+
+function networkEndpointInfo(result: BridgeResult): NetworkEndpointInfo {
+  return {
+    boxId: requiredString(result, 'box_id'),
+    boxName: requiredString(result, 'box_name'),
+    aliases: stringArray(result.aliases),
+    ipAddress: requiredString(result, 'ip_address'),
+    macAddress: requiredString(result, 'mac_address'),
+  }
+}
+
+function requiredString(result: BridgeResult, key: string): string {
+  const value = result[key]
+  if (typeof value !== 'string') bridgeTypeError(key)
+  return value
+}
+
+function requiredNumber(result: BridgeResult, key: string): number {
+  const value = result[key]
+  if (typeof value !== 'number') bridgeTypeError(key)
+  return value
+}
+
+function requiredBoolean(result: BridgeResult, key: string): boolean {
+  const value = result[key]
+  if (typeof value !== 'boolean') bridgeTypeError(key)
+  return value
+}
+
+function recordArray(result: BridgeResult, key: string): BridgeResult[] {
+  const value = result[key]
+  if (!Array.isArray(value)) bridgeTypeError(key)
+  return value.map(asRecord)
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    bridgeTypeError('array')
+  }
+  return value
+}
+
+function stringRecord(value: unknown): Readonly<Record<string, string>> {
+  const record = asRecord(value)
+  if (!Object.values(record).every((item) => typeof item === 'string')) {
+    bridgeTypeError('record')
+  }
+  return record as Record<string, string>
+}
+
+function asRecord(value: unknown): BridgeResult {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    bridgeTypeError('object')
+  }
+  return value as BridgeResult
+}
+
+function bridgeTypeError(key: string): never {
+  throw new A3SBoxError(
+    `Bridge result has an invalid ${key}`,
+    'bridge_protocol_error'
+  )
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -7,6 +7,18 @@ export {
 } from './connection.js'
 export { A3SBoxError, A3SBoxNotInstalledError } from './errors.js'
 export {
+  A3SBoxClient,
+  ImageBuilder,
+  NetworkBuilder,
+  SandboxBuilder,
+  VolumeBuilder,
+  type BuildImageInfo,
+  type ImageInfo,
+  type NetworkEndpointInfo,
+  type NetworkInfo,
+  type VolumeInfo,
+} from './client.js'
+export {
   A3SLocalRuntime,
   BRIDGE_PROTOCOL_VERSION,
   type A3SLocalRuntimeOptions,
@@ -19,13 +31,20 @@ export {
   DEFAULT_IMAGE,
   Filesystem,
   Sandbox,
+  ScriptBuilder,
   type CommandResult,
   type CommandRunOptions,
   type EntryInfo,
   type FilesystemReadOptions,
+  type FilesystemSnapshotInfo,
   type Isolation,
+  type PortMapping,
+  type SandboxNetwork,
+  type Script,
   type SandboxConnectOptions,
   type SandboxCreateOptions,
+  type TmpfsMount,
+  type VolumeMount,
   type WriteInfo,
 } from './sandbox.js'
 

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -9,6 +9,41 @@ export const DEFAULT_IMAGE = 'alpine:3.20'
 
 export type Isolation = 'microvm' | 'sandbox'
 
+export type SandboxNetwork =
+  | { readonly mode: 'tsi' }
+  | { readonly mode: 'none' }
+  | { readonly mode: 'bridge'; readonly name: string }
+
+export type VolumeMount =
+  | {
+      readonly kind: 'bind'
+      readonly source: string
+      readonly target: string
+      readonly readOnly?: boolean
+    }
+  | {
+      readonly kind: 'named'
+      readonly name: string
+      readonly target: string
+      readonly readOnly?: boolean
+    }
+
+export interface TmpfsMount {
+  target: string
+  sizeBytes?: number
+  readOnly?: boolean
+}
+
+export interface PortMapping {
+  hostPort: number
+  guestPort: number
+}
+
+export interface Script {
+  source: string | Uint8Array
+  interpreter?: readonly string[]
+}
+
 export interface SandboxCreateOptions {
   timeoutMs?: number
   envs?: Readonly<Record<string, string>>
@@ -17,6 +52,20 @@ export interface SandboxCreateOptions {
   cpus?: number
   memoryMb?: number
   isolation?: Isolation
+  filesystemSnapshotId?: string
+  workspace?: string
+  workdir?: string
+  user?: string
+  hostname?: string
+  mounts?: readonly VolumeMount[]
+  tmpfs?: readonly TmpfsMount[]
+  network?: SandboxNetwork
+  ports?: readonly PortMapping[]
+  dns?: readonly string[]
+  hostAliases?: Readonly<Record<string, string>>
+  readOnly?: boolean
+  persistent?: boolean
+  autoRemove?: boolean
   runtime?: LocalRuntime
 }
 
@@ -42,6 +91,13 @@ export interface CommandResult {
 export interface WriteInfo {
   path: string
   size: number
+}
+
+export interface FilesystemSnapshotInfo {
+  snapshotId: string
+  sizeBytes: number
+  state: string
+  generation: number
 }
 
 export interface EntryInfo {
@@ -106,6 +162,33 @@ export class Sandbox {
       ...(options.memoryMb === undefined
         ? {}
         : { memory_mb: options.memoryMb }),
+      ...(options.filesystemSnapshotId === undefined
+        ? {}
+        : { filesystem_snapshot_id: options.filesystemSnapshotId }),
+      ...(options.workspace === undefined
+        ? {}
+        : { workspace: options.workspace }),
+      ...(options.workdir === undefined ? {} : { workdir: options.workdir }),
+      ...(options.user === undefined ? {} : { user: options.user }),
+      ...(options.hostname === undefined ? {} : { hostname: options.hostname }),
+      mounts: (options.mounts ?? []).map(bridgeVolumeMount),
+      tmpfs: (options.tmpfs ?? []).map((mount) => ({
+        target: mount.target,
+        ...(mount.sizeBytes === undefined
+          ? {}
+          : { size_bytes: mount.sizeBytes }),
+        read_only: mount.readOnly ?? false,
+      })),
+      network: options.network ?? { mode: 'tsi' },
+      ports: (options.ports ?? []).map((port) => ({
+        host_port: port.hostPort,
+        guest_port: port.guestPort,
+      })),
+      dns: [...(options.dns ?? [])],
+      host_aliases: { ...(options.hostAliases ?? {}) },
+      read_only: options.readOnly ?? false,
+      persistent: options.persistent ?? false,
+      auto_remove: options.autoRemove ?? true,
     })
     return Sandbox.fromResult(result, runtime)
   }
@@ -171,6 +254,59 @@ export class Sandbox {
     }
   }
 
+  async createFilesystemSnapshot(
+    snapshotId: string
+  ): Promise<FilesystemSnapshotInfo> {
+    const result = await this.runtime.request({
+      ...this.lifecycleRequest('sandbox_snapshot_create'),
+      snapshot_id: snapshotId,
+    })
+    this.updateLifecycle(result, this.state)
+    return filesystemSnapshotInfo(result)
+  }
+
+  script(source: string | Uint8Array | Script): ScriptBuilder {
+    return this.commands.script(source)
+  }
+
+  static async filesystemSnapshotSize(
+    snapshotId: string,
+    options: SandboxConnectOptions = {}
+  ): Promise<number | undefined> {
+    const runtime = options.runtime ?? new A3SLocalRuntime()
+    const result = await runtime.request({
+      operation: 'filesystem_snapshot_size',
+      snapshot_id: snapshotId,
+    })
+    const size = result.size_bytes
+    if (size === null || size === undefined) return undefined
+    if (typeof size !== 'number') {
+      throw new A3SBoxError(
+        'Bridge result has an invalid size_bytes',
+        'bridge_protocol_error'
+      )
+    }
+    return size
+  }
+
+  static async deleteFilesystemSnapshot(
+    snapshotId: string,
+    options: SandboxConnectOptions = {}
+  ): Promise<boolean> {
+    const runtime = options.runtime ?? new A3SLocalRuntime()
+    const result = await runtime.request({
+      operation: 'filesystem_snapshot_delete',
+      snapshot_id: snapshotId,
+    })
+    if (typeof result.deleted !== 'boolean') {
+      throw new A3SBoxError(
+        'Bridge result is missing deleted',
+        'bridge_protocol_error'
+      )
+    }
+    return result.deleted
+  }
+
   bridgeRequest(request: Readonly<Record<string, unknown>>): Promise<BridgeResult> {
     return this.runtime.request(request)
   }
@@ -232,6 +368,85 @@ export class Commands {
       exitCode: requiredNumber(result, 'exit_code'),
       truncated: result.truncated === true,
     }
+  }
+
+  script(source: string | Uint8Array | Script): ScriptBuilder {
+    return new ScriptBuilder(this, source)
+  }
+
+  async runScript(
+    source: string | Uint8Array | Script,
+    options: CommandRunOptions = {}
+  ): Promise<CommandResult> {
+    let builder = this.script(source)
+    if (options.timeoutMs !== undefined) {
+      builder = builder.timeout(options.timeoutMs)
+    }
+    for (const [key, value] of Object.entries(options.envs ?? {})) {
+      builder = builder.env(key, value)
+    }
+    if (options.cwd !== undefined) builder = builder.cwd(options.cwd)
+    if (options.user !== undefined) builder = builder.user(options.user)
+    return builder.run()
+  }
+}
+
+/** Fluent script builder that sends source through stdin to an interpreter. */
+export class ScriptBuilder {
+  private readonly source: string | Uint8Array
+  private interpreterArgv: string[]
+  private options: CommandRunOptions = {}
+
+  constructor(
+    private readonly commands: Commands,
+    script: string | Uint8Array | Script
+  ) {
+    if (isScript(script)) {
+      this.source = script.source
+      this.interpreterArgv = [...(script.interpreter ?? ['/bin/sh', '-se'])]
+    } else {
+      this.source = script
+      this.interpreterArgv = ['/bin/sh', '-se']
+    }
+  }
+
+  interpreter(executable: string, ...args: string[]): ScriptBuilder {
+    this.interpreterArgv = [executable, ...args]
+    return this
+  }
+
+  timeout(timeoutMs: number): ScriptBuilder {
+    this.options = { ...this.options, timeoutMs }
+    return this
+  }
+
+  env(key: string, value: string): ScriptBuilder {
+    this.options = {
+      ...this.options,
+      envs: { ...(this.options.envs ?? {}), [key]: value },
+    }
+    return this
+  }
+
+  cwd(path: string): ScriptBuilder {
+    this.options = { ...this.options, cwd: path }
+    return this
+  }
+
+  user(user: string): ScriptBuilder {
+    this.options = { ...this.options, user }
+    return this
+  }
+
+  async run(): Promise<CommandResult> {
+    if (this.source.length === 0) throw new Error('script source cannot be empty')
+    if (this.interpreterArgv.length === 0) {
+      throw new Error('script interpreter cannot be empty')
+    }
+    return this.commands.run(this.interpreterArgv, {
+      ...this.options,
+      stdin: this.source,
+    })
   }
 }
 
@@ -348,6 +563,32 @@ export class Filesystem {
   }
 }
 
+function bridgeVolumeMount(
+  mount: VolumeMount
+): Readonly<Record<string, unknown>> {
+  return mount.kind === 'bind'
+    ? {
+        kind: 'bind',
+        source: mount.source,
+        target: mount.target,
+        read_only: mount.readOnly ?? false,
+      }
+    : {
+        kind: 'named',
+        name: mount.name,
+        target: mount.target,
+        read_only: mount.readOnly ?? false,
+      }
+}
+
+function isScript(value: string | Uint8Array | Script): value is Script {
+  return (
+    typeof value === 'object' &&
+    !(value instanceof Uint8Array) &&
+    'source' in value
+  )
+}
+
 function entryInfo(entry: Record<string, unknown>): EntryInfo {
   return {
     name: requiredString(entry, 'name'),
@@ -363,6 +604,15 @@ function entryInfo(entry: Record<string, unknown>): EntryInfo {
     ...(typeof entry.symlink_target === 'string'
       ? { symlinkTarget: entry.symlink_target }
       : {}),
+  }
+}
+
+function filesystemSnapshotInfo(result: BridgeResult): FilesystemSnapshotInfo {
+  return {
+    snapshotId: requiredString(result, 'snapshot_id'),
+    sizeBytes: requiredNumber(result, 'size_bytes'),
+    state: requiredString(result, 'state'),
+    generation: requiredNumber(result, 'generation'),
   }
 }
 

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 
 import SandboxDefault, {
+  A3SBoxClient,
   A3SLocalRuntime,
   A3SRemoteConnection,
   DEFAULT_IMAGE,
@@ -15,6 +16,35 @@ class FakeRuntime {
   async request(request) {
     this.requests.push(request)
     switch (request.operation) {
+      case 'image_build':
+        return {
+          reference: request.tag ?? 'local/build:latest',
+          digest: 'sha256:build',
+          size_bytes: 8192,
+          layer_count: 3,
+        }
+      case 'image_pull':
+        return imageResponse(request.reference)
+      case 'image_list':
+        return { images: [imageResponse('alpine:3.20')] }
+      case 'image_remove':
+        return { reference: request.reference, removed: true }
+      case 'volume_create':
+        return volumeResponse(request.name)
+      case 'volume_get':
+        return { volume: volumeResponse(request.name) }
+      case 'volume_list':
+        return { volumes: [volumeResponse('ci-cache')] }
+      case 'volume_remove':
+        return volumeResponse(request.name)
+      case 'network_create':
+        return networkResponse(request.name, request.subnet)
+      case 'network_get':
+        return { network: networkResponse(request.name, '10.89.0.0/24') }
+      case 'network_list':
+        return { networks: [networkResponse('ci-net', '10.89.0.0/24')] }
+      case 'network_remove':
+        return networkResponse(request.name, '10.89.0.0/24')
       case 'sandbox_create':
         return {
           sandbox_id: 'sandbox-local-1',
@@ -26,6 +56,23 @@ class FakeRuntime {
           sandbox_id: request.sandbox_id,
           generation: 2,
           state: 'paused',
+        }
+      case 'sandbox_snapshot_create':
+        return {
+          snapshot_id: request.snapshot_id,
+          size_bytes: 4096,
+          state: 'running',
+          generation: request.generation,
+        }
+      case 'filesystem_snapshot_size':
+        return {
+          snapshot_id: request.snapshot_id,
+          size_bytes: 4096,
+        }
+      case 'filesystem_snapshot_delete':
+        return {
+          snapshot_id: request.snapshot_id,
+          deleted: true,
         }
       case 'command_run':
         return {
@@ -70,6 +117,44 @@ class FakeRuntime {
       default:
         throw new Error(`unexpected operation: ${request.operation}`)
     }
+  }
+}
+
+function imageResponse(reference) {
+  return {
+    reference,
+    digest: 'sha256:image',
+    size_bytes: 4096,
+    pulled_at: '2026-07-23T00:00:00Z',
+    last_used: '2026-07-23T00:00:00Z',
+    path: '/tmp/image',
+  }
+}
+
+function volumeResponse(name) {
+  return {
+    name,
+    driver: 'local',
+    mount_point: `/tmp/volumes/${name}`,
+    labels: { purpose: 'ci' },
+    in_use_by: [],
+    in_use: false,
+    size_limit: 4096,
+    created_at: '2026-07-23T00:00:00Z',
+  }
+}
+
+function networkResponse(name, subnet) {
+  return {
+    name,
+    driver: 'bridge',
+    subnet,
+    gateway: '10.89.0.1',
+    labels: { purpose: 'ci' },
+    endpoints: [],
+    endpoint_count: 0,
+    isolation: 'none',
+    created_at: '2026-07-23T00:00:00Z',
   }
 }
 
@@ -119,6 +204,71 @@ assert.equal(read.path, '/workspace/notes.txt')
 assert.equal(stat.operation, 'filesystem_stat')
 assert.equal(kill.operation, 'sandbox_kill')
 
+const builderRuntime = new FakeRuntime()
+const client = new A3SBoxClient(builderRuntime)
+const builtImage = await client
+  .image('./ci')
+  .dockerfile('Dockerfile.ci')
+  .tag('local/ci-base:latest')
+  .buildArg('NODE_VERSION', '24')
+  .platform('linux/arm64')
+  .build()
+const cacheVolume = await client
+  .volume('ci-cache')
+  .label('purpose', 'ci')
+  .sizeLimit(4096)
+  .create()
+const ciNetwork = await client
+  .network('ci-net')
+  .subnet('10.89.55.0/24')
+  .label('purpose', 'ci')
+  .create()
+const builderSandbox = await client
+  .sandbox(builtImage.reference)
+  .cpus(4)
+  .memoryMb(4096)
+  .mountNamed(cacheVolume.name, '/cache')
+  .network(ciNetwork.name)
+  .publishTcp(8080, 80)
+  .workdir('/workspace')
+  .autoRemove(false)
+  .start()
+const scriptResult = await builderSandbox
+  .script('console.log(6 * 7)\n')
+  .interpreter('node', '-')
+  .env('CI', 'true')
+  .cwd('/workspace')
+  .run()
+await builderSandbox.kill()
+assert.equal(scriptResult.stdout, '42\n')
+assert.equal(builderRuntime.requests[0].operation, 'image_build')
+assert.equal(builderRuntime.requests[0].dockerfile, 'Dockerfile.ci')
+assert.deepEqual(builderRuntime.requests[0].platforms, ['linux/arm64'])
+assert.deepEqual(builderRuntime.requests[3].mounts, [
+  {
+    kind: 'named',
+    name: 'ci-cache',
+    target: '/cache',
+    read_only: false,
+  },
+])
+assert.deepEqual(builderRuntime.requests[3].network, {
+  mode: 'bridge',
+  name: 'ci-net',
+})
+assert.deepEqual(builderRuntime.requests[3].ports, [
+  { host_port: 8080, guest_port: 80 },
+])
+assert.equal(builderRuntime.requests[3].auto_remove, false)
+assert.deepEqual(builderRuntime.requests[4].argv, ['node', '-'])
+assert.equal(
+  Buffer.from(builderRuntime.requests[4].stdin_base64, 'base64').toString(),
+  'console.log(6 * 7)\n'
+)
+await client.removeNetwork(ciNetwork.name)
+await client.removeVolume(cacheVolume.name)
+await client.removeImage(builtImage.reference)
+
 const sandboxIsolationRuntime = new FakeRuntime()
 const sharedKernelSandbox = await Sandbox.create(undefined, {
   isolation: 'sandbox',
@@ -126,6 +276,43 @@ const sharedKernelSandbox = await Sandbox.create(undefined, {
 })
 await sharedKernelSandbox.kill()
 assert.equal(sandboxIsolationRuntime.requests[0].isolation, 'sandbox')
+
+const snapshotRuntime = new FakeRuntime()
+const snapshotSandbox = await Sandbox.create(undefined, {
+  isolation: 'sandbox',
+  filesystemSnapshotId: 'ci-base-source',
+  runtime: snapshotRuntime,
+})
+const snapshot = await snapshotSandbox.createFilesystemSnapshot('ci-base-captured')
+assert.equal(snapshot.snapshotId, 'ci-base-captured')
+assert.equal(snapshot.sizeBytes, 4096)
+assert.equal(
+  await Sandbox.filesystemSnapshotSize(snapshot.snapshotId, {
+    runtime: snapshotRuntime,
+  }),
+  4096
+)
+assert.equal(
+  await Sandbox.deleteFilesystemSnapshot(snapshot.snapshotId, {
+    runtime: snapshotRuntime,
+  }),
+  true
+)
+await snapshotSandbox.kill()
+assert.deepEqual(
+  snapshotRuntime.requests.map((request) => request.operation),
+  [
+    'sandbox_create',
+    'sandbox_snapshot_create',
+    'filesystem_snapshot_size',
+    'filesystem_snapshot_delete',
+    'sandbox_kill',
+  ]
+)
+assert.equal(
+  snapshotRuntime.requests[0].filesystem_snapshot_id,
+  'ci-base-source'
+)
 
 const savedEnvironment = {
   E2B_API_KEY: process.env.E2B_API_KEY,

--- a/src/core/src/port.rs
+++ b/src/core/src/port.rs
@@ -32,6 +32,11 @@ pub struct PortMapping {
 }
 
 impl PortMapping {
+    /// Create and validate one TCP port publication.
+    pub fn tcp(host_port: u16, guest_port: u16) -> Result<Self, String> {
+        parse_port_mapping(&format!("{host_port}:{guest_port}"))
+    }
+
     /// Convert to the normalized runtime `host:guest` format.
     pub fn runtime_entry(&self) -> String {
         format!("{}:{}", self.host_port, self.guest_port)
@@ -128,6 +133,12 @@ mod tests {
         assert_eq!(mapping.protocol, PortProtocol::Tcp);
         assert_eq!(mapping.protocol.as_str(), "tcp");
         assert_eq!(mapping.runtime_entry(), "8080:80");
+    }
+
+    #[test]
+    fn test_typed_tcp_mapping_validates_guest_port() {
+        assert_eq!(PortMapping::tcp(0, 8080).unwrap().runtime_entry(), "0:8080");
+        assert!(PortMapping::tcp(8080, 0).is_err());
     }
 
     #[test]

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -53,6 +53,68 @@ The facade also provides `connect`, `pause`, `resume`, `is_running`, command
 environment/working-directory/stdin options, and file metadata and mutation
 operations. `A3sBoxClient` remains available for lower-level management APIs.
 
+## Builder-Style Programmable CI/CD
+
+The E2B-style facade and the fluent builders are two entry styles over the
+same typed client and lifecycle implementation:
+
+```rust
+use a3s_box_sdk::{A3sBoxClient, SandboxNetwork};
+
+# async fn example() -> Result<(), a3s_box_sdk::ClientError> {
+let client = A3sBoxClient::new();
+let image = client
+    .image("./ci")
+    .dockerfile("Dockerfile")
+    .tag("local/ci-base:latest")
+    .build_arg("NODE_VERSION", "24")
+    .build()
+    .await?;
+let cache = client
+    .volume("npm-cache")
+    .label("purpose", "ci-cache")
+    .size_limit(10 * 1024 * 1024 * 1024)
+    .create()?;
+let network = client
+    .network("ci-net")
+    .subnet("10.89.40.0/24")
+    .create()?;
+
+let sandbox = client
+    .sandbox(image.reference)
+    .cpus(4)
+    .memory_mb(4096)
+    .mount_named(cache.name, "/root/.npm")
+    .network(SandboxNetwork::bridge(network.name))
+    .publish_tcp(8080, 8080)
+    .workdir("/workspace")
+    .start()
+    .await?;
+
+let result = sandbox
+    .script("npm ci\nnpm test\n")
+    .interpreter(["/bin/sh", "-se"])
+    .env("CI", "true")
+    .run()
+    .await?;
+sandbox.kill().await?;
+if result.exit_code != 0 {
+    return Err(a3s_box_sdk::ClientError::Guest(result.stderr));
+}
+# Ok(()) }
+```
+
+Named volumes and networks must be created explicitly before selection.
+Scripts are sent through standard input to the selected interpreter and are
+not interpolated into a host shell command. Typed bind mounts, named-volume
+mounts, tmpfs, TSI/disabled/bridge networking, TCP publications, DNS, host
+aliases, workdir/user/hostname, read-only root filesystems, persistence,
+automatic cleanup, and filesystem-snapshot restore are available on
+`SandboxBuilder` and `SandboxCreateOptions`.
+
+Named bridge networks and published ports are currently MicroVM-only. The
+shared-kernel Sandbox resolver rejects either before runtime mutation.
+
 ## Runtime-Backed Client
 
 ```rust

--- a/src/sdk/src/bridge.rs
+++ b/src/sdk/src/bridge.rs
@@ -5,11 +5,12 @@
 //! the direct Rust SDK and never parses human-facing CLI output.
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use a3s_box_core::{
-    ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionState, FilesystemEntry,
-    FilesystemEntryKind,
+    ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionSnapshot, ExecutionSnapshotId,
+    ExecutionState, FilesystemEntry, FilesystemEntryKind, Platform, PortMapping,
 };
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
@@ -17,8 +18,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
-    A3sBoxClient, ClientError, CommandRunOptions, FilesystemOptions, Sandbox, SandboxCommand,
-    SandboxCreateOptions, DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_TIMEOUT_SECONDS,
+    A3sBoxClient, BuildImage, ClientError, CommandRunOptions, CreateNetwork, CreateVolume,
+    FilesystemOptions, PullImage, Sandbox, SandboxCommand, SandboxCreateOptions, SandboxNetwork,
+    TmpfsMount, VolumeMount, DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_TIMEOUT_SECONDS,
 };
 
 pub const BRIDGE_PROTOCOL_VERSION: u8 = 1;
@@ -26,24 +28,65 @@ pub const BRIDGE_PROTOCOL_VERSION: u8 = 1;
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(tag = "operation", rename_all = "snake_case")]
 pub enum BridgeRequest {
-    SandboxCreate {
-        #[serde(default = "default_image")]
-        image: String,
-        #[serde(default = "default_timeout_seconds")]
-        timeout_seconds: u64,
+    ImageBuild {
+        context_dir: String,
         #[serde(default)]
-        env: BTreeMap<String, String>,
+        dockerfile: Option<String>,
+        #[serde(default)]
+        tag: Option<String>,
+        #[serde(default)]
+        build_args: BTreeMap<String, String>,
+        #[serde(default = "default_true")]
+        quiet: bool,
+        #[serde(default)]
+        platforms: Vec<String>,
+        #[serde(default)]
+        target: Option<String>,
+        #[serde(default)]
+        no_cache: bool,
+    },
+    ImagePull {
+        reference: String,
+        #[serde(default)]
+        force: bool,
+        #[serde(default)]
+        platform: Option<String>,
+    },
+    ImageList,
+    ImageRemove {
+        reference: String,
+    },
+    VolumeCreate {
+        name: String,
         #[serde(default)]
         labels: BTreeMap<String, String>,
         #[serde(default)]
-        name: Option<String>,
-        #[serde(default)]
-        cpus: Option<u32>,
-        #[serde(default)]
-        memory_mb: Option<u32>,
-        #[serde(default)]
-        isolation: ExecutionIsolation,
+        size_limit: u64,
     },
+    VolumeGet {
+        name: String,
+    },
+    VolumeList,
+    VolumeRemove {
+        name: String,
+        #[serde(default)]
+        force: bool,
+    },
+    NetworkCreate {
+        name: String,
+        #[serde(default = "default_network_subnet")]
+        subnet: String,
+        #[serde(default)]
+        labels: BTreeMap<String, String>,
+    },
+    NetworkGet {
+        name: String,
+    },
+    NetworkList,
+    NetworkRemove {
+        name: String,
+    },
+    SandboxCreate(Box<BridgeSandboxCreateRequest>),
     SandboxInspect {
         sandbox_id: String,
     },
@@ -60,6 +103,17 @@ pub enum BridgeRequest {
     SandboxResume {
         sandbox_id: String,
         generation: u64,
+    },
+    SandboxSnapshotCreate {
+        sandbox_id: String,
+        generation: u64,
+        snapshot_id: String,
+    },
+    FilesystemSnapshotSize {
+        snapshot_id: String,
+    },
+    FilesystemSnapshotDelete {
+        snapshot_id: String,
     },
     CommandRun {
         sandbox_id: String,
@@ -129,6 +183,125 @@ pub enum BridgeRequest {
         #[serde(default)]
         user: Option<String>,
     },
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct BridgeSandboxCreateRequest {
+    #[serde(default = "default_image")]
+    image: String,
+    #[serde(default = "default_timeout_seconds")]
+    timeout_seconds: u64,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    labels: BTreeMap<String, String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    cpus: Option<u32>,
+    #[serde(default)]
+    memory_mb: Option<u32>,
+    #[serde(default)]
+    isolation: ExecutionIsolation,
+    #[serde(default)]
+    filesystem_snapshot_id: Option<String>,
+    #[serde(default)]
+    workspace: Option<String>,
+    #[serde(default)]
+    workdir: Option<String>,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default)]
+    hostname: Option<String>,
+    #[serde(default)]
+    mounts: Vec<BridgeVolumeMount>,
+    #[serde(default)]
+    tmpfs: Vec<BridgeTmpfsMount>,
+    #[serde(default)]
+    network: BridgeSandboxNetwork,
+    #[serde(default)]
+    ports: Vec<BridgePortMapping>,
+    #[serde(default)]
+    dns: Vec<String>,
+    #[serde(default)]
+    host_aliases: BTreeMap<String, String>,
+    #[serde(default)]
+    read_only: bool,
+    #[serde(default)]
+    persistent: bool,
+    #[serde(default = "default_true")]
+    auto_remove: bool,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BridgeVolumeMount {
+    Bind {
+        source: String,
+        target: String,
+        #[serde(default)]
+        read_only: bool,
+    },
+    Named {
+        name: String,
+        target: String,
+        #[serde(default)]
+        read_only: bool,
+    },
+}
+
+impl BridgeVolumeMount {
+    fn into_mount(self) -> VolumeMount {
+        match self {
+            Self::Bind {
+                source,
+                target,
+                read_only,
+            } => VolumeMount::bind(source, target).read_only(read_only),
+            Self::Named {
+                name,
+                target,
+                read_only,
+            } => VolumeMount::named(name, target).read_only(read_only),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum BridgeSandboxNetwork {
+    #[default]
+    Tsi,
+    #[serde(rename = "none")]
+    Disabled,
+    Bridge {
+        name: String,
+    },
+}
+
+impl From<BridgeSandboxNetwork> for SandboxNetwork {
+    fn from(value: BridgeSandboxNetwork) -> Self {
+        match value {
+            BridgeSandboxNetwork::Tsi => Self::Tsi,
+            BridgeSandboxNetwork::Disabled => Self::Disabled,
+            BridgeSandboxNetwork::Bridge { name } => Self::bridge(name),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct BridgePortMapping {
+    pub host_port: u16,
+    pub guest_port: u16,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct BridgeTmpfsMount {
+    pub target: String,
+    #[serde(default)]
+    pub size_bytes: Option<u64>,
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -202,16 +375,148 @@ async fn execute_request(
     request: BridgeRequest,
 ) -> Result<Value, BridgeFailure> {
     match request {
-        BridgeRequest::SandboxCreate {
-            image,
-            timeout_seconds,
-            env,
-            labels,
-            name,
-            cpus,
-            memory_mb,
-            isolation,
+        BridgeRequest::ImageBuild {
+            context_dir,
+            dockerfile,
+            tag,
+            build_args,
+            quiet,
+            platforms,
+            target,
+            no_cache,
         } => {
+            let context_dir = PathBuf::from(context_dir);
+            // Bridge stdout is reserved for one JSON response envelope. The
+            // runtime builder's human progress renderer writes to stdout, so
+            // language SDK builds must stay quiet until progress is exposed as
+            // a separate structured event channel.
+            if !quiet {
+                return Err(invalid(
+                    "language SDK image builds must be quiet because bridge stdout is reserved for JSON; structured build progress is not implemented yet",
+                ));
+            }
+            let mut request = BuildImage::new(&context_dir).quiet(true).no_cache(no_cache);
+            if let Some(path) = dockerfile {
+                let path = PathBuf::from(path);
+                request = request.dockerfile_path(if path.is_relative() {
+                    context_dir.join(path)
+                } else {
+                    path
+                });
+            }
+            if let Some(tag) = tag {
+                request = request.tag(tag);
+            }
+            for (key, value) in build_args {
+                request = request.build_arg(key, value);
+            }
+            for platform in platforms {
+                request =
+                    request.platform(Platform::parse(&platform).map_err(ClientError::Validation)?);
+            }
+            if let Some(target) = target {
+                request = request.target(target);
+            }
+            serialize_value(client.build_image(request).await?)
+        }
+        BridgeRequest::ImagePull {
+            reference,
+            force,
+            platform,
+        } => {
+            let mut request = PullImage::new(reference).force(force);
+            if let Some(platform) = platform {
+                Platform::parse(&platform).map_err(ClientError::Validation)?;
+                request = request.platform(platform);
+            }
+            serialize_value(client.pull_image(request).await?)
+        }
+        BridgeRequest::ImageList => serialize_field("images", client.list_images().await?),
+        BridgeRequest::ImageRemove { reference } => {
+            client.remove_image(&reference).await?;
+            Ok(json!({
+                "reference": reference,
+                "removed": true,
+            }))
+        }
+        BridgeRequest::VolumeCreate {
+            name,
+            labels,
+            size_limit,
+        } => {
+            let mut request = CreateVolume::new(name).size_limit(size_limit);
+            for (key, value) in labels {
+                request = request.label(key, value);
+            }
+            serialize_value(client.create_volume(request)?)
+        }
+        BridgeRequest::VolumeGet { name } => serialize_field("volume", client.get_volume(&name)?),
+        BridgeRequest::VolumeList => serialize_field("volumes", client.list_volumes()?),
+        BridgeRequest::VolumeRemove { name, force } => {
+            serialize_value(client.remove_volume(&name, force)?)
+        }
+        BridgeRequest::NetworkCreate {
+            name,
+            subnet,
+            labels,
+        } => {
+            let mut request = CreateNetwork::new(name).subnet(subnet);
+            for (key, value) in labels {
+                request = request.label(key, value);
+            }
+            serialize_value(client.create_network(request)?)
+        }
+        BridgeRequest::NetworkGet { name } => {
+            serialize_field("network", client.get_network(&name)?)
+        }
+        BridgeRequest::NetworkList => serialize_field("networks", client.list_networks()?),
+        BridgeRequest::NetworkRemove { name } => serialize_value(client.remove_network(&name)?),
+        BridgeRequest::SandboxCreate(request) => {
+            let BridgeSandboxCreateRequest {
+                image,
+                timeout_seconds,
+                env,
+                labels,
+                name,
+                cpus,
+                memory_mb,
+                isolation,
+                filesystem_snapshot_id,
+                workspace,
+                workdir,
+                user,
+                hostname,
+                mounts,
+                tmpfs,
+                network,
+                ports,
+                dns,
+                host_aliases,
+                read_only,
+                persistent,
+                auto_remove,
+            } = *request;
+            let rootfs_snapshot_id = filesystem_snapshot_id
+                .map(ExecutionSnapshotId::new)
+                .transpose()
+                .map_err(|error| invalid(error.to_string()))?;
+            let ports = ports
+                .into_iter()
+                .map(|port| {
+                    PortMapping::tcp(port.host_port, port.guest_port)
+                        .map_err(ClientError::Validation)
+                })
+                .collect::<crate::Result<Vec<_>>>()?;
+            let tmpfs = tmpfs
+                .into_iter()
+                .map(|mount| {
+                    let mut value = TmpfsMount::new(mount.target).read_only(mount.read_only);
+                    if let Some(size_bytes) = mount.size_bytes {
+                        value = value.size_bytes(size_bytes);
+                    }
+                    value
+                })
+                .collect();
             let sandbox = Sandbox::create_with_client(
                 client.clone(),
                 SandboxCreateOptions {
@@ -223,6 +528,23 @@ async fn execute_request(
                     cpus,
                     memory_mb,
                     isolation,
+                    rootfs_snapshot_id,
+                    workspace: workspace.map(PathBuf::from),
+                    workdir,
+                    user,
+                    hostname,
+                    mounts: mounts
+                        .into_iter()
+                        .map(BridgeVolumeMount::into_mount)
+                        .collect(),
+                    tmpfs,
+                    network: network.into(),
+                    ports,
+                    dns_servers: dns,
+                    host_aliases,
+                    read_only,
+                    persistent,
+                    auto_remove,
                 },
             )
             .await?;
@@ -256,6 +578,35 @@ async fn execute_request(
             let sandbox = bridge_sandbox(client, sandbox_id, generation, ExecutionState::Paused)?;
             sandbox.resume().await?;
             Ok(sandbox_info_value(&sandbox))
+        }
+        BridgeRequest::SandboxSnapshotCreate {
+            sandbox_id,
+            generation,
+            snapshot_id,
+        } => {
+            let sandbox = connected_sandbox(client, sandbox_id, generation).await?;
+            let snapshot_id = ExecutionSnapshotId::new(snapshot_id)
+                .map_err(|error| invalid(error.to_string()))?;
+            let snapshot = sandbox.create_filesystem_snapshot(snapshot_id).await?;
+            Ok(execution_snapshot_value(&snapshot))
+        }
+        BridgeRequest::FilesystemSnapshotSize { snapshot_id } => {
+            let snapshot_id = ExecutionSnapshotId::new(snapshot_id)
+                .map_err(|error| invalid(error.to_string()))?;
+            let size_bytes = client.execution_snapshot_size(&snapshot_id).await?;
+            Ok(json!({
+                "snapshot_id": snapshot_id,
+                "size_bytes": size_bytes,
+            }))
+        }
+        BridgeRequest::FilesystemSnapshotDelete { snapshot_id } => {
+            let snapshot_id = ExecutionSnapshotId::new(snapshot_id)
+                .map_err(|error| invalid(error.to_string()))?;
+            let deleted = client.delete_execution_snapshot(&snapshot_id).await?;
+            Ok(json!({
+                "snapshot_id": snapshot_id,
+                "deleted": deleted,
+            }))
         }
         BridgeRequest::CommandRun {
             sandbox_id,
@@ -419,12 +770,46 @@ fn bridge_sandbox(
     ))
 }
 
+async fn connected_sandbox(
+    client: &A3sBoxClient,
+    sandbox_id: String,
+    generation: u64,
+) -> Result<Sandbox, BridgeFailure> {
+    let execution_id = execution_id(sandbox_id)?;
+    let expected_generation = parse_generation(generation)?;
+    let status = client.inspect_execution(&execution_id).await?;
+    if status.generation != expected_generation {
+        return Err(invalid(format!(
+            "sandbox {} generation changed from {} to {}",
+            execution_id,
+            expected_generation.get(),
+            status.generation.get()
+        )));
+    }
+    Ok(Sandbox::from_known_state(
+        client.clone(),
+        execution_id,
+        status.generation,
+        status.state,
+        status.plan.requested_isolation,
+    ))
+}
+
 fn sandbox_info_value(sandbox: &Sandbox) -> Value {
     let info = sandbox.info();
     json!({
         "sandbox_id": info.sandbox_id,
         "generation": info.generation,
         "state": state_name(info.state),
+    })
+}
+
+fn execution_snapshot_value(snapshot: &ExecutionSnapshot) -> Value {
+    json!({
+        "snapshot_id": snapshot.snapshot_id,
+        "size_bytes": snapshot.size_bytes,
+        "state": state_name(snapshot.state),
+        "generation": snapshot.lease.generation.get(),
     })
 }
 
@@ -448,6 +833,19 @@ fn entry_value(entry: &FilesystemEntry) -> Value {
     })
 }
 
+fn serialize_value(value: impl Serialize) -> Result<Value, BridgeFailure> {
+    serde_json::to_value(value).map_err(|error| BridgeFailure {
+        code: "runtime_error",
+        message: format!("failed to encode SDK bridge result: {error}"),
+    })
+}
+
+fn serialize_field(name: &str, value: impl Serialize) -> Result<Value, BridgeFailure> {
+    let mut result = serde_json::Map::new();
+    result.insert(name.to_string(), serialize_value(value)?);
+    Ok(Value::Object(result))
+}
+
 fn state_name(state: ExecutionState) -> &'static str {
     match state {
         ExecutionState::Created => "created",
@@ -469,6 +867,10 @@ fn parse_generation(value: u64) -> Result<ExecutionGeneration, BridgeFailure> {
 
 fn default_image() -> String {
     DEFAULT_SANDBOX_IMAGE.to_string()
+}
+
+fn default_network_subnet() -> String {
+    "10.89.0.0/24".to_string()
 }
 
 const fn default_timeout_seconds() -> u64 {
@@ -526,67 +928,5 @@ impl From<ClientError> for BridgeFailure {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn create_request_defaults_to_a_local_microvm() {
-        let request: BridgeRequest =
-            serde_json::from_str(r#"{"operation":"sandbox_create"}"#).unwrap();
-        let BridgeRequest::SandboxCreate {
-            image,
-            timeout_seconds,
-            isolation,
-            ..
-        } = request
-        else {
-            panic!("expected create request");
-        };
-        assert_eq!(image, DEFAULT_SANDBOX_IMAGE);
-        assert_eq!(timeout_seconds, DEFAULT_SANDBOX_TIMEOUT_SECONDS);
-        assert_eq!(isolation, ExecutionIsolation::Microvm);
-    }
-
-    #[test]
-    fn create_request_maps_language_options_to_the_runtime_facade() {
-        let (request, _) = SandboxCreateOptions {
-            image: "python:3.12-alpine".to_string(),
-            timeout_seconds: 120,
-            envs: BTreeMap::from([("MODE".to_string(), "test".to_string())]),
-            metadata: BTreeMap::from([("suite".to_string(), "sdk".to_string())]),
-            name: Some("local-sdk".to_string()),
-            cpus: Some(4),
-            memory_mb: Some(2048),
-            isolation: ExecutionIsolation::Sandbox,
-        }
-        .into_runtime_request()
-        .unwrap();
-
-        assert_eq!(request.config.image, "python:3.12-alpine");
-        assert_eq!(request.config.resources.timeout, 120);
-        assert_eq!(request.config.resources.vcpus, 4);
-        assert_eq!(request.config.resources.memory_mb, 2048);
-        assert_eq!(request.config.isolation, ExecutionIsolation::Sandbox);
-        assert_eq!(
-            request.config.cmd,
-            ["/bin/sh", "-c", "while :; do sleep 3600; done"]
-        );
-        assert_eq!(request.policy.name.as_deref(), Some("local-sdk"));
-        assert!(request.policy.auto_remove);
-        assert_eq!(request.labels.get("suite").map(String::as_str), Some("sdk"));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_returns_a_versioned_error_envelope() {
-        let response = dispatch_json("{").await;
-        assert_eq!(response.protocol_version, BRIDGE_PROTOCOL_VERSION);
-        assert!(!response.ok);
-        assert_eq!(response.error.unwrap().code, "invalid_request");
-    }
-
-    #[test]
-    fn zero_generation_is_rejected_before_runtime_access() {
-        let error = parse_generation(0).unwrap_err();
-        assert_eq!(error.code, "invalid_request");
-    }
-}
+#[path = "bridge/tests.rs"]
+mod tests;

--- a/src/sdk/src/bridge/tests.rs
+++ b/src/sdk/src/bridge/tests.rs
@@ -1,0 +1,216 @@
+use super::*;
+
+#[test]
+fn create_request_defaults_to_a_local_microvm() {
+    let request: BridgeRequest = serde_json::from_str(r#"{"operation":"sandbox_create"}"#).unwrap();
+    let BridgeRequest::SandboxCreate(request) = request else {
+        panic!("expected create request");
+    };
+    assert_eq!(request.image, DEFAULT_SANDBOX_IMAGE);
+    assert_eq!(request.timeout_seconds, DEFAULT_SANDBOX_TIMEOUT_SECONDS);
+    assert_eq!(request.isolation, ExecutionIsolation::Microvm);
+}
+
+#[test]
+fn create_request_maps_language_options_to_the_runtime_facade() {
+    let home = tempfile::tempdir().unwrap();
+    let client = A3sBoxClient::from_home(home.path());
+    let source_snapshot = ExecutionSnapshotId::new("ci-base-source").unwrap();
+    let (request, _) = SandboxCreateOptions::new("python:3.12-alpine")
+        .timeout_seconds(120)
+        .env("MODE", "test")
+        .metadata("suite", "sdk")
+        .name("local-sdk")
+        .cpus(4)
+        .memory_mb(2048)
+        .isolation(ExecutionIsolation::Sandbox)
+        .filesystem_snapshot(source_snapshot.clone())
+        .into_runtime_request(&client)
+        .unwrap();
+
+    assert_eq!(request.config.image, "python:3.12-alpine");
+    assert_eq!(request.config.resources.timeout, 120);
+    assert_eq!(request.config.resources.vcpus, 4);
+    assert_eq!(request.config.resources.memory_mb, 2048);
+    assert_eq!(request.config.isolation, ExecutionIsolation::Sandbox);
+    assert_eq!(
+        request.config.cmd,
+        ["/bin/sh", "-c", "while :; do sleep 3600; done"]
+    );
+    assert_eq!(request.policy.name.as_deref(), Some("local-sdk"));
+    assert!(request.policy.auto_remove);
+    assert_eq!(request.labels.get("suite").map(String::as_str), Some("sdk"));
+    assert_eq!(request.rootfs_snapshot_id, Some(source_snapshot));
+}
+
+#[test]
+fn builder_maps_typed_storage_network_and_runtime_options() {
+    let home = tempfile::tempdir().unwrap();
+    let client = A3sBoxClient::from_home(home.path());
+    client.volume("ci-cache").size_limit(4096).create().unwrap();
+    client
+        .network("ci-net")
+        .subnet("10.89.77.0/24")
+        .create()
+        .unwrap();
+
+    let (request, _) = SandboxCreateOptions::new("local/ci-base:latest")
+        .mount(VolumeMount::named("ci-cache", "/cache").read_only(true))
+        .tmpfs(TmpfsMount::new("/scratch").size_bytes(1024))
+        .network(SandboxNetwork::bridge("ci-net"))
+        .publish_port(PortMapping::tcp(8080, 80).unwrap())
+        .workdir("/workspace")
+        .user("1000:1000")
+        .hostname("ci-runner")
+        .dns_server("1.1.1.1")
+        .host_alias("registry.local", "10.89.77.10")
+        .read_only(true)
+        .persistent(true)
+        .auto_remove(false)
+        .into_runtime_request(&client)
+        .unwrap();
+
+    assert_eq!(request.policy.volume_names, ["ci-cache"]);
+    assert_eq!(request.config.network.to_string(), "bridge:ci-net");
+    assert_eq!(request.config.port_map, ["8080:80"]);
+    assert_eq!(request.config.tmpfs, ["/scratch:size=1024"]);
+    assert_eq!(request.config.workdir.as_deref(), Some("/workspace"));
+    assert_eq!(request.config.user.as_deref(), Some("1000:1000"));
+    assert_eq!(request.config.hostname.as_deref(), Some("ci-runner"));
+    assert_eq!(request.config.dns, ["1.1.1.1"]);
+    assert_eq!(request.config.add_hosts, ["registry.local:10.89.77.10"]);
+    assert!(request.config.volumes[0].ends_with(":/cache:ro"));
+    assert!(request.config.read_only);
+    assert!(request.config.persistent);
+    assert!(!request.policy.auto_remove);
+}
+
+#[tokio::test]
+async fn malformed_json_returns_a_versioned_error_envelope() {
+    let response = dispatch_json("{").await;
+    assert_eq!(response.protocol_version, BRIDGE_PROTOCOL_VERSION);
+    assert!(!response.ok);
+    assert_eq!(response.error.unwrap().code, "invalid_request");
+}
+
+#[tokio::test]
+async fn snapshot_ids_are_validated_before_runtime_access() {
+    let response =
+        dispatch_json(r#"{"operation":"filesystem_snapshot_size","snapshot_id":"../escape"}"#)
+            .await;
+    assert!(!response.ok);
+    assert_eq!(response.error.unwrap().code, "invalid_request");
+}
+
+#[test]
+fn zero_generation_is_rejected_before_runtime_access() {
+    let error = parse_generation(0).unwrap_err();
+    assert_eq!(error.code, "invalid_request");
+}
+
+#[test]
+fn builder_bridge_shapes_deserialize_as_typed_requests() {
+    let request: BridgeRequest = serde_json::from_str(
+        r#"{
+            "operation":"sandbox_create",
+            "image":"local/ci-base:latest",
+            "mounts":[
+                {"kind":"named","name":"ci-cache","target":"/cache","read_only":true}
+            ],
+            "network":{"mode":"bridge","name":"ci-net"},
+            "ports":[{"host_port":8080,"guest_port":80}],
+            "tmpfs":[{"target":"/scratch","size_bytes":4096}],
+            "auto_remove":false
+        }"#,
+    )
+    .unwrap();
+    let BridgeRequest::SandboxCreate(request) = request else {
+        panic!("expected sandbox builder request");
+    };
+    assert_eq!(
+        request.mounts,
+        [BridgeVolumeMount::Named {
+            name: "ci-cache".to_string(),
+            target: "/cache".to_string(),
+            read_only: true,
+        }]
+    );
+    assert_eq!(
+        request.network,
+        BridgeSandboxNetwork::Bridge {
+            name: "ci-net".to_string()
+        }
+    );
+    assert_eq!(
+        request.ports,
+        [BridgePortMapping {
+            host_port: 8080,
+            guest_port: 80
+        }]
+    );
+    assert_eq!(request.tmpfs[0].size_bytes, Some(4096));
+    assert!(!request.auto_remove);
+}
+
+#[tokio::test]
+async fn resource_bridge_operations_use_typed_runtime_stores() {
+    let home = tempfile::tempdir().unwrap();
+    let client = A3sBoxClient::from_home(home.path());
+
+    let volume = handle_request(
+        &client,
+        BridgeRequest::VolumeCreate {
+            name: "ci-cache".to_string(),
+            labels: BTreeMap::from([("purpose".to_string(), "ci".to_string())]),
+            size_limit: 4096,
+        },
+    )
+    .await;
+    assert!(volume.ok);
+    assert_eq!(
+        volume.result.unwrap()["mount_point"],
+        home.path()
+            .join("volumes/ci-cache")
+            .to_string_lossy()
+            .as_ref()
+    );
+
+    let network = handle_request(
+        &client,
+        BridgeRequest::NetworkCreate {
+            name: "ci-net".to_string(),
+            subnet: "10.89.88.0/24".to_string(),
+            labels: BTreeMap::new(),
+        },
+    )
+    .await;
+    assert!(network.ok);
+    assert_eq!(network.result.unwrap()["subnet"], "10.89.88.0/24");
+
+    let volumes = handle_request(&client, BridgeRequest::VolumeList).await;
+    assert_eq!(volumes.result.unwrap()["volumes"][0]["name"], "ci-cache");
+    let networks = handle_request(&client, BridgeRequest::NetworkList).await;
+    assert_eq!(networks.result.unwrap()["networks"][0]["name"], "ci-net");
+}
+
+#[tokio::test]
+async fn bridge_rejects_human_image_progress_on_machine_stdout() {
+    let home = tempfile::tempdir().unwrap();
+    let client = A3sBoxClient::from_home(home.path());
+    let response = handle_request(
+        &client,
+        BridgeRequest::ImageBuild {
+            context_dir: ".".to_string(),
+            dockerfile: None,
+            tag: None,
+            build_args: BTreeMap::new(),
+            quiet: false,
+            platforms: Vec::new(),
+            target: None,
+            no_cache: false,
+        },
+    )
+    .await;
+    assert!(!response.ok);
+    assert_eq!(response.error.unwrap().code, "invalid_request");
+}

--- a/src/sdk/src/client/builders.rs
+++ b/src/sdk/src/client/builders.rs
@@ -1,0 +1,154 @@
+/// Fluent OCI image builder backed by the local runtime build engine.
+#[derive(Debug, Clone)]
+pub struct ImageBuilder {
+    client: A3sBoxClient,
+    request: BuildImage,
+}
+
+impl ImageBuilder {
+    fn new(client: A3sBoxClient, context_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            client,
+            request: BuildImage::new(context_dir),
+        }
+    }
+
+    /// Select a Dockerfile. Relative paths are resolved from the build context.
+    pub fn dockerfile(mut self, path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        self.request.dockerfile_path = if path.is_relative() {
+            self.request.context_dir.join(path)
+        } else {
+            path
+        };
+        self
+    }
+
+    pub fn tag(mut self, tag: impl Into<String>) -> Self {
+        self.request.tag = Some(tag.into());
+        self
+    }
+
+    pub fn build_arg(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.request.build_args.insert(key.into(), value.into());
+        self
+    }
+
+    pub const fn quiet(mut self, quiet: bool) -> Self {
+        self.request.quiet = quiet;
+        self
+    }
+
+    pub fn platform(mut self, platform: Platform) -> Self {
+        self.request.platforms.push(platform);
+        self
+    }
+
+    pub fn target(mut self, target: impl Into<String>) -> Self {
+        self.request.target = Some(target.into());
+        self
+    }
+
+    pub const fn no_cache(mut self, no_cache: bool) -> Self {
+        self.request.no_cache = no_cache;
+        self
+    }
+
+    pub fn request(&self) -> &BuildImage {
+        &self.request
+    }
+
+    pub async fn build(self) -> Result<BuildImageSummary> {
+        self.client.build_image(self.request).await
+    }
+}
+
+/// Fluent named-volume builder.
+#[derive(Debug, Clone)]
+pub struct VolumeBuilder {
+    client: A3sBoxClient,
+    request: CreateVolume,
+}
+
+impl VolumeBuilder {
+    fn new(client: A3sBoxClient, name: impl Into<String>) -> Self {
+        Self {
+            client,
+            request: CreateVolume::new(name),
+        }
+    }
+
+    pub fn label(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.request.labels.insert(key.into(), value.into());
+        self
+    }
+
+    pub const fn size_limit(mut self, bytes: u64) -> Self {
+        self.request.size_limit = bytes;
+        self
+    }
+
+    pub fn request(&self) -> &CreateVolume {
+        &self.request
+    }
+
+    pub fn create(self) -> Result<VolumeSummary> {
+        self.client.create_volume(self.request)
+    }
+}
+
+/// Fluent bridge-network builder.
+#[derive(Debug, Clone)]
+pub struct NetworkBuilder {
+    client: A3sBoxClient,
+    request: CreateNetwork,
+}
+
+impl NetworkBuilder {
+    fn new(client: A3sBoxClient, name: impl Into<String>) -> Self {
+        Self {
+            client,
+            request: CreateNetwork::new(name),
+        }
+    }
+
+    pub fn subnet(mut self, subnet: impl Into<String>) -> Self {
+        self.request.subnet = subnet.into();
+        self
+    }
+
+    pub fn label(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.request.labels.insert(key.into(), value.into());
+        self
+    }
+
+    pub const fn isolation(mut self, isolation: IsolationMode) -> Self {
+        self.request.isolation = isolation;
+        self
+    }
+
+    pub fn request(&self) -> &CreateNetwork {
+        &self.request
+    }
+
+    pub fn create(self) -> Result<NetworkSummary> {
+        self.client.create_network(self.request)
+    }
+}
+
+impl A3sBoxClient {
+    /// Start a fluent local OCI image build.
+    pub fn image(&self, context_dir: impl Into<PathBuf>) -> ImageBuilder {
+        ImageBuilder::new(self.clone(), context_dir)
+    }
+
+    /// Start a fluent named-volume creation request.
+    pub fn volume(&self, name: impl Into<String>) -> VolumeBuilder {
+        VolumeBuilder::new(self.clone(), name)
+    }
+
+    /// Start a fluent bridge-network creation request.
+    pub fn network(&self, name: impl Into<String>) -> NetworkBuilder {
+        NetworkBuilder::new(self.clone(), name)
+    }
+}

--- a/src/sdk/src/client/lifecycle.rs
+++ b/src/sdk/src/client/lifecycle.rs
@@ -37,6 +37,48 @@ impl A3sBoxClient {
         Ok(self.execution_manager.inspect(execution_id).await?)
     }
 
+    /// Atomically capture one running or paused execution filesystem.
+    ///
+    /// The runtime temporarily quiesces a running execution, publishes the
+    /// snapshot under the validated identifier, and restores the prior stable
+    /// state before returning.
+    pub async fn create_execution_snapshot(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+        snapshot_id: &ExecutionSnapshotId,
+    ) -> Result<ExecutionSnapshot> {
+        Ok(self
+            .execution_manager
+            .create_filesystem_snapshot(execution_id, generation, snapshot_id)
+            .await?)
+    }
+
+    /// Return the published size of a runtime-managed filesystem snapshot.
+    pub async fn execution_snapshot_size(
+        &self,
+        snapshot_id: &ExecutionSnapshotId,
+    ) -> Result<Option<u64>> {
+        Ok(self
+            .execution_manager
+            .filesystem_snapshot_size(snapshot_id)
+            .await?)
+    }
+
+    /// Delete a runtime-managed filesystem snapshot.
+    ///
+    /// The runtime refuses deletion while a live execution still uses the
+    /// snapshot as its immutable copy-on-write lower.
+    pub async fn delete_execution_snapshot(
+        &self,
+        snapshot_id: &ExecutionSnapshotId,
+    ) -> Result<bool> {
+        Ok(self
+            .execution_manager
+            .delete_filesystem_snapshot(snapshot_id)
+            .await?)
+    }
+
     /// Pause a managed execution through its resolved backend.
     pub async fn pause_execution(
         &self,

--- a/src/sdk/src/client/mod.rs
+++ b/src/sdk/src/client/mod.rs
@@ -20,8 +20,9 @@ use a3s_box_core::volume::VolumeConfig;
 use a3s_box_core::{
     CreateExecutionRequest, ExecOutput, ExecRequest, ExecutionGeneration, ExecutionId,
     ExecutionLease, ExecutionManager, ExecutionReservation, ExecutionSessionManager,
-    ExecutionStatus, FileRequest, FileResponse, FilesystemRequest, FilesystemResponse, KillOutcome,
-    OperationId, ReconcileOutcome, RestartExecutionOptions, StoredImage,
+    ExecutionSnapshot, ExecutionSnapshotId, ExecutionStatus, FileRequest, FileResponse,
+    FilesystemRequest, FilesystemResponse, KillOutcome, OperationId, ReconcileOutcome,
+    RestartExecutionOptions, StoredImage,
 };
 use a3s_box_runtime::oci::BuildResult as RuntimeBuildResult;
 use a3s_box_runtime::{
@@ -43,6 +44,7 @@ use crate::box_state::{BoxRecord, StateFile};
 include!("types.rs");
 include!("summaries.rs");
 include!("core.rs");
+include!("builders.rs");
 include!("lifecycle.rs");
 include!("support.rs");
 

--- a/src/sdk/src/lib.rs
+++ b/src/sdk/src/lib.rs
@@ -16,16 +16,17 @@ pub mod pipeline;
 
 pub use client::{
     A3sBoxClient, A3sBoxPaths, BoxLogLine, BoxStatsSummary, BoxSummary, BuildImage,
-    BuildImageSummary, ClientError, CreateNetwork, CreateSnapshot, CreateVolume,
+    BuildImageSummary, ClientError, CreateNetwork, CreateSnapshot, CreateVolume, ImageBuilder,
     ImageHealthCheckSummary, ImageHistoryEntry, ImageInspectSummary, ImageSummary,
-    ListBoxesOptions, NetworkEndpointSummary, NetworkSummary, PullImage, PushImage,
+    ListBoxesOptions, NetworkBuilder, NetworkEndpointSummary, NetworkSummary, PullImage, PushImage,
     PushImageSummary, ReadBoxLogsOptions, RegistryCredentials, RemoveBox, RemoveBoxSummary,
     RestoreSnapshot, Result, RuntimeDiagnostics, RuntimeDiskUsage, RuntimeVirtualizationSummary,
-    SnapshotSummary, StopBox, StopBoxSummary, StopOutcome, TagImage, VolumeSummary,
+    SnapshotSummary, StopBox, StopBoxSummary, StopOutcome, TagImage, VolumeBuilder, VolumeSummary,
 };
 pub use sandbox::{
     CommandResult, CommandRunOptions, Commands, Filesystem, FilesystemOptions, Sandbox,
-    SandboxCommand, SandboxCreateOptions, SandboxInfo, WriteInfo, DEFAULT_SANDBOX_IMAGE,
+    SandboxBuilder, SandboxCommand, SandboxCreateOptions, SandboxInfo, SandboxNetwork,
+    ScriptBuilder, TmpfsMount, VolumeMount, VolumeSource, WriteInfo, DEFAULT_SANDBOX_IMAGE,
     DEFAULT_SANDBOX_TIMEOUT_SECONDS,
 };
 
@@ -33,9 +34,10 @@ pub use a3s_box_core::{
     BoxConfig, CreateExecutionRequest, ExecOutput, ExecRequest, ExecutionGeneration,
     ExecutionHealthCheck, ExecutionId, ExecutionIsolation, ExecutionLease, ExecutionManager,
     ExecutionManagerError, ExecutionRecordPolicy, ExecutionReservation, ExecutionRestartPolicy,
-    ExecutionState, ExecutionStatus, FileOp, FileRequest, FileResponse, FilesystemEntry,
-    FilesystemEntryKind, FilesystemOp, FilesystemRequest, FilesystemResponse, KillOutcome,
-    OperationId, Platform, ReconcileOutcome, RestartExecutionOptions,
+    ExecutionSnapshot, ExecutionSnapshotId, ExecutionState, ExecutionStatus, FileOp, FileRequest,
+    FileResponse, FilesystemEntry, FilesystemEntryKind, FilesystemOp, FilesystemRequest,
+    FilesystemResponse, KillOutcome, OperationId, Platform, PortMapping, PortProtocol,
+    ReconcileOutcome, RestartExecutionOptions,
 };
 pub use a3s_box_runtime::{RegistryAuth, RegistryProtocol, SignaturePolicy};
 

--- a/src/sdk/src/sandbox/builder.rs
+++ b/src/sdk/src/sandbox/builder.rs
@@ -1,0 +1,160 @@
+use std::path::PathBuf;
+
+use a3s_box_core::{ExecutionIsolation, ExecutionSnapshotId, PortMapping};
+
+use super::{Sandbox, SandboxCreateOptions, SandboxNetwork, TmpfsMount, VolumeMount};
+use crate::{A3sBoxClient, Result};
+
+/// Fluent builder for a local Sandbox.
+#[derive(Debug, Clone)]
+pub struct SandboxBuilder {
+    client: A3sBoxClient,
+    options: SandboxCreateOptions,
+}
+
+impl SandboxBuilder {
+    pub(crate) fn new(client: A3sBoxClient, image: impl Into<String>) -> Self {
+        Self {
+            client,
+            options: SandboxCreateOptions::new(image),
+        }
+    }
+
+    pub const fn timeout_seconds(mut self, timeout_seconds: u64) -> Self {
+        self.options.timeout_seconds = timeout_seconds;
+        self
+    }
+
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.options.envs.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.options.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.options.name = Some(name.into());
+        self
+    }
+
+    pub const fn cpus(mut self, cpus: u32) -> Self {
+        self.options.cpus = Some(cpus);
+        self
+    }
+
+    pub const fn memory_mb(mut self, memory_mb: u32) -> Self {
+        self.options.memory_mb = Some(memory_mb);
+        self
+    }
+
+    pub const fn isolation(mut self, isolation: ExecutionIsolation) -> Self {
+        self.options.isolation = isolation;
+        self
+    }
+
+    pub fn filesystem_snapshot(mut self, snapshot_id: ExecutionSnapshotId) -> Self {
+        self.options.rootfs_snapshot_id = Some(snapshot_id);
+        self
+    }
+
+    pub fn workspace(mut self, path: impl Into<PathBuf>) -> Self {
+        self.options.workspace = Some(path.into());
+        self
+    }
+
+    pub fn workdir(mut self, path: impl Into<String>) -> Self {
+        self.options.workdir = Some(path.into());
+        self
+    }
+
+    pub fn user(mut self, user: impl Into<String>) -> Self {
+        self.options.user = Some(user.into());
+        self
+    }
+
+    pub fn hostname(mut self, hostname: impl Into<String>) -> Self {
+        self.options.hostname = Some(hostname.into());
+        self
+    }
+
+    pub fn mount(mut self, mount: VolumeMount) -> Self {
+        self.options.mounts.push(mount);
+        self
+    }
+
+    pub fn mount_bind(self, source: impl Into<PathBuf>, target: impl Into<String>) -> Self {
+        self.mount(VolumeMount::bind(source, target))
+    }
+
+    pub fn mount_named(self, name: impl Into<String>, target: impl Into<String>) -> Self {
+        self.mount(VolumeMount::named(name, target))
+    }
+
+    pub fn tmpfs(mut self, mount: TmpfsMount) -> Self {
+        self.options.tmpfs.push(mount);
+        self
+    }
+
+    pub fn network(mut self, network: SandboxNetwork) -> Self {
+        self.options.network = network;
+        self
+    }
+
+    pub fn publish_port(mut self, port: PortMapping) -> Self {
+        self.options.ports.push(port);
+        self
+    }
+
+    pub fn publish_tcp(mut self, host_port: u16, guest_port: u16) -> Self {
+        self.options.ports.push(PortMapping {
+            host_port,
+            guest_port,
+            protocol: a3s_box_core::PortProtocol::Tcp,
+        });
+        self
+    }
+
+    pub fn dns_server(mut self, server: impl Into<String>) -> Self {
+        self.options.dns_servers.push(server.into());
+        self
+    }
+
+    pub fn host_alias(mut self, host: impl Into<String>, ip: impl Into<String>) -> Self {
+        self.options.host_aliases.insert(host.into(), ip.into());
+        self
+    }
+
+    pub const fn read_only(mut self, read_only: bool) -> Self {
+        self.options.read_only = read_only;
+        self
+    }
+
+    pub const fn persistent(mut self, persistent: bool) -> Self {
+        self.options.persistent = persistent;
+        self
+    }
+
+    pub const fn auto_remove(mut self, auto_remove: bool) -> Self {
+        self.options.auto_remove = auto_remove;
+        self
+    }
+
+    pub async fn start(self) -> Result<Sandbox> {
+        Sandbox::create_with_client(self.client, self.options).await
+    }
+
+    /// Return the typed request value without starting a Sandbox.
+    pub fn options(&self) -> &SandboxCreateOptions {
+        &self.options
+    }
+}
+
+impl A3sBoxClient {
+    /// Start a fluent builder for a local Sandbox.
+    pub fn sandbox(&self, image: impl Into<String>) -> SandboxBuilder {
+        SandboxBuilder::new(self.clone(), image)
+    }
+}

--- a/src/sdk/src/sandbox/mod.rs
+++ b/src/sdk/src/sandbox/mod.rs
@@ -3,19 +3,27 @@
 //! This module never reads endpoint or API-key environment variables. The
 //! default constructor opens the installed local runtime state directly.
 
+mod builder;
 mod commands;
 mod filesystem;
 mod options;
+mod script;
 
 use std::sync::{Arc, RwLock};
 
 use a3s_box_core::{
-    ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionState, ExecutionStatus,
+    ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionSnapshot, ExecutionSnapshotId,
+    ExecutionState, ExecutionStatus,
 };
 
+pub use builder::SandboxBuilder;
 pub use commands::{CommandResult, CommandRunOptions, Commands, SandboxCommand};
 pub use filesystem::{Filesystem, FilesystemOptions, WriteInfo};
-pub use options::{SandboxCreateOptions, DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_TIMEOUT_SECONDS};
+pub use options::{
+    SandboxCreateOptions, SandboxNetwork, TmpfsMount, VolumeMount, VolumeSource,
+    DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_TIMEOUT_SECONDS,
+};
+pub use script::ScriptBuilder;
 
 use crate::{A3sBoxClient, ClientError, Result};
 
@@ -119,7 +127,7 @@ impl Sandbox {
         options: SandboxCreateOptions,
     ) -> Result<Self> {
         let isolation = options.isolation;
-        let (request, operation) = options.into_runtime_request()?;
+        let (request, operation) = options.into_runtime_request(&client)?;
         let lease = client.run_box(request, &operation).await?;
         Ok(Self::from_known_state(
             client,
@@ -200,6 +208,39 @@ impl Sandbox {
 
     pub fn isolation(&self) -> ExecutionIsolation {
         self.inner.isolation
+    }
+
+    /// Build an explicitly interpreted script execution.
+    pub fn script(&self, source: impl AsRef<[u8]>) -> ScriptBuilder {
+        self.commands.script(source)
+    }
+
+    /// Capture this running or paused Sandbox filesystem without changing its
+    /// final lifecycle state.
+    pub async fn create_filesystem_snapshot(
+        &self,
+        snapshot_id: ExecutionSnapshotId,
+    ) -> Result<ExecutionSnapshot> {
+        let state = self.inner.state();
+        if state.closed
+            || !matches!(
+                state.state,
+                ExecutionState::Running | ExecutionState::Paused
+            )
+        {
+            return Err(ClientError::Validation(format!(
+                "sandbox {} cannot be snapshotted while it is {:?}",
+                self.id(),
+                state.state
+            )));
+        }
+        let snapshot = self
+            .inner
+            .client
+            .create_execution_snapshot(&self.inner.execution_id, state.generation, &snapshot_id)
+            .await?;
+        self.inner.update(snapshot.lease.generation, snapshot.state);
+        Ok(snapshot)
     }
 
     pub async fn pause(&self, keep_memory: bool) -> Result<()> {

--- a/src/sdk/src/sandbox/options.rs
+++ b/src/sdk/src/sandbox/options.rs
@@ -1,12 +1,16 @@
 use std::collections::BTreeMap;
+use std::net::IpAddr;
+use std::path::PathBuf;
 
 use a3s_box_core::config::ResourceConfig;
+use a3s_box_core::dns::parse_add_host_entries;
+use a3s_box_core::network::NetworkMode;
 use a3s_box_core::{
-    resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionIsolation,
-    ExecutionRecordPolicy, OperationId,
+    parse_port_mapping, resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionIsolation,
+    ExecutionRecordPolicy, ExecutionSnapshotId, OperationId, PortMapping,
 };
 
-use crate::{ClientError, Result};
+use crate::{A3sBoxClient, ClientError, Result};
 
 /// Default OCI image used by all native local SDKs.
 pub const DEFAULT_SANDBOX_IMAGE: &str = "alpine:3.20";
@@ -15,6 +19,135 @@ pub const DEFAULT_SANDBOX_IMAGE: &str = "alpine:3.20";
 pub const DEFAULT_SANDBOX_TIMEOUT_SECONDS: u64 = 3_600;
 
 const KEEPALIVE_COMMAND: &[&str] = &["/bin/sh", "-c", "while :; do sleep 3600; done"];
+
+/// Source of one typed volume mount.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VolumeSource {
+    /// A host path mounted directly into the box.
+    Bind(PathBuf),
+    /// An A3S-managed named volume resolved by the runtime client.
+    Named(String),
+}
+
+/// A typed read-write or read-only mount.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VolumeMount {
+    pub source: VolumeSource,
+    pub target: String,
+    pub read_only: bool,
+}
+
+impl VolumeMount {
+    pub fn bind(source: impl Into<PathBuf>, target: impl Into<String>) -> Self {
+        Self {
+            source: VolumeSource::Bind(source.into()),
+            target: target.into(),
+            read_only: false,
+        }
+    }
+
+    pub fn named(name: impl Into<String>, target: impl Into<String>) -> Self {
+        Self {
+            source: VolumeSource::Named(name.into()),
+            target: target.into(),
+            read_only: false,
+        }
+    }
+
+    pub const fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+}
+
+/// A typed in-guest tmpfs mount.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TmpfsMount {
+    pub target: String,
+    pub size_bytes: Option<u64>,
+    pub read_only: bool,
+}
+
+impl TmpfsMount {
+    pub fn new(target: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+            size_bytes: None,
+            read_only: false,
+        }
+    }
+
+    pub const fn size_bytes(mut self, size_bytes: u64) -> Self {
+        self.size_bytes = Some(size_bytes);
+        self
+    }
+
+    pub const fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+
+    fn runtime_entry(&self) -> Result<String> {
+        validate_guest_path("tmpfs target", &self.target)?;
+        if self.size_bytes == Some(0) {
+            return Err(ClientError::Validation(
+                "tmpfs size must be greater than zero".to_string(),
+            ));
+        }
+        let mut options = Vec::new();
+        if let Some(size_bytes) = self.size_bytes {
+            options.push(format!("size={size_bytes}"));
+        }
+        if self.read_only {
+            options.push("ro".to_string());
+        }
+        if options.is_empty() {
+            Ok(self.target.clone())
+        } else {
+            Ok(format!("{}:{}", self.target, options.join(",")))
+        }
+    }
+}
+
+/// Network selected for a Sandbox.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum SandboxNetwork {
+    /// Transparent socket impersonation, the default MicroVM network.
+    #[default]
+    Tsi,
+    /// Disable networking entirely.
+    Disabled,
+    /// Join an existing A3S-managed bridge network.
+    Bridge { name: String },
+}
+
+impl SandboxNetwork {
+    pub fn bridge(name: impl Into<String>) -> Self {
+        Self::Bridge { name: name.into() }
+    }
+
+    fn runtime_mode(&self, client: &A3sBoxClient) -> Result<NetworkMode> {
+        match self {
+            Self::Tsi => Ok(NetworkMode::Tsi),
+            Self::Disabled => Ok(NetworkMode::None),
+            Self::Bridge { name } => {
+                if name.trim().is_empty() {
+                    return Err(ClientError::Validation(
+                        "bridge network name cannot be empty".to_string(),
+                    ));
+                }
+                if client.get_network(name)?.is_none() {
+                    return Err(ClientError::Validation(format!(
+                        "network '{name}' does not exist; create it before starting the sandbox"
+                    )));
+                }
+                Ok(NetworkMode::Bridge {
+                    network: name.clone(),
+                })
+            }
+        }
+    }
+}
 
 /// Options for [`super::Sandbox::create_with_options`].
 ///
@@ -30,6 +163,20 @@ pub struct SandboxCreateOptions {
     pub cpus: Option<u32>,
     pub memory_mb: Option<u32>,
     pub isolation: ExecutionIsolation,
+    pub rootfs_snapshot_id: Option<ExecutionSnapshotId>,
+    pub workspace: Option<PathBuf>,
+    pub workdir: Option<String>,
+    pub user: Option<String>,
+    pub hostname: Option<String>,
+    pub mounts: Vec<VolumeMount>,
+    pub tmpfs: Vec<TmpfsMount>,
+    pub network: SandboxNetwork,
+    pub ports: Vec<PortMapping>,
+    pub dns_servers: Vec<String>,
+    pub host_aliases: BTreeMap<String, String>,
+    pub read_only: bool,
+    pub persistent: bool,
+    pub auto_remove: bool,
 }
 
 impl SandboxCreateOptions {
@@ -75,7 +222,166 @@ impl SandboxCreateOptions {
         self
     }
 
-    pub(crate) fn into_runtime_request(self) -> Result<(CreateExecutionRequest, OperationId)> {
+    /// Start from a runtime-managed immutable filesystem snapshot.
+    ///
+    /// Snapshot identifiers are typed and validated by the runtime; callers
+    /// cannot provide an arbitrary host path.
+    pub fn filesystem_snapshot(mut self, snapshot_id: ExecutionSnapshotId) -> Self {
+        self.rootfs_snapshot_id = Some(snapshot_id);
+        self
+    }
+
+    pub fn workspace(mut self, path: impl Into<PathBuf>) -> Self {
+        self.workspace = Some(path.into());
+        self
+    }
+
+    pub fn workdir(mut self, path: impl Into<String>) -> Self {
+        self.workdir = Some(path.into());
+        self
+    }
+
+    pub fn user(mut self, user: impl Into<String>) -> Self {
+        self.user = Some(user.into());
+        self
+    }
+
+    pub fn hostname(mut self, hostname: impl Into<String>) -> Self {
+        self.hostname = Some(hostname.into());
+        self
+    }
+
+    pub fn mount(mut self, mount: VolumeMount) -> Self {
+        self.mounts.push(mount);
+        self
+    }
+
+    pub fn tmpfs(mut self, mount: TmpfsMount) -> Self {
+        self.tmpfs.push(mount);
+        self
+    }
+
+    pub fn network(mut self, network: SandboxNetwork) -> Self {
+        self.network = network;
+        self
+    }
+
+    pub fn publish_port(mut self, port: PortMapping) -> Self {
+        self.ports.push(port);
+        self
+    }
+
+    pub fn dns_server(mut self, server: impl Into<String>) -> Self {
+        self.dns_servers.push(server.into());
+        self
+    }
+
+    pub fn host_alias(mut self, host: impl Into<String>, ip: impl Into<String>) -> Self {
+        self.host_aliases.insert(host.into(), ip.into());
+        self
+    }
+
+    pub const fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+
+    pub const fn persistent(mut self, persistent: bool) -> Self {
+        self.persistent = persistent;
+        self
+    }
+
+    pub const fn auto_remove(mut self, auto_remove: bool) -> Self {
+        self.auto_remove = auto_remove;
+        self
+    }
+
+    pub(crate) fn into_runtime_request(
+        self,
+        client: &A3sBoxClient,
+    ) -> Result<(CreateExecutionRequest, OperationId)> {
+        self.validate()?;
+        let network = self.network.runtime_mode(client)?;
+        let (volumes, volume_names) = resolve_mounts(client, self.mounts)?;
+        let port_map = self
+            .ports
+            .into_iter()
+            .map(|port| {
+                let entry = port.runtime_entry();
+                parse_port_mapping(&entry)
+                    .map(|mapping| mapping.runtime_entry())
+                    .map_err(ClientError::Validation)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let tmpfs = self
+            .tmpfs
+            .iter()
+            .map(TmpfsMount::runtime_entry)
+            .collect::<Result<Vec<_>>>()?;
+        let add_hosts = self
+            .host_aliases
+            .into_iter()
+            .map(|(host, ip)| format!("{host}:{ip}"))
+            .collect::<Vec<_>>();
+        parse_add_host_entries(&add_hosts).map_err(ClientError::Validation)?;
+
+        let identity = uuid::Uuid::new_v4();
+        let mut resources = ResourceConfig {
+            timeout: self.timeout_seconds,
+            ..ResourceConfig::default()
+        };
+        if let Some(cpus) = self.cpus {
+            resources.vcpus = cpus;
+        }
+        if let Some(memory_mb) = self.memory_mb {
+            resources.memory_mb = memory_mb;
+        }
+
+        let config = BoxConfig {
+            isolation: self.isolation,
+            image: self.image,
+            workspace: self.workspace.unwrap_or_default(),
+            resources,
+            cmd: KEEPALIVE_COMMAND
+                .iter()
+                .map(|part| (*part).to_string())
+                .collect(),
+            user: self.user,
+            workdir: self.workdir,
+            hostname: self.hostname,
+            volumes,
+            extra_env: self.envs.into_iter().collect(),
+            port_map,
+            dns: self.dns_servers,
+            add_hosts,
+            network,
+            tmpfs,
+            read_only: self.read_only,
+            persistent: self.persistent,
+            ..BoxConfig::default()
+        };
+        resolve_execution(&config).map_err(ClientError::Runtime)?;
+
+        let operation = OperationId::new(format!("sdk-create-{identity}"))
+            .map_err(|error| ClientError::Validation(error.to_string()))?;
+        Ok((
+            CreateExecutionRequest {
+                external_sandbox_id: format!("local-{identity}"),
+                config,
+                labels: self.metadata,
+                policy: ExecutionRecordPolicy {
+                    name: self.name,
+                    auto_remove: self.auto_remove,
+                    volume_names,
+                    ..ExecutionRecordPolicy::default()
+                },
+                rootfs_snapshot_id: self.rootfs_snapshot_id,
+            },
+            operation,
+        ))
+    }
+
+    fn validate(&self) -> Result<()> {
         if self.image.trim().is_empty() {
             return Err(ClientError::Validation(
                 "sandbox image cannot be empty".to_string(),
@@ -96,48 +402,15 @@ impl SandboxCreateOptions {
                 "sandbox memory must be greater than zero".to_string(),
             ));
         }
-
-        let identity = uuid::Uuid::new_v4();
-        let mut resources = ResourceConfig {
-            timeout: self.timeout_seconds,
-            ..ResourceConfig::default()
-        };
-        if let Some(cpus) = self.cpus {
-            resources.vcpus = cpus;
+        if let Some(workdir) = &self.workdir {
+            validate_guest_path("working directory", workdir)?;
         }
-        if let Some(memory_mb) = self.memory_mb {
-            resources.memory_mb = memory_mb;
+        for server in &self.dns_servers {
+            server.parse::<IpAddr>().map_err(|_| {
+                ClientError::Validation(format!("invalid DNS server address '{server}'"))
+            })?;
         }
-
-        let config = BoxConfig {
-            isolation: self.isolation,
-            image: self.image,
-            resources,
-            cmd: KEEPALIVE_COMMAND
-                .iter()
-                .map(|part| (*part).to_string())
-                .collect(),
-            extra_env: self.envs.into_iter().collect(),
-            ..BoxConfig::default()
-        };
-        resolve_execution(&config).map_err(ClientError::Runtime)?;
-
-        let operation = OperationId::new(format!("sdk-create-{identity}"))
-            .map_err(|error| ClientError::Validation(error.to_string()))?;
-        Ok((
-            CreateExecutionRequest {
-                external_sandbox_id: format!("local-{identity}"),
-                config,
-                labels: self.metadata,
-                policy: ExecutionRecordPolicy {
-                    name: self.name,
-                    auto_remove: true,
-                    ..ExecutionRecordPolicy::default()
-                },
-                rootfs_snapshot_id: None,
-            },
-            operation,
-        ))
+        Ok(())
     }
 }
 
@@ -152,6 +425,69 @@ impl Default for SandboxCreateOptions {
             cpus: None,
             memory_mb: None,
             isolation: ExecutionIsolation::Microvm,
+            rootfs_snapshot_id: None,
+            workspace: None,
+            workdir: None,
+            user: None,
+            hostname: None,
+            mounts: Vec::new(),
+            tmpfs: Vec::new(),
+            network: SandboxNetwork::default(),
+            ports: Vec::new(),
+            dns_servers: Vec::new(),
+            host_aliases: BTreeMap::new(),
+            read_only: false,
+            persistent: false,
+            auto_remove: true,
         }
     }
+}
+
+fn resolve_mounts(
+    client: &A3sBoxClient,
+    mounts: Vec<VolumeMount>,
+) -> Result<(Vec<String>, Vec<String>)> {
+    let mut runtime_mounts = Vec::with_capacity(mounts.len());
+    let mut volume_names = Vec::new();
+    for mount in mounts {
+        validate_guest_path("volume target", &mount.target)?;
+        let source = match mount.source {
+            VolumeSource::Bind(path) => {
+                if path.as_os_str().is_empty() {
+                    return Err(ClientError::Validation(
+                        "bind mount source cannot be empty".to_string(),
+                    ));
+                }
+                path.to_string_lossy().into_owned()
+            }
+            VolumeSource::Named(name) => {
+                let volume = client.get_volume(&name)?.ok_or_else(|| {
+                    ClientError::Validation(format!(
+                        "volume '{name}' does not exist; create it before starting the sandbox"
+                    ))
+                })?;
+                if volume.mount_point.is_empty() {
+                    return Err(ClientError::Validation(format!(
+                        "volume '{name}' has no runtime mount point"
+                    )));
+                }
+                if !volume_names.contains(&name) {
+                    volume_names.push(name);
+                }
+                volume.mount_point
+            }
+        };
+        let mode = if mount.read_only { ":ro" } else { ":rw" };
+        runtime_mounts.push(format!("{source}:{}{mode}", mount.target));
+    }
+    Ok((runtime_mounts, volume_names))
+}
+
+fn validate_guest_path(label: &str, path: &str) -> Result<()> {
+    if !path.starts_with('/') || path.contains('\0') {
+        return Err(ClientError::Validation(format!(
+            "{label} must be an absolute guest path without NUL bytes"
+        )));
+    }
+    Ok(())
 }

--- a/src/sdk/src/sandbox/script.rs
+++ b/src/sdk/src/sandbox/script.rs
@@ -1,0 +1,77 @@
+use std::time::Duration;
+
+use super::{CommandResult, CommandRunOptions, Commands, SandboxCommand};
+use crate::{ClientError, Result};
+
+/// Fluent builder for a script sent through stdin to an explicit interpreter.
+///
+/// The source is not interpolated into a shell command, so arbitrary script
+/// contents do not require host-side quoting or a temporary host file.
+#[derive(Debug, Clone)]
+pub struct ScriptBuilder {
+    commands: Commands,
+    source: Vec<u8>,
+    interpreter: Vec<String>,
+    options: CommandRunOptions,
+}
+
+impl ScriptBuilder {
+    pub(crate) fn new(commands: Commands, source: impl AsRef<[u8]>) -> Self {
+        Self {
+            commands,
+            source: source.as_ref().to_vec(),
+            interpreter: vec!["/bin/sh".to_string(), "-se".to_string()],
+            options: CommandRunOptions::default(),
+        }
+    }
+
+    /// Select the interpreter argv, for example `["python", "-"]`.
+    pub fn interpreter(mut self, command: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.interpreter = command.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub const fn timeout(mut self, timeout: Duration) -> Self {
+        self.options.timeout = Some(timeout);
+        self
+    }
+
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.options.envs.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn cwd(mut self, cwd: impl Into<String>) -> Self {
+        self.options.cwd = Some(cwd.into());
+        self
+    }
+
+    pub fn user(mut self, user: impl Into<String>) -> Self {
+        self.options.user = Some(user.into());
+        self
+    }
+
+    pub async fn run(mut self) -> Result<CommandResult> {
+        if self.source.is_empty() {
+            return Err(ClientError::Validation(
+                "script source cannot be empty".to_string(),
+            ));
+        }
+        if self.interpreter.is_empty() {
+            return Err(ClientError::Validation(
+                "script interpreter cannot be empty".to_string(),
+            ));
+        }
+        self.options.stdin = Some(self.source);
+        self.commands
+            .run_with_options(SandboxCommand::Argv(self.interpreter), self.options)
+            .await
+    }
+}
+
+impl Commands {
+    /// Start a fluent, stdin-backed script request.
+    pub fn script(&self, source: impl AsRef<[u8]>) -> ScriptBuilder {
+        ScriptBuilder::new(self.clone(), source)
+    }
+}

--- a/src/sdk/src/sandbox/tests.rs
+++ b/src/sdk/src/sandbox/tests.rs
@@ -6,16 +6,17 @@ use a3s_box_core::{
     resolve_execution, BoxConfig, CreateExecutionRequest, ExecOutput, ExecRequest,
     ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionLease, ExecutionManager,
     ExecutionManagerError, ExecutionManagerResult, ExecutionProcess, ExecutionReservation,
-    ExecutionSessionManager, ExecutionState, ExecutionStatus, FileOp, FileRequest, FileResponse,
-    FilesystemEntry, FilesystemEntryKind, FilesystemOp, FilesystemRequest, FilesystemResponse,
-    KillOutcome, OperationId, ReconcileOutcome,
+    ExecutionSessionManager, ExecutionSnapshot, ExecutionSnapshotId, ExecutionState,
+    ExecutionStatus, FileOp, FileRequest, FileResponse, FilesystemEntry, FilesystemEntryKind,
+    FilesystemOp, FilesystemRequest, FilesystemResponse, KillOutcome, OperationId,
+    ReconcileOutcome,
 };
 use async_trait::async_trait;
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use chrono::Utc;
 
-use super::{CommandRunOptions, Sandbox, SandboxCreateOptions};
+use super::{CommandRunOptions, Sandbox, SandboxCreateOptions, SandboxNetwork};
 use crate::{A3sBoxClient, A3sBoxPaths};
 
 #[derive(Debug)]
@@ -26,6 +27,7 @@ struct RecordingRuntime {
     exec_requests: Mutex<Vec<ExecRequest>>,
     file_requests: Mutex<Vec<FileRequest>>,
     filesystem_requests: Mutex<Vec<FilesystemRequest>>,
+    snapshot_requests: Mutex<Vec<ExecutionSnapshotId>>,
 }
 
 impl RecordingRuntime {
@@ -37,6 +39,7 @@ impl RecordingRuntime {
             exec_requests: Mutex::new(Vec::new()),
             file_requests: Mutex::new(Vec::new()),
             filesystem_requests: Mutex::new(Vec::new()),
+            snapshot_requests: Mutex::new(Vec::new()),
         }
     }
 
@@ -97,6 +100,47 @@ impl ExecutionManager for RecordingRuntime {
             state: *self.state.lock().unwrap(),
             plan: lease.plan,
         })
+    }
+
+    async fn create_filesystem_snapshot(
+        &self,
+        _execution_id: &ExecutionId,
+        _generation: ExecutionGeneration,
+        snapshot_id: &ExecutionSnapshotId,
+    ) -> ExecutionManagerResult<ExecutionSnapshot> {
+        self.snapshot_requests
+            .lock()
+            .unwrap()
+            .push(snapshot_id.clone());
+        Ok(ExecutionSnapshot {
+            snapshot_id: snapshot_id.clone(),
+            size_bytes: 5,
+            state: *self.state.lock().unwrap(),
+            lease: self.lease(),
+        })
+    }
+
+    async fn filesystem_snapshot_size(
+        &self,
+        snapshot_id: &ExecutionSnapshotId,
+    ) -> ExecutionManagerResult<Option<u64>> {
+        Ok(self
+            .snapshot_requests
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|candidate| candidate == snapshot_id)
+            .then_some(5))
+    }
+
+    async fn delete_filesystem_snapshot(
+        &self,
+        snapshot_id: &ExecutionSnapshotId,
+    ) -> ExecutionManagerResult<bool> {
+        let mut snapshots = self.snapshot_requests.lock().unwrap();
+        let original_len = snapshots.len();
+        snapshots.retain(|candidate| candidate != snapshot_id);
+        Ok(snapshots.len() != original_len)
     }
 
     async fn pause(
@@ -309,6 +353,114 @@ async fn e2b_style_rust_surface_supports_both_local_isolation_levels() {
         let exec = runtime.exec_requests.lock().unwrap();
         assert_eq!(exec[0].cmd, ["/bin/sh", "-lc", "python -c 'print(6 * 7)'"]);
     }
+}
+
+#[tokio::test]
+async fn sandbox_snapshot_api_uses_typed_runtime_managed_snapshots() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = Arc::new(RecordingRuntime::new());
+    let client = test_client(Arc::clone(&runtime), temp.path());
+    let source_snapshot = ExecutionSnapshotId::new("ci-base-source").unwrap();
+    let sandbox = Sandbox::create_with_client(
+        client.clone(),
+        SandboxCreateOptions::new("python:3.12-alpine")
+            .isolation(ExecutionIsolation::Sandbox)
+            .filesystem_snapshot(source_snapshot.clone()),
+    )
+    .await
+    .unwrap();
+
+    {
+        let requests = runtime.create_requests.lock().unwrap();
+        assert_eq!(
+            requests[0].rootfs_snapshot_id.as_ref(),
+            Some(&source_snapshot)
+        );
+    }
+
+    let captured_id = ExecutionSnapshotId::new("ci-captured").unwrap();
+    let captured = sandbox
+        .create_filesystem_snapshot(captured_id.clone())
+        .await
+        .unwrap();
+    assert_eq!(captured.snapshot_id, captured_id);
+    assert_eq!(captured.size_bytes, 5);
+    assert_eq!(
+        client
+            .execution_snapshot_size(&captured.snapshot_id)
+            .await
+            .unwrap(),
+        Some(5)
+    );
+
+    sandbox.kill().await.unwrap();
+    assert!(client
+        .delete_execution_snapshot(&captured.snapshot_id)
+        .await
+        .unwrap());
+    assert_eq!(
+        client
+            .execution_snapshot_size(&captured.snapshot_id)
+            .await
+            .unwrap(),
+        None
+    );
+}
+
+#[tokio::test]
+async fn fluent_builders_configure_resources_and_stream_script_source() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = Arc::new(RecordingRuntime::new());
+    let client = test_client(Arc::clone(&runtime), temp.path());
+    client
+        .volume("build-cache")
+        .label("purpose", "ci")
+        .create()
+        .unwrap();
+    client
+        .network("ci-net")
+        .subnet("10.89.66.0/24")
+        .create()
+        .unwrap();
+
+    let sandbox = client
+        .sandbox("local/ci-base:latest")
+        .cpus(4)
+        .memory_mb(4096)
+        .mount_named("build-cache", "/cache")
+        .network(SandboxNetwork::bridge("ci-net"))
+        .publish_tcp(8080, 80)
+        .workdir("/workspace")
+        .auto_remove(false)
+        .start()
+        .await
+        .unwrap();
+
+    let result = sandbox
+        .script("print(6 * 7)\n")
+        .interpreter(["python", "-"])
+        .env("CI", "true")
+        .cwd("/workspace")
+        .run()
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "42\n");
+
+    let creates = runtime.create_requests.lock().unwrap();
+    let request = &creates[0];
+    assert_eq!(request.config.resources.vcpus, 4);
+    assert_eq!(request.config.resources.memory_mb, 4096);
+    assert_eq!(request.config.network.to_string(), "bridge:ci-net");
+    assert_eq!(request.config.port_map, ["8080:80"]);
+    assert_eq!(request.policy.volume_names, ["build-cache"]);
+    assert!(!request.policy.auto_remove);
+    drop(creates);
+
+    let exec = runtime.exec_requests.lock().unwrap();
+    assert_eq!(exec[0].cmd, ["python", "-"]);
+    assert_eq!(exec[0].stdin.as_deref(), Some(b"print(6 * 7)\n".as_slice()));
+    assert_eq!(exec[0].env, ["CI=true"]);
+    assert_eq!(exec[0].working_dir.as_deref(), Some("/workspace"));
 }
 
 #[test]

--- a/src/sdk/tests/local_sandbox.rs
+++ b/src/sdk/tests/local_sandbox.rs
@@ -3,7 +3,10 @@
 use std::error::Error;
 use std::path::PathBuf;
 
-use a3s_box_sdk::{A3sBoxClient, ClientError, ExecutionIsolation, Sandbox, SandboxCreateOptions};
+use a3s_box_sdk::{
+    A3sBoxClient, ClientError, ExecutionIsolation, ExecutionSnapshotId, Sandbox,
+    SandboxCreateOptions, SandboxNetwork,
+};
 
 type AnyError = Box<dyn Error + Send + Sync>;
 
@@ -31,27 +34,63 @@ async fn e2b_style_local_sandbox_runs_without_remote_credentials() -> Result<(),
 
     let home = validated_home()?;
     let isolation = requested_isolation()?;
-    let image =
+    let base_image =
         std::env::var("A3S_BOX_SDK_SMOKE_IMAGE").unwrap_or_else(|_| "alpine:3.20".to_string());
-    let sandbox = Sandbox::create_with_client(
-        A3sBoxClient::from_home(&home),
-        SandboxCreateOptions::new(image)
-            .timeout_seconds(300)
-            .metadata("purpose", "local-sdk-smoke")
-            .isolation(isolation),
-    )
-    .await?;
+    let client = A3sBoxClient::from_home(&home);
+    let context = home.join("rust-sdk-build-context");
+    std::fs::create_dir_all(&context)?;
+    std::fs::write(
+        context.join("Dockerfile"),
+        format!("FROM {base_image}\nENV A3S_SDK_BASE=ready\nWORKDIR /workspace\n"),
+    )?;
+    let image = client
+        .image(&context)
+        .tag("local/a3s-sdk-smoke-rust:latest")
+        .build()
+        .await?;
+    let volume = client
+        .volume("rust-sdk-cache")
+        .label("purpose", "local-sdk-smoke")
+        .create()?;
+    let network = if isolation == ExecutionIsolation::Microvm {
+        Some(
+            client
+                .network("rust-sdk-network")
+                .subnet("10.89.91.0/24")
+                .create()?,
+        )
+    } else {
+        None
+    };
+    let builder = client
+        .sandbox(image.reference.clone())
+        .timeout_seconds(300)
+        .metadata("purpose", "local-sdk-smoke")
+        .isolation(isolation)
+        .mount_named(&volume.name, "/cache")
+        .workdir("/workspace");
+    let builder = match &network {
+        Some(network) => builder
+            .network(SandboxNetwork::bridge(&network.name))
+            .publish_tcp(0, 8080),
+        None => builder.network(SandboxNetwork::Disabled),
+    };
+    let sandbox = builder.start().await?;
     let sandbox_id = sandbox.id().to_string();
 
-    let exercise_result = exercise(&sandbox, isolation).await;
+    let exercise_result = exercise(&sandbox, &client, isolation, &image.reference).await;
     let cleanup_result = sandbox.kill().await;
     if let Err(error) = exercise_result {
         if let Err(cleanup_error) = cleanup_result {
             eprintln!("local SDK cleanup also failed: {cleanup_error}");
         }
+        let _ =
+            cleanup_programmable_resources(&client, &image.reference, &volume.name, network).await;
         return Err(error);
     }
     cleanup_result?;
+    cleanup_programmable_resources(&client, &image.reference, &volume.name, network).await?;
+    std::fs::remove_dir_all(&context)?;
 
     require(
         !sandbox.is_running().await?,
@@ -72,7 +111,9 @@ async fn e2b_style_local_sandbox_runs_without_remote_credentials() -> Result<(),
 
 async fn exercise(
     sandbox: &Sandbox,
+    client: &A3sBoxClient,
     expected_isolation: ExecutionIsolation,
+    image: &str,
 ) -> Result<(), AnyError> {
     require(
         sandbox.isolation() == expected_isolation,
@@ -85,6 +126,22 @@ async fn exercise(
     require(
         command.stdout == "rust-sdk-ok",
         "Rust SDK command returned unexpected stdout",
+    )?;
+    let script = sandbox
+        .script("printf 'rust-script-ok'\n")
+        .env("CI", "true")
+        .cwd("/workspace")
+        .run()
+        .await?;
+    require(script.exit_code == 0, "Rust SDK script failed")?;
+    require(
+        script.stdout == "rust-script-ok",
+        "Rust SDK script returned unexpected stdout",
+    )?;
+    sandbox.files.write("/cache/marker.txt", "cache-ok").await?;
+    require(
+        sandbox.files.read_text("/cache/marker.txt").await? == "cache-ok",
+        "named volume mount did not preserve written content",
     )?;
 
     let directory = "/tmp/a3s-local-sdk-smoke";
@@ -120,6 +177,10 @@ async fn exercise(
     )?;
     sandbox.files.remove(directory).await?;
 
+    if expected_isolation == ExecutionIsolation::Sandbox {
+        exercise_filesystem_snapshot(sandbox, client, image).await?;
+    }
+
     sandbox.pause(true).await?;
     require(
         !sandbox.is_running().await?,
@@ -129,6 +190,81 @@ async fn exercise(
     require(
         sandbox.is_running().await?,
         "resumed Sandbox is not running",
+    )?;
+    Ok(())
+}
+
+async fn cleanup_programmable_resources(
+    client: &A3sBoxClient,
+    image: &str,
+    volume: &str,
+    network: Option<a3s_box_sdk::NetworkSummary>,
+) -> Result<(), AnyError> {
+    client.remove_volume(volume, false)?;
+    if let Some(network) = network {
+        client.remove_network(&network.name)?;
+    }
+    client.remove_image(image).await?;
+    Ok(())
+}
+
+async fn exercise_filesystem_snapshot(
+    sandbox: &Sandbox,
+    client: &A3sBoxClient,
+    image: &str,
+) -> Result<(), AnyError> {
+    let marker = "/tmp/a3s-sdk-snapshot-marker.txt";
+    sandbox.files.write(marker, "snapshot-ok").await?;
+    let snapshot_id =
+        ExecutionSnapshotId::new(format!("sdk-smoke-{}", sandbox.id().replace('-', "_")))?;
+    let snapshot = sandbox
+        .create_filesystem_snapshot(snapshot_id.clone())
+        .await?;
+    require(
+        snapshot.snapshot_id == snapshot_id,
+        "snapshot returned the wrong identity",
+    )?;
+    require(
+        client.execution_snapshot_size(&snapshot_id).await? == Some(snapshot.size_bytes),
+        "snapshot size lookup did not return the published size",
+    )?;
+
+    let restored = Sandbox::create_with_client(
+        client.clone(),
+        SandboxCreateOptions::new(image)
+            .isolation(ExecutionIsolation::Sandbox)
+            .filesystem_snapshot(snapshot_id.clone()),
+    )
+    .await?;
+    let restore_result = async {
+        require(
+            restored.files.read_text(marker).await? == "snapshot-ok",
+            "restored Sandbox did not contain the captured file",
+        )?;
+        require(
+            client
+                .delete_execution_snapshot(&snapshot_id)
+                .await
+                .is_err(),
+            "snapshot deletion succeeded while a restored Sandbox was active",
+        )?;
+        Ok::<(), AnyError>(())
+    }
+    .await;
+    let cleanup_result = restored.kill().await;
+    restore_result?;
+    cleanup_result?;
+
+    require(
+        client.delete_execution_snapshot(&snapshot_id).await?,
+        "snapshot was not deleted after its restored Sandbox exited",
+    )?;
+    require(
+        client
+            .execution_snapshot_size(&snapshot_id)
+            .await?
+            .is_none(),
+        "deleted snapshot still reported a size",
     )?;
     Ok(())
 }

--- a/src/sdk/tests/local_sandbox.rs
+++ b/src/sdk/tests/local_sandbox.rs
@@ -213,7 +213,9 @@ async fn exercise_filesystem_snapshot(
     client: &A3sBoxClient,
     image: &str,
 ) -> Result<(), AnyError> {
-    let marker = "/tmp/a3s-sdk-snapshot-marker.txt";
+    // `/tmp` is an intentionally ephemeral tmpfs in Sandbox isolation and is
+    // therefore outside a filesystem snapshot. Keep the marker in the rootfs.
+    let marker = "/a3s-sdk-snapshot-marker.txt";
     sandbox.files.write(marker, "snapshot-ok").await?;
     let snapshot_id =
         ExecutionSnapshotId::new(format!("sdk-smoke-{}", sandbox.id().replace('-', "_")))?;


### PR DESCRIPTION
## Summary

- keep the zero-credential E2B-style Sandbox, commands, and files API as a first-class SDK entry point
- add fluent image, volume, network, Sandbox, and stdin-backed script builders in Rust, Python, and TypeScript
- route both API styles through the same typed Rust runtime and versioned JSON bridge
- expand the real-runtime SDK smoke to cover image builds, named volumes, networks, ports, scripts, files, snapshots, and cleanup
- remove the Distribution status section and version-specific distribution clutter from README
- document the programmable CI/CD contract and remaining parity gates

## Validation

- Rust SDK: 48 tests passed
- Python SDK: 12 tests passed; sdist and wheel built
- TypeScript SDK: build, tests, and package dry-run passed
- Rust SDK Clippy with warnings denied passed
- real macOS/HVF MicroVM smoke passed for Rust, Python, and TypeScript
- local SDK smoke shell syntax and git diff checks passed

The first CI run exposed a snapshot restore fixture that selected alpine instead of the just-built image. The corrected Rust, Python, and TypeScript fixtures now restore with the matching image reference.

Local SDK operations require neither A3S_BOX_ENDPOINT nor A3S_BOX_API_KEY.