### PR TITLE
fix(release): make registry publishing reproducible

### DIFF
--- a/.github/workflows/publish-runtime-dependency.yml
+++ b/.github/workflows/publish-runtime-dependency.yml
@@ -1,0 +1,142 @@
+name: Publish runtime dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact a3s-runtime version without a v prefix
+        required: true
+        type: string
+      release_ref:
+        description: Exact 40-character a3s-runtime commit SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-a3s-runtime-${{ inputs.version }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RELEASE_REF: ${{ inputs.release_ref }}
+  RELEASE_VERSION: ${{ inputs.version }}
+
+jobs:
+  publish:
+    name: Publish pinned a3s-runtime
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Validate inputs
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Expected a stable SemVer version, got '$RELEASE_VERSION'"
+            exit 1
+          fi
+          if [[ ! "$RELEASE_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Expected an exact 40-character commit SHA"
+            exit 1
+          fi
+
+      - name: Check out A3S Box
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          path: box
+
+      - name: Check out exact a3s-runtime commit
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          repository: A3S-Lab/Runtime
+          ref: ${{ env.RELEASE_REF }}
+          path: runtime
+
+      - name: Install Rust 1.85
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: "1.85.0"
+          components: rustfmt
+
+      - name: Verify pinned release source
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t PINNED < <(
+            python3 - <<'PY'
+          import tomllib
+
+          with open("box/src/Cargo.toml", "rb") as manifest:
+              dependency = tomllib.load(manifest)["workspace"]["dependencies"]["a3s-runtime"]
+          print(dependency["version"])
+          print(dependency["rev"])
+          PY
+          )
+          if [ "${PINNED[0]:-}" != "$RELEASE_VERSION" ] ||
+             [ "${PINNED[1]:-}" != "$RELEASE_REF" ]; then
+            echo "::error::Requested release does not match the A3S Box dependency pin"
+            exit 1
+          fi
+          if [ "$(git -C runtime rev-parse HEAD)" != "$RELEASE_REF" ]; then
+            echo "::error::Runtime checkout does not match the requested release commit"
+            exit 1
+          fi
+          PACKAGE_VERSION="$(
+            cargo metadata --locked --no-deps --format-version 1 \
+              --manifest-path runtime/Cargo.toml |
+              jq -r '.packages[] | select(.name == "a3s-runtime") | .version'
+          )"
+          if [ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "::error::Cargo version $PACKAGE_VERSION does not match $RELEASE_VERSION"
+            exit 1
+          fi
+          cargo fmt --all --check --manifest-path runtime/Cargo.toml
+          cargo test --locked --all-targets --manifest-path runtime/Cargo.toml
+          cargo publish --locked --dry-run --manifest-path runtime/Cargo.toml
+
+      - name: Publish and verify crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          CRATE_URL="https://crates.io/api/v1/crates/a3s-runtime/$RELEASE_VERSION"
+          USER_AGENT="A3S-Lab-Box-runtime-publisher/$RELEASE_VERSION (https://github.com/A3S-Lab/Box)"
+
+          crate_status() {
+            curl --retry 5 --retry-all-errors --silent --show-error \
+              --location --user-agent "$USER_AGENT" \
+              --output /dev/null --write-out '%{http_code}' "$CRATE_URL"
+          }
+
+          STATUS="$(crate_status)"
+          case "$STATUS" in
+            200)
+              echo "a3s-runtime@$RELEASE_VERSION already exists; skipping upload"
+              ;;
+            404)
+              cargo publish --locked --manifest-path runtime/Cargo.toml
+              ;;
+            *)
+              echo "::error::crates.io returned HTTP $STATUS before publication"
+              exit 1
+              ;;
+          esac
+
+          for attempt in $(seq 1 18); do
+            STATUS="$(crate_status)"
+            if [ "$STATUS" = "200" ]; then
+              echo "Verified a3s-runtime@$RELEASE_VERSION on crates.io"
+              exit 0
+            fi
+            if [ "$STATUS" != "404" ]; then
+              echo "::error::crates.io returned HTTP $STATUS during verification"
+              exit 1
+            fi
+            if [ "$attempt" -lt 18 ]; then
+              sleep 10
+            fi
+          done
+          echo "::error::a3s-runtime@$RELEASE_VERSION did not become visible on crates.io"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,45 +715,85 @@ jobs:
       - name: Publish crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        # NOTE: crates.io is NOT the primary distribution channel — the GitHub
-        # Release tarballs + Homebrew are. This step is best-effort but
-        # MUST NOT silently report success on a real failure (it used to:
-        # `cargo publish || echo "Skipped"` masked 403s / version-requirement
-        # errors as "may already be published"). Now an already-published
-        # version is skipped truthfully and a genuine failure is a ::warning::.
+        # The GitHub Release tarballs + Homebrew are the primary distribution
+        # channel, but crates.io publication remains strict and idempotent.
         run: |
+          set -euo pipefail
           cd src
           VERSION="${GITHUB_REF_NAME#v}"
           echo "Publishing version $VERSION (in dependency order)"
