### PR TITLE
fix(sandbox): preserve init paths and make recovery replay-safe

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0f0face67c282cf535e352b4fe83af02055b7e08#0f0face67c282cf535e352b4fe83af02055b7e08"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=771e5e27d005ed9eb2f52e19bdc64a43a6e4ff87#771e5e27d005ed9eb2f52e19bdc64a43a6e4ff87"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -282,7 +282,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0f0face67c282cf535e352b4fe83af02055b7e08#0f0face67c282cf535e352b4fe83af02055b7e08"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=771e5e27d005ed9eb2f52e19bdc64a43a6e4ff87#771e5e27d005ed9eb2f52e19bdc64a43a6e4ff87"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -2408,7 +2408,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3293,7 +3293,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,7 +125,7 @@ ring = "0.17"
 a3s-acl = { version = "0.2.2", git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "b0aa0c34e2c8121effbcbfbe6246a860e78ca509" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "0f0face67c282cf535e352b4fe83af02055b7e08" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "771e5e27d005ed9eb2f52e19bdc64a43a6e4ff87" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
@@ -194,7 +194,10 @@ async fn cancelled_task_apply_is_replayable(fixture: &BoxRuntimeConformanceFixtu
     require(
         recovered.state == RuntimeUnitState::Succeeded
             && recovered.provider_resource_id.as_deref() == Some(provider_id.as_str()),
-        "cancelled Task replay did not reattach to the original provider identity",
+        format!(
+            "cancelled Task replay did not reattach to the original provider identity: state={:?}, provider_resource_id={:?}, expected_provider_resource_id={provider_id}",
+            recovered.state, recovered.provider_resource_id
+        ),
     )?;
     let records = fixture
         .records_for(&restarted_driver, &request.spec)

--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -1,9 +1,13 @@
+use std::sync::Arc;
+use std::time::Duration;
+
 use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitClass, RuntimeUnitState};
 use a3s_runtime::{RuntimeDriver, RuntimeError};
 
 use super::metadata::GENERATION_LABEL;
 use super::test_support::{
     accepted, action, fake_driver, fake_driver_with_backend, runtime_spec, unit, unknown,
+    DriverFakeBackend,
 };
 
 #[tokio::test]
@@ -230,4 +234,63 @@ async fn startup_failure_without_exit_code_preserves_the_provider_error() {
         Err(RuntimeError::ProviderUnavailable(message))
             if message == "fake start response was lost"
     ));
+}
+
+#[tokio::test]
+async fn cancelled_task_inspection_completes_before_replay() {
+    let directory = tempfile::tempdir().unwrap();
+    let backend = Arc::new(DriverFakeBackend::default());
+    backend.arm_cancelled_inspection();
+    let driver = Arc::new(fake_driver_with_backend(&directory, Arc::clone(&backend)));
+    let mut spec = runtime_spec("cancelled-task-inspection", 1, RuntimeUnitClass::Task);
+    spec.resources.execution_timeout_ms = Some(2_000);
+    let current = accepted(&spec);
+    let apply = {
+        let driver = Arc::clone(&driver);
+        let spec = spec.clone();
+        let current = current.clone();
+        tokio::spawn(async move { driver.apply(&spec, &current).await })
+    };
+
+    backend.wait_for_cancelled_inspection().await;
+    let records = driver.manager.managed_records().await.unwrap();
+    assert_eq!(records.len(), 1);
+    let provider_id = records[0].id.clone();
+
+    apply.abort();
+    assert!(apply.await.unwrap_err().is_cancelled());
+
+    let restarted = Arc::new(fake_driver_with_backend(&directory, Arc::clone(&backend)));
+    let mut replay = {
+        let restarted = Arc::clone(&restarted);
+        let spec = spec.clone();
+        let current = current.clone();
+        tokio::spawn(async move { restarted.apply(&spec, &current).await })
+    };
+    let early = tokio::time::timeout(Duration::from_millis(50), &mut replay).await;
+    backend.release_cancelled_inspection();
+    let (waited_for_original_inspection, recovered) = match early {
+        Ok(result) => (false, result.unwrap().unwrap()),
+        Err(_) => (
+            true,
+            tokio::time::timeout(Duration::from_secs(2), replay)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap(),
+        ),
+    };
+
+    assert!(
+        waited_for_original_inspection,
+        "replay bypassed the cancelled inspection's lifecycle lock"
+    );
+    assert_eq!(recovered.state, RuntimeUnitState::Succeeded);
+    assert_eq!(
+        recovered.provider_resource_id.as_deref(),
+        Some(provider_id.as_str())
+    );
+    let records = restarted.manager.managed_records().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].id, provider_id);
 }

--- a/src/runtime/src/a3s_runtime_driver/test_support.rs
+++ b/src/runtime/src/a3s_runtime_driver/test_support.rs
@@ -13,6 +13,7 @@ use a3s_runtime::contract::{
 };
 use a3s_runtime::RuntimeUnitRecord;
 use async_trait::async_trait;
