### PR TITLE
fix(runtime): close final soak validation gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: e6b840b73a4e5c3bbfa72c2b5d6fd89104a60f9a
+  A3S_OCI_RUNTIME_REV: 0bd7929b9842184b3cf98986bfe1b6ef79ca5282
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: e6b840b73a4e5c3bbfa72c2b5d6fd89104a60f9a
+  A3S_OCI_RUNTIME_REV: 0bd7929b9842184b3cf98986bfe1b6ef79ca5282
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/bench/README.md
+++ b/bench/README.md
@@ -85,7 +85,8 @@ Tunables (env):
 - **leak** — snapshots host-side resources a leak would grow (orphan
   `a3s-box-shim` processes, overlay mounts under `~/.a3s/boxes`, box dirs),
   runs `CHURN` `run --rm` cycles, then asserts they return to baseline.
-  **Exits non-zero on any leak**, so it is CI-gateable.
+  **Exits non-zero when any churn run fails or any resource grows**, so a
+  missing image or boot failure cannot be reported as a leak-free pass.
 - **race** — starts `RACE` detached boxes from separate CLI processes and
   requires every launch to succeed, every unique record to persist in
   `boxes.json`, and every race box to disappear during cleanup. Per-launch

--- a/bench/README.md
+++ b/bench/README.md
@@ -46,6 +46,8 @@ Tunables (env):
 | `SANDBOX_LOG_DIR` | `/tmp/a3s-box-sandbox-lifecycle-<pid>` | raw opt-in JSONL profile logs |
 | `POOL_SIZE` | `16` | warm-pool / fork fill size |
 | `CHURN` | `30` | create/run/remove cycles for the leak test |
+| `RACE` | `8` | concurrent detached launches required to succeed and persist |
+| `RACE_WORKLOAD_SECS` | `300` | workload lifetime during the race; cleanup removes boxes earlier |
 | `PNPM_PROJECT` | unset | project directory with `package.json` and `pnpm-lock.yaml` for `pnpm` mode |
 | `PNPM_IMAGE` | `node:22-alpine` | Node image used by `pnpm` mode |
 | `PNPM_VERSION` | `10.30.3` | version passed to `corepack prepare` |
@@ -84,6 +86,10 @@ Tunables (env):
   `a3s-box-shim` processes, overlay mounts under `~/.a3s/boxes`, box dirs),
   runs `CHURN` `run --rm` cycles, then asserts they return to baseline.
   **Exits non-zero on any leak**, so it is CI-gateable.
+- **race** — starts `RACE` detached boxes from separate CLI processes and
+  requires every launch to succeed, every unique record to persist in
+  `boxes.json`, and every race box to disappear during cleanup. Per-launch
+  diagnostics are printed on failure and removed after the gate completes.
 - **pnpm** — runs `node:22-alpine` against a real project mount or the reduced
   fixture at [`fixtures/pnpm`](./fixtures/pnpm). It reports p50/p90 for VM boot,
   `corepack + pnpm` setup, `pnpm fetch` (registry download plus extraction/import
@@ -114,8 +120,8 @@ only the benchmark-owned `a3s-bench-pnpm-store` volume.
 
 ## Wiring into CI
 
-The self-hosted KVM job runs the foreground benchmark with an absolute p50 gate
-and the leak assertion with its resource-count gate (see
+The self-hosted KVM job runs the foreground benchmark with an absolute p50 gate,
+the leak assertion, and the strict cross-process race gate (see
 [`../docs/ci-kvm-runner.md`](../docs/ci-kvm-runner.md)). Keep absolute latency
 limits on a stable dedicated runner; use the Docker ratio gate for manual
 macOS/HVF comparisons on the host class from issue #33.

--- a/bench/bench-self-test.sh
+++ b/bench/bench-self-test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/a3s-box-bench-self-test.XXXXXX")"
+trap 'rm -rf -- "$TMP_ROOT"' EXIT
+mkdir -p "$TMP_ROOT/tmp"
+
+STUB="$TMP_ROOT/a3s-box"
+STATE="$TMP_ROOT/boxes"
+
+cat >"$STUB" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state="${A3S_BOX_STUB_STATE:?}"
+command="${1:-}"
+shift || true
+
+case "$command" in
+  ps)
+    if [ "${2:-}" = "--format" ] && [ -f "$state" ]; then
+      cat "$state"
+    fi
+    ;;
+  run)
+    name=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --name)
+          name="${2:-}"
+          shift 2
+          ;;
+        *) shift ;;
+      esac
+    done
+    if [ "${A3S_BOX_STUB_FAIL_LAUNCHES:-0}" = "1" ]; then
+      echo "synthetic launch failure for $name" >&2
+      exit 42
+    fi
+    printf '%s\n' "$name" >>"$state"
+    ;;
+  rm)
+    name="${2:-}"
+    if [ -f "$state" ]; then
+      awk -v name="$name" '$0 != name' "$state" >"$state.next"
+      mv "$state.next" "$state"
+    fi
+    ;;
+  *)
+    echo "unexpected stub command: $command" >&2
+    exit 64
+    ;;
+esac
+EOF
+chmod +x "$STUB"
+
+run_race() {
+  A3S_BOX="$STUB" \
+    A3S_BOX_STUB_STATE="$STATE" \
+    IMAGE=synthetic:latest \
+    RACE=3 \
+    RACE_WORKLOAD_SECS=60 \
+    TMPDIR="$TMP_ROOT/tmp" \
+    "$REPO_ROOT/bench/bench.sh" race 2>&1
+}
+
+set +e
+failure_output="$(A3S_BOX_STUB_FAIL_LAUNCHES=1 run_race)"
+failure_status=$?
+set -e
+if [ "$failure_status" -eq 0 ]; then
+  echo "race gate accepted failed launches" >&2
+  exit 1
+fi
+grep -q 'launched: 0/3 detached boxes reported success' <<<"$failure_output"
+grep -q 'FAIL: 3/3 detached launches failed' <<<"$failure_output"
+
+: >"$STATE"
+success_output="$(run_race)"
+grep -q 'launched: 3/3 detached boxes reported success' <<<"$success_output"
+grep -q 'persisted: 3 entries .* (expected 3)' <<<"$success_output"
+grep -q 'PASS: every required launch persisted' <<<"$success_output"
+test ! -s "$STATE"
+
+if find "$TMP_ROOT/tmp" -mindepth 1 -print -quit | grep -q .; then
+  echo "race self-test left temporary diagnostics behind" >&2
+  find "$TMP_ROOT/tmp" -mindepth 1 -print >&2
+  exit 1
+fi
+
+echo "bench race self-test passed"

--- a/bench/bench-self-test.sh
+++ b/bench/bench-self-test.sh
@@ -17,7 +17,13 @@ state="${A3S_BOX_STUB_STATE:?}"
 command="${1:-}"
 shift || true
 
+if [ -n "${A3S_BOX_STUB_COMMAND_LOG:-}" ]; then
+  printf '%s %s\n' "$command" "$*" >>"$A3S_BOX_STUB_COMMAND_LOG"
+fi
+
 case "$command" in
+  load|images|volume|snapshot|--version)
+    ;;
   ps)
     if [ "${2:-}" = "--format" ] && [ -f "$state" ]; then
       cat "$state"
@@ -65,6 +71,26 @@ run_race() {
     "$REPO_ROOT/bench/bench.sh" race 2>&1
 }
 
+run_leak() {
+  A3S_BOX="$STUB" \
+    A3S_BOX_STUB_STATE="$STATE" \
+    IMAGE=synthetic:latest \
+    CHURN=3 \
+    TMPDIR="$TMP_ROOT/tmp" \
+    "$REPO_ROOT/bench/bench.sh" leak 2>&1
+}
+
+set +e
+leak_failure_output="$(A3S_BOX_STUB_FAIL_LAUNCHES=1 run_leak)"
+leak_failure_status=$?
+set -e
+if [ "$leak_failure_status" -eq 0 ]; then
+  echo "leak gate accepted failed churn runs" >&2
+  exit 1
+fi
+grep -q 'FAIL: churn run 1 exited unsuccessfully' <<<"$leak_failure_output"
+grep -q 'FAIL: 3/3 churn runs failed' <<<"$leak_failure_output"
+
 set +e
 failure_output="$(A3S_BOX_STUB_FAIL_LAUNCHES=1 run_race)"
 failure_status=$?
@@ -83,10 +109,39 @@ grep -q 'persisted: 3 entries .* (expected 3)' <<<"$success_output"
 grep -q 'PASS: every required launch persisted' <<<"$success_output"
 test ! -s "$STATE"
 
+HOST_COMMAND_LOG="$TMP_ROOT/host-commands.log"
+HOST_EVIDENCE="$TMP_ROOT/host-evidence"
+OFFLINE_TAR="$TMP_ROOT/alpine.tar"
+: >"$STATE"
+: >"$HOST_COMMAND_LOG"
+: >"$OFFLINE_TAR"
+A3S_BOX="$STUB" \
+  A3S_BOX_STUB_STATE="$STATE" \
+  A3S_BOX_STUB_COMMAND_LOG="$HOST_COMMAND_LOG" \
+  A3S_HOME="$TMP_ROOT/home" \
+  A3S_BOX_TEST_ALPINE_TAR="$OFFLINE_TAR" \
+  A3S_BOX_SMOKE_IMAGE_TAR="$OFFLINE_TAR" \
+  IMAGE=synthetic:latest \
+  CHURN=1 \
+  RACE=1 \
+  RACE_WORKLOAD_SECS=60 \
+  TMPDIR="$TMP_ROOT/tmp" \
+  "$REPO_ROOT/scripts/host-integration-smoke.sh" \
+    --no-pure --soak --soak-duration 0 --soak-iterations 1 \
+    --soak-output "$HOST_EVIDENCE" >/dev/null
+
+load_count=$(grep -c '^load --input .* --tag synthetic:latest$' "$HOST_COMMAND_LOG")
+if [ "$load_count" -ne 2 ]; then
+  echo "host soak runner seeded the offline benchmark image $load_count times; expected 2" >&2
+  exit 1
+fi
+grep -q '^result=pass$' "$HOST_EVIDENCE/summary.txt"
+grep -q 'PASS: host soak evidence verified' "$HOST_EVIDENCE/verify.out"
+
 if find "$TMP_ROOT/tmp" -mindepth 1 -print -quit | grep -q .; then
   echo "race self-test left temporary diagnostics behind" >&2
   find "$TMP_ROOT/tmp" -mindepth 1 -print >&2
   exit 1
 fi
 
-echo "bench race self-test passed"
+echo "bench leak/race and offline soak seeding self-test passed"

--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -485,18 +485,37 @@ bench_leak() {
   local b_shim b_mount b_dir
   b_shim=$(shim_count); b_mount=$(mount_count); b_dir=$(boxdir_count)
   echo "  baseline: shims=$b_shim mounts=$b_mount box-dirs=$b_dir"
-  for _ in $(seq 1 "$CHURN"); do
-    "$A3S_BOX" run --rm "$IMAGE" -- true >/dev/null 2>&1
+
+  local log_dir="${TMPDIR:-/tmp}/a3s-box-bench-leak-$$"
+  rm -rf -- "$log_dir"
+  mkdir -p "$log_dir"
+
+  local i run_failures=0
+  for i in $(seq 1 "$CHURN"); do
+    if ! "$A3S_BOX" run --rm "$IMAGE" -- true >"$log_dir/run-$i.log" 2>&1; then
+      echo "  FAIL: churn run $i exited unsuccessfully"
+      sed 's/^/    /' "$log_dir/run-$i.log" | tail -n 80
+      run_failures=$(( run_failures + 1 ))
+    fi
   done
   sleep 3
   local a_shim a_mount a_dir
   a_shim=$(shim_count); a_mount=$(mount_count); a_dir=$(boxdir_count)
   echo "  after:    shims=$a_shim mounts=$a_mount box-dirs=$a_dir"
   local leak=0
+  if [ "$run_failures" -gt 0 ]; then
+    echo "  FAIL: $run_failures/$CHURN churn runs failed"
+    leak=1
+  fi
   [ "$a_shim" -gt "$b_shim" ]  && { echo "  LEAK: $(( a_shim - b_shim )) orphan shim(s)"; leak=1; }
   [ "$a_mount" -gt "$b_mount" ] && { echo "  LEAK: $(( a_mount - b_mount )) leaked overlay mount(s)"; leak=1; }
   [ "$a_dir" -gt "$b_dir" ]    && { echo "  LEAK: $(( a_dir - b_dir )) leaked box dir(s)"; leak=1; }
-  if [ "$leak" -eq 0 ]; then echo "  PASS: no orphan shims / mounts / box dirs after churn"; else echo "  FAIL: resource leak detected"; fi
+  if [ "$leak" -eq 0 ]; then
+    echo "  PASS: all churn runs completed with no orphan shims / mounts / box dirs"
+  else
+    echo "  FAIL: churn execution or resource leak assertion failed"
+  fi
+  rm -rf -- "$log_dir"
   return "$leak"
 }
 

--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -16,6 +16,7 @@
 #   POOL_SIZE warm-pool / fork fill size            (default: 16)
 #   CHURN     create/run/remove cycles for the leak test (default: 30)
 #   RACE      concurrent `run -d` processes for the cross-process race (default: 8)
+#   RACE_WORKLOAD_SECS lifetime of each race workload before forced cleanup (default: 300)
 #   FOREGROUND_RUNS samples for the cached foreground no-op benchmark (default: RUNS)
 #   FOREGROUND_WARMUPS warm-up runs per runtime before sampling (default: 1)
 #   FOREGROUND_DOCKER 1 compares Docker when available, 0 skips it (default: 1)
@@ -46,6 +47,7 @@ RUNS="${RUNS:-20}"
 POOL_SIZE="${POOL_SIZE:-16}"
 CHURN="${CHURN:-30}"
 RACE="${RACE:-8}"
+RACE_WORKLOAD_SECS="${RACE_WORKLOAD_SECS:-300}"
 FOREGROUND_RUNS="${FOREGROUND_RUNS:-$RUNS}"
 FOREGROUND_WARMUPS="${FOREGROUND_WARMUPS:-1}"
 FOREGROUND_DOCKER="${FOREGROUND_DOCKER:-1}"
