### PR TITLE
fix(release): support SDK registry token fallback

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -238,6 +238,8 @@ jobs:
           path: publish/npm
 
       - name: Publish npm package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish publish/npm/*.tgz --access public
 
   publish-pypi:
@@ -258,4 +260,5 @@ jobs:
       - name: Publish PyPI package
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
         with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: publish/pypi


### PR DESCRIPTION
## Summary

- pass the repository npm token to the SDK publish job
- pass the repository PyPI API token to the PyPI publish action
- preserve OIDC permissions so trusted publishing remains available when token secrets are absent

## Validation

- `git diff --check`
- parsed `.github/workflows/publish-sdk.yml` as YAML

This unblocks the `v3.1.0` SDK packages after the registry-side trusted publisher configuration rejected the current workflow identity.