### PR TITLE
feat(sdk): add native Go client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Test RuntimeClass installer
         run: bash deploy/scripts/test-install-runtimeclass.sh
 
-  # ── Native Python and TypeScript SDK package gate ─────────────
+  # ── Native Python, TypeScript, and Go SDK package gate ─────────
   sdk-packages:
     name: SDK Packages
     runs-on: ubuntu-latest
@@ -165,6 +165,10 @@ jobs:
           node-version: '20'
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.25.x'
+          cache-dependency-path: sdk/go/go.mod
       - name: Build and test Python package
         run: |
           python -m pip install build
@@ -179,6 +183,17 @@ jobs:
           npm run build
           npm test
           npm pack --dry-run
+      - name: Format, vet, and test Go module
+        working-directory: sdk/go
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "$unformatted"
+            exit 1
+          fi
+          go vet ./...
+          go test ./...
+          go test -race ./...
 
   # ── Real shared-kernel local SDK gate ──────────────────────────
   sdk-local-sandbox:
@@ -207,6 +222,10 @@ jobs:
           node-version: '20'
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.25.x'
+          cache-dependency-path: sdk/go/go.mod
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
       - name: Install build dependencies
         run: |
@@ -241,7 +260,7 @@ jobs:
             echo 'root:100000:65536' | sudo tee -a /etc/subuid
           grep -q '^root:' /etc/subgid ||
             echo 'root:100000:65536' | sudo tee -a /etc/subgid
-      - name: Test Rust, Python, and TypeScript SDKs without credentials
+      - name: Test Rust, Python, TypeScript, and Go SDKs without credentials
         run: |
           sudo env \
               PATH="$PATH" \
@@ -257,6 +276,7 @@ jobs:
               A3S_BOX_GUEST_INIT_BINARY="$GITHUB_WORKSPACE/src/target/x86_64-unknown-linux-musl/release/a3s-box-guest-init" \
               RUST_MIN_STACK=16777216 \
               PYTHON=python3 \
+              GO=go \
               scripts/local-sdk-smoke.sh sandbox
       - name: Verify cleanup
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,11 @@ jobs:
           node-version: '20'
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
+      # actions/setup-go v6.5.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version: '1.25.x'
+          cache-dependency-path: sdk/go/go.mod
       - name: Build and verify Python package
         run: |
           mkdir -p sdk-artifacts
@@ -104,6 +109,27 @@ jobs:
           npm run build
           npm test
           npm pack --pack-destination "$GITHUB_WORKSPACE/sdk-artifacts"
+      - name: Verify Go module and release path
+        working-directory: sdk/go
+        shell: bash
+        run: |
+          set -euo pipefail
+          major="${GITHUB_REF_NAME#v}"
+          major="${major%%.*}"
+          expected="github.com/A3S-Lab/Box/sdk/go/v${major}"
+          actual="$(go list -m)"
+          if [ "$actual" != "$expected" ]; then
+            echo "Go module $actual does not match release major v$major" >&2
+            exit 1
+          fi
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "$unformatted"
+            exit 1
+          fi
+          go vet ./...
+          go test ./...
+          go test -race ./...
       # actions/upload-artifact v6.0.0
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
@@ -917,6 +943,48 @@ jobs:
             esac
             wait_for_crate "$crate"
           done
+
+  # Go modules are published by a path-prefixed semantic version tag. The
+  # root vX.Y.Z tag alone cannot publish the nested sdk/go module.
+  publish-go-module:
+    name: Publish Go module tag
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
+      - name: Create path-prefixed Go module tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="sdk/go/${GITHUB_REF_NAME}"
+          remote_tags="$(
+            git ls-remote --tags origin \
+              "refs/tags/$tag" "refs/tags/$tag^{}"
+          )"
+          remote_commit="$(
+            printf '%s\n' "$remote_tags" |
+              awk '$2 ~ /\^\{\}$/ { print $1; exit }'
+          )"
+          if [ -z "$remote_commit" ]; then
+            remote_commit="$(
+              printf '%s\n' "$remote_tags" |
+                awk 'NF == 2 { print $1; exit }'
+            )"
+          fi
+          if [ -n "$remote_commit" ]; then
+            if [ "$remote_commit" != "$GITHUB_SHA" ]; then
+              echo "$tag already points to $remote_commit, expected $GITHUB_SHA" >&2
+              exit 1
+            fi
+            echo "$tag already exists at $GITHUB_SHA"
+            exit 0
+          fi
+          git tag "$tag" "$GITHUB_SHA"
+          git push origin "refs/tags/$tag"
 
   # ── Update Homebrew Formula ────────────────────────────────────
   publish-homebrew:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Native Go SDK.** The nested `github.com/A3S-Lab/Box/sdk/go/v3` module
+  exposes the complete checked local bridge inventory through context-aware,
+  concurrency-safe clients, typed builders, binary-safe commands and files,
+  lifecycle generation fencing, and real MicroVM/Sandbox smoke coverage. Go
+  releases use the matching path-prefixed `sdk/go/vX.Y.Z` tag.
+
 ### Removed
 
 - **Remote E2B compatibility service.** The pinned upstream protocol corpus,
   official-client fixtures, ACL control/data-plane service, dedicated runtime
   image, release binary, and their CI/release plumbing are removed. Native
-  Rust, Python, and TypeScript SDKs remain local, credential-free entry points
+  Rust, Python, TypeScript, and Go SDKs remain local, credential-free entry points
   over the core A3S Box runtime.
 
 ### Changed
@@ -23,7 +31,7 @@ All notable changes to A3S Box will be documented in this file.
 - **Real configuration qualification.** The Box Linux integration gate runs
   the pinned runtime's native private/host/donor network, read-write/read-only
   volume, tmpfs, inline/file/direct initialization, failure, and cleanup
-  matrix before exercising the Rust, Python, and TypeScript SDK lifecycle.
+  matrix before exercising the Rust, Python, TypeScript, and Go SDK lifecycle.
 
 ## [3.1.0] — 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://github.com/A3S-Lab/Box/releases/latest"><img alt="Latest A3S Box release" src="https://img.shields.io/github/v/release/A3S-Lab/Box?display_name=tag&amp;sort=semver&amp;style=flat-square&amp;color=62d78b"></a>
   <a href="https://pypi.org/project/a3s-box/"><img alt="A3S Box Python package" src="https://img.shields.io/pypi/v/a3s-box?style=flat-square&amp;color=3775a9"></a>
   <a href="https://www.npmjs.com/package/@a3s-lab/box"><img alt="A3S Box TypeScript package" src="https://img.shields.io/npm/v/@a3s-lab/box?style=flat-square&amp;color=cb3837"></a>
+  <a href="https://pkg.go.dev/github.com/A3S-Lab/Box/sdk/go/v3"><img alt="A3S Box Go package" src="https://pkg.go.dev/badge/github.com/A3S-Lab/Box/sdk/go/v3.svg"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-f5b95f?style=flat-square"></a>
 </p>
 
@@ -213,7 +214,7 @@ a3s-box compose -f compose.acl down
 
 ## Native SDKs
 
-Rust, Python, and TypeScript operate the same local images, Sandboxes, volumes,
+Rust, Python, TypeScript, and Go operate the same local images, Sandboxes, volumes,
 networks, snapshots, logs, and runtime state as the CLI. These packages expose
 no remote connection configuration: they require the installed runtime and do
 not read an endpoint, domain, or API key.
