### PR TITLE
fix(release): extract only Windows guest payload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -558,8 +558,12 @@ jobs:
           cp src/target/x86_64-pc-windows-msvc/release/a3s-box.exe "$DIR/"
           cp src/target/x86_64-pc-windows-msvc/release/a3s-box-shim.exe "$DIR/"
 
-          tar -xzf "linux-x86_64/a3s-box-${TAG}-linux-x86_64.tar.gz" -C linux-x86_64
-          cp "linux-x86_64/a3s-box-${TAG}-linux-x86_64/a3s-box-guest-init" "$DIR/"
+          LINUX_ARCHIVE="linux-x86_64/a3s-box-${TAG}-linux-x86_64.tar.gz"
+          GUEST_MEMBER="a3s-box-${TAG}-linux-x86_64/a3s-box-guest-init"
+          # Windows only needs the guest executable. Extracting the complete
+          # Linux archive would also ask Windows tar to create Unix symlinks.
+          tar -xzf "$LINUX_ARCHIVE" -C linux-x86_64 "$GUEST_MEMBER"
+          cp "linux-x86_64/$GUEST_MEMBER" "$DIR/"
 
           if [ -f "src/target/x86_64-pc-windows-msvc/release/krun.dll" ]; then
             cp src/target/x86_64-pc-windows-msvc/release/krun.dll "$DIR/"


### PR DESCRIPTION
## Summary

- extract only `a3s-box-guest-init` from the Linux archive during Windows packaging
- avoid asking Windows tar to create unrelated Unix `libkrun` symlinks

## Root cause

The final v3.1.0 run built every Windows binary successfully, then failed while extracting the complete Linux archive. Windows tar could not materialize the Linux `libkrun*.so` symlink chain. The Windows package only consumes the Linux guest executable.

## Validation

- downloaded the exact `linux-x86_64` artifact from release run 30016929743
- selectively extracted the exact guest member
- verified the extracted member is a regular file and no symlinks were created
- release YAML parses and the Windows package Bash block passes `bash -n`