### PR TITLE
feat(runtime): add fenced Sandbox port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ the host requirements below before running real workloads.
 | Isolation class | `hardware-vm` | `shared-kernel` |
 | Intended workload | Untrusted workloads and stronger tenant boundaries | Trusted or semi-trusted tools, benchmarks, and automation |
 | Required host | Linux/KVM, Apple Silicon/HVF, or Windows/WHPX | Certified Linux host with namespaces, seccomp, subordinate IDs, and delegated cgroup v2 |
-| Bridge networking and published ports | Supported within platform limits | Rejected in the current release |
+| Bridge networking and published ports | Supported within platform limits | Static publication is rejected; generation-fenced loopback forwarding is explicit |
 | TEE, warm pool, and snapshot-fork | Available on qualifying MicroVM hosts | Rejected |
 | Automatic fallback | Never | Never |
 
@@ -165,8 +165,9 @@ runtime state changes instead of being silently stored or weakened.
 - **Storage** — bind mounts, named volumes, tmpfs, file copy, diff, export,
   commit, filesystem snapshots, and copy-on-write restore.
 - **Networking and Compose** — TSI, named bridge networks, peer discovery, TCP
-  publishing, and an explicit Compose subset. ACL is the canonical project
-  format; YAML is a bounded compatibility input.
+  publishing, generation-fenced Sandbox loopback forwarding, and an explicit
+  Compose subset. ACL is the canonical project format; YAML is a bounded
+  compatibility input.
 - **Startup acceleration** — rootfs and layer caches, pre-booted warm pools,
   build leases, one-shot pool routing, and opt-in Linux/KVM snapshot-fork.
 - **Security and operations** — resource and syscall controls, audit evidence,
@@ -190,6 +191,10 @@ a3s-box snapshot create app --name checkpoint-1
 a3s-box network create backend --subnet 10.89.0.0/24
 a3s-box run -d --name api --network backend -p 8080:80 local/app:dev
 
+# Explicit host-loopback access to a Sandbox workload
+a3s-box run -d --name sandbox-api --isolation sandbox local/app:dev
+a3s-box port-forward sandbox-api --host-port 18080 --guest-port 8080
+
 # Deterministic Compose normalization and lifecycle
 a3s-box compose -f compose.acl config
 a3s-box compose -f compose.acl up -d
@@ -205,7 +210,7 @@ a3s-box compose -f compose.acl down
 | Execution | `exec`, `shell`, `attach`, `top` |
 | Images and builds | `pull`, `push`, `build`, `images`, `rmi`, `tag`, `image-inspect`, `history`, `image-prune`, `save`, `load`, `import` |
 | Filesystems | `cp`, `diff`, `export`, `commit`, `volume`, `snapshot` |
-| Networking | `network`, `port`, `compose` |
+| Networking | `network`, `port`, `port-forward`, `compose` |
 | Security and TEE | `attest`, `seal`, `unseal`, `inject-secret` |
 | Observability | `ps`, `logs`, `inspect`, `stats`, `events`, `df`, `audit`, `monitor` |
 | System | `container-update`, `system-prune`, `pool`, `login`, `logout`, `version`, `info` |

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "a3s-box-runtime",
  "a3s-box-sdk",
  "a3s-common",
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "clap",
@@ -299,7 +300,7 @@ dependencies = [
 [[package]]
 name = "a3s-runtime"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/Runtime.git?rev=cfaac63af6f76beebdc64a1ec228cedc42bb98ec#cfaac63af6f76beebdc64a1ec228cedc42bb98ec"
+source = "git+https://github.com/A3S-Lab/Runtime.git?rev=b0aa0c34e2c8121effbcbfbe6246a860e78ca509#b0aa0c34e2c8121effbcbfbe6246a860e78ca509"
 dependencies = [
  "async-trait",
  "fs2",
@@ -495,28 +496,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
 
 [[package]]
 name = "axum"
@@ -760,15 +739,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -1171,12 +1141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1395,12 +1359,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -2450,7 +2408,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3335,7 +3293,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3344,7 +3302,6 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3378,7 +3335,6 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3951,10 +3907,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -80,8 +80,8 @@ spki = "0.7"
 
 # RA-TLS (Remote Attestation TLS)
 rcgen = { version = "0.13", features = ["x509-parser"] }
-rustls = { version = "0.23", features = ["ring"] }
-tokio-rustls = "0.26"
+rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 rustls-pki-types = "1"
 
 # HTTP client (for skill downloads)
@@ -124,7 +124,7 @@ ring = "0.17"
 # Shared types (transport protocol, privacy, tools)
 a3s-acl = { version = "0.2.2", git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
-a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "cfaac63af6f76beebdc64a1ec228cedc42bb98ec" }
+a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "b0aa0c34e2c8121effbcbfbe6246a860e78ca509" }
 a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "0f0face67c282cf535e352b4fe83af02055b7e08" }
 
 # Metrics

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -80,4 +80,5 @@ windows-sys = { version = "0.48", features = [
 ] }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tempfile = { workspace = true }