@@ -223,11 +224,13 @@ not read an endpoint, domain, or API key.
 | Rust | [`a3s-box-sdk`](https://crates.io/crates/a3s-box-sdk) | Direct typed calls into the runtime and generation-fenced execution manager |
 | Python | [`a3s-box`](https://pypi.org/project/a3s-box/) | Sync and async APIs over the installed versioned machine bridge |
 | TypeScript | [`@a3s-lab/box`](https://www.npmjs.com/package/@a3s-lab/box) | Promise APIs over the installed versioned machine bridge; Node.js 20+ |
+| Go | [`github.com/A3S-Lab/Box/sdk/go/v3`](https://pkg.go.dev/github.com/A3S-Lab/Box/sdk/go/v3) | Context-aware, concurrency-safe APIs over the installed versioned machine bridge; Go 1.25+ |
 
 ```bash
 cargo add a3s-box-sdk
 python -m pip install a3s-box
 npm install @a3s-lab/box
+go get github.com/A3S-Lab/Box/sdk/go/v3
 ```
 
 The high-level `Sandbox`, `commands`, and `files` namespaces are intentionally
@@ -245,38 +248,39 @@ with Sandbox.create("python:3.12-alpine") as sandbox:
 The same clients expose fluent programmable CI/CD builders without adding a
 second workflow engine:
 
-```typescript
-import { A3SBoxClient } from '@a3s-lab/box'
+```go
+client, err := box.NewClient(ctx)
+if err != nil { return err }
 
-const client = new A3SBoxClient()
-const image = await client.image('./ci').tag('local/ci:latest').build()
-const sandbox = await client
-  .sandbox(image.reference)
-  .cpus(4)
-  .memoryMb(4096)
-  .start()
+image, err := client.Image("./ci").Tag("local/ci:latest").Build(ctx)
+if err != nil { return err }
 
-try {
-  const result = await sandbox
-    .script('npm ci\nnpm test\n')
-    .interpreter('/bin/sh', '-se')
-    .env('CI', 'true')
-    .run()
-  if (result.exitCode !== 0) throw new Error(result.stderr)
-} finally {
-  await sandbox.kill()
-}
+cache, err := client.Volume("go-cache").Create(ctx)
+if err != nil { return err }
+
+sandbox, err := client.Sandbox(image.Reference).
+    CPUs(4).
+    MemoryMiB(4096).
+    Mount(box.NamedVolume(cache.Name, "/go/pkg/mod")).
+    Start(ctx)
+if err != nil { return err }
+defer sandbox.Close(context.Background())
+
+result, err := sandbox.Script("go test ./...\n").Env("CI", "true").Run(ctx)
+if err != nil { return err }
+if result.ExitCode != 0 { return errors.New(result.StderrString()) }
 ```
 
-Python and TypeScript never parse human CLI output; they exchange one checked,
+Python, TypeScript, and Go never parse human CLI output; they exchange one checked,
 structured request and response with `a3s-box sdk-bridge`. Use runtime and SDK
 packages from the same release because the bridge rejects incompatible
 protocol versions.
 
 Read the [cross-language SDK contract](docs/sdk-api-and-programmable-cicd.md)
 or go directly to the [Rust](src/sdk/README.md),
-[Python](sdk/python/README.md), and
-[TypeScript](sdk/typescript/README.md) package guides.
+[Python](sdk/python/README.md),
+[TypeScript](sdk/typescript/README.md), and
+[Go](sdk/go/README.md) package guides.
 
 ## Platform boundaries
 
@@ -294,7 +298,7 @@ or go directly to the [Rust](src/sdk/README.md),
 | Execution path | Real-runtime evidence | Remaining boundary |
 | --- | --- | --- |
 | Default MicroVM on Windows/WHPX | [`scripts/windows-whpx-soak.ps1`](scripts/windows-whpx-soak.ps1) covers lifecycle and foreground exit, published-port networking, read-only bind mounts, named volumes, volume-backed initialization success and failure, metadata-preserving commit, filesystem commit/snapshot restore, and repeated virtio-fs traversal. The current qualification completed all 12 cases and returned the start and final runtime inventories to zero. | This proves the tested x86_64 Windows/WHPX host and workload matrix, not KVM, HVF, or TEE hardware. |
-| Explicit Linux Sandbox | The required `SDK Local Sandbox (A3S OCI Runtime)` CI job runs the pinned runtime's native Linux network, storage, and initialization profiles, then exercises the Rust, Python, and TypeScript local SDKs and verifies process cleanup. | Sandbox remains a shared-kernel preview and intentionally rejects VM-only features. |
+| Explicit Linux Sandbox | The required `SDK Local Sandbox (A3S OCI Runtime)` CI job runs the pinned runtime's native Linux network, storage, and initialization profiles, then exercises the Rust, Python, TypeScript, and Go local SDKs and verifies process cleanup. | Sandbox remains a shared-kernel preview and intentionally rejects VM-only features. |
 | Linux/KVM MicroVM | A self-hosted real-KVM workflow covers the core lifecycle, SDK, CRI, leak, race, snapshot-fork, and soak paths when `KVM_CI=true`. | The job is conditionally skipped without the enrolled runner; a green hosted build alone is not real-KVM evidence. |
 | macOS/HVF MicroVM | Hosted macOS arm64 compilation checks the supported target. | A real Apple Silicon/HVF boot and soak are separate release evidence. |
 | SEV-SNP-oriented TEE | Unit and simulation tests cover application flow and protocol behavior. | No hardware security claim is made without a qualifying SEV-SNP host and attestation evidence. |
@@ -326,7 +330,7 @@ Every shipped entry point submits the same backend-neutral local execution
 request:
 
 ```text
-CLI · Rust SDK · local machine bridge · CRI · containerd shim
+CLI · Rust SDK · Python · TypeScript · Go · CRI · containerd shim
                               │
                       ExecutionManager
            durable state · generation fencing
@@ -343,7 +347,7 @@ CLI · Rust SDK · local machine bridge · CRI · containerd shim
               logs · audit · metrics · TEE
 ```
 
-The runtime persists caller policy before allocation. Python and TypeScript
+The runtime persists caller policy before allocation. Python, TypeScript, and Go
 reach the same `ExecutionManager` through the machine bridge instead of
 constructing CLI commands; CRI and RuntimeClass adapters also reuse the same
 resolver. Lifecycle ownership, unsupported-feature rejection, audit evidence,
@@ -360,7 +364,7 @@ Repository components are grouped by responsibility:
   cluster adapters;
 - `src/shim`, `src/guest/init`, `src/netproxy` — host/guest control and
   platform integration;
-- `sdk/python`, `sdk/typescript` — native local language packages over the
+- `sdk/python`, `sdk/typescript`, `sdk/go` — native local language packages over the
   checked machine bridge.
 
 ## Documentation
@@ -400,6 +404,11 @@ cd ../typescript
 npm ci
 npm run build
 npm test
+
+cd ../go
+gofmt -w .
+go vet ./...
+go test -race ./...
 ```
 
 Host-backed MicroVM, Sandbox, networking, build, CRI, and endurance tests need

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -65,7 +65,7 @@ must:
 1. check out the exact pinned OCI Runtime revision;
 2. run its native Linux qualification script;
 3. build Box, the shim, guest init, the runtime, and the agent;
-4. execute the unchanged Rust, Python, and TypeScript local SDK lifecycles;
+4. execute the unchanged Rust, Python, TypeScript, and Go local SDK lifecycles;
 5. cover image management, named volumes, files, logs, metrics, pause/resume,
    stop/restart, filesystem snapshots, and complete cleanup;
 6. prove no Box shim, OCI owner, agent, runtime root, socket, or Box directory
@@ -131,7 +131,7 @@ The replacement is complete when all of the following are true:
 - [x] Linux release packaging contains only the pinned A3S OCI artifacts.
 - [x] Only the current A3S OCI runtime-record schema is accepted.
 - [x] The pinned native matrix covers network, volume, tmpfs, and init profiles.
-- [x] Rust, Python, and TypeScript exercise the real Box lifecycle.
+- [x] Rust, Python, TypeScript, and Go exercise the real Box lifecycle.
 - [x] Linux x86_64/aarch64, macOS arm64, and Windows x86_64 builds remain gated.
 - [ ] The change's pull-request and main-branch CI runs are green.
 

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -15,7 +15,7 @@ capability scenario has soak coverage.
 | --- | --- | --- |
 | Stub baseline | macOS or Linux with Rust, C compiler, and protoc | `scripts/host-integration-smoke.sh` |
 | Core MicroVM smoke | macOS Apple Silicon/HVF or Linux KVM, libkrun, Linux guest init, runnable image | `scripts/host-integration-smoke.sh --core` |
-| Native local SDK smoke | Same as the selected MicroVM or certified Linux Sandbox backend, plus Python 3.10+ and Node.js 20+ | `scripts/local-sdk-smoke.sh microvm` or `scripts/local-sdk-smoke.sh sandbox` |
+| Native local SDK smoke | Same as the selected MicroVM or certified Linux Sandbox backend, plus Python 3.10+, Node.js 20+, and Go 1.25+ | `scripts/local-sdk-smoke.sh microvm` or `scripts/local-sdk-smoke.sh sandbox` |
 | Host command and warm-pool smoke | Same as core smoke; optional registry credentials for push coverage | `scripts/host-integration-smoke.sh --host` |
 | Linux Dockerfile `RUN` | Linux, root, chroot-capable filesystem, local Alpine OCI archive | `sudo -E scripts/host-integration-smoke.sh --linux-run --no-pure` |
 | CRI smoke | macOS or Linux MicroVM host, `crictl`, CRI images | `scripts/host-integration-smoke.sh --cri` |
@@ -95,7 +95,7 @@ sudo usermod -aG kvm "$USER"
 
 ## Native local SDK matrix
 
-The native Rust, Python, and TypeScript SDK smoke exercises the same local
+The native Rust, Python, TypeScript, and Go SDK smoke exercises the same local
 `Sandbox`, commands, files, pause/resume, kill, and cleanup behavior against a
 real backend. Before starting the box it also verifies the bridge capability
 inventory, built-image get/inspect/history/tag/remove calls, and unused

--- a/docs/host-sandbox-backend-design.md
+++ b/docs/host-sandbox-backend-design.md
@@ -297,7 +297,7 @@ for:
 - pause, resume, stop, delete, and post-stop hooks;
 - PID, namespace, mount, cgroup, socket, owner, and session cleanup.
 
-Box then runs the real Rust, Python, and TypeScript SDK lifecycle against those
+Box then runs the real Rust, Python, TypeScript, and Go SDK lifecycle against those
 artifacts. It covers images, files, logs, metrics, named volumes, snapshots,
 pause/resume, filesystem-only restart, and final cleanup.
 

--- a/docs/sdk-api-and-programmable-cicd.md
+++ b/docs/sdk-api-and-programmable-cicd.md
@@ -1,7 +1,7 @@
 # SDK API and Programmable CI/CD Plan
 
 This document is the authoritative completion plan for the native local A3S
-Box SDKs. It covers Rust, Python, and TypeScript. Local calls remain
+Box SDKs. It covers Rust, Python, TypeScript, and Go. Local calls remain
 credential-free and execute directly through the installed A3S Box runtime.
 
 ## Product Contract
@@ -9,10 +9,10 @@ credential-free and execute directly through the installed A3S Box runtime.
 "Programmable CI/CD" means a code-first execution toolbox, similar in spirit
 to BoxLite. A user must be able to build an OCI base image, create reusable
 storage and networks, configure an isolated box, run scripts, capture results,
-and reuse a filesystem snapshot directly from normal Rust, Python, or
-TypeScript code. A separate YAML service or workflow engine is not required.
+and reuse a filesystem snapshot directly from normal Rust, Python, TypeScript,
+or Go code. A separate YAML service or workflow engine is not required.
 
-Rust is the implementation source of truth. Python and TypeScript use the
+Rust is the implementation source of truth. Python, TypeScript, and Go use the
 versioned machine bridge and never parse human CLI output. Language differences
 are limited to normal conventions such as Python sync/async variants and
 JavaScript promises.
@@ -116,17 +116,17 @@ artifact collection in application code without a dedicated pipeline engine.
 
 The naming follows each language while preserving the same concepts:
 
-| Concept | Rust | Python | TypeScript |
-| --- | --- | --- | --- |
-| Runtime client | `A3sBoxClient` | `A3SBoxClient` | `A3SBoxClient` |
-| Box handle | `Sandbox` | `Sandbox` / `AsyncSandbox` | `Sandbox` |
-| Build request | `BuildImage` | `BuildImageOptions` | `BuildImageOptions` |
-| Named volume | `CreateVolume` | `CreateVolumeOptions` | `CreateVolumeOptions` |
-| Named network | `CreateNetwork` | `CreateNetworkOptions` | `CreateNetworkOptions` |
-| Mount | `VolumeMount` | `VolumeMount` | `VolumeMount` |
-| Network selection | `SandboxNetwork` | `SandboxNetwork` | `SandboxNetwork` |
-| Published port | `PortMapping` | `PortMapping` | `PortMapping` |
-| Script | `Script` | `Script` | `Script` |
+| Concept | Rust | Python | TypeScript | Go |
+| --- | --- | --- | --- | --- |
+| Runtime client | `A3sBoxClient` | `A3SBoxClient` | `A3SBoxClient` | `Client` |
+| Box handle | `Sandbox` | `Sandbox` / `AsyncSandbox` | `Sandbox` | `Sandbox` |
+| Build request | `BuildImage` | `BuildImageOptions` | `BuildImageOptions` | `ImageBuilder` |
+| Named volume | `CreateVolume` | `CreateVolumeOptions` | `CreateVolumeOptions` | `VolumeBuilder` |
+| Named network | `CreateNetwork` | `CreateNetworkOptions` | `CreateNetworkOptions` | `NetworkBuilder` |
+| Mount | `VolumeMount` | `VolumeMount` | `VolumeMount` | `Mount` |
+| Network selection | `SandboxNetwork` | `SandboxNetwork` | `SandboxNetwork` | `SandboxNetwork` |
+| Published port | `PortMapping` | `PortMapping` | `PortMapping` | `PortMapping` |
+| Script | `Script` | `Script` | `Script` | `ScriptBuilder` |
 
 The existing `Sandbox` remains the convenient local execution facade. It is
 not overloaded with host-wide image, volume, and network management; those
@@ -168,15 +168,15 @@ If retained, the composition layer must:
 
 | Area | Required operations | Current state |
 | --- | --- | --- |
-| Images and builds | list, inspect, history, pull, build, tag, push, remove, cache eviction, platform selection, credentials, and progress | List/get/inspect/history/pull/build/tag/push/remove/evict, platform selection, registry credentials, pull signature policy, and push protocol have Rust/Python/TypeScript parity. The blocking real-Sandbox gate covers all local-store operations; authenticated registry push is covered by the opt-in host integration suite. Structured build and live pull/push progress remain pending. |
-| Typed box configuration | image, isolation, CPU/memory/lifetime, environment, workdir/user, mounts, tmpfs, network, ports, DNS/hosts, read-only root, persistence, cleanup, and snapshot restore | Implemented in Rust/Python/TypeScript options and fluent builders. The real macOS/HVF MicroVM builder gate passes; the no-KVM Ubuntu gate uses A3S OCI Runtime as the sole Sandbox backend, while Linux/KVM remains host-gated. |
-| Volumes | list, get, create, typed mount, content operations, remove, and prune | Create/get/list/remove/prune and typed bind/named mounts have three-language parity. Direct content helpers remain pending. |
-| Networking | list/create/get/remove/prune, typed attachment, published ports, and resolved endpoint inspection | Create/get/list/remove/prune, typed TSI/disabled/bridge selection, endpoint responses, and TCP publication have three-language parity. Live hot-plug is intentionally unsupported. |
-| Commands and scripts | foreground argv/shell/script execution, environment, cwd, user, stdin, timeout, binary-safe output, background processes, signals, wait, and streaming | Foreground argv/shell and stdin-backed fluent scripts have three-language parity and pass the real macOS/HVF builder-to-Sandbox smoke. Process handles, signals, wait, and streaming remain pending. |
+| Images and builds | list, inspect, history, pull, build, tag, push, remove, cache eviction, platform selection, credentials, and progress | List/get/inspect/history/pull/build/tag/push/remove/evict, platform selection, registry credentials, pull signature policy, and push protocol have Rust/Python/TypeScript/Go parity. The blocking real-Sandbox gate covers all local-store operations; authenticated registry push is covered by the opt-in host integration suite. Structured build and live pull/push progress remain pending. |
+| Typed box configuration | image, isolation, CPU/memory/lifetime, environment, workdir/user, mounts, tmpfs, network, ports, DNS/hosts, read-only root, persistence, cleanup, and snapshot restore | Implemented in Rust/Python/TypeScript/Go options and fluent builders. The real MicroVM gate remains host-specific; the no-KVM Ubuntu gate uses A3S OCI Runtime as the sole Sandbox backend, while Linux/KVM remains host-gated. |
+| Volumes | list, get, create, typed mount, content operations, remove, and prune | Create/get/list/remove/prune and typed bind/named mounts have four-language parity. Direct content helpers remain pending. |
+| Networking | list/create/get/remove/prune, typed attachment, published ports, and resolved endpoint inspection | Create/get/list/remove/prune, typed TSI/disabled/bridge selection, endpoint responses, and TCP publication have four-language parity. Live hot-plug is intentionally unsupported. |
+| Commands and scripts | foreground argv/shell/script execution, environment, cwd, user, stdin, timeout, binary-safe output, background processes, signals, wait, and streaming | Foreground argv/shell and stdin-backed fluent scripts have four-language parity. Go preserves binary output as `[]byte`; the other SDKs expose their language-native byte/text conventions. Process handles, signals, wait, and streaming remain pending. |
 | Files and artifacts | binary/text read/write, stat, exists, list, mkdir, move, remove, streaming, confined export, size limits, and hashes | Core mutations implemented; artifact/export layer and large-file streaming pending. |
-| Filesystem snapshots | capture, size, restore, delete, in-use fencing, inspection, and cleanup | Capture/size/restore/delete and live-use fencing are implemented. Rust, Python sync/async, and TypeScript expose typed list/get inspection through the checked bridge; the real Sandbox gate exercises the complete local snapshot lifecycle. |
-| Lifecycle | create, connect, inspect, list, pause, resume, restart, timeout replacement, stop, kill, remove, and deterministic cleanup | Rust, Python sync/async, and TypeScript have parity for create/connect/inspect/list/pause/resume/stop/idempotent restart/kill/remove. Restart carries a durable operation identity and optional stop deadline; stop preserves the record, remove requires a terminal state, and kill composes both. Cancellation cleanup remains pending. |
-| Observability | structured logs, stats, events, health, audit data, and runtime diagnostics | Bounded structured log snapshots, active resource stats, runtime versions/virtualization diagnostics, disk usage, and Sandbox inventory have three-language parity. Event streams, health history, and audit queries remain pending. |
+| Filesystem snapshots | capture, size, restore, delete, in-use fencing, inspection, and cleanup | Capture/size/restore/delete and live-use fencing are implemented. Rust, Python sync/async, TypeScript, and Go expose typed list/get inspection through the checked bridge; the real Sandbox gate exercises the complete local snapshot lifecycle. |
+| Lifecycle | create, connect, inspect, list, pause, resume, restart, timeout replacement, stop, kill, remove, and deterministic cleanup | Rust, Python sync/async, TypeScript, and Go have parity for create/connect/inspect/list/pause/resume/stop/idempotent restart/kill/remove. Go serializes lifecycle transitions against in-flight command and file calls. Restart carries a durable operation identity and optional stop deadline; stop preserves the record, remove requires a terminal state, and kill composes both. Cancellation cleanup remains pending across the full matrix. |
+| Observability | structured logs, stats, events, health, audit data, and runtime diagnostics | Bounded structured log snapshots, active resource stats, runtime versions/virtualization diagnostics, disk usage, and Sandbox inventory have four-language parity. Event streams, health history, and audit queries remain pending. |
 | PTY | create, resize, input, output streaming, wait, and cancellation | Rust lower-level primitives only. |
 | Security | typed isolation, resource limits, read-only policy, capabilities, devices, secret injection, and attestation | Partial; unsupported policies must be rejected rather than represented as enforced. |
 
@@ -186,14 +186,14 @@ If retained, the composition layer must:
 
 - Keep this plan and the capability matrix current.
 - Expose image build and resource-management operations through the bridge and
-  native Python/TypeScript clients.
+  native Python/TypeScript/Go clients.
 - Add typed volume mounts, network selection, published ports, workdir, and
   persistence controls to box creation.
-- Add explicit script execution and executable examples in all three languages.
+- Add explicit script execution and executable examples in all four languages.
 - Retain and validate runtime-managed filesystem snapshot operations.
 
 Implemented evidence now includes a versioned `sdk_capabilities` inventory and
-three-language parity for local image inspection/history/tagging/removal/cache
+four-language parity for local image inspection/history/tagging/removal/cache
 eviction, authenticated pull/push request shapes, and volume/network pruning.
 Structured registry/build progress remains in this phase because the current
 one-request/one-response bridge cannot represent live progress safely.
@@ -207,7 +207,7 @@ one-request/one-response bridge cannot represent live progress safely.
 
 Lifecycle, bounded structured logs, current stats, runtime diagnostics/disk
 usage, Sandbox list/get, and filesystem snapshot list/get now have typed
-Rust/Python/TypeScript parity and are part of the checked bridge inventory.
+Rust/Python/TypeScript/Go parity and are part of the checked bridge inventory.
 Restart retries use a durable operation ID, log tails are validated before
 runtime lookup, and stop is distinct from terminal removal. Confined artifact
 export and volume content helpers remain the unfinished Phase 2 work.
@@ -221,11 +221,11 @@ export and volume content helpers remain the unfinished Phase 2 work.
 ### Phase 4: Optional composition and release gates
 
 - Refactor any retained matrix or DAG helper onto the typed toolbox.
-- Run every supported operation through Rust, Python, and TypeScript against
+- Run every supported operation through Rust, Python, TypeScript, and Go against
   certified Linux Sandbox execution.
 - Run the supported matrix against Linux/KVM and macOS/HVF MicroVM execution.
 - Build and install clean package artifacts before testing them.
-- Publish Rust, Python, TypeScript, runtime, and documentation from one version
+- Publish Rust, Python, TypeScript, Go, runtime, and documentation from one version
   and verify the public registries after release.
 
 ## Completion Gates
@@ -233,10 +233,10 @@ export and volume content helpers remain the unfinished Phase 2 work.
 The SDK objective is complete only when all of the following are true:
 
 - the required native SDK surface table has no `Partial` or pending row;
-- the checked Rust/Python/TypeScript inventory reports parity;
+- the checked Rust/Python/TypeScript/Go inventory reports parity;
 - all bridge operations have success, validation, runtime-error, and malformed
   response tests;
-- the real Sandbox three-language matrix covers every supported operation;
+- the real Sandbox four-language matrix covers every supported operation;
 - the MicroVM matrix covers every operation supported on Linux/KVM and
   macOS/HVF;
 - build, volume, network, port, script, cache, snapshot, artifact, cancellation,

--- a/docs/soak-test-plan.md
+++ b/docs/soak-test-plan.md
@@ -20,7 +20,7 @@ The soak program must detect failures that short functional tests rarely find:
 - latency or throughput degradation after warm-up;
 - recovery failures after client, shim, daemon, runtime, or host interruption;
 - platform-specific regressions across KVM, HVF, WHPX, and A3S OCI Runtime;
-- divergence between the Rust, Python, and TypeScript native SDKs;
+- divergence between the Rust, Python, TypeScript, and Go native SDKs;
 - incomplete cleanup after success, failure, cancellation, and rollback.
 
 The program covers implemented product behavior only. Unsupported combinations
@@ -36,7 +36,7 @@ evidence system.
 | Entry point | Existing coverage | Current limitation |
 | --- | --- | --- |
 | `scripts/host-integration-smoke.sh --soak` | Repeats real MicroVM core, host command, Dockerfile `RUN`, Compose, CRI, leak, and state-race suites; records host resource counts and verifies evidence | Sampling follows whole-suite iterations; it does not yet report per-capability operation rates, daemon RSS/FD slopes, or independent periodic samples |
-| `scripts/local-sdk-smoke.sh` | One real Rust/Python/TypeScript pass for MicroVM or certified Sandbox execution, including builders, lifecycle, resources, diagnostics, and snapshots | Functional smoke only; no duration loop, concurrency mix, cancellation, or longitudinal resource gates |
+| `scripts/local-sdk-smoke.sh` | One real Rust/Python/TypeScript/Go pass for MicroVM or certified Sandbox execution, including builders, lifecycle, resources, diagnostics, and snapshots | Functional smoke only; no duration loop, concurrency mix, cancellation, or longitudinal resource gates |
 | `scripts/macos-fault-soak.sh` | Isolated Apple Silicon/HVF lifecycle churn with CLI/shim termination and resource samples | Covers lifecycle recovery, not the complete image/build/storage/network/SDK surface |
 | `scripts/windows-whpx-soak.ps1` | Repeats the eleven Windows-supported real tests and rejects residual A3S Box processes | Uses a Windows-specific summary and has no shared cross-capability verifier or long-term handle/RSS slope gate |
 | `deploy/scripts/runtimeclass-soak.sh` | RuntimeClass jobs, long-lived services, exec, logs, events, cleanup, node selection, sampling, and verified cluster evidence | Cluster-focused; it does not replace node-local image, build, SDK, warm-pool, or TEE lanes |
@@ -103,7 +103,7 @@ Status has a narrow meaning:
 | `SNP-01` | Filesystem snapshots | Capture, list/get/size, concurrent restore fan-out, independent mutation, delete fencing, source removal, restart, and interrupted capture/restore | Restores preserve expected image defaults and Unix metadata; copies are independent; no partial snapshot is published; final snapshot count/bytes return to baseline | Partial |
 | `NET-01` | Networking and Compose | TSI outbound churn, named bridge peers, DNS/aliases, TCP publication and port reuse, connection pressure, Compose up/logs/down, netproxy/passt termination | Success/latency stay within threshold; no cross-network reachability; published ports close on cleanup; no network, forwarder, FD, or route leak | Partial |
 | `POL-01` | Warm pool and snapshot-fork | Long-running pool daemon, acquire/release churn, min/max resize, lease expiry, deferred main, build leases, snapshot-fork fan-out, daemon/client termination | No double lease or stale template reuse; idle/active/leased counts reconcile; snapshot count is flat; p95 acquire latency and RSS slope stay within bounds | Partial |
-| `SDK-01` | Rust, Python, and TypeScript SDKs | Run the checked native operation inventory in all languages under sequential and concurrent loops on MicroVM and Sandbox; retry restart IDs and stale generations; terminate clients mid-operation | Identical typed outcomes and stable error codes; no inventory drift; deterministic cleanup; bridge timeout/process/RSS/FD counts stay bounded | Partial: one-pass native smoke and legacy KVM pipeline soak exist |
+| `SDK-01` | Rust, Python, TypeScript, and Go SDKs | Run the checked native operation inventory in all languages under sequential and concurrent loops on MicroVM and Sandbox; retry restart IDs and stale generations; terminate clients mid-operation | Identical typed outcomes and stable error codes; no inventory drift; deterministic cleanup; bridge timeout/process/RSS/FD counts stay bounded | Partial: one-pass native smoke and legacy KVM pipeline soak exist |
 | `OBS-01` | Observability and safety | Continuous logs, stats, events, monitor health/metrics, audit reads, log rotation, slow readers, daemon restart, and state reconciliation | Sample sequence is monotonic; stream identity and timestamps remain usable; no writer deadlock or unbounded log growth; daemon RSS under 50 MiB/day after warm-up | Partial |
 | `TEE-01` | TEE | Repeated real SNP attestation, policy verification, RA-TLS, seal/unseal, rollback rejection, secret injection/rotation, restart, and negative evidence | Every report verifies against the recorded policy; stale/tampered evidence fails closed; secrets do not appear in logs/evidence and remain unavailable outside the intended guest | Planned on hardware; simulation never satisfies this row |
 | `K8S-01` | Kubernetes CRI and RuntimeClass | Short Job churn plus Redis/Postgres/nginx/Python services, exec/log/stats, deletion during boot, CRI/shim/containerd restart, cleanup and optional node reboot | Existing cluster verifier passes; success rate at least 99.5% excluding declared faults; no Warning events, unexpected restarts, Pending/Unknown workloads, or residual resources | Existing |
@@ -226,7 +226,7 @@ retention but cannot waive a capability owner's failed or missing gate.
 | Image or registry | Deterministic fault suite and `R0 IMG-01` | `G2` against each production registry class; `R24` for transfer/cache changes |
 | Build or warm pool | `R0 BLD-01` and `POL-01` | `G2`; `R24` for cache, lease, snapshot-fork, or BuildKit changes |
 | Storage, snapshot, networking, Compose | Affected `R0` scenario | `G2` on every affected backend; `R24` for data-format or netproxy/passt changes |
-| Native SDK or machine bridge | Package tests and `R0 SDK-01` on MicroVM and Sandbox | `G2` three-language matrix on both isolation classes |
+| Native SDK or machine bridge | Package tests and `R0 SDK-01` on MicroVM and Sandbox | `G2` four-language matrix on both isolation classes |
 | A3S Runtime Provider | One real R17 conformance pass | `G2 PRO-01`; `R24` before provider promotion |
 | CRI/containerd | RuntimeClass smoke | Three-node `G2`; cohort `R24`; `E72` before broad rollout |
 | TEE | Simulation regression plus hardware `R0` | Hardware `G2` and `R24`; no hardware claim without both |

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Exercise the zero-configuration Rust, Python, and TypeScript local SDKs
+# Exercise the zero-configuration Rust, Python, TypeScript, and Go local SDKs
 # against one real A3S Box isolation backend.
 
 set -Eeuo pipefail
@@ -10,6 +10,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKSPACE="$REPO_ROOT/src"
 ISOLATION="${1:-microvm}"
 PYTHON="${PYTHON:-python3}"
+GO="${GO:-go}"
 A3S_BOX_BINARY="${A3S_BOX_BINARY:-$WORKSPACE/target/debug/a3s-box}"
 CARGO_PROFILE="${A3S_BOX_SDK_CARGO_PROFILE:-debug}"
 BINARY_DIR="$(cd "$(dirname "$A3S_BOX_BINARY")" && pwd)"
@@ -420,5 +421,16 @@ try {
   await rm(context, { recursive: true, force: true })
 }
 JS
+
+echo "==> Go SDK ($ISOLATION)"
+if ! command -v "$GO" >/dev/null 2>&1; then
+    echo "Go executable is not available: $GO" >&2
+    exit 1
+fi
+(
+    cd "$REPO_ROOT/sdk/go"
+    A3S_BOX_BINARY="$A3S_BOX_BINARY" \
+        "$GO" run ./cmd/local-sdk-smoke "$ISOLATION"
+)
 
 echo "All local SDK smokes passed for isolation=$ISOLATION"

--- a/sdk/go/LICENSE
+++ b/sdk/go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 A3S Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,216 @@
+# A3S Box Go SDK
+
+The Go SDK is a typed, local-first API for A3S Box. It builds OCI images,
+manages volumes and networks, configures Sandboxes with fluent builders, runs
+commands and stdin-backed scripts, and exposes binary-safe filesystem and
+snapshot operations.
+
+It talks only to the installed `a3s-box sdk-bridge` process. There is no remote
+service configuration, account setup, or credential required to use a local
+runtime. `A3S_BOX_BINARY` is optional and only selects a non-default binary.
+
+## Install
+
+Install the A3S Box runtime first and verify it on the target machine:
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh | sh
+
+a3s-box --version
+a3s-box info
+```
+
+Then add the Go module:
+
+```bash
+go get github.com/A3S-Lab/Box/sdk/go/v3
+```
+
+Use the SDK and runtime from the same A3S Box release. `NewClient` performs a
+protocol and 48-operation capability handshake before it permits any mutation.
+
+## Quick start
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	box "github.com/A3S-Lab/Box/sdk/go/v3"
+)
+
+func main() {
+	ctx := context.Background()
+	sandbox, err := box.Create(ctx, "alpine:3.20")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer sandbox.Close(context.Background())
+
+	result, err := sandbox.Run(ctx, box.Argv("printf", "hello from A3S Box"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(result.StdoutString())
+
+	if _, err := sandbox.Files().WriteString(ctx, "/tmp/note.txt", "hello"); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+Use `box.Argv(...)` for direct execution. Use `box.Shell(...)` only when shell
+syntax is intentional.
+
+## Programmable CI/CD
+
+Builders provide code-first image, cache, network, Sandbox, and script
+configuration without introducing a separate workflow format:
+
+```go
+ctx := context.Background()
+client, err := box.NewClient(ctx)
+if err != nil {
+	return err
+}
+
+image, err := client.
+	Image("./ci").
+	Dockerfile("Dockerfile").
+	Tag("local/go-ci:latest").
+	BuildArg("GO_VERSION", "1.25").
+	Build(ctx)
+if err != nil {
+	return err
+}
+
+cache, err := client.
+	Volume("go-cache").
+	Label("purpose", "dependency-cache").
+	Create(ctx)
+if err != nil {
+	return err
+}
+
+network, err := client.
+	Network("ci-network").
+	Subnet("10.89.20.0/24").
+	Create(ctx)
+if err != nil {
+	return err
+}
+
+sandbox, err := client.
+	Sandbox(image.Reference).
+	CPUs(4).
+	MemoryMiB(4096).
+	Mount(box.NamedVolume(cache.Name, "/go/pkg/mod")).
+	Network(box.BridgeNetwork(network.Name)).
+	Start(ctx)
+if err != nil {
+	return err
+}
+defer sandbox.Close(context.Background())
+
+result, err := sandbox.
+	Script("go test ./...\n").
+	Interpreter("/bin/sh", "-se").
+	Env("CI", "true").
+	Directory("/workspace").
+	Run(ctx)
+if err != nil {
+	return err
+}
+if result.ExitCode != 0 {
+	return fmt.Errorf("tests failed: %s", result.StderrString())
+}
+```
+
+Use `box.NoNetwork()` for a network-disabled Sandbox and `box.TSINetwork()` for
+the default transparent socket interception mode. Bind mounts, named volumes,
+tmpfs, bridge networks, ports, DNS servers, host aliases, snapshot restore,
+read-only roots, persistence, and automatic cleanup are all typed builder
+values.
+
+## API surface
+
+| Area | Go API |
+| --- | --- |
+| Runtime | `NewClient`, `Capabilities`, `RuntimeDiagnostics`, `RuntimeDiskUsage` |
+| Images | `Image(...).Build`, `PullImage`, `GetImage`, `ListImages`, `InspectImage`, `ImageHistory`, `TagImage`, `PushImage`, `RemoveImage`, `EvictImages` |
+| Volumes | `Volume(...).Create`, `GetVolume`, `ListVolumes`, `RemoveVolume`, `PruneVolumes` |
+| Networks | `Network(...).Create`, `GetNetwork`, `ListNetworks`, `RemoveNetwork`, `PruneNetworks` |
+| Sandbox | `Create`, `Connect`, `Sandbox(...).Start`, `Inspect`, `Stop`, `Restart`, `Pause`, `Resume`, `Kill`, `Remove`, `Close` |
+| Execution | `Run`, `Commands().Run`, `Script`, `ScriptBytes` |
+| Files | `Write`, `WriteString`, `Read`, `ReadString`, `Stat`, `Exists`, `List`, `MakeDir`, `Move`, `Remove` |
+| Snapshots | `CreateFilesystemSnapshot`, `ListFilesystemSnapshots`, `GetFilesystemSnapshot`, `FilesystemSnapshotSize`, `DeleteFilesystemSnapshot` |
+| Observability | `ListSandboxes`, `GetSandbox`, `Logs`, `Stats`, `IsRunning` |
+
+All runtime I/O accepts `context.Context`. Command and file calls on one
+`Sandbox` may run concurrently. Lifecycle transitions are serialized against
+in-flight calls and update the generation fence atomically. `Close` is bounded,
+idempotent after successful cleanup, and retryable after a cleanup failure.
+
+Command output and file primitives use `[]byte`. The `StdoutString`,
+`StderrString`, `WriteString`, and `ReadString` helpers are conveniences for
+text workloads.
+
+## Errors and cancellation
+
+Failures use `*box.Error` with a stable `ErrorCode`. Match categories with
+`errors.Is` and inspect details with `errors.As`:
+
+```go
+result, err := sandbox.Run(ctx, box.Argv("make", "test"))
+if errors.Is(err, context.DeadlineExceeded) {
+	return fmt.Errorf("job deadline exceeded: %w", err)
+}
+if errors.Is(err, box.ErrConflict) {
+	return fmt.Errorf("Sandbox generation changed: %w", err)
+}
+_ = result
+```
+
+The SDK preserves `context.Canceled` and `context.DeadlineExceeded` through
+error wrapping. Stable runtime categories include `ErrInvalidRequest`,
+`ErrNotFound`, `ErrConflict`, `ErrUnavailable`, and `ErrRuntime`.
+
+## Runtime selection
+
+The default runtime resolves `A3S_BOX_BINARY` and then `a3s-box` on `PATH`:
+
+```bash
+export A3S_BOX_BINARY=/opt/a3s/bin/a3s-box
+go run ./cmd/worker
+```
+
+Applications that need an explicit typed runtime can configure it directly:
+
+```go
+runtime := box.NewLocalRuntime(
+	box.WithBinaryPath("/opt/a3s/bin/a3s-box"),
+	box.WithBridgeTimeout(5*time.Minute),
+)
+client, err := box.NewClient(ctx, box.WithRuntime(runtime))
+```
+
+Registry credentials, when used for image pull or push, are encoded in the
+bridge request on stdin and are never placed in process arguments.
+
+## Development and release tags
+
+```bash
+gofmt -w .
+go vet ./...
+go test ./...
+go test -race ./...
+```
+
+This is a nested Go module. A repository release `vX.Y.Z` is published to the
+Go module ecosystem with the matching path-prefixed tag
+`sdk/go/vX.Y.Z`. The release workflow creates and verifies that tag after the
+tested GitHub release succeeds.

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -1,0 +1,150 @@
+package box
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/A3S-Lab/Box/sdk/go/v3/internal/bridge"
+)
+
+// Client is a concurrency-safe entry point for local A3S Box resources.
+type Client struct {
+	runtime      Runtime
+	capabilities Capabilities
+}
+
+type ClientOption interface {
+	applyClient(*clientConfig)
+}
+
+type clientOptionFunc func(*clientConfig)
+
+func (option clientOptionFunc) applyClient(config *clientConfig) { option(config) }
+
+type clientConfig struct {
+	runtime Runtime
+}
+
+// WithRuntime injects a typed runtime implementation. It is useful for tests
+// and custom local transports; normal applications can use NewClient directly.
+func WithRuntime(runtime Runtime) ClientOption {
+	return clientOptionFunc(func(config *clientConfig) {
+		config.runtime = runtime
+	})
+}
+
+// NewClient verifies the full machine bridge capability inventory before the
+// client can issue a mutating request.
+func NewClient(ctx context.Context, options ...ClientOption) (*Client, error) {
+	config := clientConfig{runtime: NewLocalRuntime()}
+	for _, option := range options {
+		if option != nil {
+			option.applyClient(&config)
+		}
+	}
+	if runtimeIsNil(config.runtime) {
+		return nil, invalid("new_client", "runtime cannot be nil")
+	}
+	client := &Client{runtime: config.runtime}
+	var capabilities Capabilities
+	if err := client.request(ctx, "sdk_capabilities", nil, &capabilities); err != nil {
+		return nil, err
+	}
+	if capabilities.ProtocolVersion != bridge.ProtocolVersion {
+		return nil, sdkError(
+			"sdk_capabilities",
+			CodeProtocol,
+			fmt.Sprintf("runtime capability protocol version %d is unsupported", capabilities.ProtocolVersion),
+			nil,
+		)
+	}
+	available := make(map[string]struct{}, len(capabilities.Operations))
+	for _, operation := range capabilities.Operations {
+		available[operation] = struct{}{}
+	}
+	missing := make([]string, 0)
+	for _, operation := range bridge.RequiredOperations {
+		if _, ok := available[operation]; !ok {
+			missing = append(missing, operation)
+		}
+	}
+	if len(missing) != 0 {
+		sort.Strings(missing)
+		return nil, sdkError(
+			"sdk_capabilities",
+			CodeUnavailable,
+			"installed A3S Box runtime is missing required operations: "+strings.Join(missing, ", "),
+			nil,
+		)
+	}
+	capabilities.Operations = append([]string(nil), capabilities.Operations...)
+	client.capabilities = capabilities
+	return client, nil
+}
+
+// Create is the shortest local Sandbox entry point.
+func Create(ctx context.Context, image string, options ...ClientOption) (*Sandbox, error) {
+	client, err := NewClient(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	return client.Sandbox(image).Start(ctx)
+}
+
+// Connect attaches to an existing local Sandbox by ID.
+func Connect(ctx context.Context, sandboxID string, options ...ClientOption) (*Sandbox, error) {
+	client, err := NewClient(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	return client.ConnectSandbox(ctx, sandboxID)
+}
+
+func (client *Client) Capabilities() Capabilities {
+	if client == nil {
+		return Capabilities{}
+	}
+	capabilities := client.capabilities
+	capabilities.Operations = append([]string(nil), capabilities.Operations...)
+	return capabilities
+}
+
+func SupportedOperations() []string {
+	return append([]string(nil), bridge.RequiredOperations...)
+}
+
+func (client *Client) request(
+	ctx context.Context,
+	operation string,
+	fields map[string]any,
+	result any,
+) error {
+	if client == nil || runtimeIsNil(client.runtime) {
+		return invalid(operation, "client is not initialized")
+	}
+	if ctx == nil {
+		return invalid(operation, "context cannot be nil")
+	}
+	request := make(map[string]any, len(fields)+1)
+	request["operation"] = operation
+	for key, value := range fields {
+		request[key] = value
+	}
+	return client.runtime.Request(ctx, request, result)
+}
+
+func runtimeIsNil(runtime Runtime) bool {
+	if runtime == nil {
+		return true
+	}
+	value := reflect.ValueOf(runtime)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1,0 +1,229 @@
+package box
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/A3S-Lab/Box/sdk/go/v3/internal/bridge"
+)
+
+func TestOperationInventoryMatchesRustContract(t *testing.T) {
+	payload, err := os.ReadFile("../bridge-operations.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var inventory []string
+	if err := json.Unmarshal(payload, &inventory); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(inventory, bridge.RequiredOperations) {
+		t.Fatalf("Go operation inventory differs from Rust contract\nGo:   %v\nRust: %v", bridge.RequiredOperations, inventory)
+	}
+	seen := make(map[string]struct{}, len(inventory))
+	for _, operation := range inventory {
+		if _, duplicate := seen[operation]; duplicate {
+			t.Fatalf("duplicate operation %q", operation)
+		}
+		seen[operation] = struct{}{}
+	}
+}
+
+func TestNewClientFailsClosedBeforeMutation(t *testing.T) {
+	operations := append([]string(nil), bridge.RequiredOperations...)
+	operations = slices.DeleteFunc(operations, func(operation string) bool {
+		return operation == "sandbox_create"
+	})
+	runtime := &fakeRuntime{handler: func(_ context.Context, request map[string]any) (any, error) {
+		if request["operation"] == "sdk_capabilities" {
+			return Capabilities{ProtocolVersion: bridge.ProtocolVersion, Operations: operations}, nil
+		}
+		return nil, errors.New("mutation must not run")
+	}}
+	// Override the helper's automatic capability response for this test.
+	runtimeWithMissing := runtimeFunc(func(ctx context.Context, request any, result any) error {
+		payload, _ := json.Marshal(request)
+		var decoded map[string]any
+		_ = json.Unmarshal(payload, &decoded)
+		runtime.mu.Lock()
+		runtime.requests = append(runtime.requests, decoded)
+		runtime.mu.Unlock()
+		return assignResult(result, Capabilities{ProtocolVersion: bridge.ProtocolVersion, Operations: operations})
+	})
+	client, err := NewClient(context.Background(), WithRuntime(runtimeWithMissing))
+	if client != nil || !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("expected unavailable handshake failure, client=%v err=%v", client, err)
+	}
+	if !strings.Contains(err.Error(), "sandbox_create") {
+		t.Fatalf("missing operation is absent from error: %v", err)
+	}
+	if got := len(runtime.Requests()); got != 1 {
+		t.Fatalf("expected exactly one non-mutating request, got %d", got)
+	}
+}
+
+func TestNewClientRejectsCapabilityProtocolMismatch(t *testing.T) {
+	runtime := runtimeFunc(func(_ context.Context, _ any, result any) error {
+		return assignResult(result, Capabilities{
+			ProtocolVersion: bridge.ProtocolVersion + 1,
+			Operations:      bridge.RequiredOperations,
+		})
+	})
+	_, err := NewClient(context.Background(), WithRuntime(runtime))
+	if !errors.Is(err, ErrProtocol) {
+		t.Fatalf("expected protocol error, got %v", err)
+	}
+}
+
+func TestBuildersValidateBeforeMutation(t *testing.T) {
+	runtime := &fakeRuntime{}
+	client := mustClient(runtime)
+	baseline := len(runtime.Requests())
+
+	if _, err := client.Image("").Build(context.Background()); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected invalid image builder, got %v", err)
+	}
+	if _, err := client.Volume("").Create(context.Background()); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected invalid volume builder, got %v", err)
+	}
+	if _, err := client.Network("ci").Subnet("not-cidr").Create(context.Background()); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected invalid network builder, got %v", err)
+	}
+	if _, err := client.Sandbox("alpine:3.20").CPUs(0).Start(context.Background()); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected invalid sandbox builder, got %v", err)
+	}
+	if got := len(runtime.Requests()); got != baseline {
+		t.Fatalf("validation issued %d unexpected requests", got-baseline)
+	}
+}
+
+func TestRegistryCredentialsDoNotFormatPassword(t *testing.T) {
+	credentials := BasicCredentials("ci", "super-secret")
+	for _, formatted := range []string{
+		fmt.Sprint(credentials),
+		fmt.Sprintf("%+v", credentials),
+		fmt.Sprintf("%#v", credentials),
+	} {
+		if strings.Contains(formatted, "super-secret") {
+			t.Fatalf("credential formatting exposed password: %s", formatted)
+		}
+	}
+	if credentials.Username() != "ci" {
+		t.Fatalf("unexpected credential username %q", credentials.Username())
+	}
+}
+
+func TestProgrammableBuildersEncodeTypedConfiguration(t *testing.T) {
+	runtime := &fakeRuntime{handler: func(_ context.Context, request map[string]any) (any, error) {
+		switch request["operation"] {
+		case "image_build":
+			return BuildImageInfo{Reference: "local/ci:latest", Digest: "sha256:1"}, nil
+		case "volume_create":
+			return VolumeInfo{Name: "go-cache", SizeLimit: 4096}, nil
+		case "network_create":
+			return NetworkInfo{Name: "ci-net", Subnet: "10.44.0.0/24"}, nil
+		case "sandbox_create":
+			return SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateRunning}, nil
+		default:
+			return map[string]any{}, nil
+		}
+	}}
+	client := mustClient(runtime)
+	ctx := context.Background()
+
+	image, err := client.Image("./ci").
+		Dockerfile("Dockerfile.ci").
+		Tag("local/ci:latest").
+		BuildArg("GO_VERSION", "1.25").
+		Platform("linux/arm64").
+		Target("test").
+		NoCache(true).
+		Build(ctx)
+	if err != nil || image.Reference != "local/ci:latest" {
+		t.Fatalf("build image: %+v, %v", image, err)
+	}
+	volume, err := client.Volume("go-cache").Label("scope", "ci").SizeLimit(4096).Create(ctx)
+	if err != nil || volume.Name != "go-cache" {
+		t.Fatalf("create volume: %+v, %v", volume, err)
+	}
+	network, err := client.Network("ci-net").Subnet("10.44.0.0/24").Label("scope", "ci").Create(ctx)
+	if err != nil || network.Name != "ci-net" {
+		t.Fatalf("create network: %+v, %v", network, err)
+	}
+	sandbox, err := client.Sandbox(image.Reference).
+		Timeout(90*time.Second).
+		Env("CI", "true").
+		Label("job", "test").
+		Name("go-test").
+		CPUs(4).
+		MemoryMiB(4096).
+		Isolation(IsolationSandbox).
+		FilesystemSnapshot("base-snapshot").
+		Workspace("/workspace").
+		Workdir("/workspace/src").
+		User("1000:1000").
+		Hostname("go-ci").
+		Mount(NamedVolume(volume.Name, "/go/pkg/mod").ReadOnly()).
+		Mount(BindMount("./src", "/workspace/src")).
+		Tmpfs(Tmpfs("/tmp").SizeBytes(1024)).
+		Network(BridgeNetwork(network.Name)).
+		PublishTCP(0, 8080).
+		DNSServer("1.1.1.1").
+		HostAlias("registry.local", "10.44.0.2").
+		ReadOnly(true).
+		Persistent(true).
+		AutoRemove(false).
+		Start(ctx)
+	if err != nil || sandbox.ID() != "box-1" {
+		t.Fatalf("start sandbox: %v, %v", sandbox, err)
+	}
+
+	requests := runtime.Requests()
+	build := requestByOperation(t, requests, "image_build")
+	if build["quiet"] != true || build["target"] != "test" {
+		t.Fatalf("unexpected image build request: %#v", build)
+	}
+	if platforms, ok := build["platforms"].([]any); !ok || len(platforms) != 1 {
+		t.Fatalf("image platforms must be a JSON array: %#v", build["platforms"])
+	}
+	create := requestByOperation(t, requests, "sandbox_create")
+	if create["timeout_seconds"] != float64(90) || create["isolation"] != string(IsolationSandbox) {
+		t.Fatalf("unexpected sandbox request: %#v", create)
+	}
+	mounts, ok := create["mounts"].([]any)
+	if !ok || len(mounts) != 2 {
+		t.Fatalf("unexpected mounts: %#v", create["mounts"])
+	}
+}
+
+func requestByOperation(t *testing.T, requests []map[string]any, operation string) map[string]any {
+	t.Helper()
+	for _, request := range requests {
+		if request["operation"] == operation {
+			return request
+		}
+	}
+	t.Fatalf("operation %q was not requested", operation)
+	return nil
+}
+
+type runtimeFunc func(context.Context, any, any) error
+
+func (function runtimeFunc) Request(ctx context.Context, request any, result any) error {
+	return function(ctx, request, result)
+}
+
+func assignResult(target, value any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(payload, target)
+}

--- a/sdk/go/cmd/local-sdk-smoke/main.go
+++ b/sdk/go/cmd/local-sdk-smoke/main.go
@@ -1,0 +1,336 @@
+// Command local-sdk-smoke exercises the public Go SDK against one real local
+// A3S Box isolation backend. It is invoked by scripts/local-sdk-smoke.sh.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	box "github.com/A3S-Lab/Box/sdk/go/v3"
+)
+
+func main() {
+	isolation, err := selectedIsolation()
+	if err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		defer cancel()
+		err = run(ctx, isolation)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Go SDK smoke failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, isolation box.Isolation) (returnErr error) {
+	client, err := box.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	diagnostics, err := client.RuntimeDiagnostics(ctx)
+	if err != nil {
+		return err
+	}
+	if diagnostics.Home != os.Getenv("A3S_HOME") || diagnostics.RuntimeVersion == "" {
+		return fmt.Errorf("runtime diagnostics did not describe the smoke runtime: %+v", diagnostics)
+	}
+	if _, err := client.RuntimeDiskUsage(ctx); err != nil {
+		return err
+	}
+	if !slices.Contains(client.Capabilities().Operations, "image_push") {
+		return errors.New("runtime capability inventory is incomplete")
+	}
+
+	contextDir := filepath.Join(os.Getenv("A3S_HOME"), "go-sdk-build-context")
+	if err := os.MkdirAll(contextDir, 0o755); err != nil {
+		return err
+	}
+	defer func() { returnErr = errors.Join(returnErr, os.RemoveAll(contextDir)) }()
+	if err := os.WriteFile(
+		filepath.Join(contextDir, "Dockerfile"),
+		[]byte("FROM alpine:3.20\nENV A3S_SDK_BASE=ready\nWORKDIR /workspace\n"),
+		0o644,
+	); err != nil {
+		return err
+	}
+
+	image, err := client.Image(contextDir).Tag("local/a3s-sdk-smoke-go:latest").Build(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cleanup, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		returnErr = errors.Join(returnErr, client.RemoveImage(cleanup, image.Reference))
+		_, evictErr := client.EvictImages(cleanup)
+		returnErr = errors.Join(returnErr, evictErr)
+	}()
+	if value, err := client.GetImage(ctx, image.Reference); err != nil || value == nil {
+		return fmt.Errorf("built image is not gettable: %w", err)
+	}
+	if value, err := client.InspectImage(ctx, image.Reference); err != nil || value == nil {
+		return fmt.Errorf("built image is not inspectable: %w", err)
+	}
+	if value, err := client.ImageHistory(ctx, image.Reference); err != nil || value == nil {
+		return fmt.Errorf("built image history is unavailable: %w", err)
+	}
+	tagged, err := client.TagImage(ctx, image.Reference, "local/a3s-sdk-smoke-go:tested")
+	if err != nil {
+		return err
+	}
+	if err := client.RemoveImage(ctx, tagged.Reference); err != nil {
+		return err
+	}
+
+	pruneVolume, err := client.Volume("go-sdk-prune-cache").Create(ctx)
+	if err != nil {
+		return err
+	}
+	prunedVolumes, err := client.PruneVolumes(ctx)
+	if err != nil || !slices.Contains(prunedVolumes, pruneVolume.Name) {
+		return fmt.Errorf("volume prune did not remove %q: %w", pruneVolume.Name, err)
+	}
+	pruneNetwork, err := client.Network("go-sdk-prune-network").Subnet("10.89.96.0/24").Create(ctx)
+	if err != nil {
+		return err
+	}
+	prunedNetworks, err := client.PruneNetworks(ctx)
+	if err != nil || !slices.Contains(prunedNetworks, pruneNetwork.Name) {
+		return fmt.Errorf("network prune did not remove %q: %w", pruneNetwork.Name, err)
+	}
+
+	volume, err := client.Volume("go-sdk-cache").Label("purpose", "sdk-smoke").Create(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cleanup, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, err := client.RemoveVolume(cleanup, volume.Name, false)
+		returnErr = errors.Join(returnErr, err)
+	}()
+
+	var network *box.NetworkInfo
+	builder := client.Sandbox(image.Reference).
+		Isolation(isolation).
+		Mount(box.NamedVolume(volume.Name, "/cache")).
+		Workdir("/workspace")
+	if isolation == box.IsolationMicroVM {
+		created, err := client.Network("go-sdk-network").Subnet("10.89.94.0/24").Create(ctx)
+		if err != nil {
+			return err
+		}
+		network = &created
+		defer func() {
+			cleanup, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_, err := client.RemoveNetwork(cleanup, network.Name)
+			returnErr = errors.Join(returnErr, err)
+		}()
+		builder = builder.Network(box.BridgeNetwork(network.Name)).PublishTCP(0, 8080)
+	} else {
+		builder = builder.Network(box.NoNetwork())
+	}
+
+	sandbox, err := builder.Start(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cleanup, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		returnErr = errors.Join(returnErr, sandbox.Close(cleanup))
+	}()
+	if _, err := client.ConnectSandbox(ctx, sandbox.ID()); err != nil {
+		return err
+	}
+	listed, err := client.ListSandboxes(ctx, true)
+	if err != nil || !hasSandbox(listed, sandbox.ID()) {
+		return fmt.Errorf("running Sandbox is absent from inventory: %w", err)
+	}
+	if value, err := client.GetSandbox(ctx, sandbox.ID()); err != nil || value == nil {
+		return fmt.Errorf("running Sandbox is not gettable: %w", err)
+	}
+
+	command, err := sandbox.Run(ctx, box.Argv("printf", "go-sdk-ok"))
+	if err != nil || command.ExitCode != 0 || command.StdoutString() != "go-sdk-ok" {
+		return fmt.Errorf("foreground command failed: result=%+v error=%w", command, err)
+	}
+	script, err := sandbox.Script("printf 'go-script-ok'\n").Env("CI", "true").Run(ctx)
+	if err != nil || script.ExitCode != 0 || script.StdoutString() != "go-script-ok" {
+		return fmt.Errorf("script failed: result=%+v error=%w", script, err)
+	}
+	files := sandbox.Files()
+	if _, err := files.WriteString(ctx, "/cache/marker.txt", "cache-ok"); err != nil {
+		return err
+	}
+	if value, err := files.ReadString(ctx, "/cache/marker.txt"); err != nil || value != "cache-ok" {
+		return fmt.Errorf("named volume cache has unexpected contents: %q: %w", value, err)
+	}
+	if err := files.MakeDir(ctx, "/workspace/artifacts"); err != nil {
+		return err
+	}
+	if _, err := files.WriteString(ctx, "/workspace/artifacts/result.txt", "hello"); err != nil {
+		return err
+	}
+	if exists, err := files.Exists(ctx, "/workspace/artifacts/result.txt"); err != nil || !exists {
+		return fmt.Errorf("written artifact does not exist: %w", err)
+	}
+	if _, err := files.Stat(ctx, "/workspace/artifacts/result.txt"); err != nil {
+		return err
+	}
+	if entries, err := files.List(ctx, "/workspace/artifacts", 1); err != nil || len(entries) == 0 {
+		return fmt.Errorf("artifact directory is empty: %w", err)
+	}
+	if err := files.Move(ctx, "/workspace/artifacts/result.txt", "/workspace/artifacts/final.txt"); err != nil {
+		return err
+	}
+	if value, err := files.ReadString(ctx, "/workspace/artifacts/final.txt"); err != nil || value != "hello" {
+		return fmt.Errorf("moved artifact has unexpected contents: %q: %w", value, err)
+	}
+	if err := files.Remove(ctx, "/workspace/artifacts"); err != nil {
+		return err
+	}
+	if logs, err := sandbox.Logs(ctx, 20); err != nil || len(logs) > 20 {
+		return fmt.Errorf("bounded logs failed: %w", err)
+	}
+	if stats, err := sandbox.Stats(ctx); err != nil || stats == nil {
+		return fmt.Errorf("sandbox stats are unavailable: %w", err)
+	}
+	if err := sandbox.Pause(ctx, true); err != nil {
+		return err
+	}
+	if running, err := sandbox.IsRunning(ctx); err != nil || running {
+		return fmt.Errorf("paused Sandbox reports itself running: %w", err)
+	}
+	if err := sandbox.Resume(ctx); err != nil {
+		return err
+	}
+	if running, err := sandbox.IsRunning(ctx); err != nil || !running {
+		return fmt.Errorf("resumed Sandbox is not running: %w", err)
+	}
+
+	if isolation == box.IsolationSandbox {
+		if err := exerciseSnapshot(ctx, client, sandbox, image.Reference); err != nil {
+			return err
+		}
+	}
+	previousGeneration := sandbox.Generation()
+	if err := sandbox.Stop(ctx); err != nil {
+		return err
+	}
+	if running, err := sandbox.IsRunning(ctx); err != nil || running {
+		return fmt.Errorf("stopped Sandbox reports itself running: %w", err)
+	}
+	if err := sandbox.Restart(
+		ctx,
+		box.RestartOperationID("go-smoke-restart-"+sandbox.ID()),
+		box.RestartStopTimeout(5*time.Second),
+	); err != nil {
+		return err
+	}
+	if sandbox.Generation() != previousGeneration+1 {
+		return errors.New("restart did not advance the Sandbox generation")
+	}
+	if err := sandbox.Stop(ctx); err != nil {
+		return err
+	}
+	if err := sandbox.Remove(ctx); err != nil {
+		return err
+	}
+	if value, err := client.GetSandbox(ctx, sandbox.ID()); err != nil || value != nil {
+		return fmt.Errorf("removed Sandbox remains in inventory: %w", err)
+	}
+
+	killProbe := client.Sandbox(image.Reference).Isolation(isolation)
+	if isolation == box.IsolationSandbox {
+		killProbe = killProbe.Network(box.NoNetwork())
+	} else if network != nil {
+		killProbe = killProbe.Network(box.BridgeNetwork(network.Name))
+	}
+	probe, err := killProbe.Start(ctx)
+	if err != nil {
+		return err
+	}
+	if err := probe.Close(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func exerciseSnapshot(ctx context.Context, client *box.Client, sandbox *box.Sandbox, image string) error {
+	marker := "/a3s-go-sdk-snapshot.txt"
+	if _, err := sandbox.Files().WriteString(ctx, marker, "snapshot-ok"); err != nil {
+		return err
+	}
+	snapshotID := "go_sdk_" + strings.ReplaceAll(sandbox.ID(), "-", "_")
+	snapshot, err := sandbox.CreateFilesystemSnapshot(ctx, snapshotID)
+	if err != nil {
+		return err
+	}
+	if size, found, err := client.FilesystemSnapshotSize(ctx, snapshotID); err != nil || !found || size != snapshot.SizeBytes {
+		return fmt.Errorf("snapshot size lookup failed: %w", err)
+	}
+	if snapshots, err := client.ListFilesystemSnapshots(ctx); err != nil || !hasSnapshot(snapshots, snapshotID) {
+		return fmt.Errorf("snapshot is absent from inventory: %w", err)
+	}
+	if value, err := client.GetFilesystemSnapshot(ctx, snapshotID); err != nil || value == nil {
+		return fmt.Errorf("snapshot is not gettable: %w", err)
+	}
+	restored, err := client.Sandbox(image).
+		Isolation(box.IsolationSandbox).
+		FilesystemSnapshot(snapshotID).
+		Network(box.NoNetwork()).
+		Start(ctx)
+	if err != nil {
+		return err
+	}
+	value, readErr := restored.Files().ReadString(ctx, marker)
+	if readErr != nil || value != "snapshot-ok" {
+		_ = restored.Close(context.Background())
+		return fmt.Errorf("restored snapshot marker is invalid: %q: %w", value, readErr)
+	}
+	if deleted, deleteErr := client.DeleteFilesystemSnapshot(ctx, snapshotID); deleteErr == nil || deleted {
+		_ = restored.Close(context.Background())
+		return errors.New("active restored Sandbox did not fence snapshot deletion")
+	}
+	if err := restored.Close(ctx); err != nil {
+		return err
+	}
+	deleted, err := client.DeleteFilesystemSnapshot(ctx, snapshotID)
+	if err != nil || !deleted {
+		return fmt.Errorf("snapshot was not deleted after restored Sandbox cleanup: %w", err)
+	}
+	if _, found, err := client.FilesystemSnapshotSize(ctx, snapshotID); err != nil || found {
+		return fmt.Errorf("deleted snapshot still reports a size: %w", err)
+	}
+	return nil
+}
+
+func selectedIsolation() (box.Isolation, error) {
+	if len(os.Args) != 2 {
+		return "", errors.New("usage: local-sdk-smoke [microvm|sandbox]")
+	}
+	switch os.Args[1] {
+	case string(box.IsolationMicroVM):
+		return box.IsolationMicroVM, nil
+	case string(box.IsolationSandbox):
+		return box.IsolationSandbox, nil
+	default:
+		return "", fmt.Errorf("unsupported isolation %q", os.Args[1])
+	}
+}
+
+func hasSandbox(values []box.SandboxSummary, id string) bool {
+	return slices.ContainsFunc(values, func(value box.SandboxSummary) bool { return value.ID == id })
+}
+
+func hasSnapshot(values []box.FilesystemSnapshotSummary, id string) bool {
+	return slices.ContainsFunc(values, func(value box.FilesystemSnapshotSummary) bool { return value.ID == id })
+}

--- a/sdk/go/commands.go
+++ b/sdk/go/commands.go
@@ -1,0 +1,164 @@
+package box
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"time"
+)
+
+// Command is an explicit argv command. Use Shell only when shell semantics are
+// intentionally required.
+type Command struct {
+	argv []string
+}
+
+func Argv(arguments ...string) Command {
+	return Command{argv: append([]string(nil), arguments...)}
+}
+
+func Shell(source string) Command {
+	return Argv("/bin/sh", "-lc", source)
+}
+
+func (command Command) Arguments() []string {
+	return append([]string(nil), command.argv...)
+}
+
+type RunOption interface{ applyRun(*runConfig) }
+type runOptionFunc func(*runConfig)
+
+func (option runOptionFunc) applyRun(config *runConfig) { option(config) }
+
+type runConfig struct {
+	timeout *time.Duration
+	env     map[string]string
+	cwd     string
+	user    string
+	stdin   *[]byte
+}
+
+func RunTimeout(timeout time.Duration) RunOption {
+	return runOptionFunc(func(config *runConfig) { config.timeout = &timeout })
+}
+
+func RunEnv(key, value string) RunOption {
+	return runOptionFunc(func(config *runConfig) { config.env[key] = value })
+}
+
+func RunDirectory(path string) RunOption {
+	return runOptionFunc(func(config *runConfig) { config.cwd = path })
+}
+
+func RunAs(user string) RunOption {
+	return runOptionFunc(func(config *runConfig) { config.user = user })
+}
+
+func RunStdin(data []byte) RunOption {
+	return runOptionFunc(func(config *runConfig) {
+		copy := append([]byte(nil), data...)
+		config.stdin = &copy
+	})
+}
+
+func RunStdinString(data string) RunOption { return RunStdin([]byte(data)) }
+
+type Commands struct {
+	sandbox *Sandbox
+}
+
+func (sandbox *Sandbox) Commands() *Commands { return &Commands{sandbox: sandbox} }
+
+func (sandbox *Sandbox) Run(
+	ctx context.Context,
+	command Command,
+	options ...RunOption,
+) (CommandResult, error) {
+	return sandbox.Commands().Run(ctx, command, options...)
+}
+
+func (commands *Commands) Run(
+	ctx context.Context,
+	command Command,
+	options ...RunOption,
+) (CommandResult, error) {
+	const op = "command_run"
+	if commands == nil || commands.sandbox == nil {
+		return CommandResult{}, invalid(op, "commands handle is not initialized")
+	}
+	if len(command.argv) == 0 {
+		return CommandResult{}, invalid(op, "command cannot be empty")
+	}
+	for _, argument := range command.argv {
+		if strings.IndexByte(argument, 0) >= 0 {
+			return CommandResult{}, invalid(op, "command arguments cannot contain NUL bytes")
+		}
+	}
+	config := runConfig{env: make(map[string]string)}
+	for _, option := range options {
+		if option != nil {
+			option.applyRun(&config)
+		}
+	}
+	if config.timeout != nil && *config.timeout <= 0 {
+		return CommandResult{}, invalid(op, "command timeout must be greater than zero")
+	}
+	if config.cwd != "" && strings.TrimSpace(config.cwd) == "" {
+		return CommandResult{}, invalid(op, "command working directory cannot be blank")
+	}
+	if config.user != "" && strings.TrimSpace(config.user) == "" {
+		return CommandResult{}, invalid(op, "command user cannot be blank")
+	}
+	for key := range config.env {
+		if strings.TrimSpace(key) == "" {
+			return CommandResult{}, invalid(op, "environment variable name cannot be empty")
+		}
+	}
+	fields := map[string]any{
+		"argv": append([]string(nil), command.argv...),
+		"env":  cloneStringMap(config.env),
+	}
+	if config.timeout != nil {
+		fields["timeout_ms"] = durationMilliseconds(*config.timeout)
+	}
+	if config.cwd != "" {
+		fields["cwd"] = config.cwd
+	}
+	if config.user != "" {
+		fields["user"] = config.user
+	}
+	if config.stdin != nil {
+		fields["stdin_base64"] = base64.StdEncoding.EncodeToString(*config.stdin)
+	}
+	var wire struct {
+		StdoutBase64 string `json:"stdout_base64"`
+		StderrBase64 string `json:"stderr_base64"`
+		ExitCode     int    `json:"exit_code"`
+		Truncated    bool   `json:"truncated"`
+	}
+	if err := commands.sandbox.readRequest(ctx, op, fields, &wire, true); err != nil {
+		return CommandResult{}, err
+	}
+	stdout, err := base64.StdEncoding.DecodeString(wire.StdoutBase64)
+	if err != nil {
+		return CommandResult{}, sdkError(op, CodeProtocol, "command stdout is not valid base64", err)
+	}
+	stderr, err := base64.StdEncoding.DecodeString(wire.StderrBase64)
+	if err != nil {
+		return CommandResult{}, sdkError(op, CodeProtocol, "command stderr is not valid base64", err)
+	}
+	return CommandResult{
+		Stdout:    stdout,
+		Stderr:    stderr,
+		ExitCode:  wire.ExitCode,
+		Truncated: wire.Truncated,
+	}, nil
+}
+
+func durationMilliseconds(duration time.Duration) uint64 {
+	milliseconds := duration / time.Millisecond
+	if duration%time.Millisecond != 0 {
+		milliseconds++
+	}
+	return uint64(milliseconds)
+}

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -1,0 +1,92 @@
+package box
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrorCode is a stable SDK or runtime error category.
+type ErrorCode string
+
+const (
+	CodeInvalidRequest   ErrorCode = "invalid_request"
+	CodeNotFound         ErrorCode = "not_found"
+	CodeConflict         ErrorCode = "conflict"
+	CodeUnavailable      ErrorCode = "unavailable"
+	CodeRuntime          ErrorCode = "runtime_error"
+	CodeProtocol         ErrorCode = "bridge_protocol_error"
+	CodeNotInstalled     ErrorCode = "not_installed"
+	CodeCanceled         ErrorCode = "canceled"
+	CodeDeadlineExceeded ErrorCode = "deadline_exceeded"
+)
+
+var (
+	ErrInvalidRequest   = &Error{Code: CodeInvalidRequest}
+	ErrNotFound         = &Error{Code: CodeNotFound}
+	ErrConflict         = &Error{Code: CodeConflict}
+	ErrUnavailable      = &Error{Code: CodeUnavailable}
+	ErrRuntime          = &Error{Code: CodeRuntime}
+	ErrProtocol         = &Error{Code: CodeProtocol}
+	ErrNotInstalled     = &Error{Code: CodeNotInstalled}
+	ErrCanceled         = &Error{Code: CodeCanceled}
+	ErrDeadlineExceeded = &Error{Code: CodeDeadlineExceeded}
+)
+
+// Error is returned for validation, transport, protocol, and runtime failures.
+// Cause is retained so errors.Is continues to recognize context cancellation
+// and process errors.
+type Error struct {
+	Op      string
+	Code    ErrorCode
+	Message string
+	Cause   error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	message := e.Message
+	if message == "" {
+		message = string(e.Code)
+	}
+	if e.Op == "" {
+		return message
+	}
+	return fmt.Sprintf("a3s-box %s: %s", e.Op, message)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func (e *Error) Is(target error) bool {
+	other, ok := target.(*Error)
+	if !ok || e == nil || other == nil {
+		return false
+	}
+	return other.Code != "" && e.Code == other.Code
+}
+
+func sdkError(op string, code ErrorCode, message string, cause error) error {
+	return &Error{Op: op, Code: code, Message: message, Cause: cause}
+}
+
+func invalid(op, message string) error {
+	return sdkError(op, CodeInvalidRequest, message, nil)
+}
+
+func contextError(op string, err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return sdkError(op, CodeCanceled, "request canceled", err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return sdkError(op, CodeDeadlineExceeded, "request deadline exceeded", err)
+	default:
+		return sdkError(op, CodeRuntime, err.Error(), err)
+	}
+}

--- a/sdk/go/files.go
+++ b/sdk/go/files.go
@@ -1,0 +1,206 @@
+package box
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+)
+
+type FileOption interface{ applyFile(*fileConfig) }
+type fileOptionFunc func(*fileConfig)
+
+func (option fileOptionFunc) applyFile(config *fileConfig) { option(config) }
+
+type fileConfig struct {
+	user string
+}
+
+func FileAs(user string) FileOption {
+	return fileOptionFunc(func(config *fileConfig) { config.user = user })
+}
+
+type Filesystem struct {
+	sandbox *Sandbox
+}
+
+func (sandbox *Sandbox) Files() *Filesystem { return &Filesystem{sandbox: sandbox} }
+
+func (filesystem *Filesystem) Write(
+	ctx context.Context,
+	path string,
+	data []byte,
+	options ...FileOption,
+) (WriteInfo, error) {
+	const op = "file_write"
+	fields, err := filesystem.fields(op, path, options)
+	if err != nil {
+		return WriteInfo{}, err
+	}
+	fields["data_base64"] = base64.StdEncoding.EncodeToString(data)
+	var result WriteInfo
+	err = filesystem.sandbox.readRequest(ctx, op, fields, &result, true)
+	return result, err
+}
+
+func (filesystem *Filesystem) WriteString(
+	ctx context.Context,
+	path, data string,
+	options ...FileOption,
+) (WriteInfo, error) {
+	return filesystem.Write(ctx, path, []byte(data), options...)
+}
+
+func (filesystem *Filesystem) Read(
+	ctx context.Context,
+	path string,
+	options ...FileOption,
+) ([]byte, error) {
+	const op = "file_read"
+	fields, err := filesystem.fields(op, path, options)
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		DataBase64 string `json:"data_base64"`
+	}
+	if err := filesystem.sandbox.readRequest(ctx, op, fields, &result, true); err != nil {
+		return nil, err
+	}
+	data, err := base64.StdEncoding.DecodeString(result.DataBase64)
+	if err != nil {
+		return nil, sdkError(op, CodeProtocol, "file contents are not valid base64", err)
+	}
+	return data, nil
+}
+
+func (filesystem *Filesystem) ReadString(
+	ctx context.Context,
+	path string,
+	options ...FileOption,
+) (string, error) {
+	data, err := filesystem.Read(ctx, path, options...)
+	return string(data), err
+}
+
+func (filesystem *Filesystem) Stat(
+	ctx context.Context,
+	path string,
+	options ...FileOption,
+) (EntryInfo, error) {
+	const op = "filesystem_stat"
+	fields, err := filesystem.fields(op, path, options)
+	if err != nil {
+		return EntryInfo{}, err
+	}
+	var result struct {
+		Entry EntryInfo `json:"entry"`
+	}
+	err = filesystem.sandbox.readRequest(ctx, op, fields, &result, true)
+	return result.Entry, err
+}
+
+func (filesystem *Filesystem) Exists(
+	ctx context.Context,
+	path string,
+	options ...FileOption,
+) (bool, error) {
+	_, err := filesystem.Stat(ctx, path, options...)
+	if errors.Is(err, ErrNotFound) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func (filesystem *Filesystem) List(
+	ctx context.Context,
+	path string,
+	depth uint32,
+	options ...FileOption,
+) ([]EntryInfo, error) {
+	const op = "filesystem_list"
+	if depth == 0 {
+		return nil, invalid(op, "filesystem list depth must be greater than zero")
+	}
+	fields, err := filesystem.fields(op, path, options)
+	if err != nil {
+		return nil, err
+	}
+	fields["depth"] = depth
+	var result struct {
+		Entries []EntryInfo `json:"entries"`
+	}
+	if err := filesystem.sandbox.readRequest(ctx, op, fields, &result, true); err != nil {
+		return nil, err
+	}
+	return result.Entries, nil
+}
+
+func (filesystem *Filesystem) MakeDir(
+	ctx context.Context,
+	path string,
+	options ...FileOption,
+) error {
+	const op = "filesystem_make_dir"
+	fields, err := filesystem.fields(op, path, options)
+	if err != nil {
+		return err
+	}
+	return filesystem.sandbox.readRequest(ctx, op, fields, &struct{}{}, true)
+}
+
+func (filesystem *Filesystem) Move(
+	ctx context.Context,
+	path, destination string,
+	options ...FileOption,
+) error {
+	const op = "filesystem_move"
+	if strings.TrimSpace(destination) == "" {
+		return invalid(op, "filesystem destination cannot be empty")
+	}
+	fields, err := filesystem.fields(op, path, options)
+	if err != nil {
+		return err
+	}
+	fields["destination"] = destination
+	return filesystem.sandbox.readRequest(ctx, op, fields, &struct{}{}, true)
+}
+
+func (filesystem *Filesystem) Remove(
+	ctx context.Context,
+	path string,
+	options ...FileOption,
+) error {
+	const op = "filesystem_remove"
+	fields, err := filesystem.fields(op, path, options)
+	if err != nil {
+		return err
+	}
+	return filesystem.sandbox.readRequest(ctx, op, fields, &struct{}{}, true)
+}
+
+func (filesystem *Filesystem) fields(
+	operation, path string,
+	options []FileOption,
+) (map[string]any, error) {
+	if filesystem == nil || filesystem.sandbox == nil {
+		return nil, invalid(operation, "filesystem handle is not initialized")
+	}
+	if strings.TrimSpace(path) == "" {
+		return nil, invalid(operation, "filesystem path cannot be empty")
+	}
+	config := fileConfig{}
+	for _, option := range options {
+		if option != nil {
+			option.applyFile(&config)
+		}
+	}
+	if config.user != "" && strings.TrimSpace(config.user) == "" {
+		return nil, invalid(operation, "filesystem user cannot be blank")
+	}
+	fields := map[string]any{"path": path}
+	if config.user != "" {
+		fields["user"] = config.user
+	}
+	return fields, nil
+}

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/A3S-Lab/Box/sdk/go/v3
+
+go 1.25

--- a/sdk/go/image_builder.go
+++ b/sdk/go/image_builder.go
@@ -1,0 +1,99 @@
+package box
+
+import (
+	"context"
+	"strings"
+)
+
+type ImageBuilder struct {
+	client     *Client
+	contextDir string
+	dockerfile string
+	tag        string
+	buildArgs  map[string]string
+	platforms  []string
+	target     string
+	noCache    bool
+}
+
+func (client *Client) Image(contextDir string) *ImageBuilder {
+	return &ImageBuilder{client: client, contextDir: contextDir, buildArgs: make(map[string]string)}
+}
+
+func (builder *ImageBuilder) Dockerfile(path string) *ImageBuilder {
+	builder.dockerfile = path
+	return builder
+}
+
+func (builder *ImageBuilder) Tag(reference string) *ImageBuilder {
+	builder.tag = reference
+	return builder
+}
+
+func (builder *ImageBuilder) BuildArg(key, value string) *ImageBuilder {
+	builder.buildArgs[key] = value
+	return builder
+}
+
+func (builder *ImageBuilder) Platform(platform string) *ImageBuilder {
+	builder.platforms = append(builder.platforms, platform)
+	return builder
+}
+
+func (builder *ImageBuilder) Target(target string) *ImageBuilder {
+	builder.target = target
+	return builder
+}
+
+func (builder *ImageBuilder) NoCache(enabled bool) *ImageBuilder {
+	builder.noCache = enabled
+	return builder
+}
+
+func (builder *ImageBuilder) Build(ctx context.Context) (BuildImageInfo, error) {
+	const op = "image_build"
+	if builder == nil || builder.client == nil {
+		return BuildImageInfo{}, invalid(op, "image builder is not initialized")
+	}
+	if strings.TrimSpace(builder.contextDir) == "" {
+		return BuildImageInfo{}, invalid(op, "build context directory cannot be empty")
+	}
+	if builder.dockerfile != "" && strings.TrimSpace(builder.dockerfile) == "" {
+		return BuildImageInfo{}, invalid(op, "Dockerfile path cannot be blank")
+	}
+	if builder.tag != "" && strings.TrimSpace(builder.tag) == "" {
+		return BuildImageInfo{}, invalid(op, "image tag cannot be blank")
+	}
+	if builder.target != "" && strings.TrimSpace(builder.target) == "" {
+		return BuildImageInfo{}, invalid(op, "build target cannot be blank")
+	}
+	for key := range builder.buildArgs {
+		if strings.TrimSpace(key) == "" {
+			return BuildImageInfo{}, invalid(op, "build argument name cannot be empty")
+		}
+	}
+	for _, platform := range builder.platforms {
+		if strings.TrimSpace(platform) == "" {
+			return BuildImageInfo{}, invalid(op, "platform cannot be empty")
+		}
+	}
+	fields := map[string]any{
+		"context_dir": builder.contextDir,
+		"build_args":  cloneStringMap(builder.buildArgs),
+		"quiet":       true,
+		"platforms":   append([]string{}, builder.platforms...),
+		"no_cache":    builder.noCache,
+	}
+	if builder.dockerfile != "" {
+		fields["dockerfile"] = builder.dockerfile
+	}
+	if builder.tag != "" {
+		fields["tag"] = builder.tag
+	}
+	if builder.target != "" {
+		fields["target"] = builder.target
+	}
+	var result BuildImageInfo
+	err := builder.client.request(ctx, op, fields, &result)
+	return result, err
+}

--- a/sdk/go/images.go
+++ b/sdk/go/images.go
@@ -1,0 +1,202 @@
+package box
+
+import (
+	"context"
+	"strings"
+)
+
+type PullOption interface{ applyPull(*pullConfig) }
+type pullOptionFunc func(*pullConfig)
+
+func (option pullOptionFunc) applyPull(config *pullConfig) { option(config) }
+
+type pullConfig struct {
+	force           bool
+	platform        string
+	credentials     *RegistryCredentials
+	signaturePolicy *SignaturePolicy
+}
+
+func PullForce() PullOption {
+	return pullOptionFunc(func(config *pullConfig) { config.force = true })
+}
+
+func PullPlatform(platform string) PullOption {
+	return pullOptionFunc(func(config *pullConfig) { config.platform = platform })
+}
+
+func PullCredentials(credentials RegistryCredentials) PullOption {
+	return pullOptionFunc(func(config *pullConfig) { config.credentials = &credentials })
+}
+
+func PullSignaturePolicy(policy SignaturePolicy) PullOption {
+	return pullOptionFunc(func(config *pullConfig) { config.signaturePolicy = &policy })
+}
+
+func (client *Client) PullImage(ctx context.Context, reference string, options ...PullOption) (ImageInfo, error) {
+	const op = "image_pull"
+	if strings.TrimSpace(reference) == "" {
+		return ImageInfo{}, invalid(op, "image reference cannot be empty")
+	}
+	config := pullConfig{}
+	for _, option := range options {
+		if option != nil {
+			option.applyPull(&config)
+		}
+	}
+	fields := map[string]any{"reference": reference, "force": config.force}
+	if config.platform != "" {
+		if strings.TrimSpace(config.platform) == "" {
+			return ImageInfo{}, invalid(op, "image platform cannot be blank")
+		}
+		fields["platform"] = config.platform
+	}
+	if config.credentials != nil {
+		if err := config.credentials.validate(); err != nil {
+			return ImageInfo{}, err
+		}
+		fields["credentials"] = config.credentials.bridgeValue()
+	}
+	if config.signaturePolicy != nil {
+		if err := config.signaturePolicy.validate(); err != nil {
+			return ImageInfo{}, err
+		}
+		fields["signature_policy"] = config.signaturePolicy.bridgeValue()
+	}
+	var image ImageInfo
+	if err := client.request(ctx, op, fields, &image); err != nil {
+		return ImageInfo{}, err
+	}
+	return image, nil
+}
+
+func (client *Client) GetImage(ctx context.Context, reference string) (*ImageInfo, error) {
+	const op = "image_get"
+	if strings.TrimSpace(reference) == "" {
+		return nil, invalid(op, "image reference cannot be empty")
+	}
+	var result struct {
+		Image *ImageInfo `json:"image"`
+	}
+	if err := client.request(ctx, op, map[string]any{"reference": reference}, &result); err != nil {
+		return nil, err
+	}
+	return result.Image, nil
+}
+
+func (client *Client) ListImages(ctx context.Context) ([]ImageInfo, error) {
+	var result struct {
+		Images []ImageInfo `json:"images"`
+	}
+	if err := client.request(ctx, "image_list", nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Images, nil
+}
+
+func (client *Client) InspectImage(ctx context.Context, reference string) (*ImageInspectInfo, error) {
+	const op = "image_inspect"
+	if strings.TrimSpace(reference) == "" {
+		return nil, invalid(op, "image reference cannot be empty")
+	}
+	var result struct {
+		Image *ImageInspectInfo `json:"image"`
+	}
+	if err := client.request(ctx, op, map[string]any{"reference": reference}, &result); err != nil {
+		return nil, err
+	}
+	return result.Image, nil
+}
+
+func (client *Client) ImageHistory(ctx context.Context, reference string) ([]ImageHistoryInfo, error) {
+	const op = "image_history"
+	if strings.TrimSpace(reference) == "" {
+		return nil, invalid(op, "image reference cannot be empty")
+	}
+	var result struct {
+		History []ImageHistoryInfo `json:"history"`
+	}
+	if err := client.request(ctx, op, map[string]any{"reference": reference}, &result); err != nil {
+		return nil, err
+	}
+	return result.History, nil
+}
+
+func (client *Client) TagImage(ctx context.Context, source, target string) (ImageInfo, error) {
+	const op = "image_tag"
+	if strings.TrimSpace(source) == "" || strings.TrimSpace(target) == "" {
+		return ImageInfo{}, invalid(op, "source and target image references cannot be empty")
+	}
+	var image ImageInfo
+	err := client.request(ctx, op, map[string]any{"source": source, "target": target}, &image)
+	return image, err
+}
+
+type PushOption interface{ applyPush(*pushConfig) }
+type pushOptionFunc func(*pushConfig)
+
+func (option pushOptionFunc) applyPush(config *pushConfig) { option(config) }
+
+type pushConfig struct {
+	credentials *RegistryCredentials
+	protocol    RegistryProtocol
+}
+
+func PushCredentials(credentials RegistryCredentials) PushOption {
+	return pushOptionFunc(func(config *pushConfig) { config.credentials = &credentials })
+}
+
+func PushProtocol(protocol RegistryProtocol) PushOption {
+	return pushOptionFunc(func(config *pushConfig) { config.protocol = protocol })
+}
+
+func (client *Client) PushImage(
+	ctx context.Context,
+	source, target string,
+	options ...PushOption,
+) (PushImageInfo, error) {
+	const op = "image_push"
+	if strings.TrimSpace(source) == "" || strings.TrimSpace(target) == "" {
+		return PushImageInfo{}, invalid(op, "source and target image references cannot be empty")
+	}
+	config := pushConfig{}
+	for _, option := range options {
+		if option != nil {
+			option.applyPush(&config)
+		}
+	}
+	fields := map[string]any{"source": source, "target": target}
+	if config.credentials != nil {
+		if err := config.credentials.validate(); err != nil {
+			return PushImageInfo{}, err
+		}
+		fields["credentials"] = config.credentials.bridgeValue()
+	}
+	if config.protocol != "" {
+		if config.protocol != RegistryHTTP && config.protocol != RegistryHTTPS {
+			return PushImageInfo{}, invalid(op, "registry protocol must be http or https")
+		}
+		fields["registry_protocol"] = config.protocol
+	}
+	var result PushImageInfo
+	err := client.request(ctx, op, fields, &result)
+	return result, err
+}
+
+func (client *Client) RemoveImage(ctx context.Context, reference string) error {
+	const op = "image_remove"
+	if strings.TrimSpace(reference) == "" {
+		return invalid(op, "image reference cannot be empty")
+	}
+	return client.request(ctx, op, map[string]any{"reference": reference}, &struct{}{})
+}
+
+func (client *Client) EvictImages(ctx context.Context) ([]string, error) {
+	var result struct {
+		References []string `json:"references"`
+	}
+	if err := client.request(ctx, "image_evict", nil, &result); err != nil {
+		return nil, err
+	}
+	return result.References, nil
+}

--- a/sdk/go/internal/bridge/protocol.go
+++ b/sdk/go/internal/bridge/protocol.go
@@ -1,0 +1,72 @@
+// Package bridge contains the versioned machine bridge contract shared by the
+// public Go API and the installed A3S Box binary.
+package bridge
+
+import "encoding/json"
+
+const ProtocolVersion = 1
+
+// RequiredOperations is the complete operation set used by this SDK version.
+// New clients verify this inventory before issuing a mutating request.
+var RequiredOperations = []string{
+	"sdk_capabilities",
+	"runtime_diagnostics",
+	"runtime_disk_usage",
+	"image_build",
+	"image_pull",
+	"image_get",
+	"image_list",
+	"image_inspect",
+	"image_history",
+	"image_tag",
+	"image_push",
+	"image_remove",
+	"image_evict",
+	"volume_create",
+	"volume_get",
+	"volume_list",
+	"volume_remove",
+	"volume_prune",
+	"network_create",
+	"network_get",
+	"network_list",
+	"network_remove",
+	"network_prune",
+	"sandbox_list",
+	"sandbox_get",
+	"sandbox_create",
+	"sandbox_inspect",
+	"sandbox_stop",
+	"sandbox_restart",
+	"sandbox_remove",
+	"sandbox_kill",
+	"sandbox_pause",
+	"sandbox_resume",
+	"sandbox_logs",
+	"sandbox_stats",
+	"sandbox_snapshot_create",
+	"filesystem_snapshot_list",
+	"filesystem_snapshot_get",
+	"filesystem_snapshot_size",
+	"filesystem_snapshot_delete",
+	"command_run",
+	"file_write",
+	"file_read",
+	"filesystem_stat",
+	"filesystem_list",
+	"filesystem_make_dir",
+	"filesystem_move",
+	"filesystem_remove",
+}
+
+type Envelope struct {
+	ProtocolVersion int             `json:"protocol_version"`
+	OK              bool            `json:"ok"`
+	Result          json.RawMessage `json:"result"`
+	Error           *RemoteError    `json:"error"`
+}
+
+type RemoteError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -1,0 +1,224 @@
+package box
+
+// Capabilities describes the local machine bridge paired with this SDK.
+type Capabilities struct {
+	ProtocolVersion int      `json:"protocol_version"`
+	Operations      []string `json:"operations"`
+}
+
+type BuildImageInfo struct {
+	Reference  string `json:"reference"`
+	Digest     string `json:"digest"`
+	SizeBytes  uint64 `json:"size_bytes"`
+	LayerCount int    `json:"layer_count"`
+}
+
+type ImageInfo struct {
+	Reference string `json:"reference"`
+	Digest    string `json:"digest"`
+	SizeBytes uint64 `json:"size_bytes"`
+	PulledAt  string `json:"pulled_at"`
+	LastUsed  string `json:"last_used"`
+	Path      string `json:"path"`
+}
+
+type ImageHealthCheckInfo struct {
+	Test        []string `json:"test"`
+	Interval    *uint64  `json:"interval"`
+	Timeout     *uint64  `json:"timeout"`
+	Retries     *uint64  `json:"retries"`
+	StartPeriod *uint64  `json:"start_period"`
+}
+
+type ImageInspectInfo struct {
+	ImageInfo
+	ManifestDigest string                `json:"manifest_digest"`
+	LayerCount     int                   `json:"layer_count"`
+	Entrypoint     []string              `json:"entrypoint"`
+	Command        []string              `json:"command"`
+	Env            map[string]string     `json:"env"`
+	WorkingDir     *string               `json:"working_dir"`
+	User           *string               `json:"user"`
+	ExposedPorts   []string              `json:"exposed_ports"`
+	Volumes        []string              `json:"volumes"`
+	StopSignal     *string               `json:"stop_signal"`
+	HealthCheck    *ImageHealthCheckInfo `json:"health_check"`
+	Onbuild        []string              `json:"onbuild"`
+	Labels         map[string]string     `json:"labels"`
+}
+
+type ImageHistoryInfo struct {
+	Created    *string `json:"created"`
+	CreatedBy  string  `json:"created_by"`
+	SizeBytes  uint64  `json:"size_bytes"`
+	Comment    string  `json:"comment"`
+	EmptyLayer bool    `json:"empty_layer"`
+}
+
+type PushImageInfo struct {
+	Reference      string `json:"reference"`
+	ManifestDigest string `json:"manifest_digest"`
+	ConfigURL      string `json:"config_url"`
+	ManifestURL    string `json:"manifest_url"`
+}
+
+type VolumeInfo struct {
+	Name       string            `json:"name"`
+	Driver     string            `json:"driver"`
+	MountPoint string            `json:"mount_point"`
+	Labels     map[string]string `json:"labels"`
+	InUseBy    []string          `json:"in_use_by"`
+	InUse      bool              `json:"in_use"`
+	SizeLimit  uint64            `json:"size_limit"`
+	CreatedAt  string            `json:"created_at"`
+}
+
+type NetworkEndpointInfo struct {
+	BoxID      string   `json:"box_id"`
+	BoxName    string   `json:"box_name"`
+	Aliases    []string `json:"aliases"`
+	IPAddress  string   `json:"ip_address"`
+	MACAddress string   `json:"mac_address"`
+}
+
+type NetworkInfo struct {
+	Name          string                `json:"name"`
+	Driver        string                `json:"driver"`
+	Subnet        string                `json:"subnet"`
+	Gateway       string                `json:"gateway"`
+	Labels        map[string]string     `json:"labels"`
+	Endpoints     []NetworkEndpointInfo `json:"endpoints"`
+	EndpointCount int                   `json:"endpoint_count"`
+	Isolation     string                `json:"isolation"`
+	CreatedAt     string                `json:"created_at"`
+}
+
+type SandboxSummary struct {
+	ID            string            `json:"id"`
+	ShortID       string            `json:"short_id"`
+	Name          string            `json:"name"`
+	Image         string            `json:"image"`
+	Isolation     string            `json:"isolation"`
+	Status        string            `json:"status"`
+	StatusSummary string            `json:"status_summary"`
+	Active        bool              `json:"active"`
+	PID           *int              `json:"pid"`
+	CPUs          uint32            `json:"cpus"`
+	MemoryMiB     uint32            `json:"memory_mb"`
+	Ports         []string          `json:"ports"`
+	Command       []string          `json:"command"`
+	Health        string            `json:"health"`
+	Labels        map[string]string `json:"labels"`
+	CreatedAt     string            `json:"created_at"`
+	StartedAt     *string           `json:"started_at"`
+	NetworkName   *string           `json:"network_name"`
+	VolumeNames   []string          `json:"volume_names"`
+}
+
+type SandboxLogEntry struct {
+	Stream    string  `json:"stream"`
+	Message   string  `json:"log"`
+	Timestamp *string `json:"time"`
+}
+
+type SandboxStats struct {
+	ID               string  `json:"id"`
+	ShortID          string  `json:"short_id"`
+	Name             string  `json:"name"`
+	Status           string  `json:"status"`
+	PID              int     `json:"pid"`
+	CPUs             uint32  `json:"cpus"`
+	CPUPercent       float64 `json:"cpu_percent"`
+	CPUPercentScaled float64 `json:"cpu_percent_scaled"`
+	MemoryBytes      uint64  `json:"memory_bytes"`
+	MemoryLimitBytes uint64  `json:"memory_limit_bytes"`
+	MemoryPercent    float64 `json:"memory_percent"`
+	NetworkRXBytes   uint64  `json:"network_rx_bytes"`
+	NetworkTXBytes   uint64  `json:"network_tx_bytes"`
+	BlockReadBytes   uint64  `json:"block_read_bytes"`
+	BlockWriteBytes  uint64  `json:"block_write_bytes"`
+}
+
+type RuntimeVirtualization struct {
+	Available bool    `json:"available"`
+	Backend   *string `json:"backend"`
+	Details   string  `json:"details"`
+}
+
+type RuntimeDiagnostics struct {
+	CoreVersion    string                `json:"core_version"`
+	RuntimeVersion string                `json:"runtime_version"`
+	SDKVersion     string                `json:"sdk_version"`
+	Home           string                `json:"home"`
+	Virtualization RuntimeVirtualization `json:"virtualization"`
+}
+
+type RuntimeDiskUsage struct {
+	Home           string `json:"home"`
+	TotalBytes     uint64 `json:"total_bytes"`
+	BoxesBytes     uint64 `json:"boxes_bytes"`
+	ImagesBytes    uint64 `json:"images_bytes"`
+	VolumesBytes   uint64 `json:"volumes_bytes"`
+	SnapshotsBytes uint64 `json:"snapshots_bytes"`
+	StateBytes     uint64 `json:"state_bytes"`
+	OtherBytes     uint64 `json:"other_bytes"`
+}
+
+type FilesystemSnapshotSummary struct {
+	ID              string            `json:"id"`
+	Name            string            `json:"name"`
+	SourceSandboxID string            `json:"source_box_id"`
+	Image           string            `json:"image"`
+	VCPUs           uint32            `json:"vcpus"`
+	MemoryMiB       uint32            `json:"memory_mb"`
+	Volumes         []string          `json:"volumes"`
+	Command         []string          `json:"command"`
+	Ports           []string          `json:"port_map"`
+	Labels          map[string]string `json:"labels"`
+	NetworkMode     *string           `json:"network_mode"`
+	SizeBytes       uint64            `json:"size_bytes"`
+	CreatedAt       string            `json:"created_at"`
+	Description     string            `json:"description"`
+}
+
+type FilesystemSnapshotInfo struct {
+	SnapshotID string       `json:"snapshot_id"`
+	SizeBytes  uint64       `json:"size_bytes"`
+	State      SandboxState `json:"state"`
+	Generation uint64       `json:"generation"`
+}
+
+type SandboxInfo struct {
+	SandboxID  string       `json:"sandbox_id"`
+	Generation uint64       `json:"generation"`
+	State      SandboxState `json:"state"`
+}
+
+type WriteInfo struct {
+	Path string `json:"path"`
+	Size uint64 `json:"size"`
+}
+
+type EntryInfo struct {
+	Name            string  `json:"name"`
+	Type            string  `json:"type"`
+	Path            string  `json:"path"`
+	Size            uint64  `json:"size"`
+	Mode            uint32  `json:"mode"`
+	Permissions     string  `json:"permissions"`
+	Owner           string  `json:"owner"`
+	Group           string  `json:"group"`
+	ModifiedSeconds int64   `json:"modified_seconds"`
+	ModifiedNanos   int32   `json:"modified_nanos"`
+	SymlinkTarget   *string `json:"symlink_target"`
+}
+
+type CommandResult struct {
+	Stdout    []byte
+	Stderr    []byte
+	ExitCode  int
+	Truncated bool
+}
+
+func (result CommandResult) StdoutString() string { return string(result.Stdout) }
+func (result CommandResult) StderrString() string { return string(result.Stderr) }

--- a/sdk/go/network_builder.go
+++ b/sdk/go/network_builder.go
@@ -1,0 +1,56 @@
+package box
+
+import (
+	"context"
+	"net"
+	"strings"
+)
+
+type NetworkBuilder struct {
+	client *Client
+	name   string
+	subnet string
+	labels map[string]string
+}
+
+func (client *Client) Network(name string) *NetworkBuilder {
+	return &NetworkBuilder{
+		client: client,
+		name:   name,
+		subnet: "10.89.0.0/24",
+		labels: make(map[string]string),
+	}
+}
+
+func (builder *NetworkBuilder) Subnet(subnet string) *NetworkBuilder {
+	builder.subnet = subnet
+	return builder
+}
+
+func (builder *NetworkBuilder) Label(key, value string) *NetworkBuilder {
+	builder.labels[key] = value
+	return builder
+}
+
+func (builder *NetworkBuilder) Create(ctx context.Context) (NetworkInfo, error) {
+	const op = "network_create"
+	if builder == nil || builder.client == nil {
+		return NetworkInfo{}, invalid(op, "network builder is not initialized")
+	}
+	if strings.TrimSpace(builder.name) == "" {
+		return NetworkInfo{}, invalid(op, "network name cannot be empty")
+	}
+	if _, _, err := net.ParseCIDR(builder.subnet); err != nil {
+		return NetworkInfo{}, invalid(op, "network subnet must be valid CIDR notation")
+	}
+	if err := validateLabels(op, builder.labels); err != nil {
+		return NetworkInfo{}, err
+	}
+	var result NetworkInfo
+	err := builder.client.request(ctx, op, map[string]any{
+		"name":   builder.name,
+		"subnet": builder.subnet,
+		"labels": cloneStringMap(builder.labels),
+	}, &result)
+	return result, err
+}

--- a/sdk/go/operation_coverage_test.go
+++ b/sdk/go/operation_coverage_test.go
@@ -1,0 +1,212 @@
+package box
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/A3S-Lab/Box/sdk/go/v3/internal/bridge"
+)
+
+func TestPublicAPIExercisesEveryBridgeOperation(t *testing.T) {
+	runtime := &fakeRuntime{handler: operationFixture}
+	client := mustClient(runtime)
+	ctx := context.Background()
+	check := func(_ any, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	check(client.RuntimeDiagnostics(ctx))
+	check(client.RuntimeDiskUsage(ctx))
+	check(client.Image(".").Tag("local/test:latest").Build(ctx))
+	check(client.PullImage(
+		ctx,
+		"alpine:3.20",
+		PullForce(),
+		PullPlatform("linux/arm64"),
+		PullCredentials(BasicCredentials("ci", "secret")),
+		PullSignaturePolicy(SkipSignatures()),
+	))
+	check(client.GetImage(ctx, "alpine:3.20"))
+	check(client.ListImages(ctx))
+	check(client.InspectImage(ctx, "alpine:3.20"))
+	check(client.ImageHistory(ctx, "alpine:3.20"))
+	check(client.TagImage(ctx, "alpine:3.20", "local/alpine:latest"))
+	check(client.PushImage(
+		ctx,
+		"local/alpine:latest",
+		"registry/alpine:latest",
+		PushCredentials(BasicCredentials("ci", "secret")),
+		PushProtocol(RegistryHTTPS),
+	))
+	mustNoError(t, client.RemoveImage(ctx, "local/alpine:latest"))
+	check(client.EvictImages(ctx))
+
+	check(client.Volume("cache").Create(ctx))
+	check(client.GetVolume(ctx, "cache"))
+	check(client.ListVolumes(ctx))
+	check(client.RemoveVolume(ctx, "cache", true))
+	check(client.PruneVolumes(ctx))
+	check(client.Network("ci-net").Create(ctx))
+	check(client.GetNetwork(ctx, "ci-net"))
+	check(client.ListNetworks(ctx))
+	check(client.RemoveNetwork(ctx, "ci-net"))
+	check(client.PruneNetworks(ctx))
+	check(client.ListSandboxes(ctx, true))
+	check(client.GetSandbox(ctx, "box-1"))
+
+	sandbox, err := client.Sandbox(DefaultImage).Start(ctx)
+	mustNoError(t, err)
+	check(client.ConnectSandbox(ctx, "box-1"))
+	mustNoError(t, sandbox.Stop(ctx))
+	mustNoError(t, sandbox.Restart(ctx, RestartOperationID("coverage-restart")))
+	mustNoError(t, sandbox.Pause(ctx, true))
+	mustNoError(t, sandbox.Resume(ctx))
+	check(sandbox.Logs(ctx, 10))
+	check(sandbox.Stats(ctx))
+	check(sandbox.CreateFilesystemSnapshot(ctx, "snap-1"))
+	check(sandbox.Run(ctx, Argv("true")))
+	files := sandbox.Files()
+	check(files.WriteString(ctx, "/tmp/value", "value"))
+	check(files.Read(ctx, "/tmp/value"))
+	check(files.Stat(ctx, "/tmp/value"))
+	check(files.List(ctx, "/tmp", 1))
+	mustNoError(t, files.MakeDir(ctx, "/tmp/dir"))
+	mustNoError(t, files.Move(ctx, "/tmp/dir", "/tmp/moved"))
+	mustNoError(t, files.Remove(ctx, "/tmp/moved"))
+	mustNoError(t, sandbox.Kill(ctx))
+
+	removable := newSandbox(runtime, SandboxInfo{SandboxID: "box-remove", Generation: 1, State: StateStopped})
+	mustNoError(t, removable.Remove(ctx))
+	check(client.ListFilesystemSnapshots(ctx))
+	check(client.GetFilesystemSnapshot(ctx, "snap-1"))
+	if _, _, err := client.FilesystemSnapshotSize(ctx, "snap-1"); err != nil {
+		t.Fatal(err)
+	}
+	check(client.DeleteFilesystemSnapshot(ctx, "snap-1"))
+
+	requests := runtime.Requests()
+	for _, field := range []struct {
+		operation string
+		name      string
+	}{
+		{"image_build", "platforms"},
+		{"sandbox_create", "ports"},
+		{"sandbox_create", "dns"},
+	} {
+		request := requestByOperation(t, requests, field.operation)
+		values, ok := request[field.name].([]any)
+		if !ok || len(values) != 0 {
+			t.Errorf("%s.%s must encode an empty JSON array, got %#v", field.operation, field.name, request[field.name])
+		}
+	}
+
+	called := make(map[string]bool)
+	for _, operation := range runtime.Operations() {
+		called[operation] = true
+	}
+	for _, operation := range bridge.RequiredOperations {
+		if !called[operation] {
+			t.Errorf("public API did not exercise bridge operation %q", operation)
+		}
+	}
+}
+
+func operationFixture(_ context.Context, request map[string]any) (any, error) {
+	switch request["operation"] {
+	case "runtime_diagnostics":
+		return RuntimeDiagnostics{CoreVersion: "3", Virtualization: RuntimeVirtualization{Available: true}}, nil
+	case "runtime_disk_usage":
+		return RuntimeDiskUsage{Home: "/tmp/a3s", TotalBytes: 1}, nil
+	case "image_build":
+		return BuildImageInfo{Reference: "local/test:latest"}, nil
+	case "image_pull", "image_tag":
+		return ImageInfo{Reference: "alpine:3.20"}, nil
+	case "image_get":
+		return map[string]any{"image": ImageInfo{Reference: "alpine:3.20"}}, nil
+	case "image_list":
+		return map[string]any{"images": []ImageInfo{{Reference: "alpine:3.20"}}}, nil
+	case "image_inspect":
+		return map[string]any{"image": ImageInspectInfo{ImageInfo: ImageInfo{Reference: "alpine:3.20"}}}, nil
+	case "image_history":
+		return map[string]any{"history": []ImageHistoryInfo{{CreatedBy: "RUN true"}}}, nil
+	case "image_push":
+		return PushImageInfo{Reference: "registry/alpine:latest"}, nil
+	case "image_remove":
+		return map[string]any{"removed": true}, nil
+	case "image_evict":
+		return map[string]any{"references": []string{"old:latest"}}, nil
+	case "volume_create", "volume_remove":
+		return VolumeInfo{Name: "cache"}, nil
+	case "volume_get":
+		return map[string]any{"volume": VolumeInfo{Name: "cache"}}, nil
+	case "volume_list":
+		return map[string]any{"volumes": []VolumeInfo{{Name: "cache"}}}, nil
+	case "volume_prune":
+		return map[string]any{"names": []string{"old-cache"}}, nil
+	case "network_create", "network_remove":
+		return NetworkInfo{Name: "ci-net", Subnet: "10.89.0.0/24"}, nil
+	case "network_get":
+		return map[string]any{"network": NetworkInfo{Name: "ci-net"}}, nil
+	case "network_list":
+		return map[string]any{"networks": []NetworkInfo{{Name: "ci-net"}}}, nil
+	case "network_prune":
+		return map[string]any{"names": []string{"old-net"}}, nil
+	case "sandbox_list":
+		return map[string]any{"sandboxes": []SandboxSummary{{ID: "box-1"}}}, nil
+	case "sandbox_get":
+		return map[string]any{"sandbox": SandboxSummary{ID: "box-1"}}, nil
+	case "sandbox_create", "sandbox_inspect":
+		return SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateRunning}, nil
+	case "sandbox_stop":
+		return SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateStopped}, nil
+	case "sandbox_restart":
+		return SandboxInfo{SandboxID: "box-1", Generation: 2, State: StateRunning}, nil
+	case "sandbox_pause":
+		return SandboxInfo{SandboxID: "box-1", Generation: 2, State: StatePaused}, nil
+	case "sandbox_resume":
+		return SandboxInfo{SandboxID: "box-1", Generation: 2, State: StateRunning}, nil
+	case "sandbox_logs":
+		return map[string]any{"logs": []SandboxLogEntry{}}, nil
+	case "sandbox_stats":
+		return map[string]any{"stats": SandboxStats{ID: "box-1"}}, nil
+	case "sandbox_snapshot_create":
+		return FilesystemSnapshotInfo{SnapshotID: "snap-1", Generation: 2}, nil
+	case "sandbox_kill":
+		return SandboxInfo{SandboxID: "box-1", Generation: 2, State: StateFailed}, nil
+	case "sandbox_remove":
+		return SandboxInfo{SandboxID: "box-remove", Generation: 1, State: StateRemoved}, nil
+	case "command_run":
+		return map[string]any{"stdout_base64": "", "stderr_base64": "", "exit_code": 0, "truncated": false}, nil
+	case "file_write":
+		return WriteInfo{Path: "/tmp/value", Size: 5}, nil
+	case "file_read":
+		return map[string]any{"data_base64": base64.StdEncoding.EncodeToString([]byte("value")), "size": 5}, nil
+	case "filesystem_stat":
+		return map[string]any{"entry": EntryInfo{Path: "/tmp/value", Type: "file"}}, nil
+	case "filesystem_list":
+		return map[string]any{"entries": []EntryInfo{}}, nil
+	case "filesystem_make_dir", "filesystem_move", "filesystem_remove":
+		return map[string]any{"ok": true}, nil
+	case "filesystem_snapshot_list":
+		return map[string]any{"snapshots": []FilesystemSnapshotSummary{{ID: "snap-1"}}}, nil
+	case "filesystem_snapshot_get":
+		return map[string]any{"snapshot": FilesystemSnapshotSummary{ID: "snap-1"}}, nil
+	case "filesystem_snapshot_size":
+		return map[string]any{"snapshot_id": "snap-1", "size_bytes": uint64(5)}, nil
+	case "filesystem_snapshot_delete":
+		return map[string]any{"snapshot_id": "snap-1", "deleted": true}, nil
+	default:
+		return map[string]any{}, nil
+	}
+}
+
+func mustNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sdk/go/resources.go
+++ b/sdk/go/resources.go
@@ -1,0 +1,189 @@
+package box
+
+import (
+	"context"
+	"strings"
+)
+
+func (client *Client) GetVolume(ctx context.Context, name string) (*VolumeInfo, error) {
+	const op = "volume_get"
+	if strings.TrimSpace(name) == "" {
+		return nil, invalid(op, "volume name cannot be empty")
+	}
+	var result struct {
+		Volume *VolumeInfo `json:"volume"`
+	}
+	if err := client.request(ctx, op, map[string]any{"name": name}, &result); err != nil {
+		return nil, err
+	}
+	return result.Volume, nil
+}
+
+func (client *Client) ListVolumes(ctx context.Context) ([]VolumeInfo, error) {
+	var result struct {
+		Volumes []VolumeInfo `json:"volumes"`
+	}
+	if err := client.request(ctx, "volume_list", nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Volumes, nil
+}
+
+func (client *Client) RemoveVolume(ctx context.Context, name string, force bool) (VolumeInfo, error) {
+	const op = "volume_remove"
+	if strings.TrimSpace(name) == "" {
+		return VolumeInfo{}, invalid(op, "volume name cannot be empty")
+	}
+	var volume VolumeInfo
+	err := client.request(ctx, op, map[string]any{"name": name, "force": force}, &volume)
+	return volume, err
+}
+
+func (client *Client) PruneVolumes(ctx context.Context) ([]string, error) {
+	var result struct {
+		Names []string `json:"names"`
+	}
+	if err := client.request(ctx, "volume_prune", nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Names, nil
+}
+
+func (client *Client) GetNetwork(ctx context.Context, name string) (*NetworkInfo, error) {
+	const op = "network_get"
+	if strings.TrimSpace(name) == "" {
+		return nil, invalid(op, "network name cannot be empty")
+	}
+	var result struct {
+		Network *NetworkInfo `json:"network"`
+	}
+	if err := client.request(ctx, op, map[string]any{"name": name}, &result); err != nil {
+		return nil, err
+	}
+	return result.Network, nil
+}
+
+func (client *Client) ListNetworks(ctx context.Context) ([]NetworkInfo, error) {
+	var result struct {
+		Networks []NetworkInfo `json:"networks"`
+	}
+	if err := client.request(ctx, "network_list", nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Networks, nil
+}
+
+func (client *Client) RemoveNetwork(ctx context.Context, name string) (NetworkInfo, error) {
+	const op = "network_remove"
+	if strings.TrimSpace(name) == "" {
+		return NetworkInfo{}, invalid(op, "network name cannot be empty")
+	}
+	var network NetworkInfo
+	err := client.request(ctx, op, map[string]any{"name": name}, &network)
+	return network, err
+}
+
+func (client *Client) PruneNetworks(ctx context.Context) ([]string, error) {
+	var result struct {
+		Names []string `json:"names"`
+	}
+	if err := client.request(ctx, "network_prune", nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Names, nil
+}
+
+func (client *Client) ListSandboxes(ctx context.Context, all bool) ([]SandboxSummary, error) {
+	var result struct {
+		Sandboxes []SandboxSummary `json:"sandboxes"`
+	}
+	if err := client.request(ctx, "sandbox_list", map[string]any{"all": all}, &result); err != nil {
+		return nil, err
+	}
+	return result.Sandboxes, nil
+}
+
+func (client *Client) GetSandbox(ctx context.Context, query string) (*SandboxSummary, error) {
+	const op = "sandbox_get"
+	if strings.TrimSpace(query) == "" {
+		return nil, invalid(op, "sandbox query cannot be empty")
+	}
+	var result struct {
+		Sandbox *SandboxSummary `json:"sandbox"`
+	}
+	if err := client.request(ctx, op, map[string]any{"query": query}, &result); err != nil {
+		return nil, err
+	}
+	return result.Sandbox, nil
+}
+
+func (client *Client) RuntimeDiagnostics(ctx context.Context) (RuntimeDiagnostics, error) {
+	var result RuntimeDiagnostics
+	err := client.request(ctx, "runtime_diagnostics", nil, &result)
+	return result, err
+}
+
+func (client *Client) RuntimeDiskUsage(ctx context.Context) (RuntimeDiskUsage, error) {
+	var result RuntimeDiskUsage
+	err := client.request(ctx, "runtime_disk_usage", nil, &result)
+	return result, err
+}
+
+func (client *Client) ListFilesystemSnapshots(ctx context.Context) ([]FilesystemSnapshotSummary, error) {
+	var result struct {
+		Snapshots []FilesystemSnapshotSummary `json:"snapshots"`
+	}
+	if err := client.request(ctx, "filesystem_snapshot_list", nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Snapshots, nil
+}
+
+func (client *Client) GetFilesystemSnapshot(
+	ctx context.Context,
+	snapshotID string,
+) (*FilesystemSnapshotSummary, error) {
+	const op = "filesystem_snapshot_get"
+	if strings.TrimSpace(snapshotID) == "" {
+		return nil, invalid(op, "snapshot ID cannot be empty")
+	}
+	var result struct {
+		Snapshot *FilesystemSnapshotSummary `json:"snapshot"`
+	}
+	if err := client.request(ctx, op, map[string]any{"snapshot_id": snapshotID}, &result); err != nil {
+		return nil, err
+	}
+	return result.Snapshot, nil
+}
+
+// FilesystemSnapshotSize returns (size, true, nil) when a snapshot exists.
+func (client *Client) FilesystemSnapshotSize(ctx context.Context, snapshotID string) (uint64, bool, error) {
+	const op = "filesystem_snapshot_size"
+	if strings.TrimSpace(snapshotID) == "" {
+		return 0, false, invalid(op, "snapshot ID cannot be empty")
+	}
+	var result struct {
+		SizeBytes *uint64 `json:"size_bytes"`
+	}
+	if err := client.request(ctx, op, map[string]any{"snapshot_id": snapshotID}, &result); err != nil {
+		return 0, false, err
+	}
+	if result.SizeBytes == nil {
+		return 0, false, nil
+	}
+	return *result.SizeBytes, true, nil
+}
+
+func (client *Client) DeleteFilesystemSnapshot(ctx context.Context, snapshotID string) (bool, error) {
+	const op = "filesystem_snapshot_delete"
+	if strings.TrimSpace(snapshotID) == "" {
+		return false, invalid(op, "snapshot ID cannot be empty")
+	}
+	var result struct {
+		Deleted bool `json:"deleted"`
+	}
+	if err := client.request(ctx, op, map[string]any{"snapshot_id": snapshotID}, &result); err != nil {
+		return false, err
+	}
+	return result.Deleted, nil
+}

--- a/sdk/go/runtime.go
+++ b/sdk/go/runtime.go
@@ -1,0 +1,217 @@
+package box
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/A3S-Lab/Box/sdk/go/v3/internal/bridge"
+)
+
+const defaultBridgeTimeout = 10 * time.Minute
+const bridgeProcessWaitDelay = 2 * time.Second
+
+// Runtime is the typed extension point used by Client. Implementations must be
+// safe for concurrent calls. The built-in LocalRuntime invokes the installed
+// a3s-box binary and does not require an endpoint or API key.
+type Runtime interface {
+	Request(ctx context.Context, request any, result any) error
+}
+
+// LocalRuntime invokes one structured sdk-bridge process per request.
+type LocalRuntime struct {
+	binaryPath string
+	timeout    time.Duration
+}
+
+type LocalRuntimeOption interface {
+	applyLocalRuntime(*LocalRuntime)
+}
+
+type localRuntimeOptionFunc func(*LocalRuntime)
+
+func (option localRuntimeOptionFunc) applyLocalRuntime(runtime *LocalRuntime) {
+	option(runtime)
+}
+
+// WithBinaryPath selects an a3s-box binary. When omitted, LocalRuntime reads
+// A3S_BOX_BINARY and then falls back to a3s-box on PATH.
+func WithBinaryPath(path string) LocalRuntimeOption {
+	return localRuntimeOptionFunc(func(runtime *LocalRuntime) {
+		runtime.binaryPath = path
+	})
+}
+
+// WithBridgeTimeout bounds a single bridge process. Callers can always set a
+// shorter deadline on their context.
+func WithBridgeTimeout(timeout time.Duration) LocalRuntimeOption {
+	return localRuntimeOptionFunc(func(runtime *LocalRuntime) {
+		runtime.timeout = timeout
+	})
+}
+
+func NewLocalRuntime(options ...LocalRuntimeOption) *LocalRuntime {
+	runtime := &LocalRuntime{timeout: defaultBridgeTimeout}
+	for _, option := range options {
+		if option != nil {
+			option.applyLocalRuntime(runtime)
+		}
+	}
+	return runtime
+}
+
+func (runtime *LocalRuntime) Request(ctx context.Context, request any, result any) error {
+	const op = "sdk-bridge"
+	if ctx == nil {
+		return invalid(op, "context cannot be nil")
+	}
+	if runtime == nil {
+		return invalid(op, "local runtime cannot be nil")
+	}
+	if runtime.timeout <= 0 {
+		return invalid(op, "bridge timeout must be greater than zero")
+	}
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return sdkError(op, CodeInvalidRequest, "cannot encode bridge request", err)
+	}
+	operation := requestOperation(payload)
+	binary, err := runtime.resolveBinary()
+	if err != nil {
+		return sdkError(operation, CodeNotInstalled, err.Error(), err)
+	}
+
+	requestContext, cancel := context.WithTimeout(ctx, runtime.timeout)
+	defer cancel()
+
+	command := exec.CommandContext(requestContext, binary, "sdk-bridge")
+	command.WaitDelay = bridgeProcessWaitDelay
+	command.Stdin = bytes.NewReader(payload)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	runErr := command.Run()
+	if requestContext.Err() != nil {
+		return contextError(operation, requestContext.Err())
+	}
+
+	decodeErr := decodeBridgeResponse(operation, stdout.Bytes(), result)
+	if decodeErr != nil {
+		if errors.Is(decodeErr, ErrProtocol) && runErr != nil {
+			detail := strings.TrimSpace(stderr.String())
+			if detail == "" {
+				detail = runErr.Error()
+			}
+			return sdkError(operation, CodeRuntime, "local bridge process failed: "+truncate(detail, 4096), runErr)
+		}
+		return decodeErr
+	}
+	if runErr != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = runErr.Error()
+		}
+		return sdkError(operation, CodeRuntime, "local bridge process failed: "+truncate(detail, 4096), runErr)
+	}
+	return nil
+}
+
+func (runtime *LocalRuntime) resolveBinary() (string, error) {
+	candidate := strings.TrimSpace(runtime.binaryPath)
+	if candidate == "" {
+		candidate = strings.TrimSpace(os.Getenv("A3S_BOX_BINARY"))
+	}
+	if candidate == "" {
+		candidate = "a3s-box"
+	}
+	if strings.ContainsRune(candidate, os.PathSeparator) || filepath.IsAbs(candidate) {
+		info, err := os.Stat(candidate)
+		if err != nil {
+			return "", fmt.Errorf("A3S Box binary %q is not installed: %w", candidate, err)
+		}
+		if info.IsDir() {
+			return "", fmt.Errorf("A3S Box binary %q is a directory", candidate)
+		}
+		return candidate, nil
+	}
+	resolved, err := exec.LookPath(candidate)
+	if err != nil {
+		return "", fmt.Errorf("A3S Box binary %q is not installed: %w", candidate, err)
+	}
+	return resolved, nil
+}
+
+func decodeBridgeResponse(operation string, output []byte, result any) error {
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	var envelope bridge.Envelope
+	if err := decoder.Decode(&envelope); err != nil {
+		return sdkError(operation, CodeProtocol, "invalid response from the local bridge", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("multiple JSON values")
+		}
+		return sdkError(operation, CodeProtocol, "invalid trailing data from the local bridge", err)
+	}
+	if envelope.ProtocolVersion != bridge.ProtocolVersion {
+		return sdkError(
+			operation,
+			CodeProtocol,
+			fmt.Sprintf("unsupported bridge protocol version %d", envelope.ProtocolVersion),
+			nil,
+		)
+	}
+	if !envelope.OK {
+		if envelope.Error == nil {
+			return sdkError(operation, CodeRuntime, "local bridge request failed", nil)
+		}
+		code := ErrorCode(envelope.Error.Code)
+		if code == "" {
+			code = CodeRuntime
+		}
+		message := envelope.Error.Message
+		if message == "" {
+			message = "local bridge request failed"
+		}
+		return sdkError(operation, code, message, nil)
+	}
+	trimmed := bytes.TrimSpace(envelope.Result)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return sdkError(operation, CodeProtocol, "local bridge response is missing an object result", nil)
+	}
+	if result == nil {
+		return nil
+	}
+	if err := json.Unmarshal(trimmed, result); err != nil {
+		return sdkError(operation, CodeProtocol, "cannot decode local bridge result", err)
+	}
+	return nil
+}
+
+func requestOperation(payload []byte) string {
+	var header struct {
+		Operation string `json:"operation"`
+	}
+	if json.Unmarshal(payload, &header) == nil && header.Operation != "" {
+		return header.Operation
+	}
+	return "sdk-bridge"
+}
+
+func truncate(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit] + "..."
+}

--- a/sdk/go/runtime_test.go
+++ b/sdk/go/runtime_test.go
@@ -1,0 +1,217 @@
+package box
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	if len(os.Args) > 1 && os.Args[1] == "sdk-bridge" {
+		runBridgeHelper()
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func runBridgeHelper() {
+	mode := os.Getenv("A3S_BOX_GO_TEST_HELPER_MODE")
+	payload, _ := io.ReadAll(os.Stdin)
+	switch mode {
+	case "malformed":
+		fmt.Print("not-json")
+	case "trailing":
+		fmt.Print(`{"protocol_version":1,"ok":true,"result":{}} {}`)
+	case "bad_version":
+		fmt.Print(`{"protocol_version":99,"ok":true,"result":{}}`)
+	case "non_object":
+		fmt.Print(`{"protocol_version":1,"ok":true,"result":[]}`)
+	case "exit":
+		fmt.Fprint(os.Stderr, "helper process failed")
+		os.Exit(7)
+	case "wait":
+		for {
+			time.Sleep(time.Hour)
+		}
+	case "credentials":
+		if len(os.Args) != 2 || os.Args[1] != "sdk-bridge" || strings.Contains(strings.Join(os.Args, " "), "super-secret") {
+			fmt.Fprint(os.Stderr, "credentials leaked through argv")
+			os.Exit(8)
+		}
+		if !strings.Contains(string(payload), `"password":"super-secret"`) {
+			fmt.Fprint(os.Stderr, "credential missing from stdin")
+			os.Exit(9)
+		}
+		writeHelperEnvelope(true, map[string]any{"accepted": true}, "", "")
+	case "error":
+		writeHelperEnvelope(false, nil, os.Getenv("A3S_BOX_GO_TEST_ERROR_CODE"), "bridge rejected request")
+	default:
+		writeHelperEnvelope(true, map[string]any{"value": "ok"}, "", "")
+	}
+}
+
+func writeHelperEnvelope(ok bool, result any, code, message string) {
+	envelope := map[string]any{"protocol_version": 1, "ok": ok}
+	if ok {
+		envelope["result"] = result
+	} else {
+		envelope["error"] = map[string]string{"code": code, "message": message}
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(envelope)
+}
+
+func TestLocalRuntimeRoundTripAndEnvironmentResolution(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("A3S_BOX_BINARY", executable)
+	t.Setenv("A3S_BOX_GO_TEST_HELPER_MODE", "success")
+	runtime := NewLocalRuntime(WithBridgeTimeout(10 * time.Second))
+	var result struct {
+		Value string `json:"value"`
+	}
+	if err := runtime.Request(context.Background(), map[string]any{"operation": "runtime_diagnostics"}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Value != "ok" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestLocalRuntimeSendsCredentialsOnlyThroughStdin(t *testing.T) {
+	t.Setenv("A3S_BOX_GO_TEST_HELPER_MODE", "credentials")
+	runtime := helperRuntime(t, 10*time.Second)
+	request := map[string]any{
+		"operation": "image_pull",
+		"credentials": map[string]string{
+			"username": "ci",
+			"password": "super-secret",
+		},
+	}
+	var result struct {
+		Accepted bool `json:"accepted"`
+	}
+	if err := runtime.Request(context.Background(), request, &result); err != nil {
+		t.Fatal(err)
+	}
+	if !result.Accepted {
+		t.Fatal("helper did not accept credentials")
+	}
+}
+
+func TestLocalRuntimeMapsStableBridgeErrors(t *testing.T) {
+	t.Setenv("A3S_BOX_GO_TEST_HELPER_MODE", "error")
+	tests := []struct {
+		code   string
+		target error
+	}{
+		{"invalid_request", ErrInvalidRequest},
+		{"not_found", ErrNotFound},
+		{"conflict", ErrConflict},
+		{"unavailable", ErrUnavailable},
+		{"runtime_error", ErrRuntime},
+	}
+	for _, test := range tests {
+		t.Run(test.code, func(t *testing.T) {
+			t.Setenv("A3S_BOX_GO_TEST_ERROR_CODE", test.code)
+			err := helperRuntime(t, 10*time.Second).Request(
+				context.Background(),
+				map[string]any{"operation": "sandbox_create"},
+				&struct{}{},
+			)
+			if !errors.Is(err, test.target) {
+				t.Fatalf("expected %v, got %v", test.target, err)
+			}
+			var sdkErr *Error
+			if !errors.As(err, &sdkErr) || sdkErr.Op != "sandbox_create" {
+				t.Fatalf("missing typed operation context: %#v", err)
+			}
+		})
+	}
+}
+
+func TestLocalRuntimeRejectsMalformedProtocol(t *testing.T) {
+	for _, mode := range []string{"malformed", "trailing", "bad_version", "non_object"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("A3S_BOX_GO_TEST_HELPER_MODE", mode)
+			err := helperRuntime(t, 10*time.Second).Request(
+				context.Background(),
+				map[string]any{"operation": "image_list"},
+				&struct{}{},
+			)
+			if !errors.Is(err, ErrProtocol) {
+				t.Fatalf("expected protocol error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLocalRuntimeReportsMissingBinary(t *testing.T) {
+	runtime := NewLocalRuntime(WithBinaryPath(t.TempDir() + "/missing"))
+	err := runtime.Request(context.Background(), map[string]any{"operation": "image_list"}, &struct{}{})
+	if !errors.Is(err, ErrNotInstalled) {
+		t.Fatalf("expected not-installed error, got %v", err)
+	}
+}
+
+func TestLocalRuntimePreservesCancellationAndDeadline(t *testing.T) {
+	t.Run("caller cancellation", func(t *testing.T) {
+		t.Setenv("A3S_BOX_GO_TEST_HELPER_MODE", "wait")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := helperRuntime(t, 10*time.Second).Request(ctx, map[string]any{"operation": "command_run"}, &struct{}{})
+		if !errors.Is(err, context.Canceled) || !errors.Is(err, ErrCanceled) {
+			t.Fatalf("expected preserved cancellation, got %v", err)
+		}
+	})
+
+	t.Run("caller deadline", func(t *testing.T) {
+		t.Setenv("A3S_BOX_GO_TEST_HELPER_MODE", "wait")
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		defer cancel()
+		err := helperRuntime(t, 10*time.Second).Request(ctx, map[string]any{"operation": "command_run"}, &struct{}{})
+		if !errors.Is(err, context.DeadlineExceeded) || !errors.Is(err, ErrDeadlineExceeded) {
+			t.Fatalf("expected preserved deadline, got %v", err)
+		}
+	})
+
+	t.Run("runtime deadline", func(t *testing.T) {
+		t.Setenv("A3S_BOX_GO_TEST_HELPER_MODE", "wait")
+		err := helperRuntime(t, 30*time.Millisecond).Request(
+			context.Background(),
+			map[string]any{"operation": "command_run"},
+			&struct{}{},
+		)
+		if !errors.Is(err, context.DeadlineExceeded) || !errors.Is(err, ErrDeadlineExceeded) {
+			t.Fatalf("expected bridge timeout, got %v", err)
+		}
+	})
+}
+
+func TestLocalRuntimeReportsProcessFailureWithoutParsingHumanOutput(t *testing.T) {
+	t.Setenv("A3S_BOX_GO_TEST_HELPER_MODE", "exit")
+	err := helperRuntime(t, 10*time.Second).Request(
+		context.Background(),
+		map[string]any{"operation": "image_list"},
+		&struct{}{},
+	)
+	if !errors.Is(err, ErrRuntime) || !strings.Contains(err.Error(), "helper process failed") {
+		t.Fatalf("unexpected process failure: %v", err)
+	}
+}
+
+func helperRuntime(t *testing.T, timeout time.Duration) *LocalRuntime {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewLocalRuntime(WithBinaryPath(executable), WithBridgeTimeout(timeout))
+}

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -1,0 +1,377 @@
+package box
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultCloseTimeout = 30 * time.Second
+
+// Sandbox is a concurrency-safe handle to one local execution generation.
+// Command and filesystem calls can run concurrently. Lifecycle transitions are
+// serialized so no call is issued with a stale generation.
+type Sandbox struct {
+	runtime Runtime
+	id      string
+
+	mu         sync.RWMutex
+	generation uint64
+	state      SandboxState
+}
+
+func newSandbox(runtime Runtime, info SandboxInfo) *Sandbox {
+	return &Sandbox{
+		runtime:    runtime,
+		id:         info.SandboxID,
+		generation: info.Generation,
+		state:      info.State,
+	}
+}
+
+func (client *Client) ConnectSandbox(ctx context.Context, sandboxID string) (*Sandbox, error) {
+	const op = "sandbox_inspect"
+	if strings.TrimSpace(sandboxID) == "" {
+		return nil, invalid(op, "sandbox ID cannot be empty")
+	}
+	var info SandboxInfo
+	if err := client.request(ctx, op, map[string]any{"sandbox_id": sandboxID}, &info); err != nil {
+		return nil, err
+	}
+	return newSandbox(client.runtime, info), nil
+}
+
+func (sandbox *Sandbox) ID() string {
+	if sandbox == nil {
+		return ""
+	}
+	return sandbox.id
+}
+
+func (sandbox *Sandbox) Generation() uint64 {
+	if sandbox == nil {
+		return 0
+	}
+	sandbox.mu.RLock()
+	defer sandbox.mu.RUnlock()
+	return sandbox.generation
+}
+
+func (sandbox *Sandbox) State() SandboxState {
+	if sandbox == nil {
+		return ""
+	}
+	sandbox.mu.RLock()
+	defer sandbox.mu.RUnlock()
+	return sandbox.state
+}
+
+func (sandbox *Sandbox) Inspect(ctx context.Context) (SandboxInfo, error) {
+	const op = "sandbox_inspect"
+	if sandbox == nil || runtimeIsNil(sandbox.runtime) {
+		return SandboxInfo{}, invalid(op, "sandbox is not initialized")
+	}
+	sandbox.mu.Lock()
+	defer sandbox.mu.Unlock()
+	var info SandboxInfo
+	if err := sandbox.requestLocked(ctx, op, map[string]any{"sandbox_id": sandbox.id}, &info); err != nil {
+		return SandboxInfo{}, err
+	}
+	sandbox.updateLocked(info, sandbox.state)
+	return info, nil
+}
+
+func (sandbox *Sandbox) IsRunning(ctx context.Context) (bool, error) {
+	info, err := sandbox.Inspect(ctx)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.State == StateRunning, nil
+}
+
+func (sandbox *Sandbox) Stop(ctx context.Context) error {
+	const op = "sandbox_stop"
+	if sandbox == nil || runtimeIsNil(sandbox.runtime) {
+		return invalid(op, "sandbox is not initialized")
+	}
+	sandbox.mu.Lock()
+	defer sandbox.mu.Unlock()
+	if sandbox.state == StateStopped || sandbox.terminalLocked() {
+		return nil
+	}
+	var info SandboxInfo
+	if err := sandbox.lifecycleRequestLocked(ctx, op, nil, &info); err != nil {
+		return err
+	}
+	sandbox.updateLocked(info, StateStopped)
+	return nil
+}
+
+type RestartOption interface{ applyRestart(*restartConfig) }
+type restartOptionFunc func(*restartConfig)
+
+func (option restartOptionFunc) applyRestart(config *restartConfig) { option(config) }
+
+type restartConfig struct {
+	operationID string
+	stopTimeout *time.Duration
+}
+
+func RestartOperationID(operationID string) RestartOption {
+	return restartOptionFunc(func(config *restartConfig) { config.operationID = operationID })
+}
+
+func RestartStopTimeout(timeout time.Duration) RestartOption {
+	return restartOptionFunc(func(config *restartConfig) { config.stopTimeout = &timeout })
+}
+
+func (sandbox *Sandbox) Restart(ctx context.Context, options ...RestartOption) error {
+	const op = "sandbox_restart"
+	if sandbox == nil || runtimeIsNil(sandbox.runtime) {
+		return invalid(op, "sandbox is not initialized")
+	}
+	config := restartConfig{}
+	for _, option := range options {
+		if option != nil {
+			option.applyRestart(&config)
+		}
+	}
+	if config.operationID != "" && strings.TrimSpace(config.operationID) == "" {
+		return invalid(op, "restart operation ID cannot be blank")
+	}
+	if config.stopTimeout != nil && *config.stopTimeout < 0 {
+		return invalid(op, "restart stop timeout cannot be negative")
+	}
+	if config.operationID == "" {
+		operationID, err := randomOperationID()
+		if err != nil {
+			return sdkError(op, CodeRuntime, "cannot generate restart operation ID", err)
+		}
+		config.operationID = operationID
+	}
+	sandbox.mu.Lock()
+	defer sandbox.mu.Unlock()
+	if sandbox.terminalLocked() {
+		return invalid(op, "sandbox has been removed")
+	}
+	extra := map[string]any{"operation_id": config.operationID}
+	if config.stopTimeout != nil {
+		extra["stop_timeout_seconds"] = durationSeconds(*config.stopTimeout)
+	}
+	var info SandboxInfo
+	if err := sandbox.lifecycleRequestLocked(ctx, op, extra, &info); err != nil {
+		return err
+	}
+	sandbox.updateLocked(info, StateRunning)
+	return nil
+}
+
+func (sandbox *Sandbox) Remove(ctx context.Context) error {
+	const op = "sandbox_remove"
+	if sandbox == nil || runtimeIsNil(sandbox.runtime) {
+		return invalid(op, "sandbox is not initialized")
+	}
+	sandbox.mu.Lock()
+	defer sandbox.mu.Unlock()
+	if sandbox.terminalLocked() {
+		return nil
+	}
+	var info SandboxInfo
+	if err := sandbox.lifecycleRequestLocked(ctx, op, nil, &info); err != nil {
+		return err
+	}
+	sandbox.updateLocked(info, StateRemoved)
+	return nil
+}
+
+func (sandbox *Sandbox) Kill(ctx context.Context) error {
+	const op = "sandbox_kill"
+	if sandbox == nil || runtimeIsNil(sandbox.runtime) {
+		return invalid(op, "sandbox is not initialized")
+	}
+	sandbox.mu.Lock()
+	defer sandbox.mu.Unlock()
+	if sandbox.terminalLocked() {
+		return nil
+	}
+	var info SandboxInfo
+	if err := sandbox.lifecycleRequestLocked(ctx, op, nil, &info); err != nil {
+		return err
+	}
+	sandbox.updateLocked(info, StateKilled)
+	sandbox.state = StateKilled
+	return nil
+}
+
+func (sandbox *Sandbox) Pause(ctx context.Context, keepMemory bool) error {
+	const op = "sandbox_pause"
+	if sandbox == nil || runtimeIsNil(sandbox.runtime) {
+		return invalid(op, "sandbox is not initialized")
+	}
+	sandbox.mu.Lock()
+	defer sandbox.mu.Unlock()
+	if sandbox.state != StateRunning {
+		return invalid(op, "only a running sandbox can be paused")
+	}
+	var info SandboxInfo
+	if err := sandbox.lifecycleRequestLocked(ctx, op, map[string]any{"keep_memory": keepMemory}, &info); err != nil {
+		return err
+	}
+	sandbox.updateLocked(info, StatePaused)
+	return nil
+}
+
+func (sandbox *Sandbox) Resume(ctx context.Context) error {
+	const op = "sandbox_resume"
+	if sandbox == nil || runtimeIsNil(sandbox.runtime) {
+		return invalid(op, "sandbox is not initialized")
+	}
+	sandbox.mu.Lock()
+	defer sandbox.mu.Unlock()
+	if sandbox.state != StatePaused {
+		return invalid(op, "only a paused sandbox can be resumed")
+	}
+	var info SandboxInfo
+	if err := sandbox.lifecycleRequestLocked(ctx, op, nil, &info); err != nil {
+		return err
+	}
+	sandbox.updateLocked(info, StateRunning)
+	return nil
+}
+
+func (sandbox *Sandbox) Logs(ctx context.Context, tail int) ([]SandboxLogEntry, error) {
+	const op = "sandbox_logs"
+	if tail < 1 || tail > 10_000 {
+		return nil, invalid(op, "log tail must be between 1 and 10000")
+	}
+	var result struct {
+		Logs []SandboxLogEntry `json:"logs"`
+	}
+	err := sandbox.readRequest(ctx, op, map[string]any{"tail": tail}, &result, false)
+	return result.Logs, err
+}
+
+func (sandbox *Sandbox) Stats(ctx context.Context) (*SandboxStats, error) {
+	const op = "sandbox_stats"
+	var result struct {
+		Stats *SandboxStats `json:"stats"`
+	}
+	if err := sandbox.readRequest(ctx, op, nil, &result, false); err != nil {
+		return nil, err
+	}
+	return result.Stats, nil
+}
+
+func (sandbox *Sandbox) CreateFilesystemSnapshot(
+	ctx context.Context,
+	snapshotID string,
+) (FilesystemSnapshotInfo, error) {
+	const op = "sandbox_snapshot_create"
+	if strings.TrimSpace(snapshotID) == "" {
+		return FilesystemSnapshotInfo{}, invalid(op, "snapshot ID cannot be empty")
+	}
+	var result FilesystemSnapshotInfo
+	err := sandbox.readRequest(ctx, op, map[string]any{"snapshot_id": snapshotID}, &result, false)
+	return result, err
+}
+
+// Close performs bounded, idempotent cleanup. A failed cleanup is retryable.
+func (sandbox *Sandbox) Close(ctx context.Context) error {
+	if ctx == nil {
+		return invalid("sandbox_close", "context cannot be nil")
+	}
+	closeContext, cancel := context.WithTimeout(ctx, defaultCloseTimeout)
+	defer cancel()
+	return sandbox.Kill(closeContext)
+}
+
+func (sandbox *Sandbox) readRequest(
+	ctx context.Context,
+	operation string,
+	extra map[string]any,
+	result any,
+	requireRunning bool,
+) error {
+	if sandbox == nil || runtimeIsNil(sandbox.runtime) {
+		return invalid(operation, "sandbox is not initialized")
+	}
+	sandbox.mu.RLock()
+	defer sandbox.mu.RUnlock()
+	if sandbox.terminalLocked() {
+		return invalid(operation, "sandbox has been removed")
+	}
+	if requireRunning && sandbox.state != StateRunning {
+		return invalid(operation, "sandbox is not running")
+	}
+	fields := map[string]any{
+		"sandbox_id": sandbox.id,
+		"generation": sandbox.generation,
+	}
+	for key, value := range extra {
+		fields[key] = value
+	}
+	return sandbox.requestLocked(ctx, operation, fields, result)
+}
+
+func (sandbox *Sandbox) lifecycleRequestLocked(
+	ctx context.Context,
+	operation string,
+	extra map[string]any,
+	result any,
+) error {
+	fields := map[string]any{
+		"sandbox_id": sandbox.id,
+		"generation": sandbox.generation,
+	}
+	for key, value := range extra {
+		fields[key] = value
+	}
+	return sandbox.requestLocked(ctx, operation, fields, result)
+}
+
+func (sandbox *Sandbox) requestLocked(
+	ctx context.Context,
+	operation string,
+	fields map[string]any,
+	result any,
+) error {
+	if ctx == nil {
+		return invalid(operation, "context cannot be nil")
+	}
+	request := make(map[string]any, len(fields)+1)
+	request["operation"] = operation
+	for key, value := range fields {
+		request[key] = value
+	}
+	return sandbox.runtime.Request(ctx, request, result)
+}
+
+func (sandbox *Sandbox) terminalLocked() bool {
+	return sandbox.state == StateKilled || sandbox.state == StateRemoved
+}
+
+func (sandbox *Sandbox) updateLocked(info SandboxInfo, fallback SandboxState) {
+	if info.Generation != 0 {
+		sandbox.generation = info.Generation
+	}
+	if info.State != "" {
+		sandbox.state = info.State
+	} else {
+		sandbox.state = fallback
+	}
+}
+
+func randomOperationID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return "sdk-restart-" + hex.EncodeToString(value[:]), nil
+}

--- a/sdk/go/sandbox_builder.go
+++ b/sdk/go/sandbox_builder.go
@@ -1,0 +1,305 @@
+package box
+
+import (
+	"context"
+	"net"
+	"strings"
+	"time"
+)
+
+type SandboxBuilder struct {
+	client               *Client
+	image                string
+	timeout              time.Duration
+	env                  map[string]string
+	labels               map[string]string
+	name                 string
+	cpus                 *uint32
+	memoryMiB            *uint32
+	isolation            Isolation
+	filesystemSnapshotID string
+	workspace            string
+	workdir              string
+	user                 string
+	hostname             string
+	mounts               []Mount
+	tmpfs                []TmpfsMount
+	network              SandboxNetwork
+	ports                []PortMapping
+	dns                  []string
+	hostAliases          map[string]string
+	readOnly             bool
+	persistent           bool
+	autoRemove           bool
+}
+
+func (client *Client) Sandbox(image string) *SandboxBuilder {
+	if strings.TrimSpace(image) == "" {
+		image = DefaultImage
+	}
+	return &SandboxBuilder{
+		client:      client,
+		image:       image,
+		timeout:     time.Hour,
+		env:         make(map[string]string),
+		labels:      make(map[string]string),
+		isolation:   IsolationMicroVM,
+		network:     TSINetwork(),
+		hostAliases: make(map[string]string),
+		autoRemove:  true,
+	}
+}
+
+func (builder *SandboxBuilder) Timeout(timeout time.Duration) *SandboxBuilder {
+	builder.timeout = timeout
+	return builder
+}
+
+func (builder *SandboxBuilder) Env(key, value string) *SandboxBuilder {
+	builder.env[key] = value
+	return builder
+}
+
+func (builder *SandboxBuilder) Label(key, value string) *SandboxBuilder {
+	builder.labels[key] = value
+	return builder
+}
+
+func (builder *SandboxBuilder) Name(name string) *SandboxBuilder {
+	builder.name = name
+	return builder
+}
+
+func (builder *SandboxBuilder) CPUs(cpus uint32) *SandboxBuilder {
+	builder.cpus = &cpus
+	return builder
+}
+
+func (builder *SandboxBuilder) MemoryMiB(memory uint32) *SandboxBuilder {
+	builder.memoryMiB = &memory
+	return builder
+}
+
+func (builder *SandboxBuilder) Isolation(isolation Isolation) *SandboxBuilder {
+	builder.isolation = isolation
+	return builder
+}
+
+func (builder *SandboxBuilder) FilesystemSnapshot(snapshotID string) *SandboxBuilder {
+	builder.filesystemSnapshotID = snapshotID
+	return builder
+}
+
+func (builder *SandboxBuilder) Workspace(path string) *SandboxBuilder {
+	builder.workspace = path
+	return builder
+}
+
+func (builder *SandboxBuilder) Workdir(path string) *SandboxBuilder {
+	builder.workdir = path
+	return builder
+}
+
+func (builder *SandboxBuilder) User(user string) *SandboxBuilder {
+	builder.user = user
+	return builder
+}
+
+func (builder *SandboxBuilder) Hostname(hostname string) *SandboxBuilder {
+	builder.hostname = hostname
+	return builder
+}
+
+func (builder *SandboxBuilder) Mount(mount Mount) *SandboxBuilder {
+	builder.mounts = append(builder.mounts, mount)
+	return builder
+}
+
+func (builder *SandboxBuilder) Tmpfs(mount TmpfsMount) *SandboxBuilder {
+	builder.tmpfs = append(builder.tmpfs, mount)
+	return builder
+}
+
+func (builder *SandboxBuilder) Network(network SandboxNetwork) *SandboxBuilder {
+	builder.network = network
+	return builder
+}
+
+func (builder *SandboxBuilder) PublishTCP(hostPort, guestPort uint16) *SandboxBuilder {
+	builder.ports = append(builder.ports, TCPPort(hostPort, guestPort))
+	return builder
+}
+
+func (builder *SandboxBuilder) DNSServer(address string) *SandboxBuilder {
+	builder.dns = append(builder.dns, address)
+	return builder
+}
+
+func (builder *SandboxBuilder) HostAlias(host, address string) *SandboxBuilder {
+	builder.hostAliases[host] = address
+	return builder
+}
+
+func (builder *SandboxBuilder) ReadOnly(enabled bool) *SandboxBuilder {
+	builder.readOnly = enabled
+	return builder
+}
+
+func (builder *SandboxBuilder) Persistent(enabled bool) *SandboxBuilder {
+	builder.persistent = enabled
+	return builder
+}
+
+func (builder *SandboxBuilder) AutoRemove(enabled bool) *SandboxBuilder {
+	builder.autoRemove = enabled
+	return builder
+}
+
+func (builder *SandboxBuilder) Start(ctx context.Context) (*Sandbox, error) {
+	const op = "sandbox_create"
+	if builder == nil || builder.client == nil {
+		return nil, invalid(op, "sandbox builder is not initialized")
+	}
+	if err := builder.validate(); err != nil {
+		return nil, err
+	}
+	mounts := make([]map[string]any, 0, len(builder.mounts))
+	for _, mount := range builder.mounts {
+		mounts = append(mounts, mount.bridgeValue())
+	}
+	tmpfs := make([]map[string]any, 0, len(builder.tmpfs))
+	for _, mount := range builder.tmpfs {
+		tmpfs = append(tmpfs, mount.bridgeValue())
+	}
+	fields := map[string]any{
+		"image":           builder.image,
+		"timeout_seconds": durationSeconds(builder.timeout),
+		"env":             cloneStringMap(builder.env),
+		"labels":          cloneStringMap(builder.labels),
+		"isolation":       builder.isolation,
+		"mounts":          mounts,
+		"tmpfs":           tmpfs,
+		"network":         builder.network.bridgeValue(),
+		"ports":           append([]PortMapping{}, builder.ports...),
+		"dns":             append([]string{}, builder.dns...),
+		"host_aliases":    cloneStringMap(builder.hostAliases),
+		"read_only":       builder.readOnly,
+		"persistent":      builder.persistent,
+		"auto_remove":     builder.autoRemove,
+	}
+	if builder.name != "" {
+		fields["name"] = builder.name
+	}
+	if builder.cpus != nil {
+		fields["cpus"] = *builder.cpus
+	}
+	if builder.memoryMiB != nil {
+		fields["memory_mb"] = *builder.memoryMiB
+	}
+	if builder.filesystemSnapshotID != "" {
+		fields["filesystem_snapshot_id"] = builder.filesystemSnapshotID
+	}
+	if builder.workspace != "" {
+		fields["workspace"] = builder.workspace
+	}
+	if builder.workdir != "" {
+		fields["workdir"] = builder.workdir
+	}
+	if builder.user != "" {
+		fields["user"] = builder.user
+	}
+	if builder.hostname != "" {
+		fields["hostname"] = builder.hostname
+	}
+	var info SandboxInfo
+	if err := builder.client.request(ctx, op, fields, &info); err != nil {
+		return nil, err
+	}
+	return newSandbox(builder.client.runtime, info), nil
+}
+
+func (builder *SandboxBuilder) validate() error {
+	const op = "sandbox_create"
+	if strings.TrimSpace(builder.image) == "" {
+		return invalid(op, "sandbox image cannot be empty")
+	}
+	if builder.timeout <= 0 {
+		return invalid(op, "sandbox timeout must be greater than zero")
+	}
+	if builder.cpus != nil && *builder.cpus == 0 {
+		return invalid(op, "CPU count must be greater than zero")
+	}
+	if builder.memoryMiB != nil && *builder.memoryMiB == 0 {
+		return invalid(op, "memory must be greater than zero")
+	}
+	if builder.isolation != IsolationMicroVM && builder.isolation != IsolationSandbox {
+		return invalid(op, "isolation must be microvm or sandbox")
+	}
+	optionalValues := map[string]string{
+		"sandbox name":           builder.name,
+		"filesystem snapshot ID": builder.filesystemSnapshotID,
+		"workspace":              builder.workspace,
+		"working directory":      builder.workdir,
+		"user":                   builder.user,
+		"hostname":               builder.hostname,
+	}
+	for name, value := range optionalValues {
+		if value != "" && strings.TrimSpace(value) == "" {
+			return invalid(op, name+" cannot be blank")
+		}
+	}
+	if err := validateLabels(op, builder.labels); err != nil {
+		return err
+	}
+	for key := range builder.env {
+		if strings.TrimSpace(key) == "" {
+			return invalid(op, "environment variable name cannot be empty")
+		}
+	}
+	if err := builder.network.validate(); err != nil {
+		return err
+	}
+	targets := make(map[string]struct{}, len(builder.mounts)+len(builder.tmpfs))
+	for _, mount := range builder.mounts {
+		if err := mount.validate(); err != nil {
+			return err
+		}
+		if _, duplicate := targets[mount.target]; duplicate {
+			return invalid(op, "mount targets must be unique")
+		}
+		targets[mount.target] = struct{}{}
+	}
+	for _, mount := range builder.tmpfs {
+		if err := mount.validate(); err != nil {
+			return err
+		}
+		if _, duplicate := targets[mount.target]; duplicate {
+			return invalid(op, "mount targets must be unique")
+		}
+		targets[mount.target] = struct{}{}
+	}
+	for _, port := range builder.ports {
+		if port.GuestPort == 0 {
+			return invalid(op, "published guest TCP ports must be greater than zero")
+		}
+	}
+	for _, address := range builder.dns {
+		if net.ParseIP(address) == nil {
+			return invalid(op, "DNS servers must be IP addresses")
+		}
+	}
+	for host, address := range builder.hostAliases {
+		if strings.TrimSpace(host) == "" || net.ParseIP(address) == nil {
+			return invalid(op, "host aliases require a host name and IP address")
+		}
+	}
+	return nil
+}
+
+func durationSeconds(duration time.Duration) uint64 {
+	seconds := duration / time.Second
+	if duration%time.Second != 0 {
+		seconds++
+	}
+	return uint64(seconds)
+}

--- a/sdk/go/sandbox_test.go
+++ b/sdk/go/sandbox_test.go
@@ -1,0 +1,319 @@
+package box
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSandboxLifecycleTracksGenerationAndState(t *testing.T) {
+	runtime := &fakeRuntime{handler: func(_ context.Context, request map[string]any) (any, error) {
+		operation := request["operation"]
+		switch operation {
+		case "sandbox_inspect":
+			return SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateRunning}, nil
+		case "sandbox_stop":
+			assertGeneration(t, request, 1)
+			return SandboxInfo{SandboxID: "box-1", Generation: 2, State: StateStopped}, nil
+		case "sandbox_restart":
+			assertGeneration(t, request, 2)
+			if !strings.HasPrefix(stringValue(request["operation_id"]), "sdk-restart-") {
+				t.Fatalf("restart operation ID was not generated: %#v", request)
+			}
+			return SandboxInfo{SandboxID: "box-1", Generation: 3, State: StateRunning}, nil
+		case "sandbox_pause":
+			assertGeneration(t, request, 3)
+			return SandboxInfo{SandboxID: "box-1", Generation: 3, State: StatePaused}, nil
+		case "sandbox_resume":
+			assertGeneration(t, request, 3)
+			return SandboxInfo{SandboxID: "box-1", Generation: 3, State: StateRunning}, nil
+		case "sandbox_logs":
+			return map[string]any{"logs": []map[string]any{{"stream": "stdout", "log": "ready"}}}, nil
+		case "sandbox_stats":
+			return map[string]any{"stats": map[string]any{"id": "box-1", "pid": 42, "cpus": 2}}, nil
+		case "sandbox_snapshot_create":
+			return FilesystemSnapshotInfo{SnapshotID: "snap-1", SizeBytes: 12, State: StateRunning, Generation: 3}, nil
+		case "sandbox_kill":
+			assertGeneration(t, request, 3)
+			return SandboxInfo{SandboxID: "box-1", Generation: 3, State: StateFailed}, nil
+		default:
+			t.Fatalf("unexpected operation: %v", operation)
+			return nil, nil
+		}
+	}}
+	sandbox := newSandbox(runtime, SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateRunning})
+	ctx := context.Background()
+
+	running, err := sandbox.IsRunning(ctx)
+	if err != nil || !running {
+		t.Fatalf("is running: %v, %v", running, err)
+	}
+	if err := sandbox.Stop(ctx); err != nil || sandbox.Generation() != 2 || sandbox.State() != StateStopped {
+		t.Fatalf("stop state=%s generation=%d err=%v", sandbox.State(), sandbox.Generation(), err)
+	}
+	if err := sandbox.Restart(ctx, RestartStopTimeout(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if sandbox.Generation() != 3 || sandbox.State() != StateRunning {
+		t.Fatalf("restart state=%s generation=%d", sandbox.State(), sandbox.Generation())
+	}
+	if err := sandbox.Pause(ctx, false); err != nil || sandbox.State() != StatePaused {
+		t.Fatalf("pause state=%s err=%v", sandbox.State(), err)
+	}
+	if err := sandbox.Resume(ctx); err != nil || sandbox.State() != StateRunning {
+		t.Fatalf("resume state=%s err=%v", sandbox.State(), err)
+	}
+	logs, err := sandbox.Logs(ctx, 10)
+	if err != nil || len(logs) != 1 || logs[0].Message != "ready" {
+		t.Fatalf("logs=%+v err=%v", logs, err)
+	}
+	stats, err := sandbox.Stats(ctx)
+	if err != nil || stats == nil || stats.PID != 42 {
+		t.Fatalf("stats=%+v err=%v", stats, err)
+	}
+	snapshot, err := sandbox.CreateFilesystemSnapshot(ctx, "snap-1")
+	if err != nil || snapshot.SnapshotID != "snap-1" {
+		t.Fatalf("snapshot=%+v err=%v", snapshot, err)
+	}
+	if err := sandbox.Kill(ctx); err != nil || sandbox.State() != StateKilled {
+		t.Fatalf("kill state=%s err=%v", sandbox.State(), err)
+	}
+	beforeClose := len(runtime.Requests())
+	if err := sandbox.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(runtime.Requests()); got != beforeClose {
+		t.Fatalf("idempotent close issued another request")
+	}
+}
+
+func TestSandboxRemoveAndConnect(t *testing.T) {
+	runtime := &fakeRuntime{handler: func(_ context.Context, request map[string]any) (any, error) {
+		switch request["operation"] {
+		case "sandbox_inspect":
+			return SandboxInfo{SandboxID: "box-2", Generation: 4, State: StateStopped}, nil
+		case "sandbox_remove":
+			assertGeneration(t, request, 4)
+			return SandboxInfo{SandboxID: "box-2", Generation: 4, State: StateRemoved}, nil
+		default:
+			return map[string]any{}, nil
+		}
+	}}
+	client := mustClient(runtime)
+	sandbox, err := client.ConnectSandbox(context.Background(), "box-2")
+	if err != nil || sandbox.Generation() != 4 {
+		t.Fatalf("connect=%v err=%v", sandbox, err)
+	}
+	if err := sandbox.Remove(context.Background()); err != nil || sandbox.State() != StateRemoved {
+		t.Fatalf("remove state=%s err=%v", sandbox.State(), err)
+	}
+	before := len(runtime.Requests())
+	if err := sandbox.Remove(context.Background()); err != nil || len(runtime.Requests()) != before {
+		t.Fatalf("remove should be idempotent: %v", err)
+	}
+}
+
+func TestCloseFailureRemainsRetryable(t *testing.T) {
+	var attempts atomic.Int32
+	runtime := &fakeRuntime{handler: func(_ context.Context, request map[string]any) (any, error) {
+		if request["operation"] != "sandbox_kill" {
+			return nil, errors.New("unexpected operation")
+		}
+		if attempts.Add(1) == 1 {
+			return nil, sdkError("sandbox_kill", CodeUnavailable, "runtime busy", nil)
+		}
+		return SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateFailed}, nil
+	}}
+	sandbox := newSandbox(runtime, SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateRunning})
+	if err := sandbox.Close(context.Background()); !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("expected first cleanup failure, got %v", err)
+	}
+	if sandbox.State() != StateRunning {
+		t.Fatalf("failed cleanup changed state to %s", sandbox.State())
+	}
+	if err := sandbox.Close(context.Background()); err != nil {
+		t.Fatalf("retry failed: %v", err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected two cleanup attempts, got %d", attempts.Load())
+	}
+}
+
+func TestLifecycleWaitsForInFlightCommand(t *testing.T) {
+	commandStarted := make(chan struct{})
+	releaseCommand := make(chan struct{})
+	killReachedRuntime := make(chan struct{})
+	runtime := &fakeRuntime{handler: func(_ context.Context, request map[string]any) (any, error) {
+		switch request["operation"] {
+		case "command_run":
+			close(commandStarted)
+			<-releaseCommand
+			return map[string]any{"stdout_base64": "", "stderr_base64": "", "exit_code": 0, "truncated": false}, nil
+		case "sandbox_kill":
+			close(killReachedRuntime)
+			return SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateFailed}, nil
+		default:
+			return map[string]any{}, nil
+		}
+	}}
+	sandbox := newSandbox(runtime, SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateRunning})
+	commandDone := make(chan error, 1)
+	go func() {
+		_, err := sandbox.Run(context.Background(), Argv("true"))
+		commandDone <- err
+	}()
+	<-commandStarted
+	killDone := make(chan error, 1)
+	go func() { killDone <- sandbox.Kill(context.Background()) }()
+	select {
+	case <-killReachedRuntime:
+		t.Fatal("lifecycle request raced with an in-flight command")
+	case <-time.After(40 * time.Millisecond):
+	}
+	close(releaseCommand)
+	if err := <-commandDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-killDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCommandsScriptsAndFilesystemAreBinarySafe(t *testing.T) {
+	binaryOutput := []byte{0xff, 0x00, 'A'}
+	runtime := &fakeRuntime{handler: func(_ context.Context, request map[string]any) (any, error) {
+		switch request["operation"] {
+		case "command_run":
+			return map[string]any{
+				"stdout_base64": base64.StdEncoding.EncodeToString(binaryOutput),
+				"stderr_base64": base64.StdEncoding.EncodeToString([]byte("warning")),
+				"exit_code":     7,
+				"truncated":     true,
+			}, nil
+		case "file_write":
+			data, err := base64.StdEncoding.DecodeString(stringValue(request["data_base64"]))
+			if err != nil || !reflect.DeepEqual(data, binaryOutput) {
+				t.Fatalf("unexpected file data: %v, %v", data, err)
+			}
+			return WriteInfo{Path: stringValue(request["path"]), Size: uint64(len(data))}, nil
+		case "file_read":
+			return map[string]any{"data_base64": base64.StdEncoding.EncodeToString(binaryOutput), "size": 3}, nil
+		case "filesystem_stat":
+			if request["path"] == "/missing" {
+				return nil, sdkError("filesystem_stat", CodeNotFound, "missing", nil)
+			}
+			return map[string]any{"entry": EntryInfo{Name: "data.bin", Type: "file", Path: "/data.bin", Size: 3}}, nil
+		case "filesystem_list":
+			return map[string]any{"entries": []EntryInfo{{Name: "data.bin", Type: "file", Path: "/data.bin"}}}, nil
+		case "filesystem_make_dir", "filesystem_move", "filesystem_remove":
+			return map[string]any{"ok": true}, nil
+		default:
+			return nil, errors.New("unexpected operation")
+		}
+	}}
+	sandbox := newSandbox(runtime, SandboxInfo{SandboxID: "box-1", Generation: 9, State: StateRunning})
+	ctx := context.Background()
+
+	result, err := sandbox.Run(
+		ctx,
+		Argv("printf", "value with spaces"),
+		RunTimeout(1500*time.Millisecond),
+		RunEnv("A", "B"),
+		RunDirectory("/workspace"),
+		RunAs("1000"),
+		RunStdin(binaryOutput),
+	)
+	if err != nil || !reflect.DeepEqual(result.Stdout, binaryOutput) || result.ExitCode != 7 || !result.Truncated {
+		t.Fatalf("command result=%+v err=%v", result, err)
+	}
+	command := requestByOperation(t, runtime.Requests(), "command_run")
+	if command["timeout_ms"] != float64(1500) || command["generation"] != float64(9) {
+		t.Fatalf("unexpected command request: %#v", command)
+	}
+
+	files := sandbox.Files()
+	write, err := files.Write(ctx, "/data.bin", binaryOutput, FileAs("1000"))
+	if err != nil || write.Size != 3 {
+		t.Fatalf("write=%+v err=%v", write, err)
+	}
+	read, err := files.Read(ctx, "/data.bin")
+	if err != nil || !reflect.DeepEqual(read, binaryOutput) {
+		t.Fatalf("read=%v err=%v", read, err)
+	}
+	entry, err := files.Stat(ctx, "/data.bin")
+	if err != nil || entry.Type != "file" {
+		t.Fatalf("stat=%+v err=%v", entry, err)
+	}
+	exists, err := files.Exists(ctx, "/missing")
+	if err != nil || exists {
+		t.Fatalf("exists=%v err=%v", exists, err)
+	}
+	entries, err := files.List(ctx, "/", 2)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("list=%+v err=%v", entries, err)
+	}
+	if err := files.MakeDir(ctx, "/new"); err != nil {
+		t.Fatal(err)
+	}
+	if err := files.Move(ctx, "/new", "/renamed"); err != nil {
+		t.Fatal(err)
+	}
+	if err := files.Remove(ctx, "/renamed"); err != nil {
+		t.Fatal(err)
+	}
+
+	scriptResult, err := sandbox.Script("echo script").
+		Interpreter("/bin/bash", "-se").
+		Env("CI", "1").
+		Directory("/workspace").
+		User("1000").
+		Timeout(time.Second).
+		Run(ctx)
+	if err != nil || scriptResult.ExitCode != 7 {
+		t.Fatalf("script=%+v err=%v", scriptResult, err)
+	}
+	requests := runtime.Requests()
+	lastCommand := requests[len(requests)-1]
+	argv, ok := lastCommand["argv"].([]any)
+	if !ok || len(argv) != 2 || argv[0] != "/bin/bash" {
+		t.Fatalf("unexpected script interpreter: %#v", lastCommand)
+	}
+	source, err := base64.StdEncoding.DecodeString(stringValue(lastCommand["stdin_base64"]))
+	if err != nil || string(source) != "echo script" {
+		t.Fatalf("unexpected script stdin: %q, %v", source, err)
+	}
+}
+
+func TestCommandValidationDoesNotReachRuntime(t *testing.T) {
+	runtime := &fakeRuntime{}
+	sandbox := newSandbox(runtime, SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateRunning})
+	if _, err := sandbox.Run(context.Background(), Argv()); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected empty command validation, got %v", err)
+	}
+	if _, err := sandbox.Script("").Run(context.Background()); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected empty script validation, got %v", err)
+	}
+	if _, err := sandbox.Files().List(context.Background(), "/", 0); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected depth validation, got %v", err)
+	}
+	if len(runtime.Requests()) != 0 {
+		t.Fatal("invalid terminal operations reached runtime")
+	}
+}
+
+func assertGeneration(t *testing.T, request map[string]any, expected float64) {
+	t.Helper()
+	if request["generation"] != expected {
+		t.Fatalf("expected generation %.0f, got %#v", expected, request["generation"])
+	}
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return text
+}

--- a/sdk/go/script.go
+++ b/sdk/go/script.go
@@ -1,0 +1,93 @@
+package box
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// ScriptBuilder executes source through stdin, so scripts never require a
+// temporary host file and their contents do not appear in process arguments.
+type ScriptBuilder struct {
+	commands    *Commands
+	source      []byte
+	interpreter Command
+	timeout     *time.Duration
+	env         map[string]string
+	cwd         string
+	user        string
+}
+
+func (sandbox *Sandbox) Script(source string) *ScriptBuilder {
+	return sandbox.Commands().Script(source)
+}
+
+func (sandbox *Sandbox) ScriptBytes(source []byte) *ScriptBuilder {
+	return sandbox.Commands().ScriptBytes(source)
+}
+
+func (commands *Commands) Script(source string) *ScriptBuilder {
+	return commands.ScriptBytes([]byte(source))
+}
+
+func (commands *Commands) ScriptBytes(source []byte) *ScriptBuilder {
+	return &ScriptBuilder{
+		commands:    commands,
+		source:      append([]byte(nil), source...),
+		interpreter: Argv("/bin/sh", "-se"),
+		env:         make(map[string]string),
+	}
+}
+
+func (builder *ScriptBuilder) Interpreter(executable string, arguments ...string) *ScriptBuilder {
+	builder.interpreter = Argv(append([]string{executable}, arguments...)...)
+	return builder
+}
+
+func (builder *ScriptBuilder) Timeout(timeout time.Duration) *ScriptBuilder {
+	builder.timeout = &timeout
+	return builder
+}
+
+func (builder *ScriptBuilder) Env(key, value string) *ScriptBuilder {
+	builder.env[key] = value
+	return builder
+}
+
+func (builder *ScriptBuilder) Directory(path string) *ScriptBuilder {
+	builder.cwd = path
+	return builder
+}
+
+func (builder *ScriptBuilder) User(user string) *ScriptBuilder {
+	builder.user = user
+	return builder
+}
+
+func (builder *ScriptBuilder) Run(ctx context.Context) (CommandResult, error) {
+	const op = "command_run"
+	if builder == nil || builder.commands == nil {
+		return CommandResult{}, invalid(op, "script builder is not initialized")
+	}
+	if len(builder.source) == 0 {
+		return CommandResult{}, invalid(op, "script source cannot be empty")
+	}
+	if len(builder.interpreter.argv) == 0 || strings.TrimSpace(builder.interpreter.argv[0]) == "" {
+		return CommandResult{}, invalid(op, "script interpreter cannot be empty")
+	}
+	options := make([]RunOption, 0, len(builder.env)+4)
+	if builder.timeout != nil {
+		options = append(options, RunTimeout(*builder.timeout))
+	}
+	for key, value := range builder.env {
+		options = append(options, RunEnv(key, value))
+	}
+	if builder.cwd != "" {
+		options = append(options, RunDirectory(builder.cwd))
+	}
+	if builder.user != "" {
+		options = append(options, RunAs(builder.user))
+	}
+	options = append(options, RunStdin(builder.source))
+	return builder.commands.Run(ctx, builder.interpreter, options...)
+}

--- a/sdk/go/test_helpers_test.go
+++ b/sdk/go/test_helpers_test.go
@@ -1,0 +1,80 @@
+package box
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/A3S-Lab/Box/sdk/go/v3/internal/bridge"
+)
+
+type fakeRuntime struct {
+	mu       sync.Mutex
+	requests []map[string]any
+	handler  func(context.Context, map[string]any) (any, error)
+}
+
+func (runtime *fakeRuntime) Request(ctx context.Context, request any, result any) error {
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return err
+	}
+	runtime.mu.Lock()
+	runtime.requests = append(runtime.requests, decoded)
+	runtime.mu.Unlock()
+
+	var value any = map[string]any{}
+	if decoded["operation"] == "sdk_capabilities" {
+		value = fullCapabilities()
+	} else if runtime.handler != nil {
+		value, err = runtime.handler(ctx, decoded)
+		if err != nil {
+			return err
+		}
+	}
+	if result == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(encoded, result)
+}
+
+func (runtime *fakeRuntime) Requests() []map[string]any {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	result := make([]map[string]any, len(runtime.requests))
+	copy(result, runtime.requests)
+	return result
+}
+
+func (runtime *fakeRuntime) Operations() []string {
+	requests := runtime.Requests()
+	operations := make([]string, 0, len(requests))
+	for _, request := range requests {
+		operations = append(operations, fmt.Sprint(request["operation"]))
+	}
+	return operations
+}
+
+func fullCapabilities() Capabilities {
+	return Capabilities{
+		ProtocolVersion: bridge.ProtocolVersion,
+		Operations:      append([]string(nil), bridge.RequiredOperations...),
+	}
+}
+
+func mustClient(runtime Runtime) *Client {
+	client, err := NewClient(context.Background(), WithRuntime(runtime))
+	if err != nil {
+		panic(err)
+	}
+	return client
+}

--- a/sdk/go/validate.go
+++ b/sdk/go/validate.go
@@ -1,0 +1,20 @@
+package box
+
+import "strings"
+
+func cloneStringMap(source map[string]string) map[string]string {
+	result := make(map[string]string, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}
+
+func validateLabels(operation string, labels map[string]string) error {
+	for key := range labels {
+		if strings.TrimSpace(key) == "" {
+			return invalid(operation, "label name cannot be empty")
+		}
+	}
+	return nil
+}

--- a/sdk/go/values.go
+++ b/sdk/go/values.go
@@ -1,0 +1,238 @@
+package box
+
+import "strings"
+
+const DefaultImage = "alpine:3.20"
+
+type Isolation string
+
+const (
+	IsolationMicroVM Isolation = "microvm"
+	IsolationSandbox Isolation = "sandbox"
+)
+
+type SandboxState string
+
+const (
+	StateCreated  SandboxState = "created"
+	StateCreating SandboxState = "creating"
+	StateRunning  SandboxState = "running"
+	StatePaused   SandboxState = "paused"
+	StateStopped  SandboxState = "stopped"
+	StateFailed   SandboxState = "failed"
+	StateKilled   SandboxState = "killed"
+	StateRemoved  SandboxState = "removed"
+)
+
+// RegistryCredentials keeps the password out of default formatting while
+// still allowing it to be passed through bridge stdin.
+type RegistryCredentials struct {
+	username string
+	password string
+}
+
+func BasicCredentials(username, password string) RegistryCredentials {
+	return RegistryCredentials{username: username, password: password}
+}
+
+func (credentials RegistryCredentials) Username() string { return credentials.username }
+
+func (credentials RegistryCredentials) String() string {
+	return "RegistryCredentials{Username:" + credentials.username + " Password:<redacted>}"
+}
+
+func (credentials RegistryCredentials) GoString() string { return credentials.String() }
+
+func (credentials RegistryCredentials) bridgeValue() map[string]string {
+	return map[string]string{
+		"username": credentials.username,
+		"password": credentials.password,
+	}
+}
+
+func (credentials RegistryCredentials) validate() error {
+	if strings.TrimSpace(credentials.username) == "" {
+		return invalid("registry_credentials", "registry username cannot be empty")
+	}
+	return nil
+}
+
+type SignaturePolicy struct {
+	mode      string
+	publicKey string
+	issuer    string
+	identity  string
+}
+
+func SkipSignatures() SignaturePolicy { return SignaturePolicy{mode: "skip"} }
+
+func CosignKey(publicKey string) SignaturePolicy {
+	return SignaturePolicy{mode: "cosign_key", publicKey: publicKey}
+}
+
+func CosignKeyless(issuer, identity string) SignaturePolicy {
+	return SignaturePolicy{mode: "cosign_keyless", issuer: issuer, identity: identity}
+}
+
+func (policy SignaturePolicy) bridgeValue() map[string]string {
+	value := map[string]string{"mode": policy.mode}
+	if policy.publicKey != "" {
+		value["public_key"] = policy.publicKey
+	}
+	if policy.issuer != "" {
+		value["issuer"] = policy.issuer
+	}
+	if policy.identity != "" {
+		value["identity"] = policy.identity
+	}
+	return value
+}
+
+func (policy SignaturePolicy) validate() error {
+	switch policy.mode {
+	case "skip":
+		return nil
+	case "cosign_key":
+		if strings.TrimSpace(policy.publicKey) == "" {
+			return invalid("signature_policy", "cosign public key cannot be empty")
+		}
+		return nil
+	case "cosign_keyless":
+		if strings.TrimSpace(policy.issuer) == "" || strings.TrimSpace(policy.identity) == "" {
+			return invalid("signature_policy", "keyless issuer and identity cannot be empty")
+		}
+		return nil
+	default:
+		return invalid("signature_policy", "signature policy is not configured")
+	}
+}
+
+type RegistryProtocol string
+
+const (
+	RegistryHTTPS RegistryProtocol = "https"
+	RegistryHTTP  RegistryProtocol = "http"
+)
+
+type Mount struct {
+	kind     string
+	source   string
+	target   string
+	readOnly bool
+}
+
+func BindMount(source, target string) Mount {
+	return Mount{kind: "bind", source: source, target: target}
+}
+
+func NamedVolume(name, target string) Mount {
+	return Mount{kind: "named", source: name, target: target}
+}
+
+func (mount Mount) ReadOnly() Mount {
+	mount.readOnly = true
+	return mount
+}
+
+func (mount Mount) bridgeValue() map[string]any {
+	value := map[string]any{
+		"kind":      mount.kind,
+		"target":    mount.target,
+		"read_only": mount.readOnly,
+	}
+	if mount.kind == "bind" {
+		value["source"] = mount.source
+	} else {
+		value["name"] = mount.source
+	}
+	return value
+}
+
+func (mount Mount) validate() error {
+	if mount.kind != "bind" && mount.kind != "named" {
+		return invalid("sandbox_create", "mount kind must be bind or named")
+	}
+	if strings.TrimSpace(mount.source) == "" || strings.TrimSpace(mount.target) == "" {
+		return invalid("sandbox_create", "mount source and target cannot be empty")
+	}
+	return nil
+}
+
+type TmpfsMount struct {
+	target    string
+	sizeBytes *uint64
+	readOnly  bool
+}
+
+func Tmpfs(target string) TmpfsMount { return TmpfsMount{target: target} }
+
+func (mount TmpfsMount) SizeBytes(size uint64) TmpfsMount {
+	mount.sizeBytes = &size
+	return mount
+}
+
+func (mount TmpfsMount) ReadOnly() TmpfsMount {
+	mount.readOnly = true
+	return mount
+}
+
+func (mount TmpfsMount) bridgeValue() map[string]any {
+	value := map[string]any{"target": mount.target, "read_only": mount.readOnly}
+	if mount.sizeBytes != nil {
+		value["size_bytes"] = *mount.sizeBytes
+	}
+	return value
+}
+
+func (mount TmpfsMount) validate() error {
+	if strings.TrimSpace(mount.target) == "" {
+		return invalid("sandbox_create", "tmpfs target cannot be empty")
+	}
+	if mount.sizeBytes != nil && *mount.sizeBytes == 0 {
+		return invalid("sandbox_create", "tmpfs size must be greater than zero")
+	}
+	return nil
+}
+
+type SandboxNetwork struct {
+	mode string
+	name string
+}
+
+func TSINetwork() SandboxNetwork { return SandboxNetwork{mode: "tsi"} }
+func NoNetwork() SandboxNetwork  { return SandboxNetwork{mode: "none"} }
+
+func BridgeNetwork(name string) SandboxNetwork {
+	return SandboxNetwork{mode: "bridge", name: name}
+}
+
+func (network SandboxNetwork) bridgeValue() map[string]string {
+	value := map[string]string{"mode": network.mode}
+	if network.name != "" {
+		value["name"] = network.name
+	}
+	return value
+}
+
+func (network SandboxNetwork) validate() error {
+	switch network.mode {
+	case "tsi", "none":
+		return nil
+	case "bridge":
+		if strings.TrimSpace(network.name) == "" {
+			return invalid("sandbox_create", "bridge network name cannot be empty")
+		}
+		return nil
+	default:
+		return invalid("sandbox_create", "sandbox network is not configured")
+	}
+}
+
+type PortMapping struct {
+	HostPort  uint16 `json:"host_port"`
+	GuestPort uint16 `json:"guest_port"`
+}
+
+func TCPPort(hostPort, guestPort uint16) PortMapping {
+	return PortMapping{HostPort: hostPort, GuestPort: guestPort}
+}

--- a/sdk/go/volume_builder.go
+++ b/sdk/go/volume_builder.go
@@ -1,0 +1,47 @@
+package box
+
+import (
+	"context"
+	"strings"
+)
+
+type VolumeBuilder struct {
+	client    *Client
+	name      string
+	labels    map[string]string
+	sizeLimit uint64
+}
+
+func (client *Client) Volume(name string) *VolumeBuilder {
+	return &VolumeBuilder{client: client, name: name, labels: make(map[string]string)}
+}
+
+func (builder *VolumeBuilder) Label(key, value string) *VolumeBuilder {
+	builder.labels[key] = value
+	return builder
+}
+
+func (builder *VolumeBuilder) SizeLimit(bytes uint64) *VolumeBuilder {
+	builder.sizeLimit = bytes
+	return builder
+}
+
+func (builder *VolumeBuilder) Create(ctx context.Context) (VolumeInfo, error) {
+	const op = "volume_create"
+	if builder == nil || builder.client == nil {
+		return VolumeInfo{}, invalid(op, "volume builder is not initialized")
+	}
+	if strings.TrimSpace(builder.name) == "" {
+		return VolumeInfo{}, invalid(op, "volume name cannot be empty")
+	}
+	if err := validateLabels(op, builder.labels); err != nil {
+		return VolumeInfo{}, err
+	}
+	var result VolumeInfo
+	err := builder.client.request(ctx, op, map[string]any{
+		"name":       builder.name,
+		"labels":     cloneStringMap(builder.labels),
+		"size_limit": builder.sizeLimit,
+	}, &result)
+	return result, err
+}

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -145,7 +145,7 @@ automatic cleanup, and filesystem-snapshot restore are available on
 Named bridge networks and published ports are currently MicroVM-only. The
 shared-kernel Sandbox resolver rejects either before runtime mutation.
 
-The same native Python and TypeScript packages expose the Rust client's local
+The native Python, TypeScript, and Go packages expose the Rust client's local
 image lifecycle; Sandbox list/get/stop/restart/remove/logs/stats; runtime
 diagnostics and disk usage; and filesystem snapshot list/get. Pull accepts
 typed registry credentials and cosign verification policies; push accepts


### PR DESCRIPTION
## Summary

- add the credential-free github.com/A3S-Lab/Box/sdk/go/v3 local Go module
- cover the full 48-operation machine bridge with typed resources, builders, lifecycle fencing, commands, scripts, files, snapshots, and stable errors
- add Go package, race, inventory, malformed-protocol, cancellation, and concurrency tests
- add a real Go runtime smoke to the existing four-language Sandbox gate
- verify and publish nested Go releases with sdk/go/vX.Y.Z tags
- update root/package documentation, architecture, qualification plans, and changelog

## Local validation

- Go 1.25.12: go vet ./..., go test ./..., go test -race ./...
- Go 1.26.5: go vet ./..., go test ./..., go test -race ./...
- staticcheck ./...
- Rust bridge contract: 15 passed
- real macOS/HVF MicroVM Go SDK smoke: passed, with zero residual Sandboxes, volumes, networks, snapshots, or shim processes
- ShellCheck, Actionlint, bash syntax, YAML parse, and git diff checks: passed

The existing Linux SDK Local Sandbox job now supplies the required shared-kernel real-runtime evidence before merge.
