### PR TITLE
fix(release): enforce crate dependency order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -738,10 +738,14 @@ jobs:
             for attempt in $(seq 1 18); do
               status="$(crate_status "$crate")"
               if [ "$status" = "200" ]; then
-                echo "Verified $crate@$VERSION on crates.io"
-                return 0
+                if cargo info "$crate@$VERSION" \
+                     --registry crates-io >/dev/null 2>&1; then
+                  echo "Verified $crate@$VERSION in the crates.io index"
+                  return 0
+                fi
+                echo "$crate@$VERSION is visible through the API; waiting for the index"
               fi
-              if [ "$status" != "404" ]; then
+              if [ "$status" != "200" ] && [ "$status" != "404" ]; then
                 echo "::error::crates.io returned HTTP $status while verifying $crate@$VERSION"
                 return 1
               fi

--- a/src/compat/Cargo.toml
+++ b/src/compat/Cargo.toml
@@ -9,8 +9,8 @@ description = "Protocol compatibility service and contract fixtures for A3S Box"
 
 [dependencies]
 a3s-acl = { workspace = true }
-a3s-box-core = { version = "3.0", path = "../core" }
-a3s-box-runtime = { version = "3.0", path = "../runtime", default-features = false, features = ["vm"] }
+a3s-box-core = { version = "3.1", path = "../core" }
+a3s-box-runtime = { version = "3.1", path = "../runtime", default-features = false, features = ["vm"] }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }

--- a/src/netproxy/Cargo.toml
+++ b/src/netproxy/Cargo.toml
@@ -12,7 +12,7 @@ name = "a3s_box_netproxy"
 path = "src/lib.rs"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-a3s-box-core = { version = "3.0", path = "../core" }
+a3s-box-core = { version = "3.1", path = "../core" }
 libc = { workspace = true }
 tracing = { workspace = true }
 smoltcp = { version = "0.11", default-features = false, features = [
@@ -28,7 +28,7 @@ smoltcp = { version = "0.11", default-features = false, features = [
 [target.'cfg(all(unix, not(target_os = "macos")))'.dev-dependencies]
 # The implementation is shipped only on macOS, but its Unix datagram, packet,
 # and proxy state tests also run on Linux CI and production validation hosts.
-a3s-box-core = { version = "3.0", path = "../core" }
+a3s-box-core = { version = "3.1", path = "../core" }
 libc = { workspace = true }
 tracing = { workspace = true }
 smoltcp = { version = "0.11", default-features = false, features = [

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -26,7 +26,7 @@ operator = []
 build = []
 
 [dependencies]
-a3s-box-core = { version = "3.0", path = "../core" }
+a3s-box-core = { version = "3.1", path = "../core" }
 a3s-transport = { workspace = true }
 
 # Async runtime
@@ -90,7 +90,7 @@ prometheus = { workspace = true }
 
 # macOS userspace network proxy (replaces gvproxy)
 [target.'cfg(target_os = "macos")'.dependencies]
-a3s-box-netproxy = { version = "3.0", path = "../netproxy" }
+a3s-box-netproxy = { version = "3.1", path = "../netproxy" }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48", features = [

--- a/src/sdk/Cargo.toml
+++ b/src/sdk/Cargo.toml
@@ -12,8 +12,8 @@ default = []
 pipeline-cli = []
 
 [dependencies]
-a3s-box-core = { version = "3.0", path = "../core" }
-a3s-box-runtime = { version = "3.0", path = "../runtime" }
+a3s-box-core = { version = "3.1", path = "../core" }
+a3s-box-runtime = { version = "3.1", path = "../runtime" }
 base64 = { workspace = true }
 chrono = { workspace = true }
 libc = { workspace = true }


### PR DESCRIPTION
## Summary

- raise internal A3S Box crate requirements from `3.0` to the actual minimum `3.1` API used by this release
- wait for each newly published crate to appear in Cargo's sparse index, not only the crates.io HTTP API

## Root cause

A publish dry-run for `a3s-box-runtime` selected `a3s-box-core 3.0.10`, which lacks APIs introduced in 3.1.0. The release already publishes in dependency order; these minimum requirements make Cargo enforce that order and prevent verification against an incompatible older crate.

## Validation

- `cargo metadata --locked --no-deps`
- `cargo fmt --all -- --check`
- `cargo publish --locked -p a3s-box-core --dry-run --allow-dirty`
- dependent crate package contents were validated before tightening the minimum version
- `cargo info a3s-runtime@0.2.0 --registry crates-io` verifies sparse-index visibility
- release YAML parses and the changed Bash block passes `bash -n`