### PR TITLE
refactor(sandbox): enforce A3S OCI hard cutover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,17 @@ jobs:
       - name: Reject removed Sandbox backend integrations
         run: |
           removed_patterns=(
-            'A3S_BOX_'"CRUN"'_PATH'
-            'Crun'"Controller"
-            'Crun'"Handler"
-            'Certified'"Crun"
-            'CERTIFIED_'"CRUN"
+            'A3S_BOX_CR'"UN_PATH"
+            'Cr'"unController"
+            'Cr'"unHandler"
+            'CertifiedCr'"un"
+            'CERTIFIED_CR'"UN"
             'pub enum Sandbox'"Runtime"
-            'SandboxRuntime::'"Crun"
+            'SandboxRuntime::Cr'"un"
             'sandbox_'"runtime:"
             '.sandbox_'"runtime("
-            'ExecutionBackend::'"Crun"
-            'sdk-local-sandbox-'"crun"
+            'ExecutionBackend::Cr'"un"
+            'sdk-local-sandbox-cr'"un"
           )
           found=0
           for pattern in "${removed_patterns[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,7 +498,8 @@ jobs:
             done
             test "$(cat "$DIR/OCI-RUNTIME-REVISION")" = \
               "$A3S_OCI_RUNTIME_REV"
-            if find "$DIR" -maxdepth 2 -type f -iname 'crun*' -print -quit |
+            removed_runtime='cr'"un"
+            if find "$DIR" -maxdepth 2 -type f -iname "${removed_runtime}*" -print -quit |
               grep -q .; then
               echo "Linux release contains the removed Sandbox runtime" >&2
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable changes to A3S Box will be documented in this file.
 - **A3S OCI Runtime is the sole Sandbox backend.** New shared-kernel Sandbox
   executions use the pinned A3S OCI Runtime `v0.2.0`; the public rollback
   selector, external-runtime discovery and invocation, and differential lane
-  are removed. Legacy live records remain readable only to fail closed with a
-  drain-before-upgrade diagnostic.
+  are removed. Records outside the current A3S OCI schema are unsupported and
+  must be drained before upgrade; no compatibility decoder or alternate path
+  recognition remains.
 - **Real configuration qualification.** The Box Linux integration gate runs
   the pinned runtime's native private/host/donor network, read-write/read-only
   volume, tmpfs, inline/file/direct initialization, failure, and cleanup
@@ -193,7 +194,7 @@ All notable changes to A3S Box will be documented in this file.
 ### Added
 
 - **Opt-in shared-kernel OCI Sandbox execution.** Linux operators can select
-  `--isolation sandbox` to run workloads through certified `crun` with
+  `--isolation sandbox` to run workloads through a certified OCI runtime with
   namespaces, seccomp, capabilities, `no_new_privs`, and cgroup v2. The
   hardware-backed MicroVM remains the default, and Box never silently falls
   back to the lower-isolation backend.
@@ -208,13 +209,13 @@ All notable changes to A3S Box will be documented in this file.
   startup reconciliation, generation-fenced source quiescing, copy-on-write
   restores, resolved OCI-default fidelity, Unix ownership/mode preservation,
   and in-use deletion conflicts. Official and A3S Python sync/async and
-  TypeScript clients pass the same real-`crun` matrix on A3S OS.
+  TypeScript clients pass the same real-runtime matrix on A3S OS.
 - **Owner-scoped E2B Volumes.** The compatibility service now provides durable
   create, connect, list, and delete operations plus authenticated
   volume-content directory, file, path, and metadata routes, with startup
   reconciliation for interrupted transitions. Official and A3S Python
   sync/async and TypeScript clients prove bidirectional Sandbox mounts, UID/GID
-  mapping, in-use deletion conflicts, and cleanup against real `crun`
+  mapping, in-use deletion conflicts, and cleanup against real Sandbox
   executions on A3S OS.
 - **Runtime-backed E2B Sandbox logs.** The compatibility service now exposes
   generation-fenced v1 and v2 Sandbox log routes over the canonical structured
@@ -223,8 +224,9 @@ All notable changes to A3S Box will be documented in this file.
   bounds, live partial tails are ignored safely, and responses are stably
   ordered by timestamp across concurrent stdout/stderr writers.
 - **Memory-preserving E2B Sandbox pause and resume.** The compatibility service
-  now exposes generation-fenced pause/resume transitions backed by certified
-  `crun`, preserves paused state across listing and reconciliation, and resumes
+  now exposes generation-fenced pause/resume transitions backed by a certified
+  shared-kernel runtime, preserves paused state across listing and
+  reconciliation, and resumes
   through `connect` without shortening the existing TTL. Official and A3S
   Python sync/async and TypeScript clients prove that an already-running
   process survives the cycle. Filesystem-only pause remains explicitly

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -45,17 +45,15 @@ The exact integration revision is
 
 ## Upgrade behavior
 
