### PR TITLE
feat(runtime): align Cloud Box provider contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- **Cloud Runtime contract alignment.** The shared `BoxRuntimeDriver` now pins
+  the exact A3S Runtime revision used by A3S Cloud and accepts digest-pinned OCI
+  image manifests and multi-platform OCI image indexes without advertising a
+  Docker manifest media type.
 - **Native Go SDK.** The nested `github.com/A3S-Lab/Box/sdk/go/v3` module
   exposes the complete checked local bridge inventory through context-aware,
   concurrency-safe clients, typed builders, binary-safe commands and files,

--- a/README.md
+++ b/README.md
@@ -312,8 +312,10 @@ evidence. Review [Host Integration](docs/host-integration.md),
 ## Integrations
 
 - **A3S Runtime provider** — Maps digest-pinned Tasks and Services onto the
-  A3S OCI shared-kernel Sandbox with generation fencing, recovery,
-  structured logs, bounded idempotent exec, resource controls, and tmpfs.
+  A3S OCI shared-kernel Sandbox with generation fencing, recovery, structured
+  logs, bounded idempotent exec, resource controls, and tmpfs. Its artifact
+  contract accepts OCI image manifests and multi-platform OCI image indexes;
+  it does not advertise a Docker manifest media type.
 - **Kubernetes RuntimeClass** — The CRI server and containerd shim let selected
   Linux/KVM pods use `runtimeClassName: a3s-box`; installers and soak manifests
   live under [`deploy/`](deploy/).

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 [[package]]
 name = "a3s-runtime"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/Runtime.git?rev=91a1b4c67ef2691915f2409a8cf835f7534020ff#91a1b4c67ef2691915f2409a8cf835f7534020ff"
+source = "git+https://github.com/A3S-Lab/Runtime.git?rev=cfaac63af6f76beebdc64a1ec228cedc42bb98ec#cfaac63af6f76beebdc64a1ec228cedc42bb98ec"
 dependencies = [
  "async-trait",
  "fs2",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -124,7 +124,7 @@ ring = "0.17"
 # Shared types (transport protocol, privacy, tools)
 a3s-acl = { version = "0.2.2", git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
-a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "91a1b4c67ef2691915f2409a8cf835f7534020ff" }
+a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "cfaac63af6f76beebdc64a1ec228cedc42bb98ec" }
 a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "0f0face67c282cf535e352b4fe83af02055b7e08" }
 
 # Metrics

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/cases.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/cases.rs
@@ -7,7 +7,7 @@ use a3s_runtime::contract::{
 };
 use a3s_runtime::{RuntimeBaseConformanceCase, RuntimeConformanceCase};
 
-use super::super::{DOCKER_IMAGE_MANIFEST, OCI_IMAGE_MANIFEST};
+use super::super::{OCI_IMAGE_INDEX, OCI_IMAGE_MANIFEST};
 use super::{require, Result};
 
 const DEFAULT_CPU_MILLIS: u64 = 500;
@@ -75,13 +75,10 @@ impl CaseFactory {
             "A3S_BOX_RUNTIME_CONFORMANCE_IMAGE is not canonical",
         )?;
         let media_type = std::env::var("A3S_BOX_RUNTIME_CONFORMANCE_MEDIA_TYPE")
