### PR TITLE
fix(runtime): recover exit during replay attachment

### DIFF
--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -245,7 +245,21 @@ impl VmLocalExecutionBackend {
             });
         }
         let visible_state = visible_active_state(record)?;
-        let handle = self.handle_from_manager(record, &manager).await?;
+        let handle = match self.handle_from_manager(record, &manager).await {
+            Ok(handle) => handle,
+            Err(ExecutionManagerError::NotFound(_)) => {
+                // The runtime state and health probes can still report a live
+                // Sandbox after its host process has exited. Treat the missing
+                // handle as the same terminal signal as a failed health probe
+                // and wait for the exact status before projecting provider
+                // loss. This closes the restart/replay race without creating a
+                // second lifecycle path.
+                return self
+                    .finish_registered_terminal(record, &shared, manager, preserve_rootfs, None)
+                    .await;
+            }
+            Err(error) => return Err(error),
+        };
         Ok(LocalExecutionObservation {
             state: visible_state,
             handle: Some(handle),

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -63,7 +63,7 @@ impl VmHandler for DelayedExitStatusHandler {
     }
 
     fn pid(&self) -> u32 {
-        42
+        u32::MAX
     }
 
     fn exit_code(&self) -> Option<i32> {

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -41,6 +41,7 @@ struct DelayedExitStatusHandler {
     exit_polls: Arc<AtomicUsize>,
     stop_calls: Arc<AtomicUsize>,
     available_after: usize,
+    reports_running: bool,
 }
 
 impl VmHandler for DelayedExitStatusHandler {
@@ -54,11 +55,11 @@ impl VmHandler for DelayedExitStatusHandler {
     }
 
     fn is_running(&self) -> bool {
-        false
+        self.reports_running
     }
 
     fn has_exited(&self) -> bool {
-        true
+        !self.reports_running
     }
 
     fn pid(&self) -> u32 {
@@ -271,6 +272,7 @@ async fn terminal_health_probe_waits_for_delayed_durable_exit_status_before_clea
             exit_polls: Arc::clone(&exit_polls),
             stop_calls: Arc::clone(&stop_calls),
             available_after: 60,
+            reports_running: false,
         }));
     }
     backend
@@ -301,6 +303,7 @@ async fn terminal_observation_retains_runtime_without_an_exact_exit_status() {
             exit_polls: Arc::clone(&exit_polls),
             stop_calls: Arc::clone(&stop_calls),
             available_after: usize::MAX,
+            reports_running: false,
         }));
     }
     backend
@@ -320,6 +323,37 @@ async fn terminal_observation_retains_runtime_without_an_exact_exit_status() {
     assert!(exit_polls.load(Ordering::SeqCst) > 1);
     assert_eq!(stop_calls.load(Ordering::SeqCst), 0);
     assert!(backend.managers.contains_key(&record.id));
+}
+
+#[tokio::test]
+async fn disappearing_live_handle_waits_for_delayed_terminal_status() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let mut record = record(temporary.path(), ExecutionIsolation::Sandbox);
+    record.status = ManagedExecutionState::Running.as_status().to_string();
+    let exit_polls = Arc::new(AtomicUsize::new(0));
+    let stop_calls = Arc::new(AtomicUsize::new(0));
+    let mut runtime = backend.new_manager(&record).unwrap();
+    runtime.exec_socket_path = Some(record.exec_socket_path.clone());
+    *runtime.state.write().await = crate::BoxState::Ready;
+    *runtime.handler.write().await = Some(Box::new(DelayedExitStatusHandler {
+        exit_polls: Arc::clone(&exit_polls),
+        stop_calls: Arc::clone(&stop_calls),
+        available_after: 3,
+        reports_running: true,
+    }));
+    let manager = Arc::new(Mutex::new(runtime));
+    backend
+        .managers
+        .insert(record.id.clone(), Arc::clone(&manager));
+
+    let observation = backend.inspect_registered(&record, manager).await.unwrap();
+
+    assert_eq!(observation.state, ExecutionState::Stopped);
+    assert_eq!(observation.exit_code, Some(0));
+    assert_eq!(exit_polls.load(Ordering::SeqCst), 4);
+    assert_eq!(stop_calls.load(Ordering::SeqCst), 1);
+    assert!(backend.managers.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- treat a disappearing live handle as a terminal convergence signal after runtime and health probes race with natural Sandbox exit
- reuse the existing bounded exact-exit collection path before projecting provider loss
- add a deterministic regression for the cancelled Task replay window

## Evidence

Cloud provider conformance run `30421717780` retained the original provider identity and durable guest exit code `0`, but projected `Failed(None)` after handle reattachment returned `NotFound`.

- the new regression fails with `NotFound` before the fix and passes afterward
- `cargo test --locked -p a3s-box-runtime --lib`: 1,447 passed, 1 ignored
- boot cleanup tests: 6 passed
- focused delayed-terminal and cancellation tests passed
- `cargo fmt --all -- --check`
- `git diff --check`