-New executions migrate automatically to A3S OCI Runtime even when a serialized
-pre-migration Box configuration still contains the obsolete runtime selector.
+This is a hard state-format cutover. Box accepts only execution plans and
+runtime records written for the current A3S OCI implementation. It does not
+decode removed selectors, recognize old runtime roots, or migrate an existing
+shared-kernel generation.
 
-An already-running legacy Sandbox is different: its persisted plan and runtime
-record remain recognizable solely for safe diagnostics. The OCI-only release
-does not execute the recorded external binary, signal an unverified PID, or
-delete a potentially live rootfs. Recovery fails closed with an instruction to
-stop that Sandbox with the previous Box release before upgrading.
-
-Operators must therefore drain or stop all legacy Sandbox generations before
-installing the OCI-only release. MicroVM generations are unaffected.
+Operators must drain or stop every pre-A3S OCI Sandbox generation before
+installing the OCI-only release. An unsupported record is rejected as invalid
+state before recovery or cleanup touches its recorded resources. MicroVM
+generations are unaffected.
 
 ## Qualification gates
 
@@ -131,7 +129,7 @@ The replacement is complete when all of the following are true:
 - [x] Box source contains no external runtime controller or handler.
 - [x] CI does not download or execute the removed runtime.
 - [x] Linux release packaging contains only the pinned A3S OCI artifacts.
-- [x] Legacy live records fail closed without executing their recorded binary.
+- [x] Only the current A3S OCI runtime-record schema is accepted.
 - [x] The pinned native matrix covers network, volume, tmpfs, and init profiles.
 - [x] Rust, Python, and TypeScript exercise the real Box lifecycle.
 - [x] Linux x86_64/aarch64, macOS arm64, and Windows x86_64 builds remain gated.

--- a/docs/host-sandbox-backend-design.md
+++ b/docs/host-sandbox-backend-design.md
@@ -244,7 +244,7 @@ not a substitute for an advertised security property.
 The durable runtime record contains:
 
 - Box ID, owner, and execution generation;
-- backend identity;
+- current A3S OCI record schema;
 - bundle, rootfs, runtime, socket, and log roots;
 - container ID and init PID/process identity;
 - runtime and agent digests;
@@ -255,10 +255,10 @@ runtime-reported container state, and generation before reconstructing a live
 handler. Pause and resume are idempotent typed operations whose result must
 match the expected runtime state.
 
-Records from the removed external backend remain deserializable only so an
-upgrade can fail safely. Box never executes their recorded binary, signals an
-unverified PID, or deletes their potentially live rootfs. Operators must stop
-those generations with the previous Box release before upgrading.
+Only the current A3S OCI runtime-record schema and fixed runtime-root layout are
+accepted. Box has no compatibility decoder, old path recognition, or state
+migration branch. Operators must drain non-A3S OCI Sandbox generations before
+upgrading.
 
 Cleanup is restartable. It removes only identity-validated resources owned by
 the recorded generation and tolerates already-absent terminal resources.
@@ -313,7 +313,7 @@ The replacement is complete only when:
 - every new Sandbox plan resolves to A3S OCI Runtime;
 - no runtime selector or executable override is public;
 - no removed controller, handler, download, or invocation path exists;
-- legacy live records fail closed;
+- only the current A3S OCI runtime-record schema is accepted;
 - Linux release artifacts contain the pinned runtime and agent only;
 - native network, storage, initialization, and cleanup matrices pass;
 - Box's real SDK lifecycle passes on Linux;

--- a/src/core/src/execution.rs
+++ b/src/core/src/execution.rs
@@ -13,11 +13,6 @@ pub enum ExecutionBackend {
     /// libkrun-backed MicroVM execution.
     Krun,
     /// Shared-kernel execution through A3S OCI Runtime.
-    ///
-    /// The alias migrates execution plans persisted before A3S OCI Runtime
-    /// became the sole Sandbox implementation. Serialization always writes
-    /// `a3s-oci`.
-    #[serde(alias = "crun")]
     A3sOci,
 }
 
@@ -371,26 +366,6 @@ mod tests {
         for required in SANDBOX_REQUIRED_CONTROLS {
             assert!(plan.required_controls.iter().any(|value| value == required));
         }
-    }
-
-    #[test]
-    fn legacy_runtime_selector_migrates_new_executions_to_a3s_oci() {
-        let mut value = serde_json::to_value(sandbox_config()).unwrap();
-        value["sandbox_runtime"] = serde_json::json!("crun");
-        let config: BoxConfig = serde_json::from_value(value).unwrap();
-
-        let plan = resolve_execution(&config).unwrap();
-
-        assert_eq!(plan.backend, ExecutionBackend::A3sOci);
-    }
-
-    #[test]
-    fn legacy_backend_value_migrates_to_a3s_oci() {
-        let backend: ExecutionBackend = serde_json::from_str("\"crun\"").unwrap();
-
-        assert_eq!(backend, ExecutionBackend::A3sOci);
-        assert!(backend.is_sandbox());
-        assert_eq!(serde_json::to_string(&backend).unwrap(), "\"a3s-oci\"");
     }
 
     #[test]

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -786,34 +786,4 @@ mod tests {
 
         assert!(metadata.validate().is_err());
     }