+use tokio::sync::{oneshot, Semaphore};
 
 use crate::{
     BoxRecord, LocalExecutionBackend, LocalExecutionHandle, LocalExecutionManager,
@@ -28,13 +29,32 @@ struct FakeExecution {
     exit_code: Option<i32>,
 }
 
+struct CancelledInspection {
+    claimed: AtomicBool,
+    completed: AtomicBool,
+    started: Semaphore,
+    release: Semaphore,
+}
+
+impl CancelledInspection {
+    fn new() -> Self {
+        Self {
+            claimed: AtomicBool::new(false),
+            completed: AtomicBool::new(false),
+            started: Semaphore::new(0),
+            release: Semaphore::new(0),
+        }
+    }
+}
+
 #[derive(Default)]
 pub(super) struct DriverFakeBackend {
-    executions: Mutex<HashMap<String, FakeExecution>>,
+    executions: Arc<Mutex<HashMap<String, FakeExecution>>>,
     starts: AtomicUsize,
     kills: AtomicUsize,
     fail_start_after_effect: AtomicBool,
     next_start_terminal: Mutex<Option<(ExecutionState, Option<i32>)>>,
+    cancelled_inspection: Mutex<Option<Arc<CancelledInspection>>>,
 }
 
 impl DriverFakeBackend {
@@ -108,6 +128,35 @@ impl DriverFakeBackend {
     pub(super) fn kills(&self) -> usize {
         self.kills.load(Ordering::SeqCst)
     }
+
+    pub(super) fn arm_cancelled_inspection(&self) {
+        *self.cancelled_inspection.lock().unwrap() = Some(Arc::new(CancelledInspection::new()));
+    }
+
+    pub(super) async fn wait_for_cancelled_inspection(&self) {
+        let inspection = self
+            .cancelled_inspection
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("cancelled inspection must be armed");
+        inspection
+            .started
+            .acquire()
+            .await
+            .expect("cancelled inspection start semaphore must remain open")
+            .forget();
+    }
+
+    pub(super) fn release_cancelled_inspection(&self) {
+        self.cancelled_inspection
+            .lock()
+            .unwrap()
+            .as_ref()
+            .expect("cancelled inspection must be armed")
+            .release
+            .add_permits(1);
+    }
 }
 
 #[async_trait]
@@ -146,6 +195,41 @@ impl LocalExecutionBackend for DriverFakeBackend {
         &self,
         record: &BoxRecord,
     ) -> ExecutionManagerResult<LocalExecutionObservation> {
+        let cancelled_inspection = self.cancelled_inspection.lock().unwrap().clone();
+        if let Some(inspection) = cancelled_inspection {
+            if inspection
+                .claimed
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                let executions = Arc::clone(&self.executions);
+                let execution_id = record.id.clone();
+                let inspection_task = Arc::clone(&inspection);
+                let (completed_tx, completed_rx) = oneshot::channel();
+                tokio::spawn(async move {
+                    inspection_task.started.add_permits(1);
+                    inspection_task
+                        .release
+                        .acquire()
+                        .await
+                        .expect("cancelled inspection release semaphore must remain open")
+                        .forget();
+                    if let Some(execution) = executions.lock().unwrap().get_mut(&execution_id) {
+                        execution.state = ExecutionState::Stopped;
+                        execution.exit_code = Some(0);
+                    }
+                    inspection_task.completed.store(true, Ordering::SeqCst);
+                    let _ = completed_tx.send(());
+                });
+                completed_rx.await.map_err(|error| {
+                    ExecutionManagerError::Internal(format!(
+                        "cancelled fake inspection task failed: {error}"
+                    ))
+                })?;
+            } else if !inspection.completed.load(Ordering::SeqCst) {
+                return Err(ExecutionManagerError::NotFound(Self::execution_id(record)));
+            }
+        }
         let executions = self.executions.lock().unwrap();
         let execution = executions
             .get(&record.id)
@@ -203,10 +287,13 @@ pub(super) fn fake_driver(
     (driver, backend)
 }
 
-pub(super) fn fake_driver_with_backend(
+pub(super) fn fake_driver_with_backend<B>(
     directory: &tempfile::TempDir,
-    backend: Arc<DriverFakeBackend>,
-) -> BoxRuntimeDriver {
+    backend: Arc<B>,
+) -> BoxRuntimeDriver
+where
+    B: LocalExecutionBackend + 'static,
+{
     let home_dir = directory.path().join("home");
     let manager =
         LocalExecutionManager::new(home_dir.join("boxes.json"), &home_dir, backend.clone());

--- a/src/runtime/src/local_execution/api.rs
+++ b/src/runtime/src/local_execution/api.rs
@@ -48,15 +48,31 @@ impl ExecutionManager for LocalExecutionManager {
     }
 
     async fn inspect(&self, execution_id: &ExecutionId) -> ExecutionManagerResult<ExecutionStatus> {
-        let _lifecycle_lock =
+        let lifecycle_lock =
             super::lifecycle_lock::acquire(&self.home_dir, execution_id.as_str()).await?;
-        let record = self
-            .get(execution_id)
-            .await?
-            .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
-        let record = self.stabilize_snapshot(record).await?;
-        let (record, state) = self.observe_record(record).await?;
-        status_from_record(&record, state)
+        let manager = self.clone();
+        let execution_id = execution_id.clone();
+        let execution_id_label = execution_id.clone();
+        tokio::spawn(async move {
+            // Inspection can reconcile provider state, release resources, and
+            // persist a terminal observation. Once its lifecycle lock has been
+            // acquired, finish that projection even if the caller is cancelled;
+            // a replay must wait for this same authoritative operation.
+            let _lifecycle_lock = lifecycle_lock;
+            let record = manager
+                .get(&execution_id)
+                .await?
+                .ok_or_else(|| ExecutionManagerError::NotFound(execution_id.clone()))?;
+            let record = manager.stabilize_snapshot(record).await?;
+            let (record, state) = manager.observe_record(record).await?;
+            status_from_record(&record, state)
+        })
+        .await
+        .map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "inspection task failed for {execution_id_label}: {error}"
+            ))
+        })?
     }
 
     async fn read_logs(

--- a/src/runtime/src/local_execution/inspection_cancellation_tests.rs
+++ b/src/runtime/src/local_execution/inspection_cancellation_tests.rs
@@ -1,0 +1,259 @@
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use a3s_box_core::{
+    BoxConfig, CreateExecutionRequest, ExecutionId, ExecutionIsolation, ExecutionManager,
+    ExecutionManagerError, ExecutionManagerResult, ExecutionState, KillOutcome, NetworkMode,
+    OperationId,
+};
+use async_trait::async_trait;
+use tokio::sync::{oneshot, Semaphore};
+
+use super::{
+    LocalExecutionBackend, LocalExecutionHandle, LocalExecutionManager, LocalExecutionObservation,
+};
+use crate::{ManagedExecutionState, ManagedExecutionStore};
+
+#[derive(Clone)]
+struct FakeExecution {
+    state: ExecutionState,
+    handle: LocalExecutionHandle,
+    exit_code: Option<i32>,
+}
+
+struct InspectionControl {
+    claimed: AtomicBool,
+    completed: AtomicBool,
+    started: Semaphore,
+    release: Semaphore,
+}
+
+impl InspectionControl {
+    fn new() -> Self {
+        Self {
+            claimed: AtomicBool::new(false),
+            completed: AtomicBool::new(false),
+            started: Semaphore::new(0),
+            release: Semaphore::new(0),
+        }
+    }
+
+    async fn wait_until_started(&self) {
+        self.started
+            .acquire()
+            .await
+            .expect("inspection start semaphore must remain open")
+            .forget();
+    }
+
+    fn release(&self) {
+        self.release.add_permits(1);
+    }
+}
+
+struct CancellationBackend {
+    execution: Arc<Mutex<Option<FakeExecution>>>,
+    inspection: Arc<InspectionControl>,
+}
+
+impl CancellationBackend {
+    fn new() -> Self {
+        Self {
+            execution: Arc::new(Mutex::new(None)),
+            inspection: Arc::new(InspectionControl::new()),
+        }
+    }
+
+    fn execution_id(record: &crate::BoxRecord) -> ExecutionId {
+        ExecutionId::new(record.id.clone()).unwrap()
+    }
+
+    fn handle(record: &crate::BoxRecord) -> LocalExecutionHandle {
+        LocalExecutionHandle {
+            started_at: chrono::Utc::now(),
+            pid: Some(std::process::id()),
+            pid_start_time: crate::process::pid_start_time(std::process::id()),
+            exec_socket_path: record.box_dir.join("sockets/exec.sock"),
+            console_log: record.box_dir.join("logs/console.log"),
+            anonymous_volumes: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl LocalExecutionBackend for CancellationBackend {
+    async fn start(
+        &self,
+        record: &crate::BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionHandle> {
+        let handle = Self::handle(record);
+        *self.execution.lock().unwrap() = Some(FakeExecution {
+            state: ExecutionState::Running,
+            handle: handle.clone(),
+            exit_code: None,
+        });
+        Ok(handle)
+    }
+
+    async fn inspect(
+        &self,
+        record: &crate::BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionObservation> {
+        if self
+            .inspection
+            .claimed
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            let execution = Arc::clone(&self.execution);
+            let inspection = Arc::clone(&self.inspection);
+            let (completed_tx, completed_rx) = oneshot::channel();
+            tokio::spawn(async move {
+                inspection.started.add_permits(1);
+                inspection
+                    .release
+                    .acquire()
+                    .await
+                    .expect("inspection release semaphore must remain open")
+                    .forget();
+                if let Some(execution) = execution.lock().unwrap().as_mut() {
+                    execution.state = ExecutionState::Stopped;
+                    execution.exit_code = Some(0);
+                }
+                inspection.completed.store(true, Ordering::SeqCst);
+                let _ = completed_tx.send(());
+            });
+            completed_rx.await.map_err(|error| {
+                ExecutionManagerError::Internal(format!("detached inspection task failed: {error}"))
+            })?;
+        } else if !self.inspection.completed.load(Ordering::SeqCst) {
+            return Err(ExecutionManagerError::NotFound(Self::execution_id(record)));
+        }
+
+        let execution = self.execution.lock().unwrap();
+        let execution = execution
+            .as_ref()
+            .ok_or_else(|| ExecutionManagerError::NotFound(Self::execution_id(record)))?;
+        Ok(LocalExecutionObservation {
+            state: execution.state,
+            handle: matches!(
+                execution.state,
+                ExecutionState::Running | ExecutionState::Paused
+            )
+            .then(|| execution.handle.clone()),
+            exit_code: execution.exit_code,
+        })
+    }
+
+    async fn pause(
+        &self,
+        record: &crate::BoxRecord,
+        _keep_memory: bool,
+    ) -> ExecutionManagerResult<LocalExecutionHandle> {
+        Err(ExecutionManagerError::Unavailable(format!(
+            "fake pause is unavailable for {}",
+            record.id
+        )))
+    }
+
+    async fn resume(
+        &self,
+        record: &crate::BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionHandle> {
+        Err(ExecutionManagerError::Unavailable(format!(
+            "fake resume is unavailable for {}",
+            record.id
+        )))
+    }
+
+    async fn kill(&self, record: &crate::BoxRecord) -> ExecutionManagerResult<KillOutcome> {
+        let mut execution = self.execution.lock().unwrap();
+        let execution = execution
+            .as_mut()
+            .ok_or_else(|| ExecutionManagerError::NotFound(Self::execution_id(record)))?;
+        if execution.state == ExecutionState::Stopped {
+            Ok(KillOutcome::AlreadyStopped)
+        } else {
+            execution.state = ExecutionState::Stopped;
+            Ok(KillOutcome::Killed)
+        }
+    }
+}
+
+fn request() -> CreateExecutionRequest {
+    CreateExecutionRequest {
+        external_sandbox_id: "cancelled-inspection".to_string(),
+        config: BoxConfig {
+            image: "alpine:3.20".to_string(),
+            isolation: ExecutionIsolation::Sandbox,
+            network: NetworkMode::None,
+            ..Default::default()
+        },
+        labels: BTreeMap::new(),
+        policy: Default::default(),
+        rootfs_snapshot_id: None,
+    }
+}
+
+#[tokio::test]
+async fn cancelled_inspection_keeps_its_lifecycle_lock_until_projection_finishes() {
+    let directory = tempfile::tempdir().unwrap();
+    let home_dir = directory.path().join("home");
+    let state_path = directory.path().join("boxes.json");
+    let backend = Arc::new(CancellationBackend::new());
+    let manager = LocalExecutionManager::new(&state_path, &home_dir, backend.clone());
+    let lease = manager
+        .create_and_start(
+            request(),
+            &OperationId::new("cancelled-inspection-operation").unwrap(),
+        )
+        .await
+        .unwrap();
+    let execution_id = lease.execution_id;
+
+    let first = {
+        let manager = manager.clone();
+        let execution_id = execution_id.clone();
+        tokio::spawn(async move { manager.inspect(&execution_id).await })
+    };
+    backend.inspection.wait_until_started().await;
+    first.abort();
+    assert!(first.await.unwrap_err().is_cancelled());
+
+    let restarted = LocalExecutionManager::new(&state_path, &home_dir, backend.clone());
+    let mut replay = {
+        let restarted = restarted.clone();
+        let execution_id = execution_id.clone();
+        tokio::spawn(async move { restarted.inspect(&execution_id).await })
+    };
+    let early = tokio::time::timeout(Duration::from_millis(50), &mut replay).await;
+    backend.inspection.release();
+    let (waited_for_original_inspection, status) = match early {
+        Ok(result) => (false, result.unwrap().unwrap()),
+        Err(_) => (
+            true,
+            tokio::time::timeout(Duration::from_secs(2), replay)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap(),
+        ),
+    };
+
+    assert!(
+        waited_for_original_inspection,
+        "replay bypassed the cancelled inspection's lifecycle lock"
+    );
+    assert_eq!(status.state, ExecutionState::Stopped);
+    let record = ManagedExecutionStore::new(state_path)
+        .get(&execution_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        record.managed_state().unwrap(),
+        Some(ManagedExecutionState::Stopped)
+    );
+    assert_eq!(record.exit_code, Some(0));
+}

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -3,6 +3,8 @@
 mod api;
 mod backend;
 mod create;
+#[cfg(test)]
+mod inspection_cancellation_tests;
 mod lifecycle_lock;
 pub use lifecycle_lock::{
     acquire_blocking as acquire_execution_lifecycle_lock, ExecutionLifecycleLock,

--- a/src/runtime/src/process.rs
+++ b/src/runtime/src/process.rs
@@ -108,6 +108,11 @@ pub(crate) fn wait_for_process_stop_with_identity(
     let deadline = std::time::Instant::now() + timeout;
     loop {
         if !is_process_running_with_identity(pid, Some(expected_start_time)) {
+            // Recovery can discard the original `Child` handle while the
+            // runtime owner remains our child. Reap that completed child when
+            // possible, while preserving the stopped semantics for processes
+            // owned by another parent.
+            let _ = try_reap_exited_child_with_identity(pid, expected_start_time);
             return true;
         }
         if std::time::Instant::now() >= deadline {
@@ -131,27 +136,44 @@ pub(crate) fn wait_for_process_exit_with_identity(
     expected_start_time: u64,
     timeout: std::time::Duration,
 ) -> bool {
-    let Ok(raw_pid) = i32::try_from(pid) else {
-        return false;
-    };
     let deadline = std::time::Instant::now() + timeout;
     loop {
         if !is_process_alive_with_identity(pid, Some(expected_start_time)) {
             return true;
         }
-        if !is_process_running_with_identity(pid, Some(expected_start_time)) {
-            let mut status = 0;
-            let waited = unsafe { libc::waitpid(raw_pid, &mut status, libc::WNOHANG) };
-            if waited == raw_pid || !is_process_alive_with_identity(pid, Some(expected_start_time))
-            {
-                return true;
-            }
+        if !is_process_running_with_identity(pid, Some(expected_start_time))
+            && try_reap_exited_child_with_identity(pid, expected_start_time)
+        {
+            return true;
         }
         if std::time::Instant::now() >= deadline {
             return false;
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
+}
+
+/// Try to reap an exited process when it is a child of the current process.
+///
+/// Returns `true` once the recorded identity has disappeared. `false` means
+/// the process is still present and must be reaped by its owning parent.
+#[cfg(target_os = "linux")]
+fn try_reap_exited_child_with_identity(pid: u32, expected_start_time: u64) -> bool {
+    if !is_process_alive_with_identity(pid, Some(expected_start_time)) {
+        return true;
+    }
+
+    let Ok(raw_pid) = i32::try_from(pid) else {
+        return false;
+    };
+    let mut status = 0;
+    let waited = unsafe { libc::waitpid(raw_pid, &mut status, libc::WNOHANG) };
+    waited == raw_pid || !is_process_alive_with_identity(pid, Some(expected_start_time))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn try_reap_exited_child_with_identity(pid: u32, expected_start_time: u64) -> bool {
+    !is_process_alive_with_identity(pid, Some(expected_start_time))
 }
 
 #[cfg(target_os = "linux")]
@@ -237,18 +259,18 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn stop_waiter_accepts_an_unreaped_completed_child() {
-        let mut child = std::process::Command::new("true").spawn().unwrap();
+    #[allow(clippy::zombie_processes)] // Deliberately drop Child to exercise recovered waitpid.
+    fn stop_waiter_reaps_an_exited_child() {
+        let child = std::process::Command::new("true").spawn().unwrap();
         let pid = child.id();
         let start_time = pid_start_time(pid).unwrap();
+        drop(child);
 
         assert!(wait_for_process_stop_with_identity(
             pid,
             start_time,
             std::time::Duration::from_secs(1),
         ));
-        assert!(!is_process_running_with_identity(pid, Some(start_time)));
-
-        child.wait().unwrap();
+        assert!(!is_process_alive_with_identity(pid, Some(start_time)));
     }
 }

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -419,18 +419,7 @@ fn cleanup_failed_owner(
         client.close();
     }
     let pid = owner.id();
-    if crate::process::is_process_alive_with_identity(pid, Some(owner_pid_start_time)) {
-        if let Ok(pid) = i32::try_from(pid) {
-            unsafe {
-                libc::kill(pid, libc::SIGTERM);
-            }
-        }
-    }
-    if !crate::process::wait_for_process_exit_with_identity(
-        pid,
-        owner_pid_start_time,
-        super::A3S_OCI_OWNER_EXIT_TIMEOUT,
-    ) {
+    if super::a3s_oci_owner::stop(pid, owner_pid_start_time).is_err() {
         let _ = owner.kill();
     }
     let _ = owner.wait();

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -25,8 +25,6 @@ use super::runtime_record::SandboxRuntimeRecord;
 use super::CertifiedA3sOci;
 
 const START_FAILURE_LOG_LIMIT_BYTES: u64 = 4 * 1024;
-const OWNER_EXIT_TIMEOUT: Duration = Duration::from_secs(3);
-
 /// Controller pinned to one verified runtime/agent artifact pair.
 pub struct A3sOciController {
     runtime: CertifiedA3sOci,
@@ -431,7 +429,7 @@ fn cleanup_failed_owner(
     if !crate::process::wait_for_process_exit_with_identity(
         pid,
         owner_pid_start_time,
-        OWNER_EXIT_TIMEOUT,
+        super::A3S_OCI_OWNER_EXIT_TIMEOUT,
     ) {
         let _ = owner.kill();
     }

--- a/src/runtime/src/sandbox/a3s_oci_handler.rs
+++ b/src/runtime/src/sandbox/a3s_oci_handler.rs
@@ -17,7 +17,6 @@ use sysinfo::{Pid, System};
 use super::a3s_oci_client::A3sOciClient;
 
 const SIGKILL_NUMBER: i32 = 9;
-const OWNER_EXIT_TIMEOUT: Duration = Duration::from_secs(3);
 const LIFECYCLE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const CLEANUP_RETRY_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -282,7 +281,7 @@ impl A3sOciHandler {
         if !crate::process::wait_for_process_stop_with_identity(
             self.owner_pid,
             self.owner_pid_start_time,
-            OWNER_EXIT_TIMEOUT,
+            super::A3S_OCI_OWNER_EXIT_TIMEOUT,
         ) {
             if crate::process::is_process_running_with_identity(
                 self.owner_pid,

--- a/src/runtime/src/sandbox/a3s_oci_handler.rs
+++ b/src/runtime/src/sandbox/a3s_oci_handler.rs
@@ -267,44 +267,7 @@ impl A3sOciHandler {
     }
 
     fn stop_owner(&mut self) -> Result<()> {
-        if crate::process::is_process_running_with_identity(
-            self.owner_pid,
-            Some(self.owner_pid_start_time),
-        ) {
-            let owner_pid = i32::try_from(self.owner_pid).map_err(|_| {
-                BoxError::StateError("A3S OCI owner PID does not fit i32".to_string())
-            })?;
-            if unsafe { libc::kill(owner_pid, libc::SIGTERM) } != 0 {
-                return Err(BoxError::IoError(std::io::Error::last_os_error()));
-            }
-        }
-        if !crate::process::wait_for_process_stop_with_identity(
-            self.owner_pid,
-            self.owner_pid_start_time,
-            super::A3S_OCI_OWNER_EXIT_TIMEOUT,
-        ) {
-            if crate::process::is_process_running_with_identity(
-                self.owner_pid,
-                Some(self.owner_pid_start_time),
-            ) {
-                let owner_pid = i32::try_from(self.owner_pid).map_err(|_| {
-                    BoxError::StateError("A3S OCI owner PID does not fit i32".to_string())
-                })?;
-                unsafe {
-                    libc::kill(owner_pid, libc::SIGKILL);
-                }
-            }
-            if !crate::process::wait_for_process_stop_with_identity(
-                self.owner_pid,
-                self.owner_pid_start_time,
-                Duration::from_secs(1),
-            ) {
-                return Err(BoxError::StateError(format!(
-                    "A3S OCI runtime owner {} did not exit",
-                    self.owner_pid
-                )));
-            }
-        }
+        super::a3s_oci_owner::stop(self.owner_pid, self.owner_pid_start_time)?;
         if let Some(mut owner) = self.owner.take() {
             let _ = owner.try_wait();
             let _ = owner.wait();

--- a/src/runtime/src/sandbox/a3s_oci_owner.rs
+++ b/src/runtime/src/sandbox/a3s_oci_owner.rs
@@ -1,0 +1,131 @@
+//! Identity-fenced shutdown of a native A3S OCI runtime owner.
+
+use std::time::Duration;
+
+use a3s_box_core::error::{BoxError, Result};
+
+const FORCED_EXIT_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Stop one exact native-service process without risking a reused PID.
+pub(crate) fn stop(owner_pid: u32, owner_start_time: u64) -> Result<()> {
+    stop_with_timeouts(
+        owner_pid,
+        owner_start_time,
+        Duration::from_millis(super::A3S_OCI_LIFECYCLE_TIMEOUT_MS),
+        FORCED_EXIT_TIMEOUT,
+    )
+}
+
+fn stop_with_timeouts(
+    owner_pid: u32,
+    owner_start_time: u64,
+    graceful_timeout: Duration,
+    forced_timeout: Duration,
+) -> Result<()> {
+    signal_if_running(owner_pid, owner_start_time, libc::SIGTERM)?;
+    if crate::process::wait_for_process_stop_with_identity(
+        owner_pid,
+        owner_start_time,
+        graceful_timeout,
+    ) {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        owner_pid,
+        graceful_timeout_ms = %graceful_timeout.as_millis(),
+        "A3S OCI runtime owner exceeded graceful shutdown; forcing exit"
+    );
+    signal_if_running(owner_pid, owner_start_time, libc::SIGKILL)?;
+    if crate::process::wait_for_process_stop_with_identity(
+        owner_pid,
+        owner_start_time,
+        forced_timeout,
+    ) {
+        Ok(())
+    } else {
+        Err(BoxError::StateError(format!(
+            "A3S OCI runtime owner {owner_pid} did not exit"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::BufRead;
+    use std::process::{Command, Stdio};
+
+    use super::*;
+
+    #[test]
+    fn stop_forces_an_identity_fenced_owner_that_ignores_sigterm() {
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "trap '' TERM; echo ready; exec sleep 3600"])
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        let start_time = crate::process::pid_start_time(pid).unwrap();
+        let mut ready = String::new();
+        std::io::BufReader::new(child.stdout.take().unwrap())
+            .read_line(&mut ready)
+            .unwrap();
+        assert_eq!(ready, "ready\n");
+
+        let result = stop_with_timeouts(
+            pid,
+            start_time,
+            Duration::from_millis(25),
+            Duration::from_secs(1),
+        );
+        let stopped = !crate::process::is_process_running_with_identity(pid, Some(start_time));
+        let _ = child.kill();
+        let _ = child.wait();
+
+        result.unwrap();
+        assert!(stopped);
+    }
+
+    #[test]
+    fn stop_does_not_signal_a_reused_pid_identity() {
+        let mut child = Command::new("sleep").arg("3600").spawn().unwrap();
+        let pid = child.id();
+        let start_time = crate::process::pid_start_time(pid).unwrap();
+
+        let result = stop_with_timeouts(
+            pid,
+            start_time.saturating_add(1),
+            Duration::ZERO,
+            Duration::ZERO,
+        );
+        let still_running = crate::process::is_process_running_with_identity(pid, Some(start_time));
+        let _ = child.kill();
+        let _ = child.wait();
+
+        result.unwrap();
+        assert!(still_running);
+    }
+}
+
+fn signal_if_running(owner_pid: u32, owner_start_time: u64, signal: i32) -> Result<()> {
+    if !crate::process::is_process_running_with_identity(owner_pid, Some(owner_start_time)) {
+        return Ok(());
+    }
+    let raw_pid = i32::try_from(owner_pid).map_err(|_| {
+        BoxError::StateError(format!(
+            "A3S OCI runtime owner PID {owner_pid} does not fit i32"
+        ))
+    })?;
+    // SAFETY: the stable start-time check immediately before this call fences
+    // the numeric PID, and kill(2) has no memory-safety preconditions.
+    if unsafe { libc::kill(raw_pid, signal) } == 0
+        || !crate::process::is_process_running_with_identity(owner_pid, Some(owner_start_time))
+    {
+        Ok(())
+    } else {
+        Err(BoxError::StateError(format!(
+            "Failed to send signal {signal} to A3S OCI runtime owner {owner_pid}: {}",
+            std::io::Error::last_os_error()
+        )))
+    }
+}

--- a/src/runtime/src/sandbox/a3s_oci_owner.rs
+++ b/src/runtime/src/sandbox/a3s_oci_owner.rs
@@ -50,6 +50,29 @@ fn stop_with_timeouts(
     }
 }
 
+fn signal_if_running(owner_pid: u32, owner_start_time: u64, signal: i32) -> Result<()> {
+    if !crate::process::is_process_running_with_identity(owner_pid, Some(owner_start_time)) {
+        return Ok(());
+    }
+    let raw_pid = i32::try_from(owner_pid).map_err(|_| {
+        BoxError::StateError(format!(
+            "A3S OCI runtime owner PID {owner_pid} does not fit i32"
+        ))
+    })?;
+    // SAFETY: the stable start-time check immediately before this call fences
+    // the numeric PID, and kill(2) has no memory-safety preconditions.
+    if unsafe { libc::kill(raw_pid, signal) } == 0
+        || !crate::process::is_process_running_with_identity(owner_pid, Some(owner_start_time))
+    {
+        Ok(())
+    } else {
+        Err(BoxError::StateError(format!(
+            "Failed to send signal {signal} to A3S OCI runtime owner {owner_pid}: {}",
+            std::io::Error::last_os_error()
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::BufRead;
@@ -104,28 +127,5 @@ mod tests {
 
         result.unwrap();
         assert!(still_running);
-    }
-}
-
-fn signal_if_running(owner_pid: u32, owner_start_time: u64, signal: i32) -> Result<()> {
-    if !crate::process::is_process_running_with_identity(owner_pid, Some(owner_start_time)) {
-        return Ok(());
-    }
-    let raw_pid = i32::try_from(owner_pid).map_err(|_| {
-        BoxError::StateError(format!(
-            "A3S OCI runtime owner PID {owner_pid} does not fit i32"
-        ))
-    })?;
-    // SAFETY: the stable start-time check immediately before this call fences
-    // the numeric PID, and kill(2) has no memory-safety preconditions.
-    if unsafe { libc::kill(raw_pid, signal) } == 0
-        || !crate::process::is_process_running_with_identity(owner_pid, Some(owner_start_time))
-    {
-        Ok(())
-    } else {
-        Err(BoxError::StateError(format!(
-            "Failed to send signal {signal} to A3S OCI runtime owner {owner_pid}: {}",
-            std::io::Error::last_os_error()
-        )))
     }
 }

--- a/src/runtime/src/sandbox/mod.rs
+++ b/src/runtime/src/sandbox/mod.rs
@@ -18,6 +18,16 @@ pub mod rootfs;
 #[cfg(target_os = "linux")]
 pub(crate) mod runtime_record;
 
+/// Bound for the pinned A3S OCI native service to stop its owned processes.
+///
+/// The native service allows its Linux executor up to ten seconds to reap a
+/// process and uses a fifteen-second shutdown envelope in its own lifecycle
+/// certification. Box must not declare provider loss before that one canonical
+/// shutdown path has had the same bounded opportunity to finish.
+#[cfg(target_os = "linux")]
+pub(crate) const A3S_OCI_OWNER_EXIT_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(15);
+
 #[cfg(target_os = "linux")]
 pub use a3s_oci_controller::A3sOciController;
 #[cfg(target_os = "linux")]

--- a/src/runtime/src/sandbox/mod.rs
+++ b/src/runtime/src/sandbox/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod a3s_oci_client;
 pub(crate) mod a3s_oci_controller;
 #[cfg(target_os = "linux")]
 pub(crate) mod a3s_oci_handler;
+#[cfg(target_os = "linux")]
+pub(crate) mod a3s_oci_owner;
 pub mod capability;
 pub mod controller;
 pub mod oci;
@@ -18,15 +20,14 @@ pub mod rootfs;
 #[cfg(target_os = "linux")]
 pub(crate) mod runtime_record;
 
-/// Bound for the pinned A3S OCI native service to stop its owned processes.
+/// Lifecycle envelope certified by the pinned A3S OCI native service.
 ///
 /// The native service allows its Linux executor up to ten seconds to reap a
 /// process and uses a fifteen-second shutdown envelope in its own lifecycle
-/// certification. Box must not declare provider loss before that one canonical
-/// shutdown path has had the same bounded opportunity to finish.
+/// certification. Box must give container wait and owner shutdown that same
+/// bounded opportunity before declaring provider loss.
 #[cfg(target_os = "linux")]
-pub(crate) const A3S_OCI_OWNER_EXIT_TIMEOUT: std::time::Duration =
-    std::time::Duration::from_secs(15);
+pub(crate) const A3S_OCI_LIFECYCLE_TIMEOUT_MS: u64 = 15_000;
 
 #[cfg(target_os = "linux")]
 pub use a3s_oci_controller::A3sOciController;

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -24,6 +24,8 @@ pub const SANDBOX_BUNDLE_SCHEMA: &str = "a3s.box.sandbox-bundle.v1";
 pub const DEFAULT_SANDBOX_PIDS_LIMIT: i64 = 4096;
 const DEFAULT_CPU_PERIOD_US: u64 = 100_000;
 const DEFAULT_TMPFS_SIZE: &str = "67108864";
+const SBIN_INIT: &str = "/sbin/init";
+const USR_SBIN_INIT: &str = "/usr/sbin/init";
 const LINUX_EPERM: u32 = 1;
 const LINUX_ENOSYS: u32 = 38;
 const LINUX_CLONE_NAMESPACE_MASK: u64 =
@@ -178,6 +180,8 @@ pub struct SandboxBundleSpec {
     pub rootfs_path: PathBuf,
     pub rootfs_read_only: bool,
     pub hostname: String,
+    /// Guest-init location already resolved against the prepared rootfs.
+    pub init_path: String,
     pub init_environment: Vec<(String, String)>,
     pub mounts: Vec<SandboxMount>,
     pub tmpfs: Vec<SandboxTmpfs>,
@@ -194,6 +198,7 @@ pub fn compile_oci_spec(input: &SandboxBundleSpec) -> Result<Spec> {
     validate_box_id(&input.box_id)?;
     validate_rootfs_path(&input.rootfs_path)?;
     validate_hostname(&input.hostname)?;
+    validate_init_path(&input.init_path)?;
     validate_digest("execution plan", &input.execution_plan_digest)?;
     validate_digest("runtime", &input.runtime_digest)?;
     validate_id_mapping_plan(&input.id_mappings)?;
@@ -207,7 +212,7 @@ pub fn compile_oci_spec(input: &SandboxBundleSpec) -> Result<Spec> {
                 .build()
                 .map_err(oci_error)?,
         )
-        .args(vec!["/sbin/init".to_string()])
+        .args(vec![input.init_path.clone()])
         .env(compile_environment(&input.init_environment)?)
         .cwd(PathBuf::from("/"))
         .capabilities(compile_capabilities(&input.requested_capabilities)?)
@@ -791,7 +796,8 @@ fn validate_user_mount(mount: &SandboxMount) -> Result<()> {
         "/dev",
         "/proc",
         "/run/a3s-box",
-        "/sbin/init",
+        SBIN_INIT,
+        USR_SBIN_INIT,
         "/sys",
         RUNTIME_EXEC_CONFIG_PATH,
         RUNTIME_ENV_PATH,
@@ -825,6 +831,16 @@ fn validate_rootfs_path(path: &Path) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+fn validate_init_path(path: &str) -> Result<()> {
+    if matches!(path, SBIN_INIT | USR_SBIN_INIT) {
+        Ok(())
+    } else {
+        Err(BoxError::ConfigError(format!(
+            "Sandbox init path must be {SBIN_INIT} or {USR_SBIN_INIT}: {path:?}"
+        )))
+    }
 }
 
 fn validate_host_absolute_normalized(path: &Path, label: &str) -> Result<()> {
@@ -1249,6 +1265,7 @@ mod tests {
             rootfs_path: std::env::temp_dir().join("a3s/boxes/box-123/rootfs"),
             rootfs_read_only: false,
             hostname: "box-123".to_string(),
+            init_path: "/sbin/init".to_string(),
             init_environment: vec![
                 ("PATH".to_string(), "/bin".to_string()),
                 (
@@ -1326,6 +1343,29 @@ mod tests {
         );
         assert_eq!(value["linux"]["resources"]["pids"]["limit"], 512);
         assert_eq!(value["linux"]["resources"]["cpu"]["cpus"], "0-1");
+    }
+
+    #[test]
+    fn compiler_uses_the_resolved_usr_sbin_init_path() {
+        let mut input = sample_input();
+        input.init_path = "/usr/sbin/init".to_string();
+
+        let value = as_json(&compile_oci_spec(&input).unwrap());
+
+        assert_eq!(
+            value["process"]["args"],
+            serde_json::json!(["/usr/sbin/init"])
+        );
+    }
+
+    #[test]
+    fn compiler_rejects_an_unresolved_init_path() {
+        let mut input = sample_input();
+        input.init_path = "/bin/sh".to_string();
+
+        let error = compile_oci_spec(&input).unwrap_err().to_string();
+
+        assert!(error.contains("Sandbox init path"), "{error}");
     }
 
     #[test]
@@ -1418,6 +1458,10 @@ mod tests {
 
         let mut input = sample_input();
         input.mounts.push(input.mounts[0].clone());
+        assert!(compile_oci_spec(&input).is_err());
+
+        let mut input = sample_input();
+        input.mounts[0].destination = PathBuf::from("/usr/sbin/init");
         assert!(compile_oci_spec(&input).is_err());
     }
 

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -469,7 +469,7 @@ fn reap_orphaned_a3s_oci(
     if !crate::process::wait_for_process_stop_with_identity(
         owner_pid,
         owner_start_time,
-        std::time::Duration::from_secs(3),
+        crate::sandbox::A3S_OCI_OWNER_EXIT_TIMEOUT,
     ) {
         tracing::error!(box_id, owner_pid, "Orphaned A3S OCI owner did not exit");
         return SandboxReap::Failed;

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -65,8 +65,8 @@ pub(crate) fn cleanup_recorded_sandbox_runtime_in(
 ) -> a3s_box_core::Result<()> {
     match reap_recorded_sandbox(home_dir, box_dir, box_id) {
         SandboxReap::NotPresent | SandboxReap::Cleaned => Ok(()),
-        SandboxReap::Failed => Err(a3s_box_core::BoxError::StateError(format!(
-            "Failed to clean recorded Sandbox runtime for {box_id}; refusing to touch its rootfs"
+        SandboxReap::Failed(reason) => Err(a3s_box_core::BoxError::StateError(format!(
+            "Failed to clean recorded Sandbox runtime for {box_id}: {reason}; refusing to touch its rootfs"
         ))),
     }
 }
@@ -81,9 +81,10 @@ fn reap_orphaned_box_in(home_dir: &Path, box_id: &str) {
 
     match reap_recorded_sandbox(home_dir, &box_dir, box_id) {
         SandboxReap::NotPresent | SandboxReap::Cleaned => {}
-        SandboxReap::Failed => {
+        SandboxReap::Failed(reason) => {
             // A live shared-kernel process may still be using the rootfs. Never
             // unmount or delete it after an unverified/failed runtime cleanup.
+            tracing::error!(box_id, %reason, "Refusing to touch an unreaped Sandbox rootfs");
             return;
         }
     }
@@ -335,7 +336,14 @@ fn sha256_file(path: &Path) -> Option<String> {
 enum SandboxReap {
     NotPresent,
     Cleaned,
-    Failed,
+    Failed(String),
+}
+
+#[cfg(target_os = "linux")]
+fn failed_sandbox_reap(box_id: &str, reason: impl Into<String>) -> SandboxReap {
+    let reason = reason.into();
+    tracing::error!(box_id, %reason, "Failed to reap recorded Sandbox runtime");
+    SandboxReap::Failed(reason)
 }
 
 /// Reconcile one durable Sandbox record before touching its rootfs.
@@ -345,8 +353,10 @@ fn reap_recorded_sandbox(home_dir: &Path, box_dir: &Path, box_id: &str) -> Sandb
         Ok(Some(record)) => record,
         Ok(None) => return SandboxReap::NotPresent,
         Err(error) => {
-            tracing::error!(box_id, %error, "Invalid Sandbox runtime record during crash recovery");
-            return SandboxReap::Failed;
+            return failed_sandbox_reap(
+                box_id,
+                format!("invalid runtime record during crash recovery: {error}"),
+            );
         }
     };
     reap_orphaned_a3s_oci(record, box_dir, box_id)
@@ -369,26 +379,29 @@ fn reap_orphaned_a3s_oci(
         record.owner_pid,
         record.owner_pid_start_time,
     ) else {
-        tracing::error!(
+        return failed_sandbox_reap(
             box_id,
-            "A3S OCI runtime record lost required recovery identity"
+            "A3S OCI runtime record lost required recovery identity",
         );
-        return SandboxReap::Failed;
     };
     let client = match crate::sandbox::a3s_oci_client::A3sOciClient::connect_blocking(
         runtime_socket.clone(),
     ) {
         Ok(client) => client,
         Err(error) => {
-            tracing::error!(box_id, %error, "Failed to connect to orphaned A3S OCI owner");
-            return SandboxReap::Failed;
+            return failed_sandbox_reap(
+                box_id,
+                format!("failed to connect to orphaned A3S OCI owner: {error}"),
+            );
         }
     };
     let container_id = match ContainerId::new(box_id) {
         Ok(container_id) => container_id,
         Err(error) => {
-            tracing::error!(box_id, %error, "Invalid A3S OCI container identity during recovery");
-            return SandboxReap::Failed;
+            return failed_sandbox_reap(
+                box_id,
+                format!("invalid A3S OCI container identity during recovery: {error}"),
+            );
         }
     };
     let target = ContainerTarget::exact(container_id, Generation(generation));
@@ -397,23 +410,29 @@ fn reap_orphaned_a3s_oci(
     }) {
         Ok(state) => state,
         Err(error) => {
-            tracing::error!(box_id, %error, "Failed to query orphaned A3S OCI state");
-            return SandboxReap::Failed;
+            return failed_sandbox_reap(
+                box_id,
+                format!("failed to query orphaned A3S OCI state: {error}"),
+            );
         }
     };
     if state.is_some_and(|state| *state.state.status() != OciContainerState::Stopped) {
         let context = match recorded_operation_context(box_id, "reap-kill") {
             Ok(context) => context,
             Err(error) => {
-                tracing::error!(box_id, %error, "Failed to construct A3S OCI recovery operation");
-                return SandboxReap::Failed;
+                return failed_sandbox_reap(
+                    box_id,
+                    format!("failed to construct A3S OCI recovery operation: {error}"),
+                );
             }
         };
         let signal = match Signal::new(libc::SIGKILL) {
             Ok(signal) => signal,
             Err(error) => {
-                tracing::error!(box_id, %error, "Failed to construct A3S OCI recovery signal");
-                return SandboxReap::Failed;
+                return failed_sandbox_reap(
+                    box_id,
+                    format!("failed to construct A3S OCI recovery signal: {error}"),
+                );
             }
         };
         if let Err(error) = client.kill(KillRequest {
@@ -422,23 +441,29 @@ fn reap_orphaned_a3s_oci(
             signal,
             all: true,
         }) {
-            tracing::error!(box_id, %error, "Failed to signal orphaned A3S OCI Sandbox");
-            return SandboxReap::Failed;
+            return failed_sandbox_reap(
+                box_id,
+                format!("failed to signal orphaned A3S OCI Sandbox: {error}"),
+            );
         }
         if let Err(error) = client.wait(WaitRequest {
             target: target.clone(),
-            timeout_ms: Some(5_000),
+            timeout_ms: Some(crate::sandbox::A3S_OCI_LIFECYCLE_TIMEOUT_MS),
         }) {
-            tracing::error!(box_id, %error, "Failed to wait for orphaned A3S OCI Sandbox");
-            return SandboxReap::Failed;
+            return failed_sandbox_reap(
+                box_id,
+                format!("failed to wait for orphaned A3S OCI Sandbox: {error}"),
+            );
         }
     }
 
     let context = match recorded_operation_context(box_id, "reap-delete") {
         Ok(context) => context,
         Err(error) => {
-            tracing::error!(box_id, %error, "Failed to construct A3S OCI delete operation");
-            return SandboxReap::Failed;
+            return failed_sandbox_reap(
+                box_id,
+                format!("failed to construct A3S OCI delete operation: {error}"),
+            );
         }
     };
     if let Err(error) = client.delete_if_present(DeleteRequest {
@@ -446,33 +471,18 @@ fn reap_orphaned_a3s_oci(
         target,
         mode: DeleteMode::Force,
     }) {
-        tracing::error!(box_id, %error, "Failed to delete orphaned A3S OCI state");
-        return SandboxReap::Failed;
+        return failed_sandbox_reap(
+            box_id,
+            format!("failed to delete orphaned A3S OCI state: {error}"),
+        );
     }
     client.close();
 
-    if crate::process::is_process_running_with_identity(owner_pid, Some(owner_start_time)) {
-        let Ok(raw_pid) = i32::try_from(owner_pid) else {
-            tracing::error!(box_id, owner_pid, "A3S OCI owner PID does not fit i32");
-            return SandboxReap::Failed;
-        };
-        if unsafe { libc::kill(raw_pid, libc::SIGTERM) } != 0 {
-            tracing::error!(
-                box_id,
-                owner_pid,
-                error = %std::io::Error::last_os_error(),
-                "Failed to terminate orphaned A3S OCI owner"
-            );
-            return SandboxReap::Failed;
-        }
-    }
-    if !crate::process::wait_for_process_stop_with_identity(
-        owner_pid,
-        owner_start_time,
-        crate::sandbox::A3S_OCI_OWNER_EXIT_TIMEOUT,
-    ) {
-        tracing::error!(box_id, owner_pid, "Orphaned A3S OCI owner did not exit");
-        return SandboxReap::Failed;
+    if let Err(error) = crate::sandbox::a3s_oci_owner::stop(owner_pid, owner_start_time) {
+        return failed_sandbox_reap(
+            box_id,
+            format!("failed to stop orphaned A3S OCI owner {owner_pid}: {error}"),
+        );
     }
 
     drain_recorded_log_worker(&record, box_id);

--- a/src/runtime/src/vm/reap_tests.rs
+++ b/src/runtime/src/vm/reap_tests.rs
@@ -94,6 +94,22 @@ fn recorded_sandbox_runtime_rejects_invalid_paths() {
 }
 
 #[test]
+fn cleanup_reports_the_exact_runtime_record_failure_and_preserves_the_rootfs() {
+    let home = tempfile::tempdir().unwrap();
+    let box_id = "cleanup-recorded-sandbox-invalid-paths";
+    let box_dir = home.path().join("boxes").join(box_id);
+    write_runtime_record(home.path(), &box_dir, box_id, |record| {
+        record.runtime_root = home.path().join("run/a3s-oci/another-box");
+    });
+
+    let error = cleanup_recorded_sandbox_runtime_in(home.path(), &box_dir, box_id).unwrap_err();
+
+    assert!(error.to_string().contains("path or identity validation"));
+    assert!(error.to_string().contains("refusing to touch its rootfs"));
+    assert!(box_dir.exists());
+}
+
+#[test]
 fn recorded_sandbox_runtime_rejects_an_unknown_schema() {
     let home = tempfile::tempdir().unwrap();
     let box_id = "recorded-sandbox-unknown-schema";

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -179,6 +179,7 @@ impl VmManager {
                     .hostname
                     .clone()
                     .unwrap_or_else(|| self.box_id.clone()),
+                init_path: instance_spec.entrypoint.executable.clone(),
                 init_environment: instance_spec.entrypoint.env.clone(),
                 mounts,
                 tmpfs,


### PR DESCRIPTION
## Summary

- preserve the guest-init path resolved from the prepared rootfs, including usr-only images that install it at `/usr/sbin/init`
- protect every supported init path from user mount replacement
- use one identity-fenced owner shutdown path for rollback, stop, and recovery, with the certified lifecycle budget and forced exact-owner reaping
- finish lifecycle-lock-protected inspection projections after caller cancellation so replay cannot race a detached provider observation
- pin OCI Runtime `771e5e27d005ed9eb2f52e19bdc64a43a6e4ff87` for replay-safe container-wide process-group signaling
- preserve exact recovery-stage errors and refuse unsafe rootfs removal

## Root causes

The BusyBox conformance image has `/usr/sbin` but no `/sbin`. Box detected guest-init at `/usr/sbin/init`, then replaced that resolved path with a hard-coded `/sbin/init`, causing OCI `execve` to fail with `ENOENT`.

Recovery could also accept an owner zombie without reaping it, used lifecycle budgets shorter than the certified OCI envelope, and lacked the identity-safe forced-exit path used by normal stop. In addition, cancelling an inspection dropped the caller future while its provider-side effect could continue; a replay could then bypass the original lifecycle operation and misclassify the exact execution.

## Validation

- `cargo fmt --all --check`
- `cargo check --locked -p a3s-box-runtime`
- macOS cancellation-safe inspection regression
- A3S Box Linux Runtime-driver cancellation/replay regression
- OCI Runtime PR #46: Ubuntu, macOS, Windows, aarch64 native lifecycle/rootless `all=true`, and static guest-agent checks
- Box CI at `6faf0366804f2b734d76d457dd4ff11efdec4c40`: Format, Clippy, Test, Containerd Shim, SDK Packages, real SDK Local Sandbox, Windows WHPX, and Linux/macOS build checks passed; PR-only KVM integration was intentionally skipped

Follow-up certification is performed by A3S Cloud PR #86 against the merged Box and OCI revisions.