--- a/src/cli/src/commands/mod.rs
+++ b/src/cli/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod network;
 mod pause;
 mod pool;
 mod port;
+mod port_forward;
 mod prune;
 mod ps;
 mod pull;
@@ -129,6 +130,8 @@ pub enum Command {
     Rename(rename::RenameArgs),
     /// List port mappings for a box
     Port(port::PortArgs),
+    /// Forward a loopback TCP port to a running Sandbox box
+    PortForward(port_forward::PortForwardArgs),
     /// Export a box's filesystem to a tar archive
     Export(export::ExportArgs),
     /// Create an image from a box's changes
@@ -642,6 +645,7 @@ pub async fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Wait(args) => wait::execute(args).await,
         Command::Rename(args) => rename::execute(args).await,
         Command::Port(args) => port::execute(args).await,
+        Command::PortForward(args) => port_forward::execute(args).await,
         Command::Export(args) => export::execute(args).await,
         Command::Commit(args) => commit::execute(args).await,
         Command::Diff(args) => diff::execute(args).await,

--- a/src/cli/src/commands/port_forward.rs
+++ b/src/cli/src/commands/port_forward.rs
@@ -46,6 +46,8 @@ pub async fn execute(_args: PortForwardArgs) -> Result<(), Box<dyn std::error::E
 
 #[cfg(target_os = "linux")]
 pub async fn execute(args: PortForwardArgs) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write as _;
+
     use a3s_box_runtime::LocalExecutionManager;
     use tokio::net::TcpListener;
     use tokio::sync::Semaphore;
@@ -94,6 +96,7 @@ pub async fn execute(args: PortForwardArgs) -> Result<(), Box<dyn std::error::Er
         "Forwarding {bind_address} to {box_name}:{}",
         args.guest_port
     );
