### PR TITLE
fix(runtime): retain short-lived Sandbox Task exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ All notable changes to A3S Box will be documented in this file.
   volume, tmpfs, inline/file/direct initialization, failure, and cleanup
   matrix before exercising the Rust, Python, TypeScript, and Go SDK lifecycle.
 
+### Fixed
+
+- **Reliable Cloud Sandbox completion.** Managed Sandbox inspection retains an
+  A3S OCI generation until its exact exit status is available, and the default
+  seccomp profile permits namespaced System V shared-memory operations needed
+  by PostgreSQL while retaining its default-deny host-control boundary.
+
 ## [3.1.0] — 2026-07-23
 
 ### Added

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -306,6 +306,9 @@ impl BoxRuntimeConformanceFixture {
             };
             for record in records {
                 self.remember(&driver.config.home_dir, &record);
+                if record.exit_code.is_none() {
+                    emit_missing_exit_diagnostics(&driver.config.home_dir, &record);
+                }
                 let unit_id = record
                     .labels
                     .get(UNIT_LABEL)
@@ -485,4 +488,49 @@ fn remove_file(path: &Path) -> std::io::Result<()> {
 
 fn remove_empty_directory(path: &Path) {
     let _ = std::fs::remove_dir(path);
+}
+
+fn emit_missing_exit_diagnostics(home_dir: &Path, record: &crate::BoxRecord) {
+    eprintln!(
+        "R17 missing-exit diagnostics: id={} status={} pid={:?} pid_start_time={:?} box_dir={} persisted_exit_code={:?}",
+        record.id,
+        record.status,
+        record.pid,
+        record.pid_start_time,
+        record.box_dir.display(),
+        crate::rootfs::read_persisted_exit_code(&record.box_dir),
+    );
+
+    let stderr_console = a3s_box_core::log::stderr_console_path(&record.console_log);
+    for (label, path) in [
+        ("console stdout", record.console_log.clone()),
+        ("console stderr", stderr_console),
+        ("Sandbox init", record.box_dir.join("logs/sandbox-init.log")),
+        (
+            "Sandbox log worker",
+            record.box_dir.join("logs/sandbox-log-worker.log"),
+        ),
+        (
+            "Sandbox runtime",
+            record.box_dir.join("sandbox/runtime.json"),
+        ),
+        (
+            "A3S OCI generation",
+            home_dir
+                .join("run/a3s-oci")
+                .join(&record.id)
+                .join("record.json"),
+        ),
+    ] {
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        const MAX_DIAGNOSTIC_BYTES: usize = 16 * 1024;
+        let start = bytes.len().saturating_sub(MAX_DIAGNOSTIC_BYTES);
+        eprintln!(
+            "R17 {label} diagnostics ({}):\n{}",
+            path.display(),
+            String::from_utf8_lossy(&bytes[start..]),
+        );
+    }
 }

--- a/src/runtime/src/a3s_runtime_driver/lifecycle.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle.rs
@@ -184,7 +184,7 @@ impl BoxRuntimeDriver {
                     .await;
                 if let Err(error) = result {
                     let current = self.load_record(spec, &execution_id).await?;
-                    if local_identity(&current)?.2.is_terminal() {
+                    if local_identity(&current)?.2.is_terminal() && current.exit_code.is_some() {
                         return Ok(current);
                     }
                     return Err(error);

--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -1,5 +1,5 @@
 use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitClass, RuntimeUnitState};
-use a3s_runtime::RuntimeDriver;
+use a3s_runtime::{RuntimeDriver, RuntimeError};
 
 use super::metadata::GENERATION_LABEL;
 use super::test_support::{
@@ -214,4 +214,20 @@ async fn response_loss_reattaches_and_confirmed_provider_loss_replaces_once() {
         loss_driver.manager.managed_records().await.unwrap().len(),
         1
     );
+}
+
+#[tokio::test]
+async fn startup_failure_without_exit_code_preserves_the_provider_error() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, backend) = fake_driver(&directory);
+    let spec = runtime_spec("startup-provider-failure", 1, RuntimeUnitClass::Task);
+    backend.fail_next_start_without_exit_code();
+
+    let result = driver.apply(&spec, &accepted(&spec)).await;
+
+    assert!(matches!(
+        result,
+        Err(RuntimeError::ProviderUnavailable(message))
+            if message == "fake start response was lost"
+    ));
 }

--- a/src/runtime/src/a3s_runtime_driver/test_support.rs
+++ b/src/runtime/src/a3s_runtime_driver/test_support.rs
@@ -34,7 +34,7 @@ pub(super) struct DriverFakeBackend {
     starts: AtomicUsize,
     kills: AtomicUsize,
     fail_start_after_effect: AtomicBool,
-    next_start_terminal: Mutex<Option<(ExecutionState, i32)>>,
+    next_start_terminal: Mutex<Option<(ExecutionState, Option<i32>)>>,
 }
 
 impl DriverFakeBackend {
@@ -72,13 +72,18 @@ impl DriverFakeBackend {
         self.fail_start_after_effect.store(true, Ordering::SeqCst);
     }
 
+    pub(super) fn fail_next_start_without_exit_code(&self) {
+        *self.next_start_terminal.lock().unwrap() = Some((ExecutionState::Failed, None));
+        self.fail_start_after_effect.store(true, Ordering::SeqCst);
+    }
+
     pub(super) fn finish_next_start(&self, exit_code: i32) {
         let state = if exit_code == 0 {
             ExecutionState::Stopped
         } else {
             ExecutionState::Failed
         };
-        *self.next_start_terminal.lock().unwrap() = Some((state, exit_code));
+        *self.next_start_terminal.lock().unwrap() = Some((state, Some(exit_code)));
     }
 
     pub(super) fn finish(&self, execution_id: &str, exit_code: i32) {
@@ -120,9 +125,7 @@ impl LocalExecutionBackend for DriverFakeBackend {
         }
         self.starts.fetch_add(1, Ordering::SeqCst);
         let terminal = self.next_start_terminal.lock().unwrap().take();
-        let (state, exit_code) = terminal
-            .map(|(state, exit_code)| (state, Some(exit_code)))
-            .unwrap_or((ExecutionState::Running, None));
+        let (state, exit_code) = terminal.unwrap_or((ExecutionState::Running, None));
         executions.insert(
             record.id.clone(),
             FakeExecution {

--- a/src/runtime/src/local_execution/create.rs
+++ b/src/runtime/src/local_execution/create.rs
@@ -42,6 +42,7 @@ impl LocalExecutionManager {
                                 )))
                             }
                             ExecutionState::Stopped | ExecutionState::Failed => {
+                                self.release_execution_resources(&record).await?;
                                 self.transition(
                                     &record,
                                     ManagedExecutionState::Starting,
@@ -185,6 +186,7 @@ impl LocalExecutionManager {
                         lease_from_record(&running)
                     }
                     ExecutionState::Stopped | ExecutionState::Failed => {
+                        self.release_execution_resources(&claimed).await?;
                         let _ = self
                             .transition(
                                 &claimed,

--- a/src/runtime/src/local_execution/recovery.rs
+++ b/src/runtime/src/local_execution/recovery.rs
@@ -255,6 +255,7 @@ impl LocalExecutionManager {
                     if observation.state == ExecutionState::Creating {
                         return Ok(ReconcileOutcome::Creating);
                     }
+                    self.release_execution_resources(&record).await?;
                     let failed = self
                         .transition(
                             &record,

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -185,30 +185,16 @@ impl VmLocalExecutionBackend {
         let mut state = manager.state().await;
         let terminal = exit_code.is_some() || state == crate::BoxState::Stopped;
         if terminal {
-            let cleanup = destroy_after_observation(&mut manager, preserve_rootfs).await;
-            let exit_code = manager.exit_code().or(exit_code);
-            drop(manager);
-            self.remove_manager(&record.id, &shared);
-            cleanup.map_err(|error| runtime_error("clean up", record, error))?;
-            return Ok(LocalExecutionObservation {
-                state: ExecutionState::Stopped,
-                handle: None,
-                exit_code,
-            });
+            return self
+                .finish_registered_terminal(record, &shared, manager, preserve_rootfs, exit_code)
+                .await;
         }
 
         if state == crate::BoxState::Created {
             if manager.has_exited().await {
-                let cleanup = destroy_after_observation(&mut manager, preserve_rootfs).await;
-                let exit_code = manager.exit_code();
-                drop(manager);
-                self.remove_manager(&record.id, &shared);
-                cleanup.map_err(|error| runtime_error("clean up", record, error))?;
-                return Ok(LocalExecutionObservation {
-                    state: ExecutionState::Stopped,
-                    handle: None,
-                    exit_code,
-                });
+                return self
+                    .finish_registered_terminal(record, &shared, manager, preserve_rootfs, None)
+                    .await;
             }
             if !self.promote_if_ready(record, &mut manager).await {
                 return Ok(LocalExecutionObservation {
@@ -225,16 +211,9 @@ impl VmLocalExecutionBackend {
             .await
             .map_err(|error| runtime_error("inspect", record, error))?
         {
-            let cleanup = destroy_after_observation(&mut manager, preserve_rootfs).await;
-            let exit_code = manager.exit_code();
-            drop(manager);
-            self.remove_manager(&record.id, &shared);
-            cleanup.map_err(|error| runtime_error("clean up", record, error))?;
-            return Ok(LocalExecutionObservation {
-                state: ExecutionState::Stopped,
-                handle: None,
-                exit_code,
-            });
+            return self
+                .finish_registered_terminal(record, &shared, manager, preserve_rootfs, None)
+                .await;
         }
 
         if state != crate::BoxState::Ready
@@ -263,6 +242,36 @@ impl VmLocalExecutionBackend {
             state: visible_state,
             handle: Some(handle),
             exit_code: None,
+        })
+    }
+
+    async fn finish_registered_terminal(
+        &self,
+        record: &BoxRecord,
+        shared: &SharedVm,
+        mut manager: tokio::sync::MutexGuard<'_, VmManager>,
+        preserve_rootfs: bool,
+        exit_code: Option<i32>,
+    ) -> ExecutionManagerResult<LocalExecutionObservation> {
+        // A workload can exit between the first non-blocking wait and the
+        // following health probe. Poll the runtime once more before teardown so
+        // its terminal record and persisted guest marker remain available.
+        let exit_code = match manager.exit_code().or(exit_code) {
+            Some(exit_code) => Some(exit_code),
+            None => manager
+                .try_wait_exit()
+                .await
+                .map_err(|error| runtime_error("collect exit status", record, error))?,
+        };
+        let cleanup = destroy_after_observation(&mut manager, preserve_rootfs).await;
+        let exit_code = manager.exit_code().or(exit_code);
+        drop(manager);
+        self.remove_manager(&record.id, shared);
+        cleanup.map_err(|error| runtime_error("clean up", record, error))?;
+        Ok(LocalExecutionObservation {
+            state: ExecutionState::Stopped,
+            handle: None,
+            exit_code,
         })
     }
 

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -548,6 +548,25 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
             }
         };
         if let Err(error) = guard.boot().await {
+            guard.config.persistent = requested_persistence;
+            // Sandbox boot cleanup synchronously asks the authoritative OCI
+            // handler for its exit status before tearing down transient host
+            // artifacts. A very short task can therefore complete while boot
+            // is still establishing readiness. Keep the manager whenever that
+            // cleanup captured an exact status so the normal inspect path can
+            // project it into the durable managed record.
+            if guard.exit_code().is_some() {
+                tracing::debug!(
+                    execution_id = %record.id,
+                    %error,
+                    "Runtime completed while startup was establishing readiness"
+                );
+                resources.disarm();
+                return Err(ExecutionManagerError::Unavailable(format!(
+                    "execution {} completed during startup",
+                    record.id
+                )));
+            }
             drop(guard);
             self.remove_manager(&record.id, &manager);
             let rollback = tokio::task::spawn_blocking(move || resources.rollback()).await;

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -562,6 +562,18 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
         }
         guard.config.persistent = requested_persistence;
         resources.disarm();
+        let exited_during_start = guard
+            .try_wait_exit()
+            .await
+            .map_err(|error| runtime_error("collect startup exit status", record, error))?
+            .is_some()
+            || guard.has_exited().await;
+        if exited_during_start {
+            return Err(ExecutionManagerError::Unavailable(format!(
+                "execution {} completed during startup",
+                record.id
+            )));
+        }
         self.handle_from_manager(record, &guard).await
     }
 

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -5,7 +5,6 @@ mod sandbox;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-#[cfg(unix)]
 use std::time::Duration;
 
 use a3s_box_core::{
@@ -26,6 +25,9 @@ use crate::{
 };
 
 type SharedVm = Arc<Mutex<VmManager>>;
+
+const TERMINAL_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const TERMINAL_EXIT_POLL_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Runtime adapter that owns live [`VmManager`] handles and reconstructs them
 /// from durable runtime evidence after a control-plane restart.
@@ -254,24 +256,35 @@ impl VmLocalExecutionBackend {
         exit_code: Option<i32>,
     ) -> ExecutionManagerResult<LocalExecutionObservation> {
         // A workload can exit between the first non-blocking wait and the
-        // following health probe. Poll the runtime once more before teardown so
-        // its terminal record and persisted guest marker remain available.
-        let exit_code = match manager.exit_code().or(exit_code) {
-            Some(exit_code) => Some(exit_code),
-            None => manager
+        // following health probe. A3S OCI publishes the exact status shortly
+        // after the process becomes non-running, so retain its terminal record
+        // and poll within a strict bound before any teardown.
+        let deadline = tokio::time::Instant::now() + TERMINAL_EXIT_POLL_TIMEOUT;
+        let mut exit_code = manager.exit_code().or(exit_code);
+        while exit_code.is_none() {
+            exit_code = manager
                 .try_wait_exit()
                 .await
-                .map_err(|error| runtime_error("collect exit status", record, error))?,
-        };
+                .map_err(|error| runtime_error("collect exit status", record, error))?;
+            if exit_code.is_some() || tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(TERMINAL_EXIT_POLL_INTERVAL).await;
+        }
+        let exit_code = exit_code.ok_or_else(|| {
+            ExecutionManagerError::Unavailable(format!(
+                "runtime reported execution {} as terminal before its exact exit status became available",
+                record.id
+            ))
+        })?;
         let cleanup = destroy_after_observation(&mut manager, preserve_rootfs).await;
-        let exit_code = manager.exit_code().or(exit_code);
         drop(manager);
         self.remove_manager(&record.id, shared);
         cleanup.map_err(|error| runtime_error("clean up", record, error))?;
         Ok(LocalExecutionObservation {
             state: ExecutionState::Stopped,
             handle: None,
-            exit_code,
+            exit_code: Some(exit_code),
         })
     }
 

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -39,11 +39,13 @@ fn record(home_dir: &Path, isolation: ExecutionIsolation) -> BoxRecord {
 
 struct DelayedExitStatusHandler {
     exit_polls: Arc<AtomicUsize>,
+    stop_calls: Arc<AtomicUsize>,
     available_after: usize,
 }
 
 impl VmHandler for DelayedExitStatusHandler {
     fn stop(&mut self, _signal: i32, _timeout_ms: u64) -> a3s_box_core::Result<()> {
+        self.stop_calls.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 
@@ -204,12 +206,14 @@ async fn terminal_health_probe_repolls_the_runtime_exit_code_before_cleanup() {
     let backend = VmLocalExecutionBackend::new(temporary.path());
     let record = record(temporary.path(), ExecutionIsolation::Sandbox);
     let exit_polls = Arc::new(AtomicUsize::new(0));
+    let stop_calls = Arc::new(AtomicUsize::new(0));
     let manager = Arc::new(Mutex::new(backend.new_manager(&record).unwrap()));
     {
         let manager = manager.lock().await;
         *manager.state.write().await = crate::BoxState::Ready;
         *manager.handler.write().await = Some(Box::new(DelayedExitStatusHandler {
             exit_polls: Arc::clone(&exit_polls),
+            stop_calls: Arc::clone(&stop_calls),
             available_after: 3,
         }));
     }
@@ -222,6 +226,7 @@ async fn terminal_health_probe_repolls_the_runtime_exit_code_before_cleanup() {
     assert_eq!(observation.state, ExecutionState::Stopped);
     assert_eq!(observation.exit_code, Some(0));
     assert_eq!(exit_polls.load(Ordering::SeqCst), 4);
+    assert_eq!(stop_calls.load(Ordering::SeqCst), 1);
     assert!(backend.managers.is_empty());
 }
 
@@ -231,12 +236,14 @@ async fn terminal_observation_retains_runtime_without_an_exact_exit_status() {
     let backend = VmLocalExecutionBackend::new(temporary.path());
     let record = record(temporary.path(), ExecutionIsolation::Sandbox);
     let exit_polls = Arc::new(AtomicUsize::new(0));
+    let stop_calls = Arc::new(AtomicUsize::new(0));
     let manager = Arc::new(Mutex::new(backend.new_manager(&record).unwrap()));
     {
         let manager = manager.lock().await;
         *manager.state.write().await = crate::BoxState::Ready;
         *manager.handler.write().await = Some(Box::new(DelayedExitStatusHandler {
             exit_polls: Arc::clone(&exit_polls),
+            stop_calls: Arc::clone(&stop_calls),
             available_after: usize::MAX,
         }));
     }
@@ -255,6 +262,7 @@ async fn terminal_observation_retains_runtime_without_an_exact_exit_status() {
             if message.contains("exact exit status")
     ));
     assert!(exit_polls.load(Ordering::SeqCst) > 1);
+    assert_eq!(stop_calls.load(Ordering::SeqCst), 0);
     assert!(backend.managers.contains_key(&record.id));
 }
 

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use a3s_box_core::{
     volume::VolumeConfig, BoxConfig, CreateExecutionRequest, ExecutionGeneration,
-    ExecutionIsolation, OperationId,
+    ExecutionIsolation, OperationId, VmHandler, VmMetrics,
 };
 
 use super::*;
@@ -34,6 +35,41 @@ fn record(home_dir: &Path, isolation: ExecutionIsolation) -> BoxRecord {
         chrono::Utc::now(),
     )
     .unwrap()
+}
+
+struct ExitAfterHealthProbeHandler {
+    exit_polls: Arc<AtomicUsize>,
+}
+
+impl VmHandler for ExitAfterHealthProbeHandler {
+    fn stop(&mut self, _signal: i32, _timeout_ms: u64) -> a3s_box_core::Result<()> {
+        Ok(())
+    }
+
+    fn metrics(&self) -> VmMetrics {
+        VmMetrics::default()
+    }
+
+    fn is_running(&self) -> bool {
+        false
+    }
+
+    fn has_exited(&self) -> bool {
+        true
+    }
+
+    fn pid(&self) -> u32 {
+        42
+    }
+
+    fn exit_code(&self) -> Option<i32> {
+        (self.exit_polls.load(Ordering::SeqCst) > 1).then_some(0)
+    }
+
+    fn try_wait_exit(&mut self) -> a3s_box_core::Result<Option<i32>> {
+        let poll = self.exit_polls.fetch_add(1, Ordering::SeqCst);
+        Ok((poll > 0).then_some(0))
+    }
 }
 
 #[test]
@@ -155,6 +191,32 @@ async fn cold_resume_observation_preserves_rootfs_when_the_replacement_exits() {
 
     assert_eq!(observation.state, ExecutionState::Stopped);
     assert_eq!(std::fs::read(&sentinel).unwrap(), b"retained");
+    assert!(backend.managers.is_empty());
+}
+
+#[tokio::test]
+async fn terminal_health_probe_repolls_the_runtime_exit_code_before_cleanup() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let record = record(temporary.path(), ExecutionIsolation::Sandbox);
+    let exit_polls = Arc::new(AtomicUsize::new(0));
+    let manager = Arc::new(Mutex::new(backend.new_manager(&record).unwrap()));
+    {
+        let manager = manager.lock().await;
+        *manager.state.write().await = crate::BoxState::Ready;
+        *manager.handler.write().await = Some(Box::new(ExitAfterHealthProbeHandler {
+            exit_polls: Arc::clone(&exit_polls),
+        }));
+    }
+    backend
+        .managers
+        .insert(record.id.clone(), Arc::clone(&manager));
+
+    let observation = backend.inspect_registered(&record, manager).await.unwrap();
+
+    assert_eq!(observation.state, ExecutionState::Stopped);
+    assert_eq!(observation.exit_code, Some(0));
+    assert_eq!(exit_polls.load(Ordering::SeqCst), 2);
     assert!(backend.managers.is_empty());
 }
 

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -37,11 +37,12 @@ fn record(home_dir: &Path, isolation: ExecutionIsolation) -> BoxRecord {
     .unwrap()
 }
 
-struct ExitAfterHealthProbeHandler {
+struct DelayedExitStatusHandler {
     exit_polls: Arc<AtomicUsize>,
+    available_after: usize,
 }
 
-impl VmHandler for ExitAfterHealthProbeHandler {
+impl VmHandler for DelayedExitStatusHandler {
     fn stop(&mut self, _signal: i32, _timeout_ms: u64) -> a3s_box_core::Result<()> {
         Ok(())
     }
@@ -63,12 +64,12 @@ impl VmHandler for ExitAfterHealthProbeHandler {
     }
 
     fn exit_code(&self) -> Option<i32> {
-        (self.exit_polls.load(Ordering::SeqCst) > 1).then_some(0)
+        (self.exit_polls.load(Ordering::SeqCst) > self.available_after).then_some(0)
     }
 
     fn try_wait_exit(&mut self) -> a3s_box_core::Result<Option<i32>> {
         let poll = self.exit_polls.fetch_add(1, Ordering::SeqCst);
-        Ok((poll > 0).then_some(0))
+        Ok((poll >= self.available_after).then_some(0))
     }
 }
 
@@ -181,8 +182,10 @@ async fn cold_resume_observation_preserves_rootfs_when_the_replacement_exits() {
     let sentinel = record.box_dir.join("rootfs/cold-resume-state.txt");
     std::fs::create_dir_all(sentinel.parent().unwrap()).unwrap();
     std::fs::write(&sentinel, b"retained").unwrap();
-    let manager = Arc::new(Mutex::new(backend.new_manager(&record).unwrap()));
-    *manager.lock().await.state.write().await = crate::BoxState::Ready;
+    let mut replacement = backend.new_manager(&record).unwrap();
+    replacement.shim_exit_code = Some(0);
+    *replacement.state.write().await = crate::BoxState::Ready;
+    let manager = Arc::new(Mutex::new(replacement));
     backend
         .managers
         .insert(record.id.clone(), Arc::clone(&manager));
@@ -190,6 +193,7 @@ async fn cold_resume_observation_preserves_rootfs_when_the_replacement_exits() {
     let observation = backend.inspect_registered(&record, manager).await.unwrap();
 
     assert_eq!(observation.state, ExecutionState::Stopped);
+    assert_eq!(observation.exit_code, Some(0));
     assert_eq!(std::fs::read(&sentinel).unwrap(), b"retained");
     assert!(backend.managers.is_empty());
 }
@@ -204,8 +208,9 @@ async fn terminal_health_probe_repolls_the_runtime_exit_code_before_cleanup() {
     {
         let manager = manager.lock().await;
         *manager.state.write().await = crate::BoxState::Ready;
-        *manager.handler.write().await = Some(Box::new(ExitAfterHealthProbeHandler {
+        *manager.handler.write().await = Some(Box::new(DelayedExitStatusHandler {
             exit_polls: Arc::clone(&exit_polls),
+            available_after: 3,
         }));
     }
     backend
@@ -216,8 +221,41 @@ async fn terminal_health_probe_repolls_the_runtime_exit_code_before_cleanup() {
 
     assert_eq!(observation.state, ExecutionState::Stopped);
     assert_eq!(observation.exit_code, Some(0));
-    assert_eq!(exit_polls.load(Ordering::SeqCst), 2);
+    assert_eq!(exit_polls.load(Ordering::SeqCst), 4);
     assert!(backend.managers.is_empty());
+}
+
+#[tokio::test]
+async fn terminal_observation_retains_runtime_without_an_exact_exit_status() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let record = record(temporary.path(), ExecutionIsolation::Sandbox);
+    let exit_polls = Arc::new(AtomicUsize::new(0));
+    let manager = Arc::new(Mutex::new(backend.new_manager(&record).unwrap()));
+    {
+        let manager = manager.lock().await;
+        *manager.state.write().await = crate::BoxState::Ready;
+        *manager.handler.write().await = Some(Box::new(DelayedExitStatusHandler {
+            exit_polls: Arc::clone(&exit_polls),
+            available_after: usize::MAX,
+        }));
+    }
+    backend
+        .managers
+        .insert(record.id.clone(), Arc::clone(&manager));
+
+    let error = backend
+        .inspect_registered(&record, manager)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ExecutionManagerError::Unavailable(message)
+            if message.contains("exact exit status")
+    ));
+    assert!(exit_polls.load(Ordering::SeqCst) > 1);
+    assert!(backend.managers.contains_key(&record.id));
 }
 
 #[test]

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -317,35 +317,36 @@ impl VmLocalExecutionBackend {
             ))
         })?;
         let box_id = record.id.clone();
-        let exit_code = tokio::task::spawn_blocking(move || {
-            let deadline = std::time::Instant::now() + TERMINAL_EXIT_POLL_TIMEOUT;
-            loop {
-                if let Some(exit_code) = crate::sandbox::A3sOciHandler::try_wait_at(
-                    &runtime_socket,
-                    &box_id,
-                    generation,
-                )? {
-                    return Ok(Some(exit_code));
+        let exit_code =
+            tokio::task::spawn_blocking(move || -> a3s_box_core::Result<Option<i32>> {
+                let deadline = std::time::Instant::now() + TERMINAL_EXIT_POLL_TIMEOUT;
+                loop {
+                    if let Some(exit_code) = crate::sandbox::A3sOciHandler::try_wait_at(
+                        &runtime_socket,
+                        &box_id,
+                        generation,
+                    )? {
+                        return Ok(Some(exit_code));
+                    }
+                    if std::time::Instant::now() >= deadline {
+                        return Ok(None);
+                    }
+                    std::thread::sleep(TERMINAL_EXIT_POLL_INTERVAL);
                 }
-                if std::time::Instant::now() >= deadline {
-                    return Ok(None);
-                }
-                std::thread::sleep(TERMINAL_EXIT_POLL_INTERVAL);
-            }
-        })
-        .await
-        .map_err(|error| {
-            ExecutionManagerError::Unavailable(format!(
-                "Sandbox exit-status task failed for {}: {error}",
-                record.id
-            ))
-        })?
-        .map_err(|error| {
-            ExecutionManagerError::Unavailable(format!(
-                "failed to collect exact Sandbox exit status for {}: {error}",
-                record.id
-            ))
-        })?;
+            })
+            .await
+            .map_err(|error| {
+                ExecutionManagerError::Unavailable(format!(
+                    "Sandbox exit-status task failed for {}: {error}",
+                    record.id
+                ))
+            })?
+            .map_err(|error| {
+                ExecutionManagerError::Unavailable(format!(
+                    "failed to collect exact Sandbox exit status for {}: {error}",
+                    record.id
+                ))
+            })?;
         exit_code.ok_or_else(|| {
             ExecutionManagerError::Unavailable(format!(
                 "Sandbox reported execution {} as terminal before its exact exit status became available",

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -60,12 +60,18 @@ impl VmLocalExecutionBackend {
                 })
             }
             "stopped" => {
-                let exit_code = crate::rootfs::read_persisted_exit_code(&record.box_dir);
+                let exit_code = match crate::rootfs::read_persisted_exit_code(&record.box_dir) {
+                    Some(exit_code) => exit_code,
+                    None => {
+                        self.collect_detached_sandbox_exit_code(record, &state)
+                            .await?
+                    }
+                };
                 self.cleanup_detached_sandbox(record).await?;
                 Ok(LocalExecutionObservation {
                     state: ExecutionState::Stopped,
                     handle: None,
-                    exit_code,
+                    exit_code: Some(exit_code),
                 })
             }
             status => Err(ExecutionManagerError::Internal(format!(
@@ -290,6 +296,75 @@ impl VmLocalExecutionBackend {
             self.cleanup_anonymous_volumes(anonymous_volumes).await;
         }
         Ok(KillOutcome::Killed)
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn collect_detached_sandbox_exit_code(
+        &self,
+        record: &BoxRecord,
+        state: &SandboxInspection,
+    ) -> ExecutionManagerResult<i32> {
+        let runtime_socket = state.runtime.runtime_socket.clone().ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "A3S OCI runtime socket is missing for {}",
+                record.id
+            ))
+        })?;
+        let generation = state.runtime.generation.ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "A3S OCI generation is missing for {}",
+                record.id
+            ))
+        })?;
+        let box_id = record.id.clone();
+        let exit_code = tokio::task::spawn_blocking(move || {
+            let deadline = std::time::Instant::now() + TERMINAL_EXIT_POLL_TIMEOUT;
+            loop {
+                if let Some(exit_code) = crate::sandbox::A3sOciHandler::try_wait_at(
+                    &runtime_socket,
+                    &box_id,
+                    generation,
+                )? {
+                    return Ok(Some(exit_code));
+                }
+                if std::time::Instant::now() >= deadline {
+                    return Ok(None);
+                }
+                std::thread::sleep(TERMINAL_EXIT_POLL_INTERVAL);
+            }
+        })
+        .await
+        .map_err(|error| {
+            ExecutionManagerError::Unavailable(format!(
+                "Sandbox exit-status task failed for {}: {error}",
+                record.id
+            ))
+        })?
+        .map_err(|error| {
+            ExecutionManagerError::Unavailable(format!(
+                "failed to collect exact Sandbox exit status for {}: {error}",
+                record.id
+            ))
+        })?;
+        exit_code.ok_or_else(|| {
+            ExecutionManagerError::Unavailable(format!(
+                "Sandbox reported execution {} as terminal before its exact exit status became available",
+                record.id
+            ))
+        })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    async fn collect_detached_sandbox_exit_code(
+        &self,
+        record: &BoxRecord,
+        _state: &SandboxInspection,
+    ) -> ExecutionManagerResult<i32> {
+        Err(unsupported(
+            record,
+            "exit-status recovery",
+            "the Sandbox backend on this host",
+        ))
     }
 
     async fn cleanup_detached_sandbox(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {

--- a/src/runtime/src/sandbox/a3s_oci_client.rs
+++ b/src/runtime/src/sandbox/a3s_oci_client.rs
@@ -148,6 +148,17 @@ impl A3sOciClient {
         self.call(|reply| ClientRequest::Wait(request, reply))
     }
 
+    /// Poll an exact container generation without turning a live process into
+    /// an error. A zero-timeout A3S OCI wait performs one authoritative child
+    /// poll and returns `DeadlineExceeded` only while no exit status exists.
+    pub(crate) fn try_wait(&self, request: WaitRequest) -> Result<Option<ExitStatus>> {
+        match self.call_sdk(|reply| ClientRequest::Wait(request, reply)) {
+            Ok(status) => Ok(Some(status)),
+            Err(error) if error.code == a3s_oci_sdk::ErrorCode::DeadlineExceeded => Ok(None),
+            Err(error) => Err(sdk_error("wait", error)),
+        }
+    }
+
     pub(crate) fn stats(&self, request: StatsRequest) -> Result<ContainerStats> {
         self.call(|reply| ClientRequest::Stats(request, reply))
     }

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -163,6 +163,13 @@ impl A3sOciController {
                     "A3S OCI create did not return the created state".to_string(),
                 ));
             }
+            let created_init_pid = created
+                .state
+                .pid()
+                .and_then(|pid| u32::try_from(pid).ok())
+                .ok_or_else(|| {
+                    BoxError::StateError("A3S OCI create returned no valid init PID".to_string())
+                })?;
             target = Some(exact_target.clone());
 
             let started = lifecycle_client.start(StartRequest {
@@ -170,20 +177,17 @@ impl A3sOciController {
                 target: exact_target.clone(),
             })?;
             validate_record(&started, &exact_target, None)?;
-            if *started.state.status() != OciContainerState::Running
-                || started.driver != DriverKind::NativeLinux
-            {
+            let started_status = *started.state.status();
+            if started.driver != DriverKind::NativeLinux {
                 return Err(BoxError::StateError(
-                    "A3S OCI start did not return a running native Linux container".to_string(),
+                    "A3S OCI start did not return a native Linux container".to_string(),
                 ));
             }
-            let init_pid = started
-                .state
-                .pid()
-                .and_then(|pid| u32::try_from(pid).ok())
-                .ok_or_else(|| {
-                    BoxError::StateError("A3S OCI start returned no valid init PID".to_string())
-                })?;
+            let init_pid = started_generation_init_pid(
+                created_init_pid,
+                started_status,
+                *started.state.pid(),
+            )?;
             Ok((init_pid, started.generation))
         }
         .await;
@@ -362,6 +366,37 @@ fn validate_required_operations(info: &a3s_oci_sdk::RuntimeInfo) -> Result<()> {
     Ok(())
 }
 
+fn started_generation_init_pid(
+    created_init_pid: u32,
+    status: OciContainerState,
+    started_init_pid: Option<i32>,
+) -> Result<u32> {
+    match status {
+        OciContainerState::Running => {
+            let started_init_pid = started_init_pid
+                .and_then(|pid| u32::try_from(pid).ok())
+                .ok_or_else(|| {
+                    BoxError::StateError(
+                        "A3S OCI running state returned no valid init PID".to_string(),
+                    )
+                })?;
+            if started_init_pid != created_init_pid {
+                return Err(BoxError::StateError(
+                    "A3S OCI start changed the init PID".to_string(),
+                ));
+            }
+            Ok(started_init_pid)
+        }
+        // OCI stopped state deliberately has no live PID. Retain the exact
+        // PID allocated behind the create/start barrier so the durable Box
+        // record still identifies this generation.
+        OciContainerState::Stopped => Ok(created_init_pid),
+        _ => Err(BoxError::StateError(
+            "A3S OCI start did not return a running or stopped container".to_string(),
+        )),
+    }
+}
+
 fn operation_context(container_id: &str, operation: &str) -> Result<OperationContext> {
     OperationId::new(format!("{container_id}-{operation}"))
         .map(OperationContext::new)
@@ -430,5 +465,36 @@ fn sdk_boot_error(error: a3s_oci_sdk::Error) -> BoxError {
     BoxError::BoxBootError {
         message: format!("A3S OCI SDK rejected Sandbox launch: {error}"),
         hint: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stopped_start_retains_the_created_generation_pid() {
+        let init_pid =
+            started_generation_init_pid(4_242, OciContainerState::Stopped, None).unwrap();
+
+        assert_eq!(init_pid, 4_242);
+    }
+
+    #[test]
+    fn running_start_requires_the_same_generation_pid() {
+        let error = started_generation_init_pid(4_242, OciContainerState::Running, Some(4_243))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("changed the init PID"));
+    }
+
+    #[test]
+    fn start_rejects_non_terminal_contract_states() {
+        let error = started_generation_init_pid(4_242, OciContainerState::Created, Some(4_242))
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("did not return a running or stopped container"));
     }
 }

--- a/src/runtime/src/sandbox/a3s_oci_handler.rs
+++ b/src/runtime/src/sandbox/a3s_oci_handler.rs
@@ -137,6 +137,25 @@ impl A3sOciHandler {
             .transpose()
     }
 
+    /// Poll the exact detached A3S OCI generation for its terminal status.
+    /// The runtime retains this status until Box explicitly deletes it.
+    pub(crate) fn try_wait_at(
+        runtime_socket: &Path,
+        container_id: &str,
+        generation: u64,
+    ) -> Result<Option<i32>> {
+        let client = A3sOciClient::connect_blocking(runtime_socket.to_path_buf())?;
+        let id = ContainerId::new(container_id).map_err(sdk_argument_error)?;
+        let result = client
+            .try_wait(WaitRequest {
+                target: ContainerTarget::exact(id, Generation(generation)),
+                timeout_ms: Some(0),
+            })
+            .map(|status| status.map(|status| exit_code(&status)));
+        client.close();
+        result
+    }
+
     pub(crate) fn pause_at(
         runtime_socket: &Path,
         container_id: &str,
@@ -419,13 +438,16 @@ impl VmHandler for A3sOciHandler {
     }
 
     fn try_wait_exit(&mut self) -> Result<Option<i32>> {
-        if self
-            .query_state()?
-            .is_some_and(|record| *record.state.status() != OciContainerState::Stopped)
-        {
-            return Ok(None);
+        if self.exit_code.is_none() {
+            let Some(status) = self.client.try_wait(WaitRequest {
+                target: self.target.clone(),
+                timeout_ms: Some(0),
+            })?
+            else {
+                return Ok(None);
+            };
+            self.exit_code = Some(exit_code(&status));
         }
-        self.capture_exit_status()?;
         let exit_code = self.exit_code;
         self.delete_runtime_state()?;
         Ok(exit_code)

--- a/src/runtime/src/sandbox/a3s_oci_handler.rs
+++ b/src/runtime/src/sandbox/a3s_oci_handler.rs
@@ -448,9 +448,10 @@ impl VmHandler for A3sOciHandler {
             };
             self.exit_code = Some(exit_code(&status));
         }
-        let exit_code = self.exit_code;
-        self.delete_runtime_state()?;
-        Ok(exit_code)
+        // Polling observes completion but does not own teardown. Keeping the
+        // terminal generation lets the backend complete its one authoritative
+        // destroy path after it has durably projected this exact status.
+        Ok(self.exit_code)
     }
 }
 

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -1189,6 +1189,10 @@ const ALLOWED_SYSCALLS: &[&str] = &[
     "setsid",
     "setsockopt",
     "setuid",
+    "shmat",
+    "shmctl",
+    "shmdt",
+    "shmget",
     "shutdown",
     "sigaltstack",
     "signalfd",
@@ -1384,6 +1388,24 @@ mod tests {
             "userfaultfd",
             "reboot",
         ] {
+            assert!(!allowed_names.iter().any(|name| name == forbidden));
+        }
+    }
+
+    #[test]
+    fn seccomp_allows_namespaced_sysv_shared_memory_for_postgresql() {
+        let value = as_json(&compile_oci_spec(&sample_input()).unwrap());
+        let allowed_names = value["linux"]["seccomp"]["syscalls"][0]["names"]
+            .as_array()
+            .unwrap();
+
+        for required in ["shmat", "shmctl", "shmdt", "shmget"] {
+            assert!(
+                allowed_names.iter().any(|name| name == required),
+                "missing {required}"
+            );
+        }
+        for forbidden in ["mount", "setns", "unshare", "bpf"] {
             assert!(!allowed_names.iter().any(|name| name == forbidden));
         }
     }

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -2016,6 +2016,10 @@ mod tests {
             42
         }
 
+        fn exit_code(&self) -> Option<i32> {
+            Some(self.code)
+        }
+
         fn try_wait_exit(&mut self) -> Result<Option<i32>> {
             Ok(Some(self.code))
         }
@@ -2114,6 +2118,25 @@ mod tests {
         assert_eq!(vm.anonymous_volumes, vec!["reused-volume".to_string()]);
         assert!(store.get("created-volume").unwrap().is_none());
         assert!(store.get("reused-volume").unwrap().is_some());
+        assert!(!box_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_boot_failure_retains_an_exact_terminal_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let box_id = "box-completed-during-boot".to_string();
+        let mut vm =
+            VmManager::with_box_id(BoxConfig::default(), EventEmitter::new(16), box_id.clone());
+        vm.home_dir = tmp.path().to_path_buf();
+        *vm.handler.write().await = Some(Box::new(CompletedHandler { code: 23 }));
+
+        let box_dir = tmp.path().join("boxes").join(&box_id);
+        std::fs::create_dir_all(box_dir.join("logs")).unwrap();
+
+        vm.cleanup_boot_failure().await;
+
+        assert_eq!(vm.exit_code(), Some(23));
+        assert!(vm.handler.read().await.is_none());
         assert!(!box_dir.exists());
     }
 


### PR DESCRIPTION
## Summary

- retain bounded R17 diagnostics before cleanup when a managed Sandbox reaches cleanup without an exit code
- capture the exact task logs, persisted exit marker, and runtime identity needed to fix the startup/inspection race without weakening provider-loss semantics

## Context

First diagnostic step for #175. A follow-up commit on this PR will apply the lifecycle fix based on the real-host evidence; Cloud will pin the exact PR revision while certifying it.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`

Relates to #175.