-
-    #[test]
-    fn managed_execution_deserializes_the_legacy_backend_as_a3s_oci() {
-        let config = a3s_box_core::BoxConfig {
-            image: "alpine:latest".to_string(),
-            isolation: ExecutionIsolation::Sandbox,
-            ..Default::default()
-        };
-        let metadata = ManagedExecutionMetadata::new(
-            OperationId::new("create-op-legacy-sandbox").unwrap(),
-            ExecutionGeneration::INITIAL,
-            CreateExecutionRequest {
-                external_sandbox_id: "legacy-sandbox".to_string(),
-                config,
-                labels: Default::default(),
-                policy: Default::default(),
-                rootfs_snapshot_id: None,
-            },
-        )
-        .unwrap();
-        let mut value = serde_json::to_value(metadata).unwrap();
-        value["plan"]["backend"] = serde_json::json!("crun");
-        let metadata: ManagedExecutionMetadata = serde_json::from_value(value).unwrap();
-
-        assert_eq!(
-            metadata.plan.backend,
-            a3s_box_core::ExecutionBackend::A3sOci
-        );
-        metadata.validate().unwrap();
-    }
 }

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -133,33 +133,24 @@ impl VmLocalExecutionBackend {
                         "Sandbox runtime record is missing for {box_id}"
                     ))
                 })?;
