### PR TITLE
test(windows): harden Box WHPX soak gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 503625b176de7f22b2e31c782b82e97897e8c368
+  A3S_OCI_RUNTIME_REV: 0f0face67c282cf535e352b4fe83af02055b7e08
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 503625b176de7f22b2e31c782b82e97897e8c368
+  A3S_OCI_RUNTIME_REV: 0f0face67c282cf535e352b4fe83af02055b7e08
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -40,8 +40,8 @@ Box now:
 - rejects any reintroduction of the removed integration symbols in CI.
 
 The exact integration revision is
-`503625b176de7f22b2e31c782b82e97897e8c368`, released as A3S OCI Runtime
-`v0.2.0`.
+`0f0face67c282cf535e352b4fe83af02055b7e08`, the post-`v0.2.0` Windows WHPX
+qualification commit.
 
 ## Upgrade behavior
 

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -124,7 +124,7 @@ two resulting artifacts:
 
 ```bash
 git clone https://github.com/A3S-Lab/OCI-Runtime.git /tmp/a3s-oci-runtime
-git -C /tmp/a3s-oci-runtime checkout 503625b176de7f22b2e31c782b82e97897e8c368
+git -C /tmp/a3s-oci-runtime checkout 0f0face67c282cf535e352b4fe83af02055b7e08
 cargo build --manifest-path /tmp/a3s-oci-runtime/Cargo.toml \
   --locked --release -p a3s-oci-cli -p a3s-oci-agent
 
@@ -469,12 +469,14 @@ boundaries. Run it on an otherwise idle host:
   -DurationSeconds 7200
 ```
 
-The eleven-test default matrix contains only Windows-supported real tests,
-including a 4,096-byte workload argument, POSIX ownership and mode replay
+The twelve-test default matrix contains only Windows-supported real tests,
+including a 4,096-byte workload argument, a read-only volume-provided init
+script with success and exact failure paths, POSIX ownership and mode replay
 through restart and commit, and the full 2,048-file, five-pass virtio-fs stress.
-It writes per-test logs plus a
-machine-readable `summary.json` beneath `src/target/a3s-box-whpx-soak/` and
-fails if any test leaves an A3S Box CLI, VM shim, or forwarding worker alive.
+It writes per-test logs plus `summary.json`, operation/resource TSVs,
+start/final process inventories, and `verify.out` beneath
+`src/target/a3s-box-whpx-soak/`. It fails on count drift, resource guardrails,
+or any residual A3S Box/A3S OCI Runtime CLI, VM shim, or forwarding worker.
 Use `-ListTests` to inspect the matrix. `-SkipBuild` is intended only when the
 matching musl guest-init and Windows binaries were already built from the same
 commit.

--- a/docs/windows-whpx.md
+++ b/docs/windows-whpx.md
@@ -87,6 +87,7 @@ the Cargo target directory.
 | Published TCP ports | Validated through the Windows named-pipe bridge, including sequential connections |
 | Bind mounts | Validated for drive-letter directory and single-file sources, including read-only enforcement |
 | Named volumes | Validated across `stop` and `restart`, including explicit removal |
+| Initialization scripts | Validated for a read-only host-provided script/config plus a named state volume, including exact success, exit 42 failure, and persisted evidence from both attempts |
 | POSIX ownership and modes | Validated for `chmod`, `chown`, and umask-created files and directories across clean stop, restart, and commit |
 | `diff`, `export`, stopped-box `commit`, and stopped-box filesystem snapshots | Validated through clean-stop metadata capture, committed-image re-run, snapshot restore, restart, and re-export. Running-box host-path capture remains unavailable because WHPX has no post-boot guest archive channel. |
 | `stats --no-stream` | Validated |
@@ -141,7 +142,9 @@ Run the Windows-specific soak harness from the Box repository root on an
 otherwise idle WHPX host. It builds the current guest-init and Windows binaries,
 then repeatedly exercises the supported lifecycle, logs, exit-code, long-argv,
 stats, published-port, bind-mount, named-volume, commit, snapshot, and virtio-fs
-paths.
+paths. The initialization profile additionally combines a read-only script
+mount with a named state volume and requires both a successful run and an exact
+nonzero failure.
 
 This runner supplies the `WIN-01` lane in the
 [Cross-Capability Soak Test Plan](soak-test-plan.md). Its evidence proves only
