### PR TITLE
fix(libkrun-sys): hash bundled runtimes in Rust

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "libc",
  "num_cpus",
  "pkg-config",
+ "sha2",
  "tempfile",
  "windows-sys 0.59.0",
 ]

--- a/src/deps/libkrun-sys/Cargo.toml
+++ b/src/deps/libkrun-sys/Cargo.toml
@@ -38,8 +38,10 @@ links = "a3s_krun"
 [build-dependencies]
 pkg-config = "0.3"
 num_cpus = "1.16"
+sha2.workspace = true
 
 [dev-dependencies]
+sha2.workspace = true
 tempfile = "3.10"
 
 [dependencies]

--- a/src/deps/libkrun-sys/build.rs
+++ b/src/deps/libkrun-sys/build.rs
@@ -628,36 +628,7 @@ fn download_file(url: &str, dest: &Path) -> io::Result<()> {
 
 /// Verifies SHA256 checksum of a file.
 fn verify_sha256(file: &Path, expected: &str) -> io::Result<()> {
-    let actual = if cfg!(target_os = "windows") {
-        // PowerShell is available on all modern Windows
-        let literal_path = file.display().to_string().replace('\'', "''");
-        let script = format!(
-            "(Get-FileHash -Algorithm SHA256 -LiteralPath '{}').Hash.ToLower()",
-            literal_path
-        );
-        let output = Command::new("powershell.exe")
-            .args(["-NoProfile", "-Command", &script])
-            .output()?;
-        if !output.status.success() {
-            return Err(io::Error::other("PowerShell Get-FileHash failed"));
-        }
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    } else {
-        let (cmd, args): (&str, Vec<&str>) = if cfg!(target_os = "linux") {
-            ("sha256sum", vec![file.to_str().unwrap()])
-        } else {
-            ("shasum", vec!["-a", "256", file.to_str().unwrap()])
-        };
-        let output = Command::new(cmd).args(&args).output()?;
-        if !output.status.success() {
-            return Err(io::Error::other(format!("{} failed", cmd)));
-        }
-        String::from_utf8_lossy(&output.stdout)
-            .split_whitespace()
-            .next()
-            .unwrap_or("")
-            .to_string()
-    };
+    let actual = build_support::sha256_file(file)?;
 
     if actual != expected {
         return Err(io::Error::new(

--- a/src/deps/libkrun-sys/build_support.rs
+++ b/src/deps/libkrun-sys/build_support.rs
@@ -1,4 +1,24 @@
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+
+/// Calculate a lowercase SHA-256 digest without relying on platform commands.
+pub(crate) fn sha256_file(path: &Path) -> io::Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
 
 /// Resolve the Cargo home used by the Cargo process launched from libkrun's
 /// Makefile.

--- a/src/deps/libkrun-sys/tests/build_support.rs
+++ b/src/deps/libkrun-sys/tests/build_support.rs
@@ -4,6 +4,18 @@ mod build_support;
 use std::path::{Path, PathBuf};
 
 #[test]
+fn sha256_file_hashes_known_content() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let path = temp.path().join("payload.bin");
+    std::fs::write(&path, b"abc").expect("write checksum fixture");
+
+    assert_eq!(
+        build_support::sha256_file(&path).expect("hash fixture"),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+#[test]
 fn nested_cargo_home_is_target_local() {
     let install_dir = Path::new("/tmp/a3s-target/build/libkrun-sys/out/libkrun");
 


### PR DESCRIPTION
## Summary

- compute bundled runtime SHA-256 digests inside the build script instead of invoking platform checksum commands
- stream files through sha2 so large source and runtime archives do not need to be loaded into memory
- cover the implementation with a standard SHA-256 known-answer test

## Why

The 3.1.0 crate reached clean-room packaging on Windows, but the packaged build script could not run PowerShell Get-FileHash. The package was not uploaded to crates.io.

## Validation

- cargo fmt --all -- --check
- A3S_DEPS_STUB=1 cargo test --locked -p a3s-libkrun-sys --test build_support
- A3S_DEPS_STUB=1 cargo check --locked -p a3s-libkrun-sys --all-targets
- A3S_DEPS_STUB=1 cargo package --locked --allow-dirty (9.3 MiB compressed)
- git diff --check