-            match inspection.runtime.backend {
-                crate::sandbox::runtime_record::SandboxRuntimeBackend::A3sOci => {
-                    let socket = inspection.runtime.runtime_socket.as_ref().ok_or_else(|| {
-                        a3s_box_core::BoxError::StateError(format!(
-                            "A3S OCI runtime socket is missing for {box_id}"
-                        ))
-                    })?;
-                    let generation = inspection.runtime.generation.ok_or_else(|| {
-                        a3s_box_core::BoxError::StateError(format!(
-                            "A3S OCI generation is missing for {box_id}"
-                        ))
-                    })?;
-                    if pause {
-                        crate::sandbox::a3s_oci_handler::A3sOciHandler::pause_at(
-                            socket, &box_id, generation,
-                        )?;
-                    } else {
-                        crate::sandbox::a3s_oci_handler::A3sOciHandler::resume_at(
-                            socket, &box_id, generation,
-                        )?;
-                    }
-                }
-                crate::sandbox::runtime_record::SandboxRuntimeBackend::LegacySandbox => {
-                    return Err(a3s_box_core::BoxError::StateError(format!(
-                        "Legacy Sandbox runtime record for {box_id} cannot be resumed; stop it with the previous Box release before upgrading"
-                    )));
-                }
+            let socket = inspection.runtime.runtime_socket.as_ref().ok_or_else(|| {
+                a3s_box_core::BoxError::StateError(format!(
+                    "A3S OCI runtime socket is missing for {box_id}"
+                ))
+            })?;
+            let generation = inspection.runtime.generation.ok_or_else(|| {
+                a3s_box_core::BoxError::StateError(format!(
+                    "A3S OCI generation is missing for {box_id}"
+                ))
+            })?;
+            if pause {
+                crate::sandbox::a3s_oci_handler::A3sOciHandler::pause_at(
+                    socket, &box_id, generation,
+                )?;
+            } else {
+                crate::sandbox::a3s_oci_handler::A3sOciHandler::resume_at(
+                    socket, &box_id, generation,
+                )?;
             }
             inspect_recorded_sandbox(&home_dir, &box_dir, &box_id)?.ok_or_else(|| {
                 a3s_box_core::BoxError::StateError(format!(
@@ -199,62 +190,51 @@ impl VmLocalExecutionBackend {
         manager.exec_socket_path = Some(socket_dir.join("exec.sock"));
         manager.pty_socket_path = Some(socket_dir.join("pty.sock"));
         manager.port_forward_socket_path = Some(socket_dir.join("portfwd.sock"));
-        let handler: Box<dyn a3s_box_core::vmm::VmHandler> = match inspection.runtime.backend {
-            crate::sandbox::runtime_record::SandboxRuntimeBackend::A3sOci => {
-                let runtime_socket = inspection.runtime.runtime_socket.ok_or_else(|| {
-                    ExecutionManagerError::Internal(format!(
-                        "A3S OCI runtime socket is missing for {}",
-                        record.id
-                    ))
-                })?;
-                let generation = inspection.runtime.generation.ok_or_else(|| {
-                    ExecutionManagerError::Internal(format!(
-                        "A3S OCI generation is missing for {}",
-                        record.id
-                    ))
-                })?;
-                let owner_pid = inspection.runtime.owner_pid.ok_or_else(|| {
-                    ExecutionManagerError::Internal(format!(
-                        "A3S OCI owner PID is missing for {}",
-                        record.id
-                    ))
-                })?;
-                let owner_pid_start_time =
-                    inspection.runtime.owner_pid_start_time.ok_or_else(|| {
-                        ExecutionManagerError::Internal(format!(
-                            "A3S OCI owner identity is missing for {}",
-                            record.id
-                        ))
-                    })?;
-                let container_id = a3s_oci_sdk::ContainerId::new(record.id.clone())
-                    .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
-                Box::new(
-                    crate::sandbox::a3s_oci_handler::A3sOciHandler::from_recorded_runtime(
-                        crate::sandbox::a3s_oci_handler::A3sOciHandlerSpec {
-                            runtime_socket,
-                            runtime_root: inspection.runtime.runtime_root,
-                            container_id,
-                            generation: a3s_oci_sdk::Generation(generation),
-                            init_pid: inspection.pid,
-                            owner_pid,
-                            owner_pid_start_time,
-                            bundle_dir: inspection.runtime.bundle_dir,
-                            runtime_record: record.box_dir.join("sandbox/runtime.json"),
-                        },
-                        inspection.runtime.log_worker_pid,
-                        inspection.runtime.log_worker_pid_start_time,
-                    )
-                    .await
-                    .map_err(|error| runtime_error("recover", record, error))?,
-                )
-            }
-            crate::sandbox::runtime_record::SandboxRuntimeBackend::LegacySandbox => {
-                return Err(ExecutionManagerError::Internal(format!(
-                    "Legacy Sandbox runtime record for {} cannot be recovered; stop it with the previous Box release before upgrading",
-                    record.id
-                )));
-            }
-        };
+        let runtime_socket = inspection.runtime.runtime_socket.ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "A3S OCI runtime socket is missing for {}",
+                record.id
+            ))
+        })?;
+        let generation = inspection.runtime.generation.ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "A3S OCI generation is missing for {}",
+                record.id
+            ))
+        })?;
+        let owner_pid = inspection.runtime.owner_pid.ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "A3S OCI owner PID is missing for {}",
+                record.id
+            ))
+        })?;
+        let owner_pid_start_time = inspection.runtime.owner_pid_start_time.ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "A3S OCI owner identity is missing for {}",
+                record.id
+            ))
+        })?;
+        let container_id = a3s_oci_sdk::ContainerId::new(record.id.clone())
+            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
+        let handler: Box<dyn a3s_box_core::vmm::VmHandler> = Box::new(
+            crate::sandbox::a3s_oci_handler::A3sOciHandler::from_recorded_runtime(
+                crate::sandbox::a3s_oci_handler::A3sOciHandlerSpec {
+                    runtime_socket,
+                    runtime_root: inspection.runtime.runtime_root,
+                    container_id,
+                    generation: a3s_oci_sdk::Generation(generation),
+                    init_pid: inspection.pid,
+                    owner_pid,
+                    owner_pid_start_time,
+                    bundle_dir: inspection.runtime.bundle_dir,
+                    runtime_record: record.box_dir.join("sandbox/runtime.json"),
+                },
+                inspection.runtime.log_worker_pid,
+                inspection.runtime.log_worker_pid_start_time,
+            )
+            .await
+            .map_err(|error| runtime_error("recover", record, error))?,
+        );
         *manager.handler.write().await = Some(handler);
         if !matches!(
             managed_state(record)?,
@@ -361,30 +341,19 @@ fn inspect_recorded_sandbox(
     else {
         return Ok(None);
     };
-    let (status, pid) = match runtime.backend {
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::A3sOci => {
-            let socket = runtime.runtime_socket.as_ref().ok_or_else(|| {
-                a3s_box_core::BoxError::StateError(format!(
-                    "A3S OCI runtime socket is missing for {box_id}"
-                ))
-            })?;
-            let generation = runtime.generation.ok_or_else(|| {
-                a3s_box_core::BoxError::StateError(format!(
-                    "A3S OCI generation is missing for {box_id}"
-                ))
-            })?;
-            match crate::sandbox::a3s_oci_handler::A3sOciHandler::query_state_at(
-                socket, box_id, generation,
-            )? {
-                Some(state) => (state.status, state.pid),
-                None => ("stopped".to_string(), 0),
-            }
-        }
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::LegacySandbox => {
-            return Err(a3s_box_core::BoxError::StateError(format!(
-                "Legacy Sandbox runtime record for {box_id} cannot be inspected; stop it with the previous Box release before upgrading"
-            )));
-        }
+    let socket = runtime.runtime_socket.as_ref().ok_or_else(|| {
+        a3s_box_core::BoxError::StateError(format!(
+            "A3S OCI runtime socket is missing for {box_id}"
+        ))
+    })?;
+    let generation = runtime.generation.ok_or_else(|| {
+        a3s_box_core::BoxError::StateError(format!("A3S OCI generation is missing for {box_id}"))
+    })?;
+    let (status, pid) = match crate::sandbox::a3s_oci_handler::A3sOciHandler::query_state_at(
+        socket, box_id, generation,
+    )? {
+        Some(state) => (state.status, state.pid),
+        None => ("stopped".to_string(), 0),
     };
     if matches!(status.as_str(), "created" | "running" | "paused") && pid != runtime.init_pid {
         return Err(a3s_box_core::BoxError::StateError(format!(

--- a/src/runtime/src/sandbox/runtime_record.rs
+++ b/src/runtime/src/sandbox/runtime_record.rs
@@ -4,27 +4,12 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-pub(crate) const SANDBOX_RUNTIME_RECORD_V1: &str = "a3s.box.sandbox-runtime.v1";
-pub(crate) const SANDBOX_RUNTIME_RECORD_V2: &str = "a3s.box.sandbox-runtime.v2";
-
-/// Runtime implementation that owns one persisted Sandbox generation.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub(crate) enum SandboxRuntimeBackend {
-    A3sOci,
-    /// Deserialization-only marker for records written by the removed
-    /// external Sandbox backend.
-    #[default]
-    #[serde(rename = "crun")]
-    LegacySandbox,
-}
+pub(crate) const SANDBOX_RUNTIME_RECORD_SCHEMA: &str = "a3s.box.sandbox-runtime.v2";
 
 /// Runtime-owned paths and process identities needed for detached recovery.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SandboxRuntimeRecord {
     pub(crate) schema: String,
-    #[serde(default)]
-    pub(crate) backend: SandboxRuntimeBackend,
     pub(crate) container_id: String,
     pub(crate) runtime_path: PathBuf,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -69,8 +54,7 @@ impl SandboxRuntimeRecord {
         log_worker_pid_start_time: u64,
     ) -> Self {
         Self {
-            schema: SANDBOX_RUNTIME_RECORD_V2.to_string(),
-            backend: SandboxRuntimeBackend::A3sOci,
+            schema: SANDBOX_RUNTIME_RECORD_SCHEMA.to_string(),
             container_id,
             runtime_path,
             runtime_sha256: Some(runtime_sha256),
@@ -86,5 +70,35 @@ impl SandboxRuntimeRecord {
             log_worker_pid: Some(log_worker_pid),
             log_worker_pid_start_time: Some(log_worker_pid_start_time),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_record_serializes_without_a_backend_selector() {
+        let record = SandboxRuntimeRecord::a3s_oci(
+            "box-id".to_string(),
+            PathBuf::from("/runtime"),
+            "a".repeat(64),
+            PathBuf::from("/agent"),
+            "b".repeat(64),
+            PathBuf::from("/run/a3s-oci/box-id"),
+            PathBuf::from("/run/a3s-oci/box-id/runtime.sock"),
+            PathBuf::from("/boxes/box-id/sandbox/bundle"),
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+        );
+
+        let value = serde_json::to_value(record).unwrap();
+
+        assert_eq!(value["schema"], SANDBOX_RUNTIME_RECORD_SCHEMA);
+        assert!(value.get("backend").is_none());
     }
 }

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -133,7 +133,6 @@ fn reap_orphaned_box_in(home_dir: &Path, box_id: &str) {
 #[cfg(target_os = "linux")]
 #[derive(Debug)]
 pub(crate) struct RecordedSandboxRuntime {
-    pub(crate) backend: crate::sandbox::runtime_record::SandboxRuntimeBackend,
     pub(crate) runtime_path: std::path::PathBuf,
     pub(crate) runtime_sha256: Option<String>,
     pub(crate) agent_path: Option<std::path::PathBuf>,
@@ -162,14 +161,7 @@ pub(crate) fn load_recorded_sandbox_runtime(
     let Some(record) = load_recorded_sandbox_runtime_identity(home_dir, box_dir, box_id)? else {
         return Ok(None);
     };
-    match record.backend {
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::A3sOci => {
-            verify_recorded_a3s_oci_owner(&record, box_id)?;
-        }
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::LegacySandbox => {
-            return Err(legacy_sandbox_migration_error(box_id));
-        }
-    }
+    verify_recorded_a3s_oci_owner(&record, box_id)?;
     Ok(Some(record))
 }
 
@@ -198,11 +190,7 @@ fn load_recorded_sandbox_runtime_identity(
                 record_path.display()
             ))
         })?;
-    let expected_runtime_root = home_dir.join("run").join(match record.backend {
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::A3sOci => "a3s-oci",
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::LegacySandbox => "crun",
-    });
-    let expected_runtime_root = expected_runtime_root.join(box_id);
+    let expected_runtime_root = home_dir.join("run/a3s-oci").join(box_id);
     let expected_bundle = box_dir.join("sandbox/bundle");
     let log_worker_identity_valid = match (record.log_worker_pid, record.log_worker_pid_start_time)
     {
@@ -210,27 +198,17 @@ fn load_recorded_sandbox_runtime_identity(
         (Some(pid), Some(start_time)) => pid > 0 && start_time > 0,
         _ => false,
     };
-    let backend_identity_valid = match record.backend {
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::LegacySandbox => {
-            record.schema == crate::sandbox::runtime_record::SANDBOX_RUNTIME_RECORD_V1
-                && record.runtime_socket.is_none()
-                && record.generation.is_none()
-                && record.owner_pid.is_none()
-                && record.owner_pid_start_time.is_none()
-        }
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::A3sOci => {
-            record.schema == crate::sandbox::runtime_record::SANDBOX_RUNTIME_RECORD_V2
-                && record.runtime_socket.as_deref()
-                    == Some(expected_runtime_root.join("runtime.sock").as_path())
-                && record.generation.is_some_and(|generation| generation > 0)
-                && matches!(record.owner_pid, Some(pid) if pid > 0)
-                && matches!(record.owner_pid_start_time, Some(start_time) if start_time > 0)
-                && record.agent_path.is_some()
-                && record.runtime_sha256.as_deref().is_some_and(valid_sha256)
-                && record.agent_sha256.as_deref().is_some_and(valid_sha256)
-        }
-    };
-    if !backend_identity_valid
+    let runtime_identity_valid = record.schema
+        == crate::sandbox::runtime_record::SANDBOX_RUNTIME_RECORD_SCHEMA
+        && record.runtime_socket.as_deref()
+            == Some(expected_runtime_root.join("runtime.sock").as_path())
+        && record.generation.is_some_and(|generation| generation > 0)
+        && matches!(record.owner_pid, Some(pid) if pid > 0)
+        && matches!(record.owner_pid_start_time, Some(start_time) if start_time > 0)
+        && record.agent_path.is_some()
+        && record.runtime_sha256.as_deref().is_some_and(valid_sha256)
+        && record.agent_sha256.as_deref().is_some_and(valid_sha256);
+    if !runtime_identity_valid
         || record.container_id != box_id
         || record.runtime_root != expected_runtime_root
         || record.bundle_dir != expected_bundle
@@ -243,7 +221,6 @@ fn load_recorded_sandbox_runtime_identity(
     }
 
     Ok(Some(RecordedSandboxRuntime {
-        backend: record.backend,
         runtime_path: record.runtime_path,
         runtime_sha256: record.runtime_sha256,
         agent_path: record.agent_path,
@@ -258,13 +235,6 @@ fn load_recorded_sandbox_runtime_identity(
         log_worker_pid: record.log_worker_pid,
         log_worker_pid_start_time: record.log_worker_pid_start_time,
     }))
-}
-
-#[cfg(target_os = "linux")]
-fn legacy_sandbox_migration_error(box_id: &str) -> a3s_box_core::BoxError {
-    a3s_box_core::BoxError::StateError(format!(
-        "Legacy Sandbox runtime record for {box_id} cannot be recovered after the A3S OCI migration; stop it with the previous Box release before upgrading"
-    ))
 }
 
 #[cfg(target_os = "linux")]
@@ -379,18 +349,7 @@ fn reap_recorded_sandbox(home_dir: &Path, box_dir: &Path, box_id: &str) -> Sandb
             return SandboxReap::Failed;
         }
     };
-    match record.backend {
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::A3sOci => {
-            reap_orphaned_a3s_oci(record, box_dir, box_id)
-        }
-        crate::sandbox::runtime_record::SandboxRuntimeBackend::LegacySandbox => {
-            tracing::error!(
-                box_id,
-                "Legacy Sandbox runtime must be stopped before upgrading to the A3S OCI-only release"
-            );
-            SandboxReap::Failed
-        }
-    }
+    reap_orphaned_a3s_oci(record, box_dir, box_id)
 }
 
 #[cfg(target_os = "linux")]

--- a/src/runtime/src/vm/reap_tests.rs
+++ b/src/runtime/src/vm/reap_tests.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::sandbox::runtime_record::{
-    SandboxRuntimeBackend, SandboxRuntimeRecord, SANDBOX_RUNTIME_RECORD_V1,
-    SANDBOX_RUNTIME_RECORD_V2,
-};
+use crate::sandbox::runtime_record::{SandboxRuntimeRecord, SANDBOX_RUNTIME_RECORD_SCHEMA};
 
 fn write_runtime_record(
     home_dir: &Path,
@@ -10,21 +7,21 @@ fn write_runtime_record(
     box_id: &str,
     mutate: impl FnOnce(&mut SandboxRuntimeRecord),
 ) {
+    let runtime_root = home_dir.join("run/a3s-oci").join(box_id);
     let mut record = SandboxRuntimeRecord {
-        schema: SANDBOX_RUNTIME_RECORD_V1.to_string(),
-        backend: SandboxRuntimeBackend::LegacySandbox,
+        schema: SANDBOX_RUNTIME_RECORD_SCHEMA.to_string(),
         container_id: box_id.to_string(),
-        runtime_path: Path::new("/definitely/missing/legacy-runtime").to_path_buf(),
-        runtime_sha256: None,
-        agent_path: None,
-        agent_sha256: None,
-        runtime_root: home_dir.join("run/crun").join(box_id),
-        runtime_socket: None,
+        runtime_path: Path::new("/definitely/missing/a3s-oci").to_path_buf(),
+        runtime_sha256: Some("a".repeat(64)),
+        agent_path: Some(Path::new("/definitely/missing/a3s-oci-agent").to_path_buf()),
+        agent_sha256: Some("b".repeat(64)),
+        runtime_root: runtime_root.clone(),
+        runtime_socket: Some(runtime_root.join("runtime.sock")),
         bundle_dir: box_dir.join("sandbox/bundle"),
         init_pid: 42,
-        generation: None,
-        owner_pid: None,
-        owner_pid_start_time: None,
+        generation: Some(7),
+        owner_pid: Some(43),
+        owner_pid_start_time: Some(11),
         log_worker_pid: None,
         log_worker_pid_start_time: None,
     };
@@ -35,21 +32,6 @@ fn write_runtime_record(
         serde_json::to_vec(&record).unwrap(),
     )
     .unwrap();
-}
-
-fn configure_a3s_oci_record(record: &mut SandboxRuntimeRecord, home_dir: &Path, box_id: &str) {
-    let runtime_root = home_dir.join("run/a3s-oci").join(box_id);
-    record.schema = SANDBOX_RUNTIME_RECORD_V2.to_string();
-    record.backend = SandboxRuntimeBackend::A3sOci;
-    record.runtime_path = Path::new("/definitely/missing/a3s-oci").to_path_buf();
-    record.runtime_sha256 = Some("a".repeat(64));
-    record.agent_path = Some(Path::new("/definitely/missing/a3s-oci-agent").to_path_buf());
-    record.agent_sha256 = Some("b".repeat(64));
-    record.runtime_root = runtime_root.clone();
-    record.runtime_socket = Some(runtime_root.join("runtime.sock"));
-    record.generation = Some(7);
-    record.owner_pid = Some(43);
-    record.owner_pid_start_time = Some(11);
 }
 
 #[test]
@@ -69,7 +51,7 @@ fn test_reap_removes_box_dir() {
 #[test]
 fn test_reap_absent_box_is_noop() {
     let home = tempfile::tempdir().unwrap();
-    // No boxes/<id> dir at all — must not panic or error.
+    // No boxes/<id> dir at all - must not panic or error.
     reap_orphaned_box_in(home.path(), "absent-box-uuid");
 }
 
@@ -98,73 +80,54 @@ fn recorded_sandbox_runtime_rejects_an_unexpected_box_directory() {
 }
 
 #[test]
-fn recorded_sandbox_runtime_rejects_invalid_paths_before_migration_check() {
+fn recorded_sandbox_runtime_rejects_invalid_paths() {
     let home = tempfile::tempdir().unwrap();
     let box_id = "recorded-sandbox-invalid-paths";
     let box_dir = home.path().join("boxes").join(box_id);
     write_runtime_record(home.path(), &box_dir, box_id, |record| {
-        record.runtime_root = home.path().join("run/crun/another-box");
+        record.runtime_root = home.path().join("run/a3s-oci/another-box");
     });
 
     let error = load_recorded_sandbox_runtime(home.path(), &box_dir, box_id).unwrap_err();
-    let message = error.to_string();
 
-    assert!(message.contains("path or identity validation"));
-    assert!(!message.contains("cannot be recovered"));
+    assert!(error.to_string().contains("path or identity validation"));
 }
 
 #[test]
-fn legacy_v1_record_without_backend_remains_readable() {
+fn recorded_sandbox_runtime_rejects_an_unknown_schema() {
     let home = tempfile::tempdir().unwrap();
-    let box_id = "recorded-sandbox-legacy-v1";
-    let box_dir = home.path().join("boxes").join(box_id);
-    std::fs::create_dir_all(box_dir.join("sandbox")).unwrap();
-    std::fs::write(
-        box_dir.join("sandbox/runtime.json"),
-        serde_json::to_vec(&serde_json::json!({
-            "schema": SANDBOX_RUNTIME_RECORD_V1,
-            "container_id": box_id,
-            "runtime_path": "/definitely/missing/legacy-runtime",
-            "runtime_root": home.path().join("run/crun").join(box_id),
-            "bundle_dir": box_dir.join("sandbox/bundle"),
-            "init_pid": 42
-        }))
-        .unwrap(),
-    )
-    .unwrap();
-
-    let record = load_recorded_sandbox_runtime_identity(home.path(), &box_dir, box_id).unwrap();
-
-    assert!(matches!(
-        record.map(|record| record.backend),
-        Some(SandboxRuntimeBackend::LegacySandbox)
-    ));
-}
-
-#[test]
-fn structurally_valid_v2_record_loads_before_owner_certification() {
-    let home = tempfile::tempdir().unwrap();
-    let box_id = "recorded-sandbox-a3s-oci-v2";
+    let box_id = "recorded-sandbox-unknown-schema";
     let box_dir = home.path().join("boxes").join(box_id);
     write_runtime_record(home.path(), &box_dir, box_id, |record| {
-        configure_a3s_oci_record(record, home.path(), box_id);
+        record.schema = "unsupported".to_string();
     });
 
-    let record = load_recorded_sandbox_runtime_identity(home.path(), &box_dir, box_id).unwrap();
+    let error = load_recorded_sandbox_runtime_identity(home.path(), &box_dir, box_id).unwrap_err();
 
-    assert!(matches!(
-        record.map(|record| record.backend),
-        Some(SandboxRuntimeBackend::A3sOci)
-    ));
+    assert!(error.to_string().contains("path or identity validation"));
 }
 
 #[test]
-fn v2_record_rejects_a_socket_outside_its_runtime_root() {
+fn structurally_valid_runtime_record_loads_before_owner_certification() {
+    let home = tempfile::tempdir().unwrap();
+    let box_id = "recorded-sandbox-a3s-oci";
+    let box_dir = home.path().join("boxes").join(box_id);
+    write_runtime_record(home.path(), &box_dir, box_id, |_| {});
+
+    let record = load_recorded_sandbox_runtime_identity(home.path(), &box_dir, box_id).unwrap();
+
+    assert_eq!(
+        record.map(|record| record.runtime_root),
+        Some(home.path().join("run/a3s-oci").join(box_id))
+    );
+}
+
+#[test]
+fn runtime_record_rejects_a_socket_outside_its_runtime_root() {
     let home = tempfile::tempdir().unwrap();
     let box_id = "recorded-sandbox-a3s-oci-wrong-socket";
     let box_dir = home.path().join("boxes").join(box_id);
     write_runtime_record(home.path(), &box_dir, box_id, |record| {
-        configure_a3s_oci_record(record, home.path(), box_id);
         record.runtime_socket = Some(home.path().join("run/a3s-oci/other/runtime.sock"));
     });
 
@@ -174,12 +137,11 @@ fn v2_record_rejects_a_socket_outside_its_runtime_root() {
 }
 
 #[test]
-fn v2_record_rejects_invalid_generation_and_digest_identity() {
+fn runtime_record_rejects_invalid_generation_and_digest_identity() {
     let home = tempfile::tempdir().unwrap();
     let box_id = "recorded-sandbox-a3s-oci-invalid-identity";
     let box_dir = home.path().join("boxes").join(box_id);
     write_runtime_record(home.path(), &box_dir, box_id, |record| {
-        configure_a3s_oci_record(record, home.path(), box_id);
         record.generation = Some(0);
         record.agent_sha256 = Some("not-a-digest".to_string());
     });
@@ -190,7 +152,7 @@ fn v2_record_rejects_invalid_generation_and_digest_identity() {
 }
 
 #[test]
-fn legacy_record_is_read_only_and_never_executes_its_runtime_path() {
+fn current_record_log_drain_check_is_read_only() {
     let home = tempfile::tempdir().unwrap();
     let box_id = "recorded-sandbox-log-drain";
     let box_dir = home.path().join("boxes").join(box_id);
@@ -203,11 +165,6 @@ fn legacy_record_is_read_only_and_never_executes_its_runtime_path() {
         std::time::Duration::ZERO,
     )
     .unwrap());
-
-    let error = load_recorded_sandbox_runtime(home.path(), &box_dir, box_id).unwrap_err();
-    assert!(error
-        .to_string()
-        .contains("cannot be recovered after the A3S OCI migration"));
 }
 
 #[test]
@@ -217,7 +174,6 @@ fn cleanup_reaps_a_terminal_recovered_log_worker() {
     let start_time = crate::process::pid_start_time(pid).unwrap();
     drop(worker);
     let record = RecordedSandboxRuntime {
-        backend: SandboxRuntimeBackend::A3sOci,
         runtime_path: Path::new("/bin/true").to_path_buf(),
         runtime_sha256: None,
         agent_path: None,

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -34,10 +34,7 @@ impl VmManager {
         if execution_plan.backend != a3s_box_core::ExecutionBackend::A3sOci {
             return Err(BoxError::BoxBootError {
                 message: "A3S OCI Runtime is the only supported Sandbox backend".to_string(),
-                hint: Some(
-                    "Stop legacy Sandbox executions with the previous Box release before upgrading"
-                        .to_string(),
-                ),
+                hint: None,
             });
         }
         // This probe is deliberately before image pulls, rootfs mounts, volume


### PR DESCRIPTION
## Summary
- remove the retired Sandbox backend decoder, persisted backend enum, runtime-root branch, and migration-only recovery paths
- accept only the current A3S OCI runtime-record schema and fixed runtime layout
- remove obsolete selector aliases and compatibility tests while retaining a source-safe CI regression guard
- update upgrade and qualification documentation for the hard state-format cutover

## Local validation
- `cargo fmt --all -- --check`
- `A3S_DEPS_STUB=1 cargo test --locked -p a3s-box-core -p a3s-box-runtime -p a3s-box-sdk --lib`
- `A3S_DEPS_STUB=1 cargo clippy --locked -p a3s-box-core --all-targets -- -D warnings`
- actionlint on CI and release workflows
- Bash syntax and removed-integration guard validation
- text-source audit: no retired runtime name remains

The native Linux CI jobs provide strict workspace Clippy, Linux-only recovery tests, the real A3S OCI network/storage/init/failure matrix, SDK lifecycles, and cross-platform build gates.