@@ -161,14 +164,16 @@ functional tests rather than being inferred from another host.
 ```
 
 Evidence is written under `src/target/a3s-box-whpx-soak/` by default. Each test
-has its own log, while `summary.json` records the commit, image digest, timings,
-failure, and any residual process details. The runner requires no active
-`a3s-box` or `a3s-box-shim` processes at startup and verifies the same invariant
-after every test.
+has its own log. `summary.json`, `operations.tsv`, `resource-samples.tsv`,
+start/final inventories, `host.json`, and `verify.out` record the commit, image
+digest, timings, peak runtime working set, handles, process counts, failures,
+and cleanup. The runner requires no active A3S Box or A3S OCI Runtime process
+at startup, verifies the same invariant after every test, and fails when
+requested/completed counts or resource guardrails drift.
 
-The eleven-test default matrix includes a 4,096-byte workload argument and
-POSIX ownership and mode replay through restart and commit. Use `-ListTests` to
-inspect the exact selection.
+The twelve-test default matrix includes a 4,096-byte workload argument,
+volume-backed init success/failure, and POSIX ownership and mode replay through
+restart and commit. Use `-ListTests` to inspect the exact selection.
 
 The virtio-fs case intentionally scans 2,048 files five times with cache mode
 `none`. Real WHPX validation took 373 seconds on the host described above, so

--- a/scripts/windows-whpx-soak.ps1
+++ b/scripts/windows-whpx-soak.ps1
@@ -9,6 +9,10 @@ param(
     [int]$CommandTimeoutSeconds = 300,
     [ValidateRange(1, 86400)]
     [int]$VirtiofsTimeoutSeconds = 900,
+    [ValidateRange(1, 16384)]
+    [int]$MaxRuntimeWorkingSetMiB = 2048,
+    [ValidateRange(1, 65536)]
+    [int]$MaxRuntimeHandles = 8192,
     [string]$OutputDirectory = '',
     [switch]$SkipBuild,
     [switch]$SkipVirtiofsStress,
@@ -29,6 +33,7 @@ $tests = @(
     'real_core_published_port_http_smoke',
     'real_core_bind_mounts_preserve_host_paths_and_read_only_mode',
     'real_core_named_volume_persists_across_stop_restart',
+    'real_core_volume_backed_init_script_success_and_failure',
     'real_core_commit_preserves_guest_ownership_and_modes_after_stop',
     'real_core_filesystem_image_snapshot_commands',
     'real_core_virtiofs_tar_closes_every_source_file_cleanly'
@@ -73,12 +78,141 @@ if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
     $OutputDirectory = Join-Path $workspace "target/a3s-box-whpx-soak/$runId"
 }
 $evidenceDirectory = [IO.Path]::GetFullPath($OutputDirectory)
-New-Item -ItemType Directory -Path $evidenceDirectory -Force | Out-Null
+if (Test-Path -LiteralPath $evidenceDirectory) {
+    throw "Refusing to overwrite an existing evidence directory: $evidenceDirectory"
+}
+New-Item -ItemType Directory -Path $evidenceDirectory | Out-Null
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+function Write-Utf8Text {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [AllowEmptyString()]
+        [Parameter(Mandatory)]
+        [string]$Text
+    )
+
+    [IO.File]::WriteAllText($Path, $Text, $script:utf8NoBom)
+}
+
+function Write-JsonFile {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [object]$Value
+    )
+
+    $json = ConvertTo-Json -InputObject $Value -Depth 20
+    if ($null -eq $json) {
+        $json = 'null'
+    }
+    Write-Utf8Text -Path $Path -Text $json
+}
+
+function Get-RecordValue {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Record,
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    if ($Record -is [Collections.IDictionary]) {
+        if ($Record.Contains($Name)) {
+            return $Record[$Name]
+        }
+        return $null
+    }
+    $property = $Record.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+    $property.Value
+}
+
+function ConvertTo-TsvCell {
+    param([AllowNull()][object]$Value)
+
+    if ($null -eq $Value) {
+        return ''
+    }
+    if ($Value -is [bool]) {
+        return $Value.ToString().ToLowerInvariant()
+    }
+    ([string]$Value).Replace("`t", ' ').Replace("`r", ' ').Replace("`n", ' ')
+}
+
+function Write-RecordsTsv {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string[]]$Columns,
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$Rows
+    )
+
+    $lines = New-Object 'System.Collections.Generic.List[string]'
+    $lines.Add(($Columns -join "`t"))
+    foreach ($row in $Rows) {
+        $cells = @(
+            foreach ($column in $Columns) {
+                ConvertTo-TsvCell -Value (
+                    Get-RecordValue -Record $row -Name $column
+                )
+            }
+        )
+        $lines.Add(($cells -join "`t"))
+    }
+    Write-Utf8Text -Path $Path -Text (($lines -join "`n") + "`n")
+}
 
 function Get-BoxProcesses {
     @(
-        Get-Process -Name 'a3s-box', 'a3s-box-shim' -ErrorAction SilentlyContinue |
-            Select-Object Id, ProcessName, StartTime, CPU, Handles, WorkingSet64, Path
+        Get-Process -Name (
+            'a3s-box',
+            'a3s-box-shim',
+            'a3s-oci',
+            'a3s-oci-krun-shim'
+        ) -ErrorAction SilentlyContinue |
+            ForEach-Object {
+                $process = $_
+                $processIdentifier = $null
+                $processName = $null
+                $path = $null
+                $startedAt = $null
+                $cpu = $null
+                $handles = $null
+                $workingSet = $null
+                try {
+                    $processIdentifier = $process.Id
+                    $processName = $process.ProcessName
+                    $process.Refresh()
+                    $path = $process.Path
+                    $startedAt = $process.StartTime.ToUniversalTime().ToString('o')
+                    $cpu = $process.CPU
+                    $handles = $process.Handles
+                    $workingSet = $process.WorkingSet64
+                }
+                catch {
+                    # A process may exit while its resource fields are sampled.
+                }
+                if ($null -ne $processIdentifier -and
+                    -not [string]::IsNullOrWhiteSpace($processName)) {
+                    [pscustomobject][ordered]@{
+                        process_id = $processIdentifier
+                        name = "$processName.exe"
+                        started_at = $startedAt
+                        cpu_seconds = $cpu
+                        handles = $handles
+                        working_set_bytes = $workingSet
+                        executable_path = $path
+                    }
+                }
+            }
     )
 }
 