-          FAILED=""
-          libkrun_code=$(curl -s -o /dev/null -w '%{http_code}' \
-            "https://crates.io/api/v1/crates/a3s-libkrun-sys/$VERSION")
-          if [ "$libkrun_code" != "200" ]; then
-            echo "::error title=missing a3s-libkrun-sys release::Publish and verify a3s-libkrun-sys@$VERSION with publish-libkrun-sys.yml before running the general release."
-            exit 1
-          fi
+          CRATES_IO_USER_AGENT="A3S-Lab-Box-release-publisher/$VERSION (https://github.com/A3S-Lab/Box)"
+
+          crate_status() {
+            local crate="$1"
+            curl --retry 5 --retry-all-errors --silent --show-error \
+              --location --user-agent "$CRATES_IO_USER_AGENT" \
+              --output /dev/null --write-out '%{http_code}' \
+              "https://crates.io/api/v1/crates/$crate/$VERSION"
+          }
+
+          wait_for_crate() {
+            local crate="$1"
+            local attempt status
+            for attempt in $(seq 1 18); do
+              status="$(crate_status "$crate")"
+              if [ "$status" = "200" ]; then
+                echo "Verified $crate@$VERSION on crates.io"
+                return 0
+              fi
+              if [ "$status" != "404" ]; then
+                echo "::error::crates.io returned HTTP $status while verifying $crate@$VERSION"
+                return 1
+              fi
+              if [ "$attempt" -lt 18 ]; then
+                sleep 10
+              fi
+            done
+            echo "::error::$crate@$VERSION did not become visible on crates.io"
+            return 1
+          }
+
+          libkrun_code="$(crate_status a3s-libkrun-sys)"
+          case "$libkrun_code" in
+            200) ;;
+            404)
+              echo "::error title=missing a3s-libkrun-sys release::Publish and verify a3s-libkrun-sys@$VERSION with publish-libkrun-sys.yml before running the general release."
+              exit 1
+              ;;
+            *)
+              echo "::error::crates.io returned HTTP $libkrun_code while checking a3s-libkrun-sys@$VERSION"
+              exit 1
+              ;;
+          esac
+
           # Order matters: a dependent is published AFTER its internal deps so
           # the index has them. libkrun-sys is deliberately excluded: its
           # dedicated workflow performs native clean-package, size, and
           # corresponding-source gates that this stub-mode job cannot bypass.
           for crate in a3s-box-core a3s-box-netproxy a3s-box-runtime a3s-box-sdk; do
-            code=$(curl -s -o /dev/null -w '%{http_code}' "https://crates.io/api/v1/crates/$crate/$VERSION")
-            if [ "$code" = "200" ]; then
-              echo "✓ $crate@$VERSION already on crates.io — skipping"
-              continue
-            fi
-            echo "Publishing $crate@$VERSION..."
-            if cargo publish --locked -p "$crate" --allow-dirty; then
-              echo "✓ published $crate@$VERSION"
-              sleep 30   # let the sparse index update before dependents publish
-            else
-              echo "::warning title=crates.io publish failed::$crate@$VERSION failed (token/auth or version requirement). GitHub Release + Homebrew are unaffected."
-              FAILED="$FAILED $crate"
-            fi
+            code="$(crate_status "$crate")"
+            case "$code" in
+              200)
+                echo "$crate@$VERSION already exists; skipping upload"
+                ;;
+              404)
+                echo "Publishing $crate@$VERSION..."
+                if ! cargo publish --locked -p "$crate" --allow-dirty; then
+                  code="$(crate_status "$crate")"
+                  if [ "$code" != "200" ]; then
+                    echo "::error::$crate@$VERSION publication failed"
+                    exit 1
+                  fi
+                  echo "$crate@$VERSION became visible after a concurrent publication"
+                fi
+                ;;
+              *)
+                echo "::error::crates.io returned HTTP $code while checking $crate@$VERSION"
+                exit 1
+                ;;
+            esac
+            wait_for_crate "$crate"
           done
-          if [ -n "$FAILED" ]; then
-            echo "::warning::crates.io publish incomplete for:$FAILED — does NOT block the release; rotate CARGO_REGISTRY_TOKEN / fix version requirements to resolve."
-          fi
 
   # ── Update Homebrew Formula ────────────────────────────────────
   publish-homebrew:

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,9 +125,9 @@ base64 = "0.22"
 ring = "0.17"
 
 # Shared types (transport protocol, privacy, tools)
-a3s-acl = { git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
+a3s-acl = { version = "0.2.2", git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
-a3s-runtime = { git = "https://github.com/A3S-Lab/Runtime.git", rev = "91a1b4c67ef2691915f2409a8cf835f7534020ff" }
+a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "91a1b4c67ef2691915f2409a8cf835f7534020ff" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary

- add crates.io-compatible project User-Agent headers and strict status handling
- wait for each crate to become visible before publishing its dependents
- add the required crates.io versions alongside pinned git revisions for `a3s-acl` and `a3s-runtime`
- add an exact-commit Action for publishing the pinned `a3s-runtime` prerequisite with the Box registry credential

## Root causes addressed

The first v3.1.0 registry job stopped because crates.io rejects anonymous/default curl identification under its data-access policy. Publish dry-runs also exposed that the new `a3s-runtime` dependency was not yet on crates.io and that the pinned git dependencies lacked publishable version metadata.

## Validation

- workflow YAML parsing
- changed embedded Bash blocks pass `bash -n`
- `cargo metadata --locked --no-deps`
- `cargo publish --locked -p a3s-box-core --dry-run --allow-dirty`
- `cargo publish --locked -p a3s-box-netproxy --dry-run --allow-dirty`
- crates.io API returns 200 with the project User-Agent
- pinned `a3s-runtime` source passes its own `cargo publish --locked --dry-run`