@@ -109,11 +111,22 @@ require_runtime() {
 # Count host-side resources that a leak would grow.
 shim_count() {
   local count
-  count=$(pgrep -xc 'a3s-box-shim' 2>/dev/null || pgrep -fc 'a3s-box-shim' 2>/dev/null || true)
-  echo "${count:-0}"
+  count=$({ pgrep -x 'a3s-box-shim' 2>/dev/null || true; } | awk 'END { print NR + 0 }')
+  echo "$count"
 }
-mount_count() { mount 2>/dev/null | awk '/\/\.a3s\/boxes|\/a3s\/boxes/ { n++ } END { print n + 0 }'; }
-boxdir_count() { find "${HOME}/.a3s/boxes" -mindepth 1 -maxdepth 1 -print 2>/dev/null | awk 'END { print NR + 0 }'; }
+a3s_home_dir() { echo "${A3S_HOME:-${HOME}/.a3s}"; }
+mount_count() {
+  local boxes_dir
+  boxes_dir="$(a3s_home_dir)/boxes"
+  mount 2>/dev/null | awk -v boxes_dir="$boxes_dir" '
+    index($0, boxes_dir) { n++ }
+    END { print n + 0 }
+  '
+}
+boxdir_count() {
+  find "$(a3s_home_dir)/boxes" -mindepth 1 -maxdepth 1 -print 2>/dev/null |
+    awk 'END { print NR + 0 }'
+}
 
 bench_cold() {
   echo "## Cold boot ($RUNS runs, $IMAGE)"
@@ -502,21 +515,45 @@ bench_race() {
   local tag="race-$$"
   echo "## Cross-process race ($N concurrent run -d -> boxes.json)"
 
+  case "$N" in
+    ''|*[!0-9]*|0) echo "  ERROR: RACE must be a positive integer" >&2; return 2 ;;
+  esac
+  case "$RACE_WORKLOAD_SECS" in
+    ''|*[!0-9]*|0) echo "  ERROR: RACE_WORKLOAD_SECS must be a positive integer" >&2; return 2 ;;
+  esac
+
   # Baseline must load cleanly, so a failure below is attributable to the race.
   if ! "$A3S_BOX" ps -a >/dev/null 2>&1; then
     echo "  FAIL: boxes.json does not load before the race"; return 1
   fi
 
+  local log_dir="${TMPDIR:-/tmp}/a3s-box-bench-race-$$"
+  rm -rf -- "$log_dir"
+  mkdir -p "$log_dir"
+
   local pids="" p
   for i in $(seq 1 "$N"); do
-    "$A3S_BOX" run -d --name "$tag-$i" "$IMAGE" -- sleep 30 >/dev/null 2>&1 &
+    "$A3S_BOX" run -d --name "$tag-$i" "$IMAGE" -- \
+      sleep "$RACE_WORKLOAD_SECS" >"$log_dir/launch-$i.log" 2>&1 &
     pids="$pids $!"
   done
-  local ok=0
-  for p in $pids; do wait "$p" && ok=$(( ok + 1 )); done
+  local ok=0 rc=0 launch_index=0
+  for p in $pids; do
+    launch_index=$(( launch_index + 1 ))
+    if wait "$p"; then
+      ok=$(( ok + 1 ))
+    else
+      rc=1
+      echo "  FAIL: detached launch $launch_index exited unsuccessfully"
+      sed 's/^/    /' "$log_dir/launch-$launch_index.log" | tail -n 80
+    fi
+  done
   echo "  launched: $ok/$N detached boxes reported success"
+  if [ "$ok" -ne "$N" ]; then
+    echo "  FAIL: $(( N - ok ))/$N detached launches failed"
+    rc=1
+  fi
 
-  local rc=0
   # The CLI re-reads boxes.json here; a torn write makes this fail or quarantine.
   if ! "$A3S_BOX" ps -a >/dev/null 2>&1; then
     echo "  FAIL: boxes.json is unreadable after the race (torn write)"
@@ -524,21 +561,27 @@ bench_race() {
   else
     local persisted
     persisted=$("$A3S_BOX" ps -a --format '{{.Names}}' 2>/dev/null | grep -c "^$tag-")
-    echo "  persisted: $persisted entries named $tag-* (expected $ok)"
-    if [ "$persisted" -ne "$ok" ]; then
-      echo "  FAIL: lost update — $ok launches succeeded but only $persisted persisted"
+    echo "  persisted: $persisted entries named $tag-* (expected $N)"
+    if [ "$persisted" -ne "$N" ]; then
+      echo "  FAIL: persistence mismatch — $N launches were required but $persisted entries persisted"
       rc=1
     else
-      echo "  PASS: every successful launch persisted (no lost update, JSON intact)"
+      echo "  PASS: every required launch persisted (no lost update, JSON intact)"
     fi
   fi
 
   # Cleanup: remove every race box and verify none linger (the test must not leak).
-  for i in $(seq 1 "$N"); do "$A3S_BOX" rm -f "$tag-$i" >/dev/null 2>&1; done
+  for i in $(seq 1 "$N"); do
+    if ! "$A3S_BOX" rm -f "$tag-$i" >/dev/null 2>&1; then
+      echo "  FAIL: could not remove race box $tag-$i"
+      rc=1
+    fi
+  done
   sleep 2
   local left
   left=$("$A3S_BOX" ps -a --format '{{.Names}}' 2>/dev/null | grep -c "^$tag-")
   [ "$left" -ne 0 ] && { echo "  FAIL: $left race box(es) survived cleanup"; rc=1; }
+  rm -rf -- "$log_dir"
   return "$rc"
 }
 

--- a/deploy/scripts/runtimeclass-soak.sh
+++ b/deploy/scripts/runtimeclass-soak.sh
@@ -700,15 +700,7 @@ handle_exit() {
     trap - EXIT
     stop_sampler
     if [ -f "$OUTPUT_DIR/summary.txt" ] && grep -q '^result=pass$' "$OUTPUT_DIR/summary.txt"; then
-        {
-            echo "finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "result=fail"
-            echo "duration_secs=$(duration_secs)"
-            echo "exit_code=$exit_code"
-            echo "failed_at=${FAILED_AT:-unknown}"
-            echo "failed_command=${FAILED_COMMAND:-unknown}"
-            echo "evidence_dir=$OUTPUT_DIR"
-        } >"$OUTPUT_DIR/failure-summary.txt"
+        write_failure_summary "$exit_code"
         collect_post_cleanup_evidence
         log "RuntimeClass soak failed after cleanup: exit_code=$exit_code evidence=$OUTPUT_DIR"
         exit "$exit_code"

--- a/deploy/scripts/soak-evidence-self-test.sh
+++ b/deploy/scripts/soak-evidence-self-test.sh
@@ -878,6 +878,58 @@ require_tsv_phase_count 1 final "$host_runner_fail_dir/resource-samples.tsv"
 expect_failure host-runner-failure-diagnostic 'host soak failed: failed_iterations=1' \
     "$VERIFY_SCRIPT" --kind host "$host_runner_fail_dir"
 
+log "Verifying host soak runner stops after a real binary build failure"
+host_build_fail_dir="$TMP_ROOT/host-build-fail"
+host_build_fail_bin="$TMP_ROOT/host-build-fail-bin"
+host_build_fail_calls="$TMP_ROOT/host-build-fail-cargo.calls"
+host_build_fail_image="$TMP_ROOT/host-build-fail-image.tar"
+mkdir -p "$host_build_fail_bin"
+write_nonempty_file "$host_build_fail_image"
+cat >"$host_build_fail_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--version" ]; then
+    echo "cargo synthetic"
+    exit 0
+fi
+printf '%s\n' "$*" >>"$HOST_BUILD_FAIL_CALLS"
+exit 17
+EOF
+cat >"$host_build_fail_bin/a3s-box" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--version" ]; then
+    echo "a3s-box synthetic"
+fi
+EOF
+chmod +x "$host_build_fail_bin/cargo" "$host_build_fail_bin/a3s-box"
+set +e
+PATH="$host_build_fail_bin:$PATH" \
+    HOST_BUILD_FAIL_CALLS="$host_build_fail_calls" \
+    A3S_BOX="$host_build_fail_bin/a3s-box" \
+    A3S_HOME="$TMP_ROOT/host-build-fail-home" \
+    A3S_BOX_TEST_ALPINE_TAR="$host_build_fail_image" \
+    "$HOST_INTEGRATION" --no-pure --core --soak --soak-no-bench \
+        --soak-duration 0 --soak-iterations 1 --soak-output "$host_build_fail_dir" \
+        >"$host_build_fail_dir.out" 2>"$host_build_fail_dir.err"
+host_build_fail_status="$?"
+set -e
+if [ "$host_build_fail_status" -eq 0 ]; then
+    fail "host runner build failure rehearsal unexpectedly passed"
+fi
+require_grep '^result=fail$' "$host_build_fail_dir/summary.txt"
+require_grep '^failed_iterations=1$' "$host_build_fail_dir/summary.txt"
+require_grep '^failed_at=iteration-1-core$' "$host_build_fail_dir/summary.txt"
+require_grep '^failed_command=run_core_suite$' "$host_build_fail_dir/summary.txt"
+require_grep '^build -p a3s-box-cli -p a3s-box-shim$' "$host_build_fail_calls"
+if [ "$(wc -l <"$host_build_fail_calls" | tr -d ' ')" -ne 1 ]; then
+    fail "host runner continued invoking cargo after the binary build failed"
+fi
+if grep -qE -- 'a3s-box-guest-init|(^| )test( |$)' "$host_build_fail_calls"; then
+    fail "host runner continued into guest or test work after the binary build failed"
+fi
+require_tsv_phase_count 1 final "$host_build_fail_dir/resource-samples.tsv"
+
 log "Verifying synthetic cluster evidence"
 cluster_pass="$TMP_ROOT/cluster-pass"
 make_cluster_bundle "$cluster_pass"

--- a/deploy/scripts/soak-evidence-self-test.sh
+++ b/deploy/scripts/soak-evidence-self-test.sh
@@ -83,6 +83,17 @@ require_grep() {
     grep -qE -- "$pattern" "$file" || fail "pattern '$pattern' not found in $file"
 }
 
+require_tsv_phase_count() {
+    local expected="$1"
+    local phase="$2"
+    local file="$3"
+    local actual
+
+    actual="$(awk -F '\t' -v phase="$phase" 'NR > 1 && $2 == phase { count++ } END { print count + 0 }' "$file")"
+    [ "$actual" -eq "$expected" ] ||
+        fail "phase '$phase' appeared $actual times in $file; expected $expected"
+}
+
 expect_failure() {
     local name="$1"
     local pattern="$2"
@@ -840,6 +851,7 @@ require_grep '^failed_iterations=0$' "$host_runner_gate_fail_dir/summary.txt"
 require_grep 'failed_command=.*/deploy/scripts/verify-soak-evidence.sh --kind host --min-duration-secs 3600 ' \
     "$host_runner_gate_fail_dir/summary.txt"
 require_grep 'host soak duration too short' "$host_runner_gate_fail_dir/verify.out"
+require_tsv_phase_count 1 final "$host_runner_gate_fail_dir/resource-samples.tsv"
 expect_failure host-runner-gate-failure-diagnostic 'host soak failed: failed_iterations=0' \
     "$VERIFY_SCRIPT" --kind host "$host_runner_gate_fail_dir"
 
@@ -862,6 +874,7 @@ require_grep '^failed_iterations=1$' "$host_runner_fail_dir/summary.txt"
 require_grep '^exit_code=1$' "$host_runner_fail_dir/summary.txt"
 require_grep '^failed_at=iteration-1-bench-leak$' "$host_runner_fail_dir/summary.txt"
 require_grep '^failed_command=run_bench_leak$' "$host_runner_fail_dir/summary.txt"
+require_tsv_phase_count 1 final "$host_runner_fail_dir/resource-samples.tsv"
 expect_failure host-runner-failure-diagnostic 'host soak failed: failed_iterations=1' \
     "$VERIFY_SCRIPT" --kind host "$host_runner_fail_dir"
 

--- a/docs/ci-kvm-runner.md
+++ b/docs/ci-kvm-runner.md
@@ -70,8 +70,9 @@ that PR branch to run the same gate before merge.
    cycles and asserts orphan shims, overlay mounts, and box dirs all return to
    baseline. A resource-leak regression fails the gate.
 7. **Race assertion** (`bench/bench.sh race`) — boots `RACE` detached boxes
-   concurrently and asserts `boxes.json` still parses and every successful
-   launch persisted. This is the only check that exercises the cross-process
+   concurrently and requires all `RACE` launches to succeed, `boxes.json` to
+   remain readable, and all `RACE` records to persist. This is the only check
+   that exercises the cross-process
    advisory lock (`flock` on `boxes.json.lock`) across separate processes — the
    unit tests only race in-process threads. A lost update fails the gate.
 

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -43,7 +43,7 @@ Box now:
 - rejects any reintroduction of the removed integration symbols in CI.
 
 The exact integration revision is
-`e6b840b73a4e5c3bbfa72c2b5d6fd89104a60f9a`, which implements the versioned
+`0bd7929b9842184b3cf98986bfe1b6ef79ca5282`, which implements the versioned
 control/workload cgroup layout and retains the earlier cross-platform
 qualification.
 

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -39,11 +39,19 @@ cd crates/box
 # Optional but recommended for offline/reproducible runs.
 export A3S_BOX_TEST_ALPINE_TAR=/path/to/alpine-oci.tar
 export A3S_BOX_SMOKE_IMAGE_TAR="$A3S_BOX_TEST_ALPINE_TAR"
+export A3S_BOX_BUILDKIT_SMOKE_IMAGE_TAR=/path/to/buildkit-arm64-oci.tar
 export A3S_BOX_SMOKE_SKIP_PULL=1
 export A3S_BOX_SMOKE_TIMEOUT_SECS=300
 
 scripts/host-integration-smoke.sh --core
 ```
+
+The BuildKit archive must contain the Linux arm64 image selected by
+`A3S_BOX_BUILDKIT_IMAGE` (default: `moby/buildkit:latest`). The core suite loads
+it into each isolated test home before running the macOS BuildKit cases. This
+avoids repeatedly downloading the large helper image. Cross-architecture
+Dockerfile base images must still be reachable by BuildKit through their image
+references, such as a local registry or a configured registry mirror.
 
 If you do not have an offline archive and want to pull from the registry during
 the run, add:

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -387,6 +387,11 @@ runner repeats the selected real suites, runs `bench/bench.sh leak` and
 `bench/bench.sh race` by default, samples host resource counts, and writes an
 evidence directory under `src/target/a3s-box-soak/`.
 
+When `A3S_BOX_TEST_ALPINE_TAR` or `A3S_BOX_SMOKE_IMAGE_TAR` is set, the runner
+reloads that archive with the configured `IMAGE` tag before each benchmark
+step. This keeps the leak and race gates reproducibly offline even when an
+earlier host suite intentionally runs `system-prune --all`.
+
 ```bash
 cd crates/box
 export A3S_BOX_TEST_ALPINE_TAR=/path/to/alpine-oci.tar

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -395,6 +395,7 @@ export A3S_BOX_HOST_SMOKE_TIMEOUT_SECS=300
 export IMAGE=docker.m.daocloud.io/library/alpine:latest
 export CHURN=2500
 export RACE=32
+export RACE_WORKLOAD_SECS=300
 
 scripts/host-integration-smoke.sh \
   --no-pure \

--- a/docs/production-cluster-tests.md
+++ b/docs/production-cluster-tests.md
@@ -151,7 +151,8 @@ Pass criteria:
 - `core_smoke` and `host_smoke` pass on every admitted node.
 - `bench/bench.sh leak` returns to the baseline count for shims, mounts, and
   box directories.
-- `bench/bench.sh race` reports no lost update and leaves no race boxes behind.
+- `bench/bench.sh race` reports `RACE/RACE` successful launches, persists all
+  `RACE` records without a lost update, and leaves no race boxes behind.
 - `a3s-box ps -a`, `a3s-box images`, `a3s-box volume ls`, and
   `a3s-box snapshot ls` are readable after the run.
 
@@ -243,6 +244,7 @@ Per selected node:
 export IMAGE=docker.m.daocloud.io/library/alpine:latest
 export CHURN=2500
 export RACE=32
+export RACE_WORKLOAD_SECS=300
 scripts/host-integration-smoke.sh \
   --no-pure \
   --core \

--- a/scripts/host-integration-smoke.sh
+++ b/scripts/host-integration-smoke.sh
@@ -35,6 +35,7 @@ SOAK_FAILED_COMMAND=""
 SOAK_SUMMARY_ITERATIONS=0
 SOAK_SUMMARY_FAILURES=0
 SOAK_STARTED_EPOCH=0
+SOAK_FINAL_CAPTURED=0
 
 usage() {
     cat <<'EOF'
@@ -618,6 +619,18 @@ capture_cli_snapshot() {
     } >"$SOAK_EVIDENCE_DIR/${label}-cli-snapshot.txt"
 }
 
+capture_final_soak_state() {
+    if [ "$SOAK_FINAL_CAPTURED" -eq 1 ]; then
+        return
+    fi
+
+    # Arm the guard before writing either artifact so an ERR/EXIT trap cannot
+    # append a second final sample while handling a partial capture failure.
+    SOAK_FINAL_CAPTURED=1
+    write_resource_sample "final"
+    capture_cli_snapshot "final"
+}
+
 prepare_bench_image() {
     local tar_path bin image
     tar_path="$(offline_image_tar)"
@@ -772,8 +785,7 @@ handle_soak_exit() {
     trap - ERR
     trap - EXIT
     if [ -n "$SOAK_EVIDENCE_DIR" ] && [ -d "$SOAK_EVIDENCE_DIR" ]; then
-        write_resource_sample "final" || true
-        capture_cli_snapshot "final" || true
+        capture_final_soak_state || true
         write_soak_summary "fail" "$SOAK_SUMMARY_ITERATIONS" "$SOAK_SUMMARY_FAILURES" "$rc"
         log "Host soak failed: exit_code=$rc evidence=$SOAK_EVIDENCE_DIR"
     fi
@@ -813,6 +825,7 @@ run_soak_suite() {
     SOAK_EVIDENCE_DIR="${SOAK_OUTPUT_DIR:-$WORKSPACE/target/a3s-box-soak/$SOAK_RUN_ID}"
     export SOAK_RUN_ID SOAK_EVIDENCE_DIR
     mkdir -p "$SOAK_EVIDENCE_DIR"
+    SOAK_FINAL_CAPTURED=0
     SOAK_FAILURE_TRAP_ARMED=1
     trap 'record_soak_failure' ERR
     trap 'handle_soak_exit "$?"' EXIT
@@ -859,8 +872,7 @@ run_soak_suite() {
         fi
     done
 
-    write_resource_sample "final"
-    capture_cli_snapshot "final"
+    capture_final_soak_state
     if [ "$failures" -eq 0 ]; then
         write_soak_summary "pass" "$iteration" "$failures"
     else

--- a/scripts/host-integration-smoke.sh
+++ b/scripts/host-integration-smoke.sh
@@ -72,6 +72,8 @@ Options:
 
 Common environment:
   A3S_BOX_SMOKE_IMAGE_TAR=/path/to/alpine-oci.tar   Offline core_smoke image.
+  A3S_BOX_BUILDKIT_SMOKE_IMAGE_TAR=/path/to/buildkit-oci.tar
+                                                    Preloaded macOS BuildKit helper image.
   A3S_BOX_TEST_ALPINE_TAR=/path/to/alpine-oci.tar   Offline host/core image.
   A3S_BOX_SMOKE_SKIP_PULL=1                         Reuse preloaded core image.
   A3S_BOX_ALLOW_REGISTRY_PULL=1                     Allow live registry pulls.
@@ -425,8 +427,8 @@ EOF
 
 build_real_binaries() {
     log "Building real host binaries"
-    run_real cargo build -p a3s-box-cli -p a3s-box-shim
-    build_guest_init
+    run_real cargo build -p a3s-box-cli -p a3s-box-shim || return $?
+    build_guest_init || return $?
 }
 
 run_pure_suite() {
@@ -439,23 +441,23 @@ run_pure_suite() {
 }
 
 run_core_suite() {
-    require_image_source "core smoke"
-    build_real_binaries
+    require_image_source "core smoke" || return $?
+    build_real_binaries || return $?
     log "Running real MicroVM core smoke"
     run_real cargo test -p a3s-box-cli --test core_smoke -- --ignored --nocapture --test-threads=1
 }
 
 run_host_suite() {
-    require_image_source "host smoke"
-    build_real_binaries
+    require_image_source "host smoke" || return $?
+    build_real_binaries || return $?
     log "Running host VM command matrix"
-    run_real cargo test -p a3s-box-cli --test host_smoke test_real_vm_command_matrix -- --ignored --nocapture --test-threads=1
+    run_real cargo test -p a3s-box-cli --test host_smoke test_real_vm_command_matrix -- --ignored --nocapture --test-threads=1 || return $?
     log "Running warm-pool command smoke"
-    run_real cargo test -p a3s-box-cli --test host_smoke test_real_pool_warm_run -- --ignored --nocapture --test-threads=1
+    run_real cargo test -p a3s-box-cli --test host_smoke test_real_pool_warm_run -- --ignored --nocapture --test-threads=1 || return $?
     log "Running warm-pool Dockerfile RUN smoke"
-    run_real cargo test -p a3s-box-cli --test host_smoke test_real_build_run_pool_smoke -- --ignored --nocapture --test-threads=1
+    run_real cargo test -p a3s-box-cli --test host_smoke test_real_build_run_pool_smoke -- --ignored --nocapture --test-threads=1 || return $?
     log "Running host Compose smoke"
-    run_real cargo test -p a3s-box-cli --test host_smoke test_real_compose_acl_smoke -- --ignored --nocapture --test-threads=1
+    run_real cargo test -p a3s-box-cli --test host_smoke test_real_compose_acl_smoke -- --ignored --nocapture --test-threads=1 || return $?
 
     if [ -n "${A3S_BOX_PUSH_TEST_REF:-}" ]; then
         log "Running registry push smoke"
@@ -481,15 +483,15 @@ run_linux_run_suite() {
         return
     fi
 
-    build_real_binaries
+    build_real_binaries || return $?
     log "Running Linux Dockerfile RUN chroot smoke"
     run_real cargo test -p a3s-box-cli --test host_smoke test_linux_build_run_chroot_smoke -- --ignored --nocapture --test-threads=1
 }
 
 run_cri_suite() {
-    build_real_binaries
+    build_real_binaries || return $?
     log "Building CRI server"
-    run_real cargo build -p a3s-box-cri
+    run_real cargo build -p a3s-box-cri || return $?
     log "Running crictl CRI smoke"
     printf '+ A3S_BOX_CRI_SMOKE=1 cargo test -p a3s-box-cri --test crictl_smoke -- --ignored --nocapture --test-threads=1\n'
     env -u A3S_DEPS_STUB A3S_BOX_CRI_SMOKE=1 \

--- a/scripts/host-integration-smoke.sh
+++ b/scripts/host-integration-smoke.sh
@@ -618,11 +618,27 @@ capture_cli_snapshot() {
     } >"$SOAK_EVIDENCE_DIR/${label}-cli-snapshot.txt"
 }
 
+prepare_bench_image() {
+    local tar_path bin image
+    tar_path="$(offline_image_tar)"
+    if [ -z "$tar_path" ]; then
+        return
+    fi
+
+    prepare_offline_image_env
+    bin="${A3S_BOX:-$WORKSPACE/target/debug/a3s-box}"
+    image="${IMAGE:-alpine:latest}"
+    log "Seeding offline benchmark image $image"
+    run_real "$bin" load --input "$tar_path" --tag "$image"
+}
+
 run_bench_leak() {
+    prepare_bench_image
     A3S_BOX="${A3S_BOX:-$WORKSPACE/target/debug/a3s-box}" run_real "$REPO_ROOT/bench/bench.sh" leak
 }
 
 run_bench_race() {
+    prepare_bench_image
     A3S_BOX="${A3S_BOX:-$WORKSPACE/target/debug/a3s-box}" run_real "$REPO_ROOT/bench/bench.sh" race
 }
 

--- a/scripts/host-integration-smoke.sh
+++ b/scripts/host-integration-smoke.sh
@@ -430,6 +430,7 @@ build_real_binaries() {
 
 run_pure_suite() {
     log "Running stub-backed baseline checks"
+    run_real "$REPO_ROOT/bench/bench-self-test.sh"
     run cargo fmt --all -- --check
     run_stub cargo clippy --workspace --all-targets --all-features -- -D warnings
     run_stub cargo test --workspace --lib
@@ -496,12 +497,17 @@ run_cri_suite() {
 
 shim_count() {
     local count
-    count="$(pgrep -xc 'a3s-box-shim' 2>/dev/null || pgrep -fc 'a3s-box-shim' 2>/dev/null || true)"
-    echo "${count:-0}"
+    count="$({ pgrep -x 'a3s-box-shim' 2>/dev/null || true; } | awk 'END { print NR + 0 }')"
+    echo "$count"
 }
 
 mount_count() {
-    mount 2>/dev/null | awk '/\/\.a3s\/boxes|\/a3s\/boxes/ { n++ } END { print n + 0 }'
+    local boxes_dir
+    boxes_dir="$(a3s_home_dir)/boxes"
+    mount 2>/dev/null | awk -v boxes_dir="$boxes_dir" '
+        index($0, boxes_dir) { n++ }
+        END { print n + 0 }
+    '
 }
 
 boxdir_count() {
@@ -659,19 +665,25 @@ run_soak_iteration() {
 
     if [ "$RUN_CORE" -eq 1 ]; then
         run_soak_step "$iteration" core run_core_suite || rc=1
+        write_resource_sample "iteration-${iteration}-after-core"
     fi
     if [ "$RUN_HOST" -eq 1 ]; then
         run_soak_step "$iteration" host run_host_suite || rc=1
+        write_resource_sample "iteration-${iteration}-after-host"
     fi
     if [ "$RUN_LINUX_RUN" -eq 1 ]; then
         run_soak_step "$iteration" linux-run run_linux_run_suite || rc=1
+        write_resource_sample "iteration-${iteration}-after-linux-run"
     fi
     if [ "$RUN_CRI" -eq 1 ]; then
         run_soak_step "$iteration" cri run_cri_suite || rc=1
+        write_resource_sample "iteration-${iteration}-after-cri"
     fi
     if [ "$SOAK_RUN_BENCH" -eq 1 ]; then
         run_soak_step "$iteration" bench-leak run_bench_leak || rc=1
+        write_resource_sample "iteration-${iteration}-after-bench-leak"
         run_soak_step "$iteration" bench-race run_bench_race || rc=1
+        write_resource_sample "iteration-${iteration}-after-bench-race"
     fi
 
     capture_cli_snapshot "iteration-${iteration}"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=e6b840b73a4e5c3bbfa72c2b5d6fd89104a60f9a#e6b840b73a4e5c3bbfa72c2b5d6fd89104a60f9a"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0bd7929b9842184b3cf98986bfe1b6ef79ca5282#0bd7929b9842184b3cf98986bfe1b6ef79ca5282"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=e6b840b73a4e5c3bbfa72c2b5d6fd89104a60f9a#e6b840b73a4e5c3bbfa72c2b5d6fd89104a60f9a"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0bd7929b9842184b3cf98986bfe1b6ef79ca5282#0bd7929b9842184b3cf98986bfe1b6ef79ca5282"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -2409,7 +2409,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3279,7 +3279,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,7 +125,7 @@ ring = "0.17"
 a3s-acl = { version = "0.2.2", git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "b0aa0c34e2c8121effbcbfbe6246a860e78ca509" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "e6b840b73a4e5c3bbfa72c2b5d6fd89104a60f9a" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "0bd7929b9842184b3cf98986bfe1b6ef79ca5282" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/cli/src/commands/build_buildkit_vm.rs
+++ b/src/cli/src/commands/build_buildkit_vm.rs
@@ -83,7 +83,11 @@ pub(super) async fn execute(options: Build) -> Result<(), Box<dyn std::error::Er
         )
         .into());
     }
-    let load_args = load_args(&output_tar, options.tag.as_deref());
+    let load_args = load_args(
+        &output_tar,
+        options.tag.as_deref(),
+        options.platform.as_deref(),
+    );
     run_current_a3s_box(&load_args).await?;
     Ok(())
 }
@@ -342,7 +346,7 @@ fn output_attr(options: &Build, output_name: &str) -> Result<String, Box<dyn std
     Ok(format!("type=oci,dest=/out/{output_name}"))
 }
 
-fn load_args(output_tar: &Path, tag: Option<&str>) -> Vec<String> {
+fn load_args(output_tar: &Path, tag: Option<&str>, platform: Option<&str>) -> Vec<String> {
     let mut args = vec![
         "load".to_string(),
         "--input".to_string(),
@@ -351,6 +355,10 @@ fn load_args(output_tar: &Path, tag: Option<&str>) -> Vec<String> {
     if let Some(tag) = tag {
         args.push("--tag".to_string());
         args.push(tag.to_string());
+    }
+    if let Some(platform) = platform {
+        args.push("--platform".to_string());
+        args.push(platform.to_string());
     }
     args
 }
@@ -531,8 +539,12 @@ mod tests {
     }
 
     #[test]
-    fn test_load_args_adds_tag() {
-        let args = load_args(Path::new("/tmp/out/image.tar"), Some("app:latest"));
+    fn test_load_args_preserves_tag_and_platform() {
+        let args = load_args(
+            Path::new("/tmp/out/image.tar"),
+            Some("app:latest"),
+            Some("linux/amd64"),
+        );
         assert_eq!(
             args,
             vec![
@@ -540,7 +552,9 @@ mod tests {
                 "--input",
                 "/tmp/out/image.tar",
                 "--tag",
-                "app:latest"
+                "app:latest",
+                "--platform",
+                "linux/amd64"
             ]
         );
     }

--- a/src/cli/src/commands/mod.rs
+++ b/src/cli/src/commands/mod.rs
@@ -244,10 +244,10 @@ pub(crate) fn resolve_box_rootfs(box_dir: &std::path::Path) -> Option<PathBuf> {
     }
     let rootfs = box_dir.join("rootfs");
     let apfs_data = rootfs.join(".a3s-rootfs");
-    if apfs_data.is_dir() {
+    if is_populated(&apfs_data) {
         return Some(apfs_data);
     }
-    if rootfs.is_dir() {
+    if is_populated(&rootfs) {
         return Some(rootfs);
     }
     None
@@ -686,6 +686,31 @@ pub async fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 mod isolation_cli_tests {
     use super::*;
     use clap::Parser;
+
+    #[test]
+    fn rootfs_resolution_ignores_empty_provider_mountpoints() {
+        let temporary = tempfile::tempdir().unwrap();
+        let rootfs = temporary.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+
+        assert_eq!(resolve_box_rootfs(temporary.path()), None);
+
+        std::fs::write(rootfs.join("file"), "rootfs").unwrap();
+        assert_eq!(resolve_box_rootfs(temporary.path()), Some(rootfs));
+    }
+
+    #[test]
+    fn rootfs_resolution_prefers_populated_merged_view() {
+        let temporary = tempfile::tempdir().unwrap();
+        let rootfs = temporary.path().join("rootfs");
+        let merged = temporary.path().join("merged");
+        std::fs::create_dir_all(&rootfs).unwrap();
+        std::fs::create_dir_all(&merged).unwrap();
+        std::fs::write(rootfs.join("file"), "rootfs").unwrap();
+        std::fs::write(merged.join("file"), "merged").unwrap();
+
+        assert_eq!(resolve_box_rootfs(temporary.path()), Some(merged));
+    }
 
     #[test]
     fn run_accepts_explicit_sandbox_isolation() {

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -154,6 +154,13 @@ struct RunContext {
     completed_during_start: bool,
 }
 
+pub(super) fn is_completed_managed_start(record: &BoxRecord) -> bool {
+    record.exit_code.is_some()
+        && record
+            .managed_state()
+            .is_ok_and(|state| state == Some(a3s_box_runtime::ManagedExecutionState::Stopped))
+}
+
 pub async fn execute(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     validate_run_mode(&args, std::io::stdin().is_terminal())
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
@@ -400,7 +407,7 @@ use setup::setup_and_boot;
 #[cfg(test)]
 use setup::{
     build_box_config, build_execution_request, interactive_keepalive_entrypoint,
-    is_completed_managed_start, should_create_diff_baseline, RunRecordPolicy,
+    should_create_diff_baseline, RunRecordPolicy,
 };
 
 // ============================================================================
@@ -686,7 +693,7 @@ async fn run_foreground(
         );
     }
 
-    let persisted_exit_code = a3s_box_runtime::rootfs::read_persisted_exit_code(&ctx.box_dir);
+    let persisted_exit_code = foreground_workload_exit_code(&ctx.box_dir, ctx.record.exit_code);
     let exit_code = foreground_exit_code(stop_reason, persisted_exit_code);
     let archive_start = std::time::Instant::now();
     archive_auto_removed_logs(&ctx, args.rm, exit_code, stop_reason.stopped_by_user());
@@ -809,6 +816,13 @@ fn foreground_exit_code(reason: ForegroundStopReason, vm_exit_code: Option<i32>)
         ForegroundStopReason::VmUnhealthy => vm_exit_code.or(Some(1)),
         ForegroundStopReason::TimedOut => Some(124),
     }
+}
+
+fn foreground_workload_exit_code(
+    box_dir: &std::path::Path,
+    recorded_exit_code: Option<i32>,
+) -> Option<i32> {
+    a3s_box_runtime::rootfs::read_persisted_exit_code(box_dir).or(recorded_exit_code)
 }
 
 fn managed_process_alive(ctx: &RunContext) -> bool {

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -640,8 +640,8 @@ async fn run_foreground(
         foreground_start.elapsed(),
     );
 
-    let sandbox_natural_exit =
-        stop_reason == ForegroundStopReason::ProcessExited && ctx.record.isolation.is_sandbox();
+    let natural_exit = stop_reason == ForegroundStopReason::ProcessExited;
+    let sandbox_natural_exit = natural_exit && ctx.record.isolation.is_sandbox();
     if sandbox_natural_exit {
         // The generation-owned worker exits only after the A3S OCI owner has closed both
         // raw console streams and projected their final records. Once it is
@@ -656,9 +656,13 @@ async fn run_foreground(
     }
 
     let raw_log_drain_start = std::time::Instant::now();
+    // A natural Sandbox completion is published only after its generation-owned
+    // log worker exits. A natural MicroVM completion is published only after the
+    // shim closes the raw streams and joins its log processor. In both cases the
+    // lengths are immutable, so wait only for the terminal tailers to catch up.
     wait_for_foreground_log_drain(
         &[(&console_log, &stdout_pos), (&console_err, &stderr_pos)],
-        sandbox_natural_exit,
+        natural_exit,
     )
     .await;
     a3s_box_core::lifecycle_profile::record_lifecycle_phase(

--- a/src/cli/src/commands/run/setup.rs
+++ b/src/cli/src/commands/run/setup.rs
@@ -240,14 +240,7 @@ fn completed_start_record(box_id: &str) -> Result<Option<BoxRecord>, Box<dyn std
     let Some(record) = state.find_by_id(box_id) else {
         return Ok(None);
     };
-    Ok(is_completed_managed_start(record).then(|| record.clone()))
-}
-
-pub(super) fn is_completed_managed_start(record: &BoxRecord) -> bool {
-    record.exit_code.is_some()
-        && record
-            .managed_state()
-            .is_ok_and(|state| state == Some(a3s_box_runtime::ManagedExecutionState::Stopped))
+    Ok(super::is_completed_managed_start(record).then(|| record.clone()))
 }
 
 fn pull_progress_callback(image_name: String) -> a3s_box_runtime::PullProgressFn {

--- a/src/cli/src/commands/run/tests.rs
+++ b/src/cli/src/commands/run/tests.rs
@@ -871,7 +871,7 @@ fn test_foreground_poll_cadence_avoids_fixed_startup_delay() {
 }
 
 #[tokio::test]
-async fn finished_sandbox_writers_need_no_additional_quiet_period() {
+async fn finished_foreground_writers_need_no_additional_quiet_period() {
     let directory = tempfile::tempdir().unwrap();
     let log = directory.path().join("console.log");
     std::fs::write(&log, b"complete").unwrap();
@@ -886,7 +886,7 @@ async fn finished_sandbox_writers_need_no_additional_quiet_period() {
 }
 
 #[tokio::test]
-async fn finished_sandbox_writer_wait_still_requires_tail_catch_up() {
+async fn finished_foreground_writer_wait_still_requires_tail_catch_up() {
     let directory = tempfile::tempdir().unwrap();
     let log = directory.path().join("console.log");
     std::fs::write(&log, b"pending").unwrap();

--- a/src/cli/src/commands/run/tests.rs
+++ b/src/cli/src/commands/run/tests.rs
@@ -820,6 +820,24 @@ fn test_foreground_exit_code_preserves_vm_code() {
 }
 
 #[test]
+fn test_foreground_workload_exit_code_falls_back_to_completed_start_record() {
+    let temporary = tempfile::tempdir().unwrap();
+
+    assert_eq!(
+        foreground_workload_exit_code(temporary.path(), Some(0)),
+        Some(0)
+    );
+
+    let exit_path = temporary.path().join("upper/.a3s_exit_code");
+    std::fs::create_dir_all(exit_path.parent().unwrap()).unwrap();
+    std::fs::write(exit_path, "7\n").unwrap();
+    assert_eq!(
+        foreground_workload_exit_code(temporary.path(), Some(1)),
+        Some(7)
+    );
+}
+
+#[test]
 fn test_foreground_natural_exit_without_guest_result_fails_closed() {
     assert_eq!(
         foreground_exit_code(ForegroundStopReason::ProcessExited, None),

--- a/src/cli/src/commands/snapshot.rs
+++ b/src/cli/src/commands/snapshot.rs
@@ -182,6 +182,10 @@ async fn execute_create(args: SnapshotCreateArgs) -> Result<(), Box<dyn std::err
 
     // Snapshot the box's current root filesystem (overlay `merged` or the plain
     // provider's `rootfs`), so runtime changes are captured — not an empty dir.
+    // A stopped macOS box retains that filesystem in its APFS sparse image, so
+    // attach it for the duration of the copy instead of archiving the empty
+    // mountpoint left behind after runtime teardown.
+    let _attached_rootfs = a3s_box_runtime::rootfs::attach_persistent_rootfs(&record.box_dir)?;
     let rootfs_path = super::resolve_box_rootfs(&record.box_dir).ok_or_else(|| {
         format!(
             "Rootfs not found for box '{}' under {} (looked for merged/ and rootfs/); \

--- a/src/cli/src/commands/start.rs
+++ b/src/cli/src/commands/start.rs
@@ -94,13 +94,11 @@ async fn start_one(state: &StateFile, query: &str) -> Result<(), Box<dyn std::er
             drop(lifecycle_lock.take());
             let home = a3s_box_core::dirs_home();
             let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
-            match managed_plan {
+            let start_result = match managed_plan {
                 StartPlan::Managed {
                     execution_id,
                     generation,
-                } => {
-                    manager.start(&execution_id, generation).await?;
-                }
+                } => manager.start(&execution_id, generation).await,
                 StartPlan::ManagedRestart {
                     execution_id,
                     generation,
@@ -118,9 +116,22 @@ async fn start_one(state: &StateFile, query: &str) -> Result<(), Box<dyn std::er
                             &operation_id,
                             RestartExecutionOptions { stop_timeout_secs },
                         )
-                        .await?;
+                        .await
                 }
                 StartPlan::Legacy => unreachable!("legacy starts use the legacy branch"),
+            };
+            if let Err(error) = start_result {
+                // A short workload may complete between the backend start and
+                // its readiness handshake. The runtime persists the exact exit
+                // code and terminal state before returning that startup error;
+                // `start` should still succeed, just like a normal detached
+                // start whose process exits immediately afterward.
+                let completed = StateFile::load_readonly()?
+                    .find_by_id(&box_id)
+                    .is_some_and(super::run::is_completed_managed_start);
+                if !completed {
+                    return Err(error.into());
+                }
             }
 
             let baseline_box_dir = record.box_dir.clone();
@@ -152,7 +163,7 @@ async fn start_one(state: &StateFile, query: &str) -> Result<(), Box<dyn std::er
         }
     };
     drop(lifecycle_lock);
-    if let Some(record) = started_record {
+    if let Some(record) = started_record.filter(crate::status::is_active) {
         crate::health::spawn_detached_health_checker(&record)
             .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
     }

--- a/src/cli/tests/core_smoke.rs
+++ b/src/cli/tests/core_smoke.rs
@@ -504,6 +504,7 @@ impl CoreSmoke {
         panic!("timeout waiting for {name} to become {expected}\nlast inspect:\n{last}");
     }
 
+    #[cfg(target_os = "macos")]
     fn wait_for_named_terminal_status(&self, name: &str) -> serde_json::Value {
         let start = Instant::now();
         let mut last = String::new();

--- a/src/cli/tests/core_smoke.rs
+++ b/src/cli/tests/core_smoke.rs
@@ -14,6 +14,8 @@
 //! - `A3S_BOX_SMOKE_IMAGE`: image to use (default: `docker.io/library/alpine:latest`)
 //! - `A3S_BOX_SMOKE_IMAGE_TAR`: load this OCI archive into the isolated `A3S_HOME`
 //!   before running, useful for offline HVF/KVM smoke tests
+//! - `A3S_BOX_BUILDKIT_SMOKE_IMAGE_TAR`: preload the BuildKit helper image from
+//!   this OCI archive for reproducible macOS BuildKit smoke tests
 //! - `A3S_BOX_TEST_ALPINE_TAR`: fallback OCI archive path shared with host smoke coverage
 //! - `A3S_BOX_SMOKE_SKIP_PULL=1`: skip the explicit `pull` step for cached images
 //! - `A3S_BOX_SMOKE_TIMEOUT_SECS`: command and polling timeout (default: 300)
@@ -502,6 +504,22 @@ impl CoreSmoke {
         panic!("timeout waiting for {name} to become {expected}\nlast inspect:\n{last}");
     }
 
+    fn wait_for_named_terminal_status(&self, name: &str) -> serde_json::Value {
+        let start = Instant::now();
+        let mut last = String::new();
+
+        while start.elapsed() < self.timeout {
+            let value = self.inspect_json(name);
+            last = value.to_string();
+            if matches!(json_string_field(&value, "status"), "stopped" | "dead") {
+                return value;
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+
+        panic!("timeout waiting for {name} to become terminal\nlast inspect:\n{last}");
+    }
+
     fn wait_for_named_health(&self, name: &str, expected: &str) -> serde_json::Value {
         let start = Instant::now();
         let mut last = String::new();
@@ -722,6 +740,26 @@ fn smoke_image_tar() -> Option<String> {
         .ok()
         .or_else(|| std::env::var("A3S_BOX_TEST_ALPINE_TAR").ok())
         .filter(|path| !path.trim().is_empty())
+}
+
+#[cfg(target_os = "macos")]
+fn seed_optional_image_tar(smoke: &CoreSmoke, variable: &str, image: &str) {
+    let Ok(path) = std::env::var(variable) else {
+        return;
+    };
+    if path.trim().is_empty() {
+        return;
+    }
+    smoke.ok(&["load", "--input", &path, "--tag", image]);
+}
+
+#[cfg(target_os = "macos")]
+fn seed_buildkit_image(smoke: &CoreSmoke) {
+    let image = std::env::var("A3S_BOX_BUILDKIT_IMAGE")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "moby/buildkit:latest".to_string());
+    seed_optional_image_tar(smoke, "A3S_BOX_BUILDKIT_SMOKE_IMAGE_TAR", &image);
 }
 
 fn skip_pull() -> bool {
@@ -1213,12 +1251,11 @@ fn real_core_published_port_http_smoke() {
 #[cfg(target_os = "macos")]
 #[test]
 #[ignore]
-fn real_core_tsi_published_redis_nonblocking_accept_and_exec() {
+fn real_core_tsi_published_tcp_nonblocking_accept_and_exec() {
     use std::io::{Read, Write};
 
     let smoke = CoreSmoke::new();
-    let image =
-        std::env::var("A3S_BOX_REDIS_SMOKE_IMAGE").unwrap_or_else(|_| "redis:7-alpine".to_string());
+    let image = smoke_image();
     let host_port = unused_tcp_port();
     let publish = format!("{host_port}:6379");
     let _cleanup = NamedBoxCleanup {
@@ -1226,15 +1263,34 @@ fn real_core_tsi_published_redis_nonblocking_accept_and_exec() {
         name: smoke.name.clone(),
     };
 
-    smoke.ok(&["pull", &image]);
-    smoke.ok(&["run", "-d", "--name", &smoke.name, "-p", &publish, &image]);
+    seed_smoke_image(&smoke, &image);
+    smoke.ok(&[
+        "run",
+        "-d",
+        "--name",
+        &smoke.name,
+        "-p",
+        &publish,
+        &image,
+        "--",
+        "/bin/sh",
+        "-c",
+        r#"cat >/tmp/a3s-pong <<'EOF'
+#!/bin/sh
+dd bs=1 count=14 of=/dev/null 2>/dev/null
+printf '+PONG\r\n'
+EOF
+chmod +x /tmp/a3s-pong
+echo TSI_ACCEPT_READY
+exec nc -ll -p 6379 -e /tmp/a3s-pong"#,
+    ]);
     smoke.wait_for_running();
-    smoke.wait_for_logs("Ready to accept connections");
+    smoke.wait_for_logs("TSI_ACCEPT_READY");
 
     let address = std::net::SocketAddr::from(([127, 0, 0, 1], host_port));
     for connection in 1..=2 {
         let mut stream = std::net::TcpStream::connect_timeout(&address, Duration::from_secs(5))
-            .unwrap_or_else(|error| panic!("connect Redis client {connection}: {error}"));
+            .unwrap_or_else(|error| panic!("connect TSI client {connection}: {error}"));
         stream
             .set_read_timeout(Some(Duration::from_secs(10)))
             .unwrap();
@@ -1242,7 +1298,7 @@ fn real_core_tsi_published_redis_nonblocking_accept_and_exec() {
         let mut pong = [0u8; 7];
         stream
             .read_exact(&mut pong)
-            .unwrap_or_else(|error| panic!("read Redis PONG for client {connection}: {error}"));
+            .unwrap_or_else(|error| panic!("read TSI PONG for client {connection}: {error}"));
         assert_eq!(&pong, b"+PONG\r\n");
     }
 
@@ -1254,7 +1310,7 @@ fn real_core_tsi_published_redis_nonblocking_accept_and_exec() {
         "-c",
         "echo EXEC_AFTER_PONG",
     ]);
-    assert_contains(&exec, "EXEC_AFTER_PONG", "exec after Redis PONG");
+    assert_contains(&exec, "EXEC_AFTER_PONG", "exec after TSI PONG");
 
     smoke.ok(&["rm", "-f", &smoke.name]);
 }
@@ -2709,7 +2765,7 @@ fi"#;
     ]);
     let first = smoke.wait_for_named_logs(&smoke.name, "CASE_SENSITIVE_CREATED");
     assert_contains(&first, "CASE_SENSITIVE_CREATED", "first case-sensitive run");
-    smoke.wait_for_named_status(&smoke.name, "dead");
+    smoke.wait_for_named_terminal_status(&smoke.name);
 
     smoke.ok(&["start", &smoke.name]);
     let second = smoke.wait_for_named_logs(&smoke.name, "CASE_SENSITIVE_PERSISTED");
@@ -2718,6 +2774,7 @@ fi"#;
         "CASE_SENSITIVE_PERSISTED",
         "persistent case-sensitive restart",
     );
+    smoke.wait_for_named_terminal_status(&smoke.name);
 
     smoke.ok(&["rm", &smoke.name]);
     let boxes_dir = smoke.home_path().join("boxes");
@@ -2746,7 +2803,7 @@ fi"#;
     assert!(
         smoke
             .home_path()
-            .join("cache/rootfs-apfs")
+            .join("cache/rootfs-apfs-v2")
             .read_dir()
             .map(|mut entries| entries.next().is_some())
             .unwrap_or(false),
@@ -2759,19 +2816,26 @@ fi"#;
 #[ignore]
 fn real_core_buildkit_vm_preserves_multiple_build_args_with_spaces() {
     let smoke = CoreSmoke::new();
-    let base = smoke_image();
     let tag = format!("{}-build-args:latest", smoke.name);
     let context = smoke.home_path().join("buildkit-context");
     std::fs::create_dir_all(&context).unwrap();
+    std::fs::write(context.join("payload"), "buildkit-offline-smoke\n").unwrap();
     std::fs::write(
         context.join("Dockerfile"),
-        format!(
-            "FROM {base} AS chosen\nARG FIRST=default\nARG SECOND=none\nRUN printf '%s|%s' \"$FIRST\" \"$SECOND\" >/ok\n\nFROM {base} AS default\nRUN printf wrong >/ok\n"
-        ),
+        "FROM scratch AS chosen\n\
+         ARG FIRST=default\n\
+         ARG SECOND=none\n\
+         COPY payload /payload\n\
+         LABEL a3s.smoke.first=\"$FIRST\" a3s.smoke.second=\"$SECOND\" a3s.smoke.target=\"chosen\"\n\
+         \n\
+         FROM scratch AS default\n\
+         COPY payload /payload\n\
+         LABEL a3s.smoke.target=\"default\"\n",
     )
     .unwrap();
     let context_arg = context.to_string_lossy().to_string();
 
+    seed_buildkit_image(&smoke);
     smoke.ok(&[
         "build",
         "--builder",
@@ -2790,8 +2854,12 @@ fn real_core_buildkit_vm_preserves_multiple_build_args_with_spaces() {
         &tag,
         &context_arg,
     ]);
-    let result = smoke.ok(&["run", "--rm", "--entrypoint", "/bin/cat", &tag, "--", "/ok"]);
-    assert_contains(&result, "two words|custom", "BuildKit build args");
+    let result: serde_json::Value =
+        serde_json::from_str(&smoke.ok(&["image-inspect", &tag])).unwrap();
+    let labels = &result[0]["Config"]["Labels"];
+    assert_eq!(labels["a3s.smoke.first"], "two words");
+    assert_eq!(labels["a3s.smoke.second"], "custom");
+    assert_eq!(labels["a3s.smoke.target"], "chosen");
 }
 
 #[cfg(target_os = "macos")]
@@ -2810,6 +2878,7 @@ fn real_core_buildkit_vm_executes_amd64_run_on_arm64_host() {
     .unwrap();
     let context_arg = context.to_string_lossy().to_string();
 
+    seed_buildkit_image(&smoke);
     smoke.ok(&[
         "build",
         "--platform",

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -2165,6 +2165,18 @@ fn read_bounded_pipe(mut pipe: impl Read, limit: usize) -> BoundedPipeOutput {
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn one_shot_exec_poll_delay(
+    elapsed: Duration,
+    timeout: Duration,
+    max_interval: Duration,
+) -> Option<Duration> {
+    timeout
+        .checked_sub(elapsed)
+        .filter(|remaining| !remaining.is_zero())
+        .map(|remaining| remaining.min(max_interval))
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn execute_command(
     cmd: &[String],
     timeout_ns: u64,
@@ -2231,7 +2243,8 @@ fn execute_command(
                 );
             }
             Ok(None) => {
-                if start.elapsed() >= timeout {
+                let Some(delay) = one_shot_exec_poll_delay(start.elapsed(), timeout, poll_interval)
+                else {
                     warn!("Exec command timed out after {:?}, killing", timeout);
                     kill_child_process_group(&mut child);
 
@@ -2240,8 +2253,8 @@ fn execute_command(
                     stderr.extend_from_slice(b"\nProcess killed: timeout exceeded");
 
                     return bounded_exec_output_with_truncation(stdout, stderr, 137, truncated);
-                }
-                std::thread::sleep(poll_interval);
+                };
+                std::thread::sleep(delay);
             }
             Err(ref e) if e.raw_os_error() == Some(libc::ECHILD) => {
                 // Child already reaped (timing race in microVM PID 1 context).
@@ -3338,6 +3351,26 @@ mod tests {
         let output = execute_command(&[], 0, &[], None, None, None, None);
         assert_eq!(output.exit_code, 1);
         assert_eq!(output.stderr, b"Empty command");
+    }
+
+    #[test]
+    fn one_shot_exec_poll_never_sleeps_past_timeout() {
+        assert_eq!(
+            one_shot_exec_poll_delay(
+                Duration::from_millis(10),
+                Duration::from_millis(25),
+                Duration::from_millis(50),
+            ),
+            Some(Duration::from_millis(15))
+        );
+        assert_eq!(
+            one_shot_exec_poll_delay(
+                Duration::from_millis(25),
+                Duration::from_millis(25),
+                Duration::from_millis(50),
+            ),
+            None
+        );
     }
 
     #[test]

--- a/src/guest/init/src/lib.rs
+++ b/src/guest/init/src/lib.rs
@@ -5,6 +5,11 @@
 //! host-to-guest command execution, and network configuration for
 //! passt-based virtio-net interfaces.
 
+// The guest library executes on Linux. macOS builds it only so the host
+// workspace can compile and cross-build the real Linux guest artifact; Linux-
+// only entrypoints consequently appear unused to host-target linting.
+#![cfg_attr(not(target_os = "linux"), allow(dead_code, unused_imports))]
+
 pub mod attest_server;
 #[cfg(target_os = "linux")]
 pub mod cgroup;

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -119,6 +119,9 @@ rustls-pki-types = { workspace = true }
 # Sealed storage
 ring = { workspace = true }
 
+# Typed OCI model and the versioned A3S control/workload cgroup contract.
+a3s-oci-sdk = { workspace = true }
+
 # Extra Dockerfile ADD archive formats. These crates build C libraries, so they
 # stay off Windows where .tar/.tar.gz remain supported without a C toolchain.
 bzip2 = "0.5"

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -236,7 +236,7 @@ impl BoxRuntimeConformanceFixture {
         for ((home, id), resource) in seen {
             for (kind, path) in [
                 ("box-dir", home.join("boxes").join(&id)),
-                ("a3s-oci-root", home.join("run/a3s-oci").join(&id)),
+                ("a3s-oci-root", crate::vm::sandbox_runtime_root(&home, &id)),
                 (
                     "socket-dir",
                     PathBuf::from("/tmp/a3s-box-sockets").join(&id),
@@ -529,10 +529,7 @@ fn emit_missing_exit_diagnostics(home_dir: &Path, record: &crate::BoxRecord) {
         ),
         (
             "A3S OCI generation",
-            home_dir
-                .join("run/a3s-oci")
-                .join(&record.id)
-                .join("record.json"),
+            crate::vm::sandbox_runtime_root(home_dir, &record.id).join("record.json"),
         ),
     ] {
         let Ok(bytes) = std::fs::read(&path) else {

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
@@ -76,6 +76,10 @@ pub(super) async fn run(
             control_cgroup.display()
         ),
     )?;
+    require(
+        control_cgroup.is_dir(),
+        "Sandbox control cgroup was not created",
+    )?;
     let management_cgroup = control_cgroup.parent().ok_or_else(|| {
         super::protocol(format!(
             "Sandbox control cgroup has no management parent: {}",
@@ -83,15 +87,15 @@ pub(super) async fn run(
         ))
     })?;
     require(
-        management_cgroup.ends_with(&expected_management_suffix),
+        management_cgroup.ends_with(&expected_management_suffix) && management_cgroup.is_dir(),
         format!(
-            "Sandbox control cgroup has an unexpected management parent: {}",
+            "Sandbox management cgroup was not created at the expected path: {}",
             management_cgroup.display()
         ),
     )?;
     require(
-        management_cgroup.is_dir() && control_cgroup.is_dir(),
-        "Sandbox management/control cgroups were not created",
+        read_trimmed(&management_cgroup.join("cgroup.procs"))?.is_empty(),
+        "Sandbox management cgroup retained processes after staged activation",
     )?;
     let outer_cpu_max = read_trimmed(&management_cgroup.join("cpu.max"))?;
     let mut outer_cpu_fields = outer_cpu_max.split_whitespace();
@@ -148,6 +152,10 @@ pub(super) async fn run(
     let expected_cpu_max = format!("{CPU_QUOTA_US} {CPU_PERIOD_US}");
     let expected_memory_max = MEMORY_BYTES.to_string();
     let expected_pids_max = PIDS.to_string();
+    require(
+        workload_namespace_path == format!("/{WORKLOAD_CGROUP_NAME}"),
+        format!("workload joined an unexpected cgroup namespace path: {workload_namespace_path:?}"),
+    )?;
     require(
         visible_cpu_max == Some(expected_cpu_max.as_str())
             && visible_memory_max == Some(expected_memory_max.as_str())

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -413,12 +413,19 @@ async fn namespace_separation(fixture: &BoxRuntimeConformanceFixture) -> Result<
     // Keep this independent provider namespace short enough for the fixed
     // A3S OCI `runtime.sock` path. This profile certifies namespace separation;
     // nesting it under the already isolated primary home would instead test
-    // the platform `sockaddr_un.sun_path` limit.
+    // the platform `sockaddr_un.sun_path` limit. Seed only the immutable,
+    // digest-addressed image store so a registry outage cannot turn this local
+    // security oracle into a network test.
     let namespace_id = uuid::Uuid::new_v4().simple().to_string();
     let sibling_home = std::env::temp_dir().join(format!("a3s-r17n-{}", &namespace_id[..16]));
     std::fs::create_dir(&sibling_home)
         .map_err(|error| super::external("create sibling provider namespace", error))?;
     fixture.register_removable_home(sibling_home.clone());
+    crate::cache::layer_cache::copy_dir_recursive(
+        &fixture.home_dir.join("images"),
+        &sibling_home.join("images"),
+    )
+    .map_err(|error| super::external("seed sibling immutable image store", error))?;
     let sibling_state_root = sibling_home.join("runtime-state");
     fixture.register_state_root(sibling_state_root.clone());
     let sibling_driver = Arc::new(BoxRuntimeDriver::new(BoxRuntimeDriverConfig {

--- a/src/runtime/src/a3s_runtime_driver/exec.rs
+++ b/src/runtime/src/a3s_runtime_driver/exec.rs
@@ -15,7 +15,8 @@ use super::metadata::{
 use super::BoxRuntimeDriver;
 
 const NANOS_PER_MILLISECOND: u64 = 1_000_000;
-const EXEC_RESPONSE_BUDGET_MS: u64 = 100;
+const MAX_EXEC_RESPONSE_BUDGET_MS: u64 = 100;
+const MIN_EXEC_PHASE_BUDGET_MS: u64 = 10;
 
 impl BoxRuntimeDriver {
     pub(super) async fn execute_runtime_command(
@@ -152,14 +153,18 @@ fn effective_timeout_at(request: &RuntimeExecRequest, now_ms: u64) -> RuntimeRes
         let remaining_ms = deadline_at_ms.checked_sub(now_ms).ok_or_else(|| {
             RuntimeError::DeadlineExceeded("exec request expired before provider dispatch".into())
         })?;
-        let execution_budget_ms = remaining_ms
-            .checked_sub(EXEC_RESPONSE_BUDGET_MS)
-            .filter(|budget| *budget > 0)
-            .ok_or_else(|| {
-                RuntimeError::DeadlineExceeded(
-                    "exec request has insufficient time for a provider response".into(),
-                )
-            })?;
+        // Prefer the full response allowance for ordinary requests. Tight
+        // deadlines split the remaining window evenly so the command timeout
+        // and its replayable response both retain useful, non-zero budgets.
+        let response_budget_ms = MAX_EXEC_RESPONSE_BUDGET_MS.min(remaining_ms / 2);
+        let execution_budget_ms = remaining_ms.saturating_sub(response_budget_ms);
+        if response_budget_ms < MIN_EXEC_PHASE_BUDGET_MS
+            || execution_budget_ms < MIN_EXEC_PHASE_BUDGET_MS
+        {
+            return Err(RuntimeError::DeadlineExceeded(
+                "exec request has insufficient time for a provider response".into(),
+            ));
+        }
         // Runtime bounds the complete provider future by this same deadline.
         // Stop the guest command first so the driver can collect its bounded
         // output, reconstruct the observation, and return a replayable result.
@@ -223,6 +228,12 @@ mod tests {
         );
 
         request.deadline_at_ms = Some(1_100);
+        assert_eq!(
+            effective_timeout_at(&request, 1_000).unwrap(),
+            Duration::from_millis(50)
+        );
+
+        request.deadline_at_ms = Some(1_019);
         assert!(matches!(
             effective_timeout_at(&request, 1_000),
             Err(RuntimeError::DeadlineExceeded(message))

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -392,6 +392,7 @@ pub enum ManagedExecutionOperation {
 #[serde(rename_all = "snake_case")]
 pub enum ManagedRestartOutcome {
     Running,
+    Stopped,
     Failed,
 }
 

--- a/src/runtime/src/cache/layer_cache.rs
+++ b/src/runtime/src/cache/layer_cache.rs
@@ -260,7 +260,14 @@ pub(crate) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
         let dst_preexisted = dst.exists();
-        if copy_dir_recursive_cow(src, dst).unwrap_or(false) {
+        // copyfile(3) gives an existing destination directory different
+        // semantics from this helper: it creates `dst/src.file_name()` instead
+        // of copying the source directory's contents directly into `dst`.
+        // APFS rootfs mountpoints already exist, so taking that fast path would
+        // restore a snapshot below `.a3s-rootfs/rootfs/`. Fall back to the
+        // entry-by-entry copy for an existing destination; nested directories
+        // can still use APFS clones once their destination does not exist.
+        if !dst_preexisted && copy_dir_recursive_cow(src, dst).unwrap_or(false) {
             return Ok(());
         }
         if !dst_preexisted && dst.exists() {
@@ -976,6 +983,30 @@ mod tests {
             std::fs::read_to_string(dst.join("sub/deep/c.txt")).unwrap(),
             "ccc"
         );
+    }
+
+    #[test]
+    fn test_copy_dir_recursive_copies_contents_into_existing_destination() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("rootfs");
+        let dst = tmp.path().join("existing");
+
+        create_test_layer(&src, &[("bin/sh", "shell"), ("etc/config", "value")]);
+        std::fs::create_dir_all(&dst).unwrap();
+        std::fs::write(dst.join("marker"), "keep").unwrap();
+
+        copy_dir_recursive(&src, &dst).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(dst.join("bin/sh")).unwrap(),
+            "shell"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.join("etc/config")).unwrap(),
+            "value"
+        );
+        assert_eq!(std::fs::read_to_string(dst.join("marker")).unwrap(), "keep");
+        assert!(!dst.join("rootfs").exists());
     }
 
     #[cfg(unix)]

--- a/src/runtime/src/local_execution/recovery.rs
+++ b/src/runtime/src/local_execution/recovery.rs
@@ -183,15 +183,23 @@ impl LocalExecutionManager {
                 ManagedExecutionState::RestartStarting,
                 ExecutionState::Stopped | ExecutionState::Failed,
             ) => {
+                self.release_execution_resources(&record).await?;
+                let terminal_state =
+                    startup_terminal_state(observation.state, observation.exit_code);
                 let record = self
                     .transition(
                         &record,
                         ManagedExecutionState::RestartStarting,
-                        ManagedExecutionState::Failed,
-                        RuntimeUpdate::RestartFailed(observation.exit_code),
+                        terminal_state,
+                        RuntimeUpdate::RestartTerminal(observation.exit_code),
                     )
                     .await?;
-                Ok((record, ExecutionState::Failed))
+                let state = if terminal_state == ManagedExecutionState::Stopped {
+                    ExecutionState::Stopped
+                } else {
+                    ExecutionState::Failed
+                };
+                Ok((record, state))
             }
             (ManagedExecutionState::Running, ExecutionState::Running) => {
                 Ok((record, ExecutionState::Running))

--- a/src/runtime/src/local_execution/remove.rs
+++ b/src/runtime/src/local_execution/remove.rs
@@ -15,6 +15,7 @@ use super::{BoxRecord, LocalExecutionManager};
 
 impl LocalExecutionManager {
     /// Load one managed record without reconciling provider state.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) async fn managed_record(
         &self,
         execution_id: &ExecutionId,
@@ -23,6 +24,7 @@ impl LocalExecutionManager {
     }
 
     /// Load the complete managed inventory without exposing legacy CLI boxes.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) async fn managed_records(&self) -> ExecutionManagerResult<Vec<BoxRecord>> {
         let store = self.store.clone();
         run_store(move || store.list()).await

--- a/src/runtime/src/local_execution/remove.rs
+++ b/src/runtime/src/local_execution/remove.rs
@@ -95,10 +95,14 @@ fn cleanup_execution_paths(home_dir: &Path, record: &BoxRecord) -> ExecutionMana
     remove_tree_if_present(&socket_dir)
         .map_err(|error| cleanup_error(record, "remove the runtime socket directory", error))?;
 
-    let runtime_root = home_dir.join("run/a3s-oci").join(&record.id);
-    remove_tree_if_present(&runtime_root).map_err(|error| {
-        cleanup_error(record, "remove the Sandbox runtime state directory", error)
-    })?;
+    for runtime_root in [
+        crate::vm::sandbox_runtime_root(home_dir, &record.id),
+        crate::vm::legacy_sandbox_runtime_root(home_dir, &record.id),
+    ] {
+        remove_tree_if_present(&runtime_root).map_err(|error| {
+            cleanup_error(record, "remove the Sandbox runtime state directory", error)
+        })?;
+    }
 
     let bind_mount_dir = std::env::temp_dir().join(format!("a3s-fs-mount-{}", record.id));
     remove_tree_if_present(&bind_mount_dir)

--- a/src/runtime/src/local_execution/restart.rs
+++ b/src/runtime/src/local_execution/restart.rs
@@ -3,6 +3,7 @@ use a3s_box_core::{
     ExecutionState, OperationId, RestartExecutionOptions,
 };
 
+use super::create::startup_terminal_state;
 use super::record::{execution_id, lease_from_record};
 use super::store::RuntimeUpdate;
 use super::support::{generation, managed_state, require_generation, required_handle};
@@ -290,8 +291,14 @@ impl LocalExecutionManager {
                         .await
                     }
                     ExecutionState::Stopped | ExecutionState::Failed => {
-                        self.publish_restart_failure(&record, observation.exit_code)
-                            .await?;
+                        let terminal_state =
+                            startup_terminal_state(observation.state, observation.exit_code);
+                        self.publish_restart_terminal(
+                            &record,
+                            terminal_state,
+                            observation.exit_code,
+                        )
+                        .await?;
                         Err(start_error)
                     }
                     ExecutionState::Created | ExecutionState::Creating | ExecutionState::Paused => {
@@ -300,16 +307,18 @@ impl LocalExecutionManager {
                 }
             }
             Err(ExecutionManagerError::NotFound(_)) => {
-                self.publish_restart_failure(&record, None).await?;
+                self.publish_restart_terminal(&record, ManagedExecutionState::Failed, None)
+                    .await?;
                 Err(start_error)
             }
             Err(_) => Err(start_error),
         }
     }
 
-    async fn publish_restart_failure(
+    async fn publish_restart_terminal(
         &self,
         record: &BoxRecord,
+        terminal_state: ManagedExecutionState,
         exit_code: Option<i32>,
     ) -> ExecutionManagerResult<()> {
         self.release_execution_resources(record).await?;
@@ -319,8 +328,8 @@ impl LocalExecutionManager {
             .transition(
                 record,
                 ManagedExecutionState::RestartStarting,
-                ManagedExecutionState::Failed,
-                RuntimeUpdate::RestartFailed(exit_code),
+                terminal_state,
+                RuntimeUpdate::RestartTerminal(exit_code),
             )
             .await
         {
@@ -457,14 +466,26 @@ fn completed_restart_result(
             ),
         })));
     }
-    if completed.outcome == ManagedRestartOutcome::Failed {
-        return Ok(Some(Err(ExecutionManagerError::Conflict {
-            execution_id: id,
-            message: format!(
-                "restart operation {operation_id} failed at generation {}",
-                completed.target_generation.get()
-            ),
-        })));
+    match completed.outcome {
+        ManagedRestartOutcome::Failed => {
+            return Ok(Some(Err(ExecutionManagerError::Conflict {
+                execution_id: id,
+                message: format!(
+                    "restart operation {operation_id} failed at generation {}",
+                    completed.target_generation.get()
+                ),
+            })));
+        }
+        ManagedRestartOutcome::Stopped => {
+            return Ok(Some(Err(ExecutionManagerError::Conflict {
+                execution_id: id,
+                message: format!(
+                    "restart operation {operation_id} completed in stopped state at generation {}",
+                    completed.target_generation.get()
+                ),
+            })));
+        }
+        ManagedRestartOutcome::Running => {}
     }
     let current_generation = generation(record, &id)?;
     if managed_state(record)? == ManagedExecutionState::Running

--- a/src/runtime/src/local_execution/store.rs
+++ b/src/runtime/src/local_execution/store.rs
@@ -178,7 +178,7 @@ impl LocalExecutionManager {
                 }
                 RuntimeUpdate::RestartAdvance => clear_live_runtime(record, None),
                 RuntimeUpdate::RestartHandle(handle) => apply_restart_handle(record, &handle),
-                RuntimeUpdate::RestartFailed(exit_code) => clear_live_runtime(record, exit_code),
+                RuntimeUpdate::RestartTerminal(exit_code) => clear_live_runtime(record, exit_code),
             })
         })
         .await
@@ -265,7 +265,7 @@ pub(super) enum RuntimeUpdate {
     },
     RestartAdvance,
     RestartHandle(LocalExecutionHandle),
-    RestartFailed(Option<i32>),
+    RestartTerminal(Option<i32>),
 }
 
 pub(super) async fn run_store<T>(

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -1735,6 +1735,75 @@ async fn restart_running_execution_advances_generation_once_and_is_idempotent() 
 }
 
 #[tokio::test]
+async fn restart_completion_with_exact_exit_code_is_persisted_as_stopped() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(
+            request("restart-completion"),
+            &operation("create-restart-completion"),
+        )
+        .await
+        .unwrap();
+    let restart_operation = operation("restart-completion-operation");
+    *backend.start_terminal_exit_code.lock().unwrap() = Some(0);
+
+    let error = manager
+        .restart(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ExecutionManagerError::Unavailable(message)
+            if message.contains("fake execution completed during startup")
+    ));
+    let starts_after_completion = backend.starts.load(Ordering::Relaxed);
+    let stopped = persisted(&manager, &running.execution_id);
+    assert_eq!(
+        stopped.managed_state().unwrap(),
+        Some(ManagedExecutionState::Stopped)
+    );
+    assert_eq!(stopped.exit_code, Some(0));
+    assert_eq!(
+        stopped.managed_execution.as_ref().unwrap().generation,
+        ExecutionGeneration::new(2).unwrap()
+    );
+    let completed = stopped
+        .managed_execution
+        .as_ref()
+        .unwrap()
+        .last_restart
+        .as_ref()
+        .unwrap();
+    assert_eq!(completed.operation_id, restart_operation);
+    assert_eq!(completed.source_generation, running.generation);
+    assert_eq!(
+        completed.target_generation,
+        ExecutionGeneration::new(2).unwrap()
+    );
+    assert_eq!(completed.outcome, crate::ManagedRestartOutcome::Stopped);
+
+    let retry = manager
+        .restart(
+            &running.execution_id,
+            running.generation,
+            &restart_operation,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(retry, ExecutionManagerError::Conflict { .. }));
+    assert_eq!(
+        backend.starts.load(Ordering::Relaxed),
+        starts_after_completion
+    );
+}
+
+#[tokio::test]
 async fn stale_restart_generation_has_no_backend_side_effects() {
     let (_directory, manager, backend) = harness();
     let running = manager
@@ -2003,6 +2072,66 @@ async fn restart_recovers_after_generation_advance_before_backend_start() {
 
     assert_eq!(restarted.generation, ExecutionGeneration::new(2).unwrap());
     assert_eq!(backend.starts.load(Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn restart_observation_with_exact_exit_code_completes_as_stopped() {
+    let (_directory, manager, backend) = harness();
+    let running = manager
+        .create_and_start(
+            request("restart-observation"),
+            &operation("create-restart-observation"),
+        )
+        .await
+        .unwrap();
+    let restart_operation = operation("restart-observation-operation");
+    let record = persisted(&manager, &running.execution_id);
+    let claimed = manager
+        .transition(
+            &record,
+            ManagedExecutionState::Running,
+            ManagedExecutionState::RestartStopping,
+            RuntimeUpdate::RestartClaim {
+                operation_id: restart_operation.clone(),
+                options: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+    backend.kill(&claimed).await.unwrap();
+    let restarting = manager
+        .transition(
+            &claimed,
+            ManagedExecutionState::RestartStopping,
+            ManagedExecutionState::RestartStarting,
+            RuntimeUpdate::RestartAdvance,
+        )
+        .await
+        .unwrap();
+    *backend.start_terminal_exit_code.lock().unwrap() = Some(0);
+    let start_error = backend.start(&restarting).await.unwrap_err();
+    assert!(matches!(start_error, ExecutionManagerError::Unavailable(_)));
+    let starts_after_completion = backend.starts.load(Ordering::Relaxed);
+
+    let status = manager.inspect(&running.execution_id).await.unwrap();
+
+    assert_eq!(status.state, ExecutionState::Stopped);
+    assert_eq!(status.generation, ExecutionGeneration::new(2).unwrap());
+    assert_eq!(
+        backend.starts.load(Ordering::Relaxed),
+        starts_after_completion
+    );
+    let stopped = persisted(&manager, &running.execution_id);
+    assert_eq!(stopped.exit_code, Some(0));
+    assert_eq!(
+        stopped
+            .managed_execution
+            .unwrap()
+            .last_restart
+            .unwrap()
+            .outcome,
+        crate::ManagedRestartOutcome::Stopped
+    );
 }
 
 #[tokio::test]

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -349,7 +349,9 @@ impl ManagedExecutionStore {
             if expected_state == ManagedExecutionState::RestartStarting
                 && matches!(
                     next_state,
-                    ManagedExecutionState::Running | ManagedExecutionState::Failed
+                    ManagedExecutionState::Running
+                        | ManagedExecutionState::Stopped
+                        | ManagedExecutionState::Failed
                 )
             {
                 let Some(ManagedExecutionOperation::Restart {
@@ -363,15 +365,22 @@ impl ManagedExecutionStore {
                         "restart completion for {execution_id} has no persisted restart intent"
                     )));
                 };
+                let outcome = if next_state == ManagedExecutionState::Running {
+                    ManagedRestartOutcome::Running
+                } else if next_state == ManagedExecutionState::Stopped {
+                    ManagedRestartOutcome::Stopped
+                } else if next_state == ManagedExecutionState::Failed {
+                    ManagedRestartOutcome::Failed
+                } else {
+                    return Err(ManagedExecutionStoreError::InvalidRecord(format!(
+                        "restart completion for {execution_id} has non-terminal state {next_state}"
+                    )));
+                };
                 metadata.last_restart = Some(ManagedRestartCompletion {
                     operation_id: operation_id.clone(),
                     source_generation: *source_generation,
                     target_generation: next_generation,
-                    outcome: if next_state == ManagedExecutionState::Running {
-                        ManagedRestartOutcome::Running
-                    } else {
-                        ManagedRestartOutcome::Failed
-                    },
+                    outcome,
                     stop_timeout_secs: *stop_timeout_secs,
                 });
             }
@@ -497,7 +506,7 @@ fn transition_generation(
             | (Killing, Stopped | Failed)
             | (Stopped | Failed, RestartStopping)
             | (RestartStopping, RestartStarting)
-            | (RestartStarting, Running | Failed)
+            | (RestartStarting, Running | Stopped | Failed)
     );
     if !legal {
         return Err(ManagedExecutionStoreError::InvalidTransition {

--- a/src/runtime/src/process.rs
+++ b/src/runtime/src/process.rs
@@ -100,6 +100,7 @@ pub fn is_process_running_with_identity(pid: u32, expected_start_time: Option<u6
 /// owner was spawned by a short-lived client process: a later recovery process
 /// cannot reap the former client's child, but it can safely remove runtime
 /// state once that child has finished executing.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) fn wait_for_process_stop_with_identity(
     pid: u32,
     expected_start_time: u64,
@@ -172,6 +173,7 @@ fn try_reap_exited_child_with_identity(pid: u32, expected_start_time: u64) -> bo
 }
 
 #[cfg(not(target_os = "linux"))]
+#[allow(dead_code)]
 fn try_reap_exited_child_with_identity(pid: u32, expected_start_time: u64) -> bool {
     !is_process_alive_with_identity(pid, Some(expected_start_time))
 }

--- a/src/runtime/src/snapshot.rs
+++ b/src/runtime/src/snapshot.rs
@@ -96,6 +96,7 @@ impl SnapshotStore {
 
     /// Save a managed Sandbox snapshot with an authoritative terminal rootfs
     /// metadata manifest captured while the source execution is quiesced.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) fn save_managed(
         &self,
         metadata: SnapshotMetadata,

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -31,6 +31,20 @@ pub(crate) fn runtime_socket_dir(home_dir: &Path, box_id: &str) -> PathBuf {
     }
 }
 
+/// Short host path for one Sandbox runtime owner and its private control socket.
+///
+/// Unix-domain socket paths have a small fixed kernel limit. Keeping the A3S
+/// OCI root below the already-short external socket directory makes Sandbox
+/// startup independent of the configured A3S home path length.
+pub(crate) fn sandbox_runtime_root(home_dir: &Path, box_id: &str) -> PathBuf {
+    runtime_socket_dir(home_dir, box_id).join("oci")
+}
+
+/// Runtime root used before Sandbox owners moved beside the short socket paths.
+pub(crate) fn legacy_sandbox_runtime_root(home_dir: &Path, box_id: &str) -> PathBuf {
+    home_dir.join("run").join("a3s-oci").join(box_id)
+}
+
 fn registry_auth_for_image(home_dir: &Path, reference: &str) -> Result<crate::oci::RegistryAuth> {
     let parsed = crate::oci::ImageReference::parse(reference)?;
     Ok(crate::oci::RegistryAuth::from_credential_store_at(
@@ -777,13 +791,46 @@ impl VmManager {
     /// Find the guest init binary in common locations.
     ///
     /// Searches in order:
-    /// 1. Same directory as current executable
-    /// 2. target/debug or target/release (for development)
-    /// 3. PATH
+    /// 1. The installed `A3S_HOME/bin` asset
+    /// 2. Same directory as current executable
+    /// 3. target/debug or target/release (for development)
+    /// 4. PATH
     ///
     /// The binary must be a Linux ELF executable since it runs inside the VM.
     pub(crate) fn find_guest_init() -> Result<PathBuf> {
-        let mut candidates = Self::find_binary_candidates("a3s-box-guest-init");
+        let name = "a3s-box-guest-init";
+        let installed = a3s_box_core::dirs_home().join("bin").join(name);
+        let candidates = Self::find_binary_candidates(name);
+
+        if let Some(path) = Self::select_guest_init(&installed, candidates) {
+            return Ok(path);
+        }
+
+        Err(BoxError::BoxBootError {
+            message: "Linux guest init binary not found".to_string(),
+            hint: Some(
+                "Cross-compile the static guest init for your guest arch, e.g.: \
+                 cargo build -p a3s-box-guest-init --release --target x86_64-unknown-linux-musl \
+                 (or aarch64-unknown-linux-musl). A glibc-dynamic host build is rejected because \
+                 it cannot run as PID 1 inside a minimal guest rootfs."
+                    .to_string(),
+            ),
+        })
+    }
+
+    fn select_guest_init(installed: &Path, mut candidates: Vec<PathBuf>) -> Option<PathBuf> {
+        // An explicitly installed asset belongs to the active A3S_HOME and must
+        // not be shadowed by a stale development artifact in target/. Release
+        // installation already puts the static guest binary at this fixed path.
+        if Self::is_linux_elf(installed) {
+            return Some(installed.to_path_buf());
+        }
+        if installed.exists() {
+            tracing::debug!(
+                path = %installed.display(),
+                "Skipping installed guest init (not a static Linux ELF binary)"
+            );
+        }
 
         // Prefer the cross-compiled musl-static build over any host build on
         // ALL platforms. On a Linux x86_64 host, `cargo build --workspace`
@@ -802,7 +849,7 @@ impl VmManager {
 
         for path in candidates {
             if Self::is_linux_elf(&path) {
-                return Ok(path);
+                return Some(path);
             }
             tracing::debug!(
                 path = %path.display(),
@@ -810,16 +857,7 @@ impl VmManager {
             );
         }
 
-        Err(BoxError::BoxBootError {
-            message: "Linux guest init binary not found".to_string(),
-            hint: Some(
-                "Cross-compile the static guest init for your guest arch, e.g.: \
-                 cargo build -p a3s-box-guest-init --release --target x86_64-unknown-linux-musl \
-                 (or aarch64-unknown-linux-musl). A glibc-dynamic host build is rejected because \
-                 it cannot run as PID 1 inside a minimal guest rootfs."
-                    .to_string(),
-            ),
-        })
+        None
     }
 
     /// Search common locations for a binary by name.
@@ -869,12 +907,6 @@ impl VmManager {
             if path.exists() {
                 candidates.push(path);
             }
-        }
-
-        // Try PATH
-        let home_bin = a3s_box_core::dirs_home().join("bin").join(name);
-        if home_bin.exists() {
-            candidates.push(home_bin);
         }
 
         // Try PATH
@@ -1057,6 +1089,14 @@ mod tests {
     use tempfile::TempDir;
     use tokio::sync::RwLock;
 
+    struct RuntimeSocketDirGuard(PathBuf);
+
+    impl Drop for RuntimeSocketDirGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
     fn make_vm_manager_with_home(home_dir: &Path) -> VmManager {
         use a3s_box_core::event::EventEmitter;
         let config = BoxConfig::default();
@@ -1089,6 +1129,63 @@ mod tests {
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
         }
+    }
+
+    fn write_static_test_elf(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut elf = vec![0_u8; 64];
+        elf[0..4].copy_from_slice(b"\x7fELF");
+        elf[4] = 2;
+        elf[5] = 1;
+        std::fs::write(path, elf).unwrap();
+    }
+
+    #[test]
+    fn installed_guest_init_cannot_be_shadowed_by_a_stale_development_build() {
+        let temporary = TempDir::new().unwrap();
+        let installed = temporary.path().join("home/bin/a3s-box-guest-init");
+        let development = temporary
+            .path()
+            .join("target/x86_64-unknown-linux-musl/debug/a3s-box-guest-init");
+        write_static_test_elf(&installed);
+        write_static_test_elf(&development);
+
+        assert_eq!(
+            VmManager::select_guest_init(&installed, vec![development]),
+            Some(installed)
+        );
+    }
+
+    #[test]
+    fn invalid_installed_guest_init_falls_back_to_a_static_development_build() {
+        let temporary = TempDir::new().unwrap();
+        let installed = temporary.path().join("home/bin/a3s-box-guest-init");
+        let development = temporary
+            .path()
+            .join("target/x86_64-unknown-linux-musl/release/a3s-box-guest-init");
+        std::fs::create_dir_all(installed.parent().unwrap()).unwrap();
+        std::fs::write(&installed, b"not an ELF executable").unwrap();
+        write_static_test_elf(&development);
+
+        assert_eq!(
+            VmManager::select_guest_init(&installed, vec![development.clone()]),
+            Some(development)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sandbox_runtime_socket_stays_below_the_unix_path_limit_for_long_homes() {
+        let long_home = PathBuf::from("/var/lib")
+            .join("a3s-home-component".repeat(16))
+            .join("nested-provider-namespace");
+        let box_id = "01234567-89ab-cdef-0123-456789abcdef";
+        let runtime_root = sandbox_runtime_root(&long_home, box_id);
+        let runtime_socket = runtime_root.join("runtime.sock");
+
+        assert!(runtime_root.starts_with(runtime_socket_dir(&long_home, box_id)));
+        assert!(runtime_socket.as_os_str().len() < 108);
+        assert!(!runtime_root.starts_with(&long_home));
     }
 
     fn image_health_check(test: &[&str]) -> crate::oci::OciHealthCheck {
@@ -1226,14 +1323,16 @@ mod tests {
         )
         .unwrap();
 
-        let box_dir = home.path().join("boxes/test-box");
+        let mut vm = make_vm_manager_with_home(home.path());
+        vm.box_id = format!("layout-test-{}", uuid::Uuid::new_v4().simple());
+        let _socket_dir_guard = RuntimeSocketDirGuard(vm.socket_dir());
+        let box_dir = home.path().join("boxes").join(&vm.box_id);
         std::fs::create_dir_all(&box_dir).unwrap();
         std::fs::write(
             box_dir.join(".snapshot-lower"),
             lower.to_string_lossy().as_bytes(),
         )
         .unwrap();
-        let mut vm = make_vm_manager_with_home(home.path());
         vm.config.image = "example.invalid/runtime:latest".to_string();
         vm.rootfs_provider = Box::new(crate::rootfs::CopyProvider);
 

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -848,18 +848,18 @@ impl VmManager {
             return Ok(Some(code));
         }
 
-        // Unix guests expose the overlay exit file only once their shutdown is
-        // effectively complete. On Windows the shared-rootfs file appears while
-        // the shim still has to relay guest stdout/stderr into the host logs, so
-        // treating it as completion here races teardown against that relay.
         #[cfg(not(target_os = "windows"))]
-        if let Some(code) = self.persisted_exit_code() {
-            self.shim_exit_code = Some(code);
-            return Ok(Some(code));
-        }
+        let persisted_exit_code = self.persisted_exit_code();
 
         let mut handler = self.handler.write().await;
         let Some(handler) = handler.as_mut() else {
+            // A recovered terminal manager can have no live provider handle.
+            // In that state the durable guest result is the remaining source
+            // of truth and no runtime writer can still append console bytes.
+            #[cfg(not(target_os = "windows"))]
+            if let Some(code) = persisted_exit_code {
+                self.shim_exit_code = Some(code);
+            }
             return Ok(self.shim_exit_code);
         };
 
@@ -870,31 +870,52 @@ impl VmManager {
                 &self.log_config,
                 code,
             )?;
+            #[cfg(not(target_os = "windows"))]
+            let code = persisted_exit_code.unwrap_or(code);
             self.shim_exit_code = Some(code);
             return Ok(Some(code));
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        if handler.has_exited() {
+            // Attached handlers cannot reap another process owner's child, but
+            // zombie-aware provider completion still proves that the shim has
+            // closed the raw streams and joined its log processor. Prefer the
+            // durable workload status over a provider-specific status.
+            if let Some(code) = persisted_exit_code.or_else(|| handler.exit_code()) {
+                self.shim_exit_code = Some(code);
+                return Ok(Some(code));
+            }
         }
 
         Ok(None)
     }
 
-    /// Return true once the foreground container is known to have finished, even
-    /// if the shim exit status has not been reaped yet.
+    /// Return true once the runtime provider has finished its terminal work.
+    ///
+    /// The guest can persist its workload status before the shim has relayed the
+    /// final console bytes. That durable status alone must not publish provider
+    /// completion or foreground cleanup can terminate the shim mid-drain.
     pub async fn has_exited(&self) -> bool {
         if self.shim_exit_code.is_some() {
             return true;
         }
 
+        let handler = self.handler.read().await;
+        if let Some(handler) = handler.as_ref() {
+            return handler.has_exited();
+        }
+        drop(handler);
+
         #[cfg(not(target_os = "windows"))]
-        if self.persisted_exit_code().is_some() {
-            return true;
+        {
+            self.persisted_exit_code().is_some()
         }
 
-        self.handler
-            .read()
-            .await
-            .as_ref()
-            .map(|handler| handler.has_exited())
-            .unwrap_or(false)
+        #[cfg(target_os = "windows")]
+        {
+            false
+        }
     }
 
     /// Run a command as the container MAIN in an IDLE-booted (deferred-main) VM.
@@ -2521,6 +2542,32 @@ mod tests {
         assert_eq!(vm.try_wait_exit().await.unwrap(), Some(42));
         assert_eq!(vm.exit_code(), Some(42));
         assert!(vm.has_exited().await);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_guest_exit_code_waits_for_runtime_log_drain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let box_id = "box-pending-log-drain".to_string();
+        let mut vm =
+            VmManager::with_box_id(BoxConfig::default(), EventEmitter::new(16), box_id.clone());
+        vm.home_dir = tmp.path().to_path_buf();
+        *vm.handler.write().await = Some(Box::new(RecordingHandler {
+            stopped: Arc::new(AtomicBool::new(false)),
+        }));
+
+        let exit_path = tmp
+            .path()
+            .join("boxes")
+            .join(&box_id)
+            .join("upper")
+            .join(".a3s_exit_code");
+        std::fs::create_dir_all(exit_path.parent().unwrap()).unwrap();
+        std::fs::write(exit_path, "7\n").unwrap();
+
+        assert_eq!(vm.try_wait_exit().await.unwrap(), None);
+        assert_eq!(vm.exit_code(), None);
+        assert!(!vm.has_exited().await);
     }
 
     #[tokio::test]

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -434,6 +434,8 @@ impl VmManager {
 
     /// Remove host-side boot artifacts after a failed boot attempt.
     async fn cleanup_boot_failure(&mut self) {
+        let box_dir = self.home_dir.join("boxes").join(&self.box_id);
+
         if let Some(mut handler) = self.handler.write().await.take() {
             // A short-lived workload can finish before the runtime publishes
             // its readiness endpoint. That is a normal terminal completion,
@@ -468,9 +470,17 @@ impl VmManager {
                     "Failed to stop VM handler after boot failure"
                 );
             }
-            self.shim_exit_code = handler.exit_code().or(self.shim_exit_code);
+            let provider_exit_code = handler.exit_code().or(self.shim_exit_code);
+            #[cfg(not(target_os = "windows"))]
+            {
+                self.shim_exit_code =
+                    crate::rootfs::read_persisted_exit_code(&box_dir).or(provider_exit_code);
+            }
+            #[cfg(target_os = "windows")]
+            {
+                self.shim_exit_code = provider_exit_code;
+            }
             if exited_before_cleanup && self.shim_exit_code.is_none() {
-                let box_dir = self.home_dir.join("boxes").join(&self.box_id);
                 self.shim_exit_code =
                     wait_for_delayed_terminal_exit(handler.as_mut(), &box_dir, &self.box_id).await;
             }
@@ -849,7 +859,7 @@ impl VmManager {
         }
 
         #[cfg(not(target_os = "windows"))]
-        let persisted_exit_code = self.persisted_exit_code();
+        let box_dir = self.home_dir.join("boxes").join(&self.box_id);
 
         let mut handler = self.handler.write().await;
         let Some(handler) = handler.as_mut() else {
@@ -857,7 +867,7 @@ impl VmManager {
             // In that state the durable guest result is the remaining source
             // of truth and no runtime writer can still append console bytes.
             #[cfg(not(target_os = "windows"))]
-            if let Some(code) = persisted_exit_code {
+            if let Some(code) = crate::rootfs::read_persisted_exit_code(&box_dir) {
                 self.shim_exit_code = Some(code);
             }
             return Ok(self.shim_exit_code);
@@ -871,7 +881,7 @@ impl VmManager {
                 code,
             )?;
             #[cfg(not(target_os = "windows"))]
-            let code = persisted_exit_code.unwrap_or(code);
+            let code = crate::rootfs::read_persisted_exit_code(&box_dir).unwrap_or(code);
             self.shim_exit_code = Some(code);
             return Ok(Some(code));
         }
@@ -882,7 +892,9 @@ impl VmManager {
             // zombie-aware provider completion still proves that the shim has
             // closed the raw streams and joined its log processor. Prefer the
             // durable workload status over a provider-specific status.
-            if let Some(code) = persisted_exit_code.or_else(|| handler.exit_code()) {
+            if let Some(code) =
+                crate::rootfs::read_persisted_exit_code(&box_dir).or_else(|| handler.exit_code())
+            {
                 self.shim_exit_code = Some(code);
                 return Ok(Some(code));
             }
@@ -2182,6 +2194,45 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
+    struct PersistedExitOnCompletionHandler {
+        provider_code: i32,
+        persisted_code: i32,
+        exit_path: PathBuf,
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    impl VmHandler for PersistedExitOnCompletionHandler {
+        fn stop(&mut self, _signal: i32, _timeout_ms: u64) -> Result<()> {
+            Ok(())
+        }
+
+        fn metrics(&self) -> crate::vmm::VmMetrics {
+            crate::vmm::VmMetrics::default()
+        }
+
+        fn is_running(&self) -> bool {
+            false
+        }
+
+        fn has_exited(&self) -> bool {
+            true
+        }
+
+        fn pid(&self) -> u32 {
+            42
+        }
+
+        fn exit_code(&self) -> Option<i32> {
+            Some(self.provider_code)
+        }
+
+        fn try_wait_exit(&mut self) -> Result<Option<i32>> {
+            std::fs::write(&self.exit_path, format!("{}\n", self.persisted_code))?;
+            Ok(Some(self.provider_code))
+        }
+    }
+
     struct CompletionCollectedByStopHandler {
         code: i32,
         collected: bool,
@@ -2542,6 +2593,67 @@ mod tests {
         assert_eq!(vm.try_wait_exit().await.unwrap(), Some(42));
         assert_eq!(vm.exit_code(), Some(42));
         assert!(vm.has_exited().await);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_try_wait_exit_rereads_guest_exit_code_after_provider_completion() {
+        let tmp = tempfile::tempdir().unwrap();
+        let box_id = "box-exit-code-during-completion".to_string();
+        let mut vm =
+            VmManager::with_box_id(BoxConfig::default(), EventEmitter::new(16), box_id.clone());
+        vm.home_dir = tmp.path().to_path_buf();
+
+        let exit_path = tmp
+            .path()
+            .join("boxes")
+            .join(&box_id)
+            .join("upper")
+            .join(".a3s_exit_code");
+        std::fs::create_dir_all(exit_path.parent().unwrap()).unwrap();
+        *vm.handler.write().await = Some(Box::new(PersistedExitOnCompletionHandler {
+            provider_code: 1,
+            persisted_code: 0,
+            exit_path,
+        }));
+
+        assert_eq!(vm.try_wait_exit().await.unwrap(), Some(0));
+        assert_eq!(vm.exit_code(), Some(0));
+        assert!(vm.has_exited().await);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_boot_cleanup_prefers_guest_exit_written_during_provider_completion() {
+        let tmp = tempfile::tempdir().unwrap();
+        let box_id = "box-boot-cleanup-exit-code".to_string();
+        let mut vm = VmManager::with_box_id(
+            BoxConfig {
+                persistent: true,
+                ..BoxConfig::default()
+            },
+            EventEmitter::new(16),
+            box_id.clone(),
+        );
+        vm.home_dir = tmp.path().to_path_buf();
+
+        let exit_path = tmp
+            .path()
+            .join("boxes")
+            .join(&box_id)
+            .join("upper")
+            .join(".a3s_exit_code");
+        std::fs::create_dir_all(exit_path.parent().unwrap()).unwrap();
+        *vm.handler.write().await = Some(Box::new(PersistedExitOnCompletionHandler {
+            provider_code: 1,
+            persisted_code: 0,
+            exit_path,
+        }));
+
+        vm.cleanup_boot_failure().await;
+
+        assert_eq!(vm.exit_code(), Some(0));
+        assert!(vm.preserve_rootfs_on_boot_failure);
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -9,7 +9,10 @@ mod spec;
 #[cfg(windows)]
 mod windows_stop;
 
-pub(crate) use layout::{persistent_rootfs_generation_exists, runtime_socket_dir};
+pub(crate) use layout::{
+    legacy_sandbox_runtime_root, persistent_rootfs_generation_exists, runtime_socket_dir,
+    sandbox_runtime_root,
+};
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -194,7 +194,8 @@ fn load_recorded_sandbox_runtime_identity(
                 record_path.display()
             ))
         })?;
-    let expected_runtime_root = home_dir.join("run/a3s-oci").join(box_id);
+    let expected_runtime_root = crate::vm::sandbox_runtime_root(home_dir, box_id);
+    let legacy_runtime_root = crate::vm::legacy_sandbox_runtime_root(home_dir, box_id);
     let expected_bundle = box_dir.join("sandbox/bundle");
     let log_worker_identity_valid = match (record.log_worker_pid, record.log_worker_pid_start_time)
     {
@@ -205,7 +206,7 @@ fn load_recorded_sandbox_runtime_identity(
     let runtime_identity_valid = record.schema
         == crate::sandbox::runtime_record::SANDBOX_RUNTIME_RECORD_SCHEMA
         && record.runtime_socket.as_deref()
-            == Some(expected_runtime_root.join("runtime.sock").as_path())
+            == Some(record.runtime_root.join("runtime.sock").as_path())
         && record.generation.is_some_and(|generation| generation > 0)
         && matches!(record.owner_pid, Some(pid) if pid > 0)
         && matches!(record.owner_pid_start_time, Some(start_time) if start_time > 0)
@@ -214,7 +215,8 @@ fn load_recorded_sandbox_runtime_identity(
         && record.agent_sha256.as_deref().is_some_and(valid_sha256);
     if !runtime_identity_valid
         || record.container_id != box_id
-        || record.runtime_root != expected_runtime_root
+        || (record.runtime_root != expected_runtime_root
+            && record.runtime_root != legacy_runtime_root)
         || record.bundle_dir != expected_bundle
         || record.init_pid == 0
         || !log_worker_identity_valid

--- a/src/runtime/src/vm/reap_tests.rs
+++ b/src/runtime/src/vm/reap_tests.rs
@@ -7,7 +7,7 @@ fn write_runtime_record(
     box_id: &str,
     mutate: impl FnOnce(&mut SandboxRuntimeRecord),
 ) {
-    let runtime_root = home_dir.join("run/a3s-oci").join(box_id);
+    let runtime_root = crate::vm::sandbox_runtime_root(home_dir, box_id);
     let mut record = SandboxRuntimeRecord {
         schema: SANDBOX_RUNTIME_RECORD_SCHEMA.to_string(),
         container_id: box_id.to_string(),
@@ -134,8 +134,24 @@ fn structurally_valid_runtime_record_loads_before_owner_certification() {
 
     assert_eq!(
         record.map(|record| record.runtime_root),
-        Some(home.path().join("run/a3s-oci").join(box_id))
+        Some(crate::vm::sandbox_runtime_root(home.path(), box_id))
     );
+}
+
+#[test]
+fn structurally_valid_legacy_runtime_record_remains_recoverable() {
+    let home = tempfile::tempdir().unwrap();
+    let box_id = "recorded-sandbox-legacy-a3s-oci";
+    let box_dir = home.path().join("boxes").join(box_id);
+    let legacy_root = crate::vm::legacy_sandbox_runtime_root(home.path(), box_id);
+    write_runtime_record(home.path(), &box_dir, box_id, |record| {
+        record.runtime_root = legacy_root.clone();
+        record.runtime_socket = Some(legacy_root.join("runtime.sock"));
+    });
+
+    let record = load_recorded_sandbox_runtime_identity(home.path(), &box_dir, box_id).unwrap();
+
+    assert_eq!(record.map(|record| record.runtime_root), Some(legacy_root));
 }
 
 #[test]

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -63,7 +63,7 @@ impl VmManager {
         let box_dir = self.home_dir.join("boxes").join(&self.box_id);
         let sandbox_dir = box_dir.join("sandbox");
         let bundle_dir = sandbox_dir.join("bundle");
-        let runtime_root = self.home_dir.join("run").join("a3s-oci").join(&self.box_id);
+        let runtime_root = super::sandbox_runtime_root(&self.home_dir, &self.box_id);
         let runtime_record = sandbox_dir.join("runtime.json");
         let runtime = capabilities
             .a3s_oci


### PR DESCRIPTION
## Summary

- pin the namespace-safe OCI cgroup handoff validated at OCI commit 0bd7929
- reconcile exact terminal restart outcomes and bound tight exec deadlines
- harden R17 topology, namespace, cleanup, and socket-path validation
- make host soak resource sampling phase-aware and evidence failures authoritative
- require every concurrent benchmark launch to succeed and persist, with a hermetic self-test

## Validation completed

- macOS runtime unit tests: 1450 passed, 1 ignored
- macOS guest-init tests: 123 passed
- bench race self-test: passed on macOS and Linux
- soak evidence self-test: passed on macOS and Linux
- real Linux KVM strict race: 8/8 launched, 8/8 persisted, zero process/socket/cgroup/mount residue
- prior staged Linux runtime, guest-init, R17, KVM core/host, SDK, and strict Clippy gates passed

## Merge gate

The final commit-specific two-hour Linux soak and real macOS/HVF soak remain required before merge.