@@ -128,6 +262,150 @@ function Invoke-LoggedNative {
     }
 }
 
+function ConvertTo-NativeArgument {
+    param(
+        [AllowEmptyString()]
+        [Parameter(Mandatory)]
+        [string]$Argument
+    )
+
+    if ($Argument.Contains('"')) {
+        throw "Native argument contains an unsupported quote: $Argument"
+    }
+    if ($Argument.Length -eq 0 -or $Argument -match '\s') {
+        return '"' + $Argument + '"'
+    }
+    $Argument
+}
+
+function Invoke-SoakTest {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Test,
+        [Parameter(Mandatory)]
+        [string]$LogPath
+    )
+
+    $arguments = @(
+        'test',
+        '-p', 'a3s-box-cli',
+        '--test', 'core_smoke',
+        $Test,
+        '--',
+        '--ignored',
+        '--nocapture',
+        '--test-threads=1'
+    )
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = (Get-Command cargo.exe -ErrorAction Stop).Source
+    $startInfo.Arguments = (
+        $arguments | ForEach-Object { ConvertTo-NativeArgument -Argument $_ }
+    ) -join ' '
+    $startInfo.WorkingDirectory = $script:workspace
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.CreateNoWindow = $true
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) {
+        throw "Failed to start cargo test for $Test"
+    }
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    $timer = [Diagnostics.Stopwatch]::StartNew()
+    [int64]$peakRunnerWorkingSet = 0
+    [int64]$peakRuntimeWorkingSet = 0
+    [int64]$peakRuntimeHandles = 0
+    [int]$peakRuntimeProcesses = 0
+    [int]$runtimeSampleCount = 0
+    $observedNames = New-Object 'System.Collections.Generic.HashSet[string]'
+    $timeoutSeconds = if (
+        $Test -eq 'real_core_virtiofs_tar_closes_every_source_file_cleanly'
+    ) {
+        $VirtiofsTimeoutSeconds + 120
+    }
+    else {
+        $CommandTimeoutSeconds + 120
+    }
+    $timedOut = $false
+
+    while (-not $process.HasExited) {
+        try {
+            $process.Refresh()
+            $peakRunnerWorkingSet = [Math]::Max(
+                $peakRunnerWorkingSet,
+                [Math]::Max(
+                    [int64]$process.WorkingSet64,
+                    [int64]$process.PeakWorkingSet64
+                )
+            )
+        }
+        catch {
+            # The cargo process can exit between HasExited and Refresh.
+        }
+
+        $runtimeProcesses = @(Get-BoxProcesses)
+        if ($runtimeProcesses.Count -gt 0) {
+            $runtimeSampleCount++
+        }
+        [int64]$workingSet = 0
+        [int64]$handles = 0
+        foreach ($runtimeProcess in $runtimeProcesses) {
+            $name = [string]$runtimeProcess.name
+            if (-not [string]::IsNullOrWhiteSpace($name)) {
+                [void]$observedNames.Add($name)
+            }
+            if ($null -ne $runtimeProcess.working_set_bytes) {
+                $workingSet += [int64]$runtimeProcess.working_set_bytes
+            }
+            if ($null -ne $runtimeProcess.handles) {
+                $handles += [int64]$runtimeProcess.handles
+            }
+        }
+        $peakRuntimeProcesses = [Math]::Max(
+            $peakRuntimeProcesses,
+            $runtimeProcesses.Count
+        )
+        $peakRuntimeWorkingSet = [Math]::Max(
+            $peakRuntimeWorkingSet,
+            $workingSet
+        )
+        $peakRuntimeHandles = [Math]::Max($peakRuntimeHandles, $handles)
+
+        if ($timer.Elapsed.TotalSeconds -ge $timeoutSeconds) {
+            $timedOut = $true
+            $process.Kill()
+            break
+        }
+        [void]$process.WaitForExit(100)
+    }
+    $process.WaitForExit()
+    $timer.Stop()
+    $exitCode = if ($timedOut) { -1 } else { $process.ExitCode }
+    $stdout = $stdoutTask.Result
+    $stderr = $stderrTask.Result
+    $process.Dispose()
+    Write-Utf8Text -Path $LogPath -Text (
+        "# stdout`n$stdout`n# stderr`n$stderr"
+    )
+
+    [pscustomobject][ordered]@{
+        exit_code = $exitCode
+        timed_out = $timedOut
+        duration_milliseconds = $timer.ElapsedMilliseconds
+        peak_runner_working_set_bytes = $peakRunnerWorkingSet
+        peak_runtime_working_set_bytes = $peakRuntimeWorkingSet
+        peak_runtime_handles = $peakRuntimeHandles
+        peak_runtime_processes = $peakRuntimeProcesses
+        runtime_sample_count = $runtimeSampleCount
+        observed_runtime_processes = @($observedNames) -join ','
+        stdout = $stdout
+        stderr = $stderr
+    }
+}
+
 $commit = (& git -C $repositoryRoot rev-parse HEAD).Trim()
 if ($LASTEXITCODE -ne 0) {
     throw 'Unable to resolve the repository commit.'
@@ -140,17 +418,172 @@ if ($LASTEXITCODE -ne 0) {
 $startedAt = [DateTime]::UtcNow
 $soakStartedAt = $null
 $samples = @()
+$startInventory = @()
+$finalInventory = @()
+$verification = 'running'
+$verificationFailures = @()
 $completedTests = 0
 $completedIterations = 0
 $failure = $null
 $result = 'running'
 
+function Get-SampleMaximum {
+    param([Parameter(Mandatory)][string]$Name)
+
+    [int64]$maximum = 0
+    foreach ($sample in $script:samples) {
+        $value = Get-RecordValue -Record $sample -Name $Name
+        if ($null -ne $value) {
+            $maximum = [Math]::Max($maximum, [int64]$value)
+        }
+    }
+    $maximum
+}
+
+function Write-EvidenceTables {
+    $columns = @(
+        'sequence',
+        'iteration',
+        'test',
+        'result',
+        'exit_code',
+        'timed_out',
+        'started_at',
+        'finished_at',
+        'duration_milliseconds',
+        'peak_runner_working_set_bytes',
+        'peak_runtime_working_set_bytes',
+        'peak_runtime_handles',
+        'peak_runtime_processes',
+        'runtime_sample_count',
+        'observed_runtime_processes',
+        'residual_process_count',
+        'log'
+    )
+    $rows = @()
+    $sequence = 0
+    foreach ($sample in $script:samples) {
+        $sequence++
+        $row = [ordered]@{ sequence = $sequence }
+        foreach ($column in ($columns | Where-Object { $_ -ne 'sequence' })) {
+            $row[$column] = Get-RecordValue -Record $sample -Name $column
+        }
+        $rows += $row
+    }
+    Write-RecordsTsv -Path (Join-Path $script:evidenceDirectory 'operations.tsv') `
+        -Columns $columns -Rows $rows
+    Write-RecordsTsv `
+        -Path (Join-Path $script:evidenceDirectory 'resource-samples.tsv') `
+        -Columns @(
+            'sequence',
+            'iteration',
+            'test',
+            'duration_milliseconds',
+            'peak_runner_working_set_bytes',
+            'peak_runtime_working_set_bytes',
+            'peak_runtime_handles',
+            'peak_runtime_processes',
+            'runtime_sample_count'
+        ) `
+        -Rows $rows
+}
+
+function Get-VerificationFailures {
+    $failures = New-Object 'System.Collections.Generic.List[string]'
+    if ($script:result -ne 'pass') {
+        $failures.Add("runner result is $($script:result)")
+    }
+    if ($script:startInventory.Count -ne 0) {
+        $failures.Add(
+            "start inventory contains $($script:startInventory.Count) runtime processes"
+        )
+    }
+    if ($script:finalInventory.Count -ne 0) {
+        $failures.Add(
+            "final inventory contains $($script:finalInventory.Count) runtime processes"
+        )
+    }
+    if ($script:completedIterations -le 0) {
+        $failures.Add('no complete WHPX soak iteration finished')
+    }
+    if ($DurationSeconds -eq 0) {
+        if ($script:completedIterations -ne $Iterations) {
+            $failures.Add(
+                "completed iteration count is $($script:completedIterations), " +
+                "expected $Iterations"
+            )
+        }
+        $expectedTests = $Iterations * $tests.Count
+        if ($script:completedTests -ne $expectedTests) {
+            $failures.Add(
+                "completed test count is $($script:completedTests), expected $expectedTests"
+            )
+        }
+    }
+    if ($script:samples.Count -ne $script:completedTests) {
+        $failures.Add(
+            "operation sample count is $($script:samples.Count), " +
+            "expected $($script:completedTests)"
+        )
+    }
+    foreach ($sample in $script:samples) {
+        $test = Get-RecordValue -Record $sample -Name 'test'
+        if ((Get-RecordValue -Record $sample -Name 'result') -ne 'pass') {
+            $failures.Add(
+                "operation failed: $test"
+            )
+        }
+        if ([int](Get-RecordValue -Record $sample `
+                -Name 'runtime_sample_count') -le 0) {
+            $failures.Add("operation captured no A3S runtime sample: $test")
+        }
+        if ([int64](Get-RecordValue -Record $sample `
+                -Name 'peak_runtime_working_set_bytes') -le 0) {
+            $failures.Add("operation captured no A3S runtime working set: $test")
+        }
+        if ([int64](Get-RecordValue -Record $sample `
+                -Name 'peak_runtime_handles') -le 0) {
+            $failures.Add("operation captured no A3S runtime handles: $test")
+        }
+        if ([int](Get-RecordValue -Record $sample `
+                -Name 'peak_runtime_processes') -le 0) {
+            $failures.Add("operation captured no A3S runtime process: $test")
+        }
+        if ([int](Get-RecordValue -Record $sample `
+                -Name 'residual_process_count') -ne 0) {
+            $failures.Add("operation retained residual A3S processes: $test")
+        }
+    }
+
+    $maxWorkingSet = Get-SampleMaximum -Name 'peak_runtime_working_set_bytes'
+    $workingSetLimit = [int64]$MaxRuntimeWorkingSetMiB * 1MB
+    if ($script:samples.Count -gt 0 -and $maxWorkingSet -le 0) {
+        $failures.Add('no A3S runtime working-set sample was captured')
+    }
+    if ($maxWorkingSet -gt $workingSetLimit) {
+        $failures.Add(
+            "peak A3S runtime working set $maxWorkingSet exceeds " +
+            "$workingSetLimit bytes"
+        )
+    }
+    $maxHandles = Get-SampleMaximum -Name 'peak_runtime_handles'
+    if ($maxHandles -gt $MaxRuntimeHandles) {
+        $failures.Add(
+            "peak A3S runtime handle count $maxHandles exceeds $MaxRuntimeHandles"
+        )
+    }
+    @($failures)
+}
+
 function Write-Summary {
     $finishedAt = [DateTime]::UtcNow
+    Write-EvidenceTables
     $summary = [ordered]@{
-        schema = 'a3s.box.windows-whpx-soak.v1'
+        schema = 'a3s.box.windows-whpx-soak.v2'
         run_id = $runId
         result = $result
+        verification = $verification
+        verification_failures = $verificationFailures
         commit = $commit
         worktree_dirty = $worktreeStatus.Count -gt 0
         image_tar = $resolvedImageTar
@@ -167,31 +600,61 @@ function Write-Summary {
         requested_iterations = $Iterations
         requested_duration_seconds = $DurationSeconds
         completed_iterations = $completedIterations
+        selected_test_count = $tests.Count
         completed_tests = $completedTests
         command_timeout_seconds = $CommandTimeoutSeconds
         virtiofs_timeout_seconds = $VirtiofsTimeoutSeconds
+        start_inventory_processes = $startInventory.Count
+        final_inventory_processes = $finalInventory.Count
+        max_runtime_working_set_bytes = (
+            Get-SampleMaximum -Name 'peak_runtime_working_set_bytes'
+        )
+        max_runtime_working_set_limit_bytes = (
+            [int64]$MaxRuntimeWorkingSetMiB * 1MB
+        )
+        max_runtime_handles = Get-SampleMaximum -Name 'peak_runtime_handles'
+        max_runtime_handles_limit = $MaxRuntimeHandles
         selected_tests = $tests
         failure = $failure
+        evidence_contract = @(
+            'host.json',
+            'inventory-start.json',
+            'inventory-final.json',
+            'operations.tsv',
+            'resource-samples.tsv',
+            'summary.json',
+            'verify.out'
+        )
         samples = $samples
     }
-    $summary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (
-        Join-Path $evidenceDirectory 'summary.json'
-    ) -Encoding utf8
+    Write-JsonFile -Path (Join-Path $evidenceDirectory 'summary.json') `
+        -Value $summary
 }
 
 try {
     $preexisting = @(Get-BoxProcesses)
+    $startInventory = $preexisting
+    Write-JsonFile -Path (Join-Path $evidenceDirectory 'inventory-start.json') `
+        -Value @($startInventory)
     if ($preexisting.Count -gt 0) {
         $description = ($preexisting | ForEach-Object {
-            '{0}:{1}' -f $_.ProcessName, $_.Id
+            '{0}:{1}' -f $_.name, $_.process_id
         }) -join ', '
         throw "Refusing to start with active A3S Box processes: $description"
     }
 
-    Get-ComputerInfo -Property WindowsProductName, WindowsVersion, OsBuildNumber, OsArchitecture |
-        ConvertTo-Json | Set-Content -LiteralPath (
-            Join-Path $evidenceDirectory 'host.json'
-        ) -Encoding utf8
+    $operatingSystem = Get-ItemProperty `
+        'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
+    Write-JsonFile -Path (Join-Path $evidenceDirectory 'host.json') `
+        -Value ([ordered]@{
+            caption = $operatingSystem.ProductName
+            display_version = $operatingSystem.DisplayVersion
+            version = [Environment]::OSVersion.Version.ToString()
+            build_number = $operatingSystem.CurrentBuildNumber
+            update_build_revision = $operatingSystem.UBR
+            architecture = $env:PROCESSOR_ARCHITECTURE
+            logical_processors = [Environment]::ProcessorCount
+        })
 
     Set-Location -LiteralPath $workspace
     if (-not $SkipBuild) {
@@ -231,45 +694,53 @@ try {
             )
             Write-Host "WHPX soak iteration ${iteration}: $test"
 
-            $testExitCode = -1
-            $previousErrorActionPreference = $ErrorActionPreference
-            try {
-                $ErrorActionPreference = 'Continue'
-                & cargo test -p a3s-box-cli --test core_smoke $test -- `
-                    --ignored --nocapture --test-threads=1 2>&1 |
-                    Tee-Object -FilePath $logPath
-                $testExitCode = $LASTEXITCODE
-            }
-            finally {
-                $ErrorActionPreference = $previousErrorActionPreference
-            }
+            $testRun = Invoke-SoakTest -Test $test -LogPath $logPath
+            $testExitCode = $testRun.exit_code
             $residual = @(Wait-ForBoxProcessesToExit -TimeoutSeconds 10)
             $testFinishedAt = [DateTime]::UtcNow
-            $passed = $testExitCode -eq 0 -and $residual.Count -eq 0
+            $passed = (
+                $testExitCode -eq 0 -and
+                -not $testRun.timed_out -and
+                $residual.Count -eq 0
+            )
 
             $samples += [ordered]@{
                 iteration = $iteration
                 test = $test
                 result = if ($passed) { 'pass' } else { 'fail' }
                 exit_code = $testExitCode
+                timed_out = $testRun.timed_out
                 started_at = $testStartedAt.ToString('o')
                 finished_at = $testFinishedAt.ToString('o')
-                duration_seconds = [Math]::Round(
-                    ($testFinishedAt - $testStartedAt).TotalSeconds,
-                    3
+                duration_milliseconds = $testRun.duration_milliseconds
+                peak_runner_working_set_bytes = (
+                    $testRun.peak_runner_working_set_bytes
                 )
+                peak_runtime_working_set_bytes = (
+                    $testRun.peak_runtime_working_set_bytes
+                )
+                peak_runtime_handles = $testRun.peak_runtime_handles
+                peak_runtime_processes = $testRun.peak_runtime_processes
+                runtime_sample_count = $testRun.runtime_sample_count
+                observed_runtime_processes = (
+                    $testRun.observed_runtime_processes
+                )
+                residual_process_count = $residual.Count
                 residual_processes = @($residual)
                 log = $logPath
             }
             $completedTests++
             Write-Summary
 
+            if ($testRun.timed_out) {
+                throw "WHPX soak test $test exceeded its outer timeout"
+            }
             if ($testExitCode -ne 0) {
                 throw "WHPX soak test $test failed with exit code $testExitCode"
             }
             if ($residual.Count -gt 0) {
                 $description = ($residual | ForEach-Object {
-                    '{0}:{1}' -f $_.ProcessName, $_.Id
+                    '{0}:{1}' -f $_.name, $_.process_id
                 }) -join ', '
                 throw "WHPX soak test $test leaked processes: $description"
             }
@@ -286,6 +757,33 @@ catch {
 }
 finally {
     Set-Location -LiteralPath $repositoryRoot
+    $finalInventory = @(Wait-ForBoxProcessesToExit -TimeoutSeconds 20)
+    Write-JsonFile -Path (Join-Path $evidenceDirectory 'inventory-final.json') `
+        -Value @($finalInventory)
+    if ($finalInventory.Count -gt 0 -and $null -eq $failure) {
+        $result = 'fail'
+        $failure = 'The soak finished with residual A3S runtime processes.'
+    }
+    $verificationFailures = @(Get-VerificationFailures)
+    if ($verificationFailures.Count -eq 0) {
+        $verification = 'pass'
+        Write-Utf8Text -Path (Join-Path $evidenceDirectory 'verify.out') `
+            -Text "PASS`n"
+    }
+    else {
+        $verification = 'fail'
+        if ($result -eq 'pass') {
+            $result = 'fail'
+            $failure = 'Evidence verification failed: ' + (
+                $verificationFailures -join '; '
+            )
+        }
+        $verificationText = "FAIL`n" + (
+            ($verificationFailures | ForEach-Object { "- $_" }) -join "`n"
+        )
+        Write-Utf8Text -Path (Join-Path $evidenceDirectory 'verify.out') `
+            -Text ($verificationText + "`n")
+    }
     Write-Summary
 }
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=503625b176de7f22b2e31c782b82e97897e8c368#503625b176de7f22b2e31c782b82e97897e8c368"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0f0face67c282cf535e352b4fe83af02055b7e08#0f0face67c282cf535e352b4fe83af02055b7e08"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=503625b176de7f22b2e31c782b82e97897e8c368#503625b176de7f22b2e31c782b82e97897e8c368"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0f0face67c282cf535e352b4fe83af02055b7e08#0f0face67c282cf535e352b4fe83af02055b7e08"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -128,7 +128,7 @@ ring = "0.17"
 a3s-acl = { version = "0.2.2", git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "91a1b4c67ef2691915f2409a8cf835f7534020ff" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "503625b176de7f22b2e31c782b82e97897e8c368" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "0f0face67c282cf535e352b4fe83af02055b7e08" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/cli/tests/core_smoke.rs
+++ b/src/cli/tests/core_smoke.rs
@@ -1436,6 +1436,124 @@ fn real_core_named_volume_persists_across_stop_restart() {
     );
 }
 
+#[test]
+#[ignore]
+fn real_core_volume_backed_init_script_success_and_failure() {
+    let smoke = CoreSmoke::new();
+    let image = smoke_image();
+    let init_source = tempfile::tempdir().expect("temporary init-script source");
+    let init_script = init_source.path().join("init.sh");
+    let init_config = init_source.path().join("init.conf");
+    let volume = format!("{}-init-state", smoke.name);
+    let state_mount = format!("{volume}:/state");
+    let init_mount = format!("{}:/opt/a3s-init:ro", init_source.path().display());
+    let _volume_cleanup = NamedVolumeCleanup {
+        smoke: &smoke,
+        name: volume.clone(),
+    };
+
+    std::fs::write(
+        &init_script,
+        r#"#!/bin/sh
+set -eu
+
+test "$(cat /opt/a3s-init/init.conf)" = profile=windows-whpx
+if printf tamper >>/opt/a3s-init/init.conf 2>/dev/null; then
+    exit 31
+fi
+
+case "${A3S_INIT_MODE:-}" in
+    success)
+        printf success >/state/success
+        printf 'box-init-success\n'
+        ;;
+    failure)
+        printf failure >/state/failure
+        printf 'box-init-expected-failure\n' >&2
+        exit 42
+        ;;
+    *)
+        exit 32
+        ;;
+esac
+"#,
+    )
+    .expect("write init script");
+    std::fs::write(&init_config, "profile=windows-whpx").expect("write init config");
+
+    seed_smoke_image(&smoke, &image);
+    smoke.ok(&["volume", "create", &volume]);
+
+    let success = smoke.ok(&[
+        "run",
+        "--rm",
+        "--name",
+        &format!("{}-init-success", smoke.name),
+        "-e",
+        "A3S_INIT_MODE=success",
+        "-v",
+        &state_mount,
+        "-v",
+        &init_mount,
+        &image,
+        "--",
+        "/bin/sh",
+        "/opt/a3s-init/init.sh",
+    ]);
+    assert_contains(&success, "box-init-success", "successful init output");
+
+    let failure = smoke.output(&[
+        "run",
+        "--rm",
+        "--name",
+        &format!("{}-init-failure", smoke.name),
+        "-e",
+        "A3S_INIT_MODE=failure",
+        "-v",
+        &state_mount,
+        "-v",
+        &init_mount,
+        &image,
+        "--",
+        "/bin/sh",
+        "/opt/a3s-init/init.sh",
+    ]);
+    assert_eq!(
+        failure.code,
+        Some(42),
+        "failing init did not retain exit 42\nstdout:\n{}\nstderr:\n{}",
+        failure.stdout,
+        failure.stderr
+    );
+    assert_contains(
+        &failure.stderr,
+        "box-init-expected-failure",
+        "failing init stderr",
+    );
+
+    let persisted = smoke.ok(&[
+        "run",
+        "--rm",
+        "--name",
+        &format!("{}-init-state", smoke.name),
+        "-v",
+        &state_mount,
+        &image,
+        "--",
+        "/bin/sh",
+        "-c",
+        "test \"$(cat /state/success)\" = success; test \"$(cat /state/failure)\" = failure; printf box-init-state-persisted",
+    ]);
+    assert_contains(
+        &persisted,
+        "box-init-state-persisted",
+        "init state volume evidence",
+    );
+
+    let config = std::fs::read_to_string(&init_config).expect("read init config");
+    assert_eq!(config, "profile=windows-whpx");
+}
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 #[ignore]


### PR DESCRIPTION
## Summary
- pin Box SDK/CI/release/docs to merged A3S OCI Runtime `0f0face67c282cf535e352b4fe83af02055b7e08`
- add real WHPX coverage for read-only init scripts, environment propagation, exact failure exit codes, and named-volume persistence
- promote the Windows soak runner to a schema-v2 evidence gate with per-operation logs, resource samples, inventories, residual-process checks, and strict verification
- document the complete 12-test Windows network/storage/init/commit/snapshot/virtio-fs matrix

## Validation
- `cargo fmt --all -- --check`
- `cargo metadata --locked`
- `cargo test -p a3s-box-cli --test core_smoke --no-run`
- `cargo test -p a3s-box-cli --test core_smoke real_core_volume_backed_init_script_success_and_failure -- --ignored --nocapture --test-threads=1`
- `cargo test -p a3s-box-cli --test core_smoke real_core_filesystem_image_snapshot_commands -- --ignored --nocapture --test-threads=1`
- Box CLI unit/integration suite: 770 passed
- runtime library suite passed
- full Windows WHPX soak: 12/12 passed, verifier PASS, start/final runtime inventory 0/0, peak working set 168,972,288 bytes, peak handles 678

A3S OCI Runtime PR A3S-Lab/OCI-Runtime#43 is merged and all five platform CI jobs passed.