+    std::io::stdout().flush()?;
 
     loop {
         let permit = Arc::clone(&connection_limit)

--- a/src/cli/src/commands/port_forward.rs
+++ b/src/cli/src/commands/port_forward.rs
@@ -1,0 +1,277 @@
+//! `a3s-box port-forward` command — forward host loopback TCP to a Sandbox box.
+
+use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
+#[cfg(target_os = "linux")]
+use std::sync::Arc;
+#[cfg(any(target_os = "linux", test))]
+use std::time::Duration;
+
+#[cfg(any(target_os = "linux", test))]
+use a3s_box_core::{ExecutionId, ExecutionPortConnector};
+use clap::Args;
+#[cfg(any(target_os = "linux", test))]
+use tokio::io::{AsyncRead, AsyncWrite};
+
+#[cfg(target_os = "linux")]
+use crate::resolve;
+#[cfg(target_os = "linux")]
+use crate::state::StateFile;
+
+#[derive(Args)]
+pub struct PortForwardArgs {
+    /// Box name or ID
+    pub r#box: String,
+
+    /// Host loopback TCP port to listen on
+    #[arg(long)]
+    pub host_port: NonZeroU16,
+
+    /// TCP port exposed on the Sandbox loopback interface
+    #[arg(long)]
+    pub guest_port: NonZeroU16,
+
+    /// Maximum number of concurrent forwarded connections
+    #[arg(long, default_value = "64")]
+    pub max_connections: NonZeroUsize,
+
+    /// Timeout for each connection to the Sandbox workload
+    #[arg(long, default_value = "5")]
+    pub connect_timeout_secs: NonZeroU64,
+}
+
+#[cfg(not(target_os = "linux"))]
+pub async fn execute(_args: PortForwardArgs) -> Result<(), Box<dyn std::error::Error>> {
+    Err("Sandbox port forwarding requires Linux network namespaces".into())
+}
+
+#[cfg(target_os = "linux")]
+pub async fn execute(args: PortForwardArgs) -> Result<(), Box<dyn std::error::Error>> {
+    use a3s_box_runtime::LocalExecutionManager;
+    use tokio::net::TcpListener;
+    use tokio::sync::Semaphore;
+
+    let (execution_id, generation, box_name) = {
+        let state = StateFile::load_default()?;
+        let record = resolve::resolve(&state, &args.r#box)?;
+        if record.status != "running" {
+            return Err(format!("Box {} is not running", record.name).into());
+        }
+        let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+            format!(
+                "Box {} is not owned by the generation-fenced execution manager",
+                record.name
+            )
+        })?;
+        if !metadata.plan.backend.is_sandbox() {
+            return Err(format!(
+                "Box {} does not expose a Sandbox network namespace",
+                record.name
+            )
+            .into());
+        }
+
+        (
+            ExecutionId::new(record.id.clone())?,
+            metadata.generation,
+            record.name.clone(),
+        )
+    };
+
+    let home = a3s_box_core::dirs_home();
+    let connector = Arc::new(LocalExecutionManager::with_vm_backend(
+        home.join("boxes.json"),
+        &home,
+    ));
+    let bind_address =
+        std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, args.host_port.get()));
+    let listener = TcpListener::bind(bind_address).await.map_err(|error| {
+        format!("Failed to bind Box port-forward listener at {bind_address}: {error}")
+    })?;
+    let connection_limit = Arc::new(Semaphore::new(args.max_connections.get()));
+    let connect_timeout = Duration::from_secs(args.connect_timeout_secs.get());
+
+    println!(
+        "Forwarding {bind_address} to {box_name}:{}",
+        args.guest_port
+    );
+
+    loop {
+        let permit = Arc::clone(&connection_limit)
+            .acquire_owned()
+            .await
+            .map_err(|_| "Box port-forward connection limiter closed")?;
+        let (host_stream, peer_address) = listener
+            .accept()
+            .await
+            .map_err(|error| format!("Failed to accept a Box port-forward connection: {error}"))?;
+        host_stream.set_nodelay(true)?;
+
+        let connector = Arc::clone(&connector);
+        let execution_id = execution_id.clone();
+        let guest_port = args.guest_port;
+        tokio::spawn(async move {
+            let _permit = permit;
+            if let Err(error) = proxy_connection(
+                connector.as_ref(),
+                &execution_id,
+                generation,
+                guest_port,
+                connect_timeout,
+                host_stream,
+            )
+            .await
+            {
+                tracing::warn!(
+                    peer = %peer_address,
+                    execution_id = %execution_id,
+                    guest_port = guest_port.get(),
+                    error = %error,
+                    "Sandbox port-forward connection failed"
+                );
+            }
+        });
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+async fn proxy_connection<C, S>(
+    connector: &C,
+    execution_id: &ExecutionId,
+    generation: a3s_box_core::ExecutionGeneration,
+    guest_port: NonZeroU16,
+    connect_timeout: Duration,
+    mut host_stream: S,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    C: ExecutionPortConnector + ?Sized,
+    S: AsyncRead + AsyncWrite + Send + Unpin,
+{
+    let mut guest_stream = connector
+        .connect_port(execution_id, generation, guest_port, connect_timeout)
+        .await?;
+    tokio::io::copy_bidirectional(&mut host_stream, &mut guest_stream)
+        .await
+        .map_err(|error| format!("Failed to relay Sandbox port-forward traffic: {error}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use a3s_box_core::{
+        ExecutionGeneration, ExecutionManagerError, ExecutionManagerResult, ExecutionPortStream,
+    };
+    use async_trait::async_trait;
+    use clap::Parser;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    struct StubConnector {
+        stream: Mutex<Option<ExecutionPortStream>>,
+    }
+
+    #[test]
+    fn parses_a_bounded_loopback_forward() {
+        let cli = crate::commands::Cli::try_parse_from([
+            "a3s-box",
+            "port-forward",
+            "database",
+            "--host-port",
+            "54320",
+            "--guest-port",
+            "5432",
+        ])
+        .unwrap();
+        let crate::commands::Command::PortForward(args) = cli.command else {
+            panic!("expected port-forward command");
+        };
+
+        assert_eq!(args.r#box, "database");
+        assert_eq!(args.host_port.get(), 54320);
+        assert_eq!(args.guest_port.get(), 5432);
+        assert_eq!(args.max_connections.get(), 64);
+        assert_eq!(args.connect_timeout_secs.get(), 5);
+    }
+
+    #[test]
+    fn rejects_zero_ports_and_connection_limits() {
+        for invalid_args in [
+            &["--host-port", "0", "--guest-port", "5432"][..],
+            &["--host-port", "54320", "--guest-port", "0"][..],
+            &[
+                "--host-port",
+                "54320",
+                "--guest-port",
+                "5432",
+                "--max-connections",
+                "0",
+            ][..],
+        ] {
+            let mut args = vec!["a3s-box", "port-forward", "database"];
+            args.extend(invalid_args);
+            assert!(crate::commands::Cli::try_parse_from(args).is_err());
+        }
+    }
+
+    #[async_trait]
+    impl ExecutionPortConnector for StubConnector {
+        async fn connect_port(
+            &self,
+            _execution_id: &ExecutionId,
+            _generation: ExecutionGeneration,
+            _port: NonZeroU16,
+            _timeout: Duration,
+        ) -> ExecutionManagerResult<ExecutionPortStream> {
+            self.stream
+                .lock()
+                .expect("stub connector lock")
+                .take()
+                .ok_or_else(|| {
+                    ExecutionManagerError::Unavailable(
+                        "stub connector stream already consumed".to_string(),
+                    )
+                })
+        }
+    }
+
+    #[tokio::test]
+    async fn relays_bidirectional_bytes_through_the_canonical_connector() {
+        let (host_client, host_proxy) = tokio::io::duplex(128);
+        let (guest_proxy, mut guest_server) = tokio::io::duplex(128);
+        let connector = StubConnector {
+            stream: Mutex::new(Some(Box::pin(guest_proxy))),
+        };
+        let execution_id = ExecutionId::new("execution-1").unwrap();
+
+        let proxy = tokio::spawn(async move {
+            proxy_connection(
+                &connector,
+                &execution_id,
+                ExecutionGeneration::INITIAL,
+                NonZeroU16::new(5432).unwrap(),
+                Duration::from_secs(1),
+                host_proxy,
+            )
+            .await
+        });
+        let client = tokio::spawn(async move {
+            let mut host_client = host_client;
+            host_client.write_all(b"request").await.unwrap();
+            let mut response = [0_u8; 8];
+            host_client.read_exact(&mut response).await.unwrap();
+            host_client.shutdown().await.unwrap();
+            response
+        });
+
+        let mut request = [0_u8; 7];
+        guest_server.read_exact(&mut request).await.unwrap();
+        assert_eq!(&request, b"request");
+        guest_server.write_all(b"response").await.unwrap();
+        guest_server.shutdown().await.unwrap();
+
+        assert_eq!(&client.await.unwrap(), b"response");
+        proxy.await.unwrap().unwrap();
+    }
+}

--- a/src/cli/tests/command_coverage.rs
+++ b/src/cli/tests/command_coverage.rs
@@ -44,6 +44,7 @@ const TOP_LEVEL_COMMANDS: &[&str] = &[
     "wait",
     "rename",
     "port",
+    "port-forward",
     "export",
     "commit",
     "diff",

--- a/src/runtime/src/local_execution/port.rs
+++ b/src/runtime/src/local_execution/port.rs
@@ -8,6 +8,7 @@ use a3s_box_core::{
 use async_trait::async_trait;
 
 use super::LocalExecutionManager;
+#[cfg(target_os = "linux")]
 use crate::BoxRecord;
 
 #[async_trait]
@@ -71,6 +72,7 @@ impl ExecutionPortConnector for LocalExecutionManager {
     }
 }
 
+#[cfg(target_os = "linux")]
 impl LocalExecutionManager {
     async fn require_connectable(
         &self,


### PR DESCRIPTION
## Summary

- add a loopback-only `a3s-box port-forward` command for Sandbox workloads
- reuse the canonical generation-fenced `ExecutionPortConnector` with bounded connection concurrency
- select rustls `ring` exclusively and update the A3S Runtime pin for structured provider observations
- document the explicit Sandbox forwarding boundary

## Validation

- `cargo test -p a3s-box-cli --lib port_forward --locked`
- `cargo test -p a3s-box-cli --test command_coverage test_all_top_level_command_help --locked`
- `cargo test -p a3s-box-cli --test command_coverage test_top_level_help_matches_coverage_list --locked`
- `cargo tree -i aws-lc-rs --locked` confirms no matching package

Linux namespace compilation and real-runtime behavior are delegated to the required repository CI gates.