-            .unwrap_or_else(|_| DOCKER_IMAGE_MANIFEST.to_string());
+            .unwrap_or_else(|_| OCI_IMAGE_MANIFEST.to_string());
         require(
-            matches!(
-                media_type.as_str(),
-                OCI_IMAGE_MANIFEST | DOCKER_IMAGE_MANIFEST
-            ),
-            "A3S_BOX_RUNTIME_CONFORMANCE_MEDIA_TYPE is not a supported image manifest",
+            matches!(media_type.as_str(), OCI_IMAGE_MANIFEST | OCI_IMAGE_INDEX),
+            "A3S_BOX_RUNTIME_CONFORMANCE_MEDIA_TYPE is not a supported OCI image manifest or index",
         )?;
         let digest = format!("sha256:{digest_hex}");
         let artifact = ArtifactRef {

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -15,7 +15,7 @@ use a3s_runtime::{RuntimeError, RuntimeResult};
 use url::Position;
 
 use super::metadata::{managed_labels, operation_id};
-use super::{DOCKER_IMAGE_MANIFEST, OCI_IMAGE_MANIFEST};
+use super::{OCI_IMAGE_INDEX, OCI_IMAGE_MANIFEST};
 
 const CPU_PERIOD_US: u64 = 100_000;
 const BYTES_PER_MIB: u64 = 1024 * 1024;
@@ -117,7 +117,7 @@ pub(super) fn operation(spec: &RuntimeUnitSpec) -> RuntimeResult<a3s_box_core::O
 fn validate_supported_shape(spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
     if !matches!(
         spec.artifact.media_type.as_str(),
-        OCI_IMAGE_MANIFEST | DOCKER_IMAGE_MANIFEST
+        OCI_IMAGE_MANIFEST | OCI_IMAGE_INDEX
     ) {
         return Err(RuntimeError::UnsupportedCapabilities(vec![format!(
             "artifact_media_type:{}",

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -23,8 +23,7 @@ use tokio::sync::OnceCell;
 use crate::LocalExecutionManager;
 
 pub(super) const OCI_IMAGE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
-pub(super) const DOCKER_IMAGE_MANIFEST: &str =
-    "application/vnd.docker.distribution.manifest.v2+json";
+pub(super) const OCI_IMAGE_INDEX: &str = "application/vnd.oci.image.index.v1+json";
 
 /// Host paths and bounds for one Box Runtime provider instance.
 #[derive(Debug, Clone)]
@@ -162,7 +161,7 @@ impl RuntimeDriver for BoxRuntimeDriver {
             provider_id: self.provider_id.clone(),
             provider_build: self.provider_build().await?,
             unit_classes: vec![RuntimeUnitClass::Task, RuntimeUnitClass::Service],
-            artifact_media_types: vec![OCI_IMAGE_MANIFEST.into(), DOCKER_IMAGE_MANIFEST.into()],
+            artifact_media_types: vec![OCI_IMAGE_MANIFEST.into(), OCI_IMAGE_INDEX.into()],
             isolation_levels: vec![IsolationLevel::Sandbox],
             network_modes: vec![NetworkMode::None],
             mount_kinds: vec![MountKind::Tmpfs],

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -97,6 +97,10 @@ async fn capabilities_claim_only_the_mapped_box_surface() {
     let capabilities = driver.capabilities().await.unwrap();
     assert_eq!(capabilities.provider_id.as_str(), "a3s-box");
     assert_eq!(
+        capabilities.artifact_media_types,
+        vec![OCI_IMAGE_MANIFEST.into(), OCI_IMAGE_INDEX.into()]
+    );
+    assert_eq!(
         capabilities.unit_classes,
         vec![RuntimeUnitClass::Task, RuntimeUnitClass::Service]
     );
@@ -265,7 +269,7 @@ fn mapping_rejects_protected_or_unencodable_tmpfs_targets() {
 }
 
 #[test]
-fn mapping_rejects_unpinned_mismatched_and_unsupported_artifacts() {
+fn mapping_accepts_oci_indexes_and_rejects_unpinned_mismatched_or_unsupported_artifacts() {
     let mut value = spec(RuntimeUnitClass::Service);
     value.artifact.uri = "oci://registry.example/a3s/runtime:latest".into();
     assert!(creation_request(&value).is_err());
@@ -278,7 +282,11 @@ fn mapping_rejects_unpinned_mismatched_and_unsupported_artifacts() {
     assert!(creation_request(&value).is_err());
 
     let mut value = spec(RuntimeUnitClass::Service);
-    value.artifact.media_type = "application/vnd.oci.image.index.v1+json".into();
+    value.artifact.media_type = OCI_IMAGE_INDEX.into();
+    assert!(creation_request(&value).is_ok());
+
+    let mut value = spec(RuntimeUnitClass::Service);
+    value.artifact.media_type = "application/vnd.docker.distribution.manifest.v2+json".into();
     assert!(matches!(
         creation_request(&value),
         Err(RuntimeError::UnsupportedCapabilities(_))

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -98,7 +98,7 @@ async fn capabilities_claim_only_the_mapped_box_surface() {
     assert_eq!(capabilities.provider_id.as_str(), "a3s-box");
     assert_eq!(
         capabilities.artifact_media_types,
-        vec![OCI_IMAGE_MANIFEST.into(), OCI_IMAGE_INDEX.into()]
+        vec![OCI_IMAGE_MANIFEST.to_string(), OCI_IMAGE_INDEX.to_string(),]
     );
     assert_eq!(
         capabilities.unit_classes,


### PR DESCRIPTION
## Summary

- pin the exact A3S Runtime revision already used by A3S Cloud
- advertise digest-pinned OCI image manifests and OCI image indexes
- remove the Box Runtime driver Docker manifest media-type dependency
- make real-provider conformance default to OCI and document the contract

Closes #172 only in part; networking, health, typed mounts, Secrets, outputs, evidence, and full clean-host certification remain tracked there.

## Validation

- cargo fmt --all -- --check
- cargo metadata --locked --no-deps --format-version 1
- focused multi-platform OCI index pull test passes
- macOS library run: 1413 passed, 1 ignored; two unrelated tests also fail on origin/main (Unix socket path length and BSD build-fixture digest)
- Linux-only Box Runtime driver coverage is delegated to required PR CI
