### PR TITLE
feat(website): add canvas experience and agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,9 @@ evidence. Review [Host Integration](docs/host-integration.md),
 - **Coding agents** — The first-party
   [A3S Box Skill](integrations/skills/a3s-box/SKILL.md) teaches supported agents
   CLI lifecycle, snapshots, warm pools, networking boundaries, and recovery.
+  Its installer supports project or user scope across A3S Code, Codex, Claude
+  Code, and the shared `.agents/skills` convention, including remote streamed
+  installation with a durable local copy.
 
 ## Architecture
 

--- a/integrations/skills/README.md
+++ b/integrations/skills/README.md
@@ -6,6 +6,22 @@ file* works in every agent that supports skills — there is no per-agent varian
 
 ## Install
 
+Install directly from GitHub at user scope:
+
+```sh
+# A3S Code
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home a3s-code
+
+# Every supported skill root
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home all
+```
+
+Or install from a repository checkout:
+
 ```sh
 ./install.sh all                   # .agents + .claude + .codex + .a3s, this repo
 ./install.sh --home agents claude  # user-wide (~/.agents, ~/.claude)
@@ -13,8 +29,14 @@ file* works in every agent that supports skills — there is no per-agent varian
 ./install.sh --copy all            # copy instead of symlink
 ```
 
-The installer symlinks the one `SKILL.md` into each skills root (single source
-of truth). Manual equivalent: `ln -s "$(pwd)/a3s-box/SKILL.md" <root>/a3s-box/SKILL.md`.
+From a checkout, the installer symlinks the one `SKILL.md` into each skills
+root by default (single source of truth). A streamed installer downloads and
+copies `SKILL.md`, because a symlink to its temporary download would not remain
+valid. The manual equivalent is:
+
+```sh
+ln -s "$(pwd)/a3s-box/SKILL.md" <root>/a3s-box/SKILL.md
+```
 
 ## Which agents this reaches
 

--- a/integrations/skills/install.sh
+++ b/integrations/skills/install.sh
@@ -6,6 +6,7 @@
 # Usage:
 #   ./install.sh [--copy] [--home] <agent>...
 #   ./install.sh --dir <path>            # install into an explicit skills dir
+#   curl -fsSL <raw-install-url> | sh -s -- --home <agent>
 #
 #   agents:  agents  claude  codex  a3s-code  all
 #     agents   -> .agents/skills   cross-tool standard: Codex, Gemini CLI, Amp,
@@ -22,10 +23,53 @@
 #   ./install.sh all                     # wire every root in this repo
 #   ./install.sh --home agents claude    # user-wide cross-tool + Claude Code
 #   ./install.sh --dir ./my-agent/skills # any SKILL.md-format agent dir
+#   curl .../install.sh | sh -s -- --home a3s-code
 set -eu
 
-SRC="$(CDPATH= cd -- "$(dirname -- "$0")/a3s-box" && pwd)/SKILL.md"
-[ -f "$SRC" ] || { echo "error: SKILL.md not found at $SRC" >&2; exit 1; }
+SKILL_URL="${A3S_BOX_SKILL_URL:-https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/a3s-box/SKILL.md}"
+SRC=""
+REMOTE_SOURCE=0
+TEMP_SOURCE_DIR=""
+
+if [ -f "$0" ]; then
+  SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+  [ -f "$SCRIPT_DIR/a3s-box/SKILL.md" ] && SRC="$SCRIPT_DIR/a3s-box/SKILL.md"
+fi
+
+cleanup() {
+  [ -n "$TEMP_SOURCE_DIR" ] && rm -rf "$TEMP_SOURCE_DIR"
+}
+
+if [ -z "$SRC" ]; then
+  command -v curl >/dev/null 2>&1 || {
+    echo "error: curl is required when install.sh is streamed" >&2
+    exit 1
+  }
+  TEMP_SOURCE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/a3s-box-skill.XXXXXX")"
+  trap cleanup 0
+  trap 'cleanup; exit 1' HUP INT TERM
+  SRC="$TEMP_SOURCE_DIR/SKILL.md"
+  curl --proto '=https' --tlsv1.2 -fsSL "$SKILL_URL" -o "$SRC"
+  REMOTE_SOURCE=1
+fi
+
+grep -q '^name: a3s-box$' "$SRC" || {
+  echo "error: downloaded file is not the a3s-box Skill" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  install.sh [--copy] [--home] <agent>...
+  install.sh --dir <path>
+
+Agents: agents | claude | codex | a3s-code | all
+  --home   install in the user-level skills root
+  --copy   copy SKILL.md instead of creating a symlink
+  --dir P  install into an explicit skills root
+USAGE
+}
 
 COPY=0; SCOPE=project; DIR=""; AGENTS=""
 while [ $# -gt 0 ]; do
@@ -34,11 +78,15 @@ while [ $# -gt 0 ]; do
     --home) SCOPE=home ;;
     --dir)  shift; DIR="${1:?--dir needs a path}" ;;
     agents|claude|codex|a3s-code|all) AGENTS="$AGENTS $1" ;;
-    -h|--help) sed -n '2,23p' "$0"; exit 0 ;;
+    -h|--help) usage; exit 0 ;;
     *) echo "error: unknown arg '$1'" >&2; exit 1 ;;
   esac
   shift
 done
+
+# A streamed installer downloads SKILL.md into a temporary directory. Copy it
+# so the installed skill remains valid after cleanup, even without --copy.
+[ "$REMOTE_SOURCE" -eq 1 ] && COPY=1
 
 # skills root for a named agent at the chosen scope
 root_for() {

--- a/website/README.md
+++ b/website/README.md
@@ -14,8 +14,10 @@ Use `npm run dev` for local authoring. The site is versioned under `docs/v3`.
 Chinese lives in `docs/v3/zh` and is served without a language prefix. The
 complete English mirror lives in `docs/v3/en` and is served below `/en/`.
 Language parity, complete SDK programs, the shared language Tabs, Code Hike
-walkthrough snapshots, and the custom ACL grammar are checked during every
-build. Mark only walkthrough snapshots with the `walkthrough` code-fence meta;
+walkthrough snapshots, Agent Skill install routes, and the custom ACL grammar
+are checked during every build. The homepage uses a Canvas UI-inspired 2D grid
+with reduced-motion behavior; attribution lives in `THIRD_PARTY_NOTICES.md`.
+Mark only walkthrough snapshots with the `walkthrough` code-fence meta;
 ordinary code blocks continue to use Rspress highlighting. All internal links
 must remain valid when the site is hosted below the `/Box/` GitHub Pages base
 path.

--- a/website/THIRD_PARTY_NOTICES.md
+++ b/website/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,42 @@
+# Third-party notices
+
+## Canvas UI — Grid
+
+`theme/components/CanvasGridEffect.tsx` is a lightweight adaptation of the
+interaction model used by the `Grid` component from
+[DavidHDev/canvas-ui](https://github.com/DavidHDev/canvas-ui) at commit
+`6c9cccf`. The website implementation uses a conventional 2D canvas rather
+than Canvas UI's experimental HTML-in-canvas rendering path.
+
+The source is used under the license reproduced below.
+
+---
+
+# MIT + Commons Clause License Condition v1.0
+
+Copyright (c) 2026 David Haz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, and distribute the Software **as part of
+an application, website, or product**, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+## Commons Clause Restriction
+
+You may use this Software, including for any commercial purpose, **so long as
+you do not sell, sublicense, or redistribute the components themselves -
+whether alone, in a bundle, or as a ported version.**
+
+## No Warranty
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/website/docs/v3/en/_nav.json
+++ b/website/docs/v3/en/_nav.json
@@ -10,6 +10,10 @@
     "activeMatch": "^/sdk/"
   },
   {
+    "text": "Agent Skill",
+    "link": "/guide/agent-skill.html"
+  },
+  {
     "text": "Reference",
     "link": "/reference/",
     "activeMatch": "^/reference/"

--- a/website/docs/v3/en/guide/_meta.json
+++ b/website/docs/v3/en/guide/_meta.json
@@ -2,6 +2,7 @@
   "index",
   "installation",
   "quick-start",
+  "agent-skill",
   "architecture",
   "images-builds",
   "networking-compose",

--- a/website/docs/v3/en/guide/agent-skill.mdx
+++ b/website/docs/v3/en/guide/agent-skill.mdx
@@ -1,0 +1,141 @@
+---
+title: Agent Skill
+description: Install and use the A3S Box Skill with A3S Code, Codex, Claude Code, and other skill-aware agents.
+---
+
+# A3S Box Agent Skill
+
+The A3S Box Skill teaches a coding agent how to run OCI workloads through the
+Box CLI without guessing lifecycle, isolation, networking, or cleanup rules.
+It is one shared `SKILL.md`, not a separate integration for each agent.
+
+The Skill does not install the Box runtime. Complete the
+[installation guide](./installation/) first, then verify the host:
+
+```bash
+a3s-box --version
+a3s-box info
+```
+
+## Install for your agent
+
+The commands below install the current Skill at user scope. The streamed
+installer downloads a durable copy of `SKILL.md`; it does not leave a symlink
+to a temporary file.
+
+### A3S Code
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home a3s-code
+```
+
+Target: `~/.a3s/skills/a3s-box/SKILL.md`
+
+### Codex
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home codex
+```
+
+Target: `~/.codex/skills/a3s-box/SKILL.md`
+
+### Claude Code
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home claude
+```
+
+Target: `~/.claude/skills/a3s-box/SKILL.md`
+
+### Every supported root
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home all
+```
+
+`all` installs the same file into `.agents`, `.claude`, `.codex`, and `.a3s`
+under the selected scope. It is useful when several agents share one machine.
+
+> [!TIP]
+> A network pipe executes the installer from `main`. Download and review the
+> script first when your environment requires a pinned or audited source.
+
+## User scope or project scope
+
+`--home` selects user scope. Omit it to install for only the current project:
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- a3s-code
+```
+
+| Agent target | Project root     | User root          |
+| ------------ | ---------------- | ------------------ |
+| Cross-tool   | `.agents/skills` | `~/.agents/skills` |
+| Claude Code  | `.claude/skills` | `~/.claude/skills` |
+| Codex        | `.codex/skills`  | `~/.codex/skills`  |
+| A3S Code     | `.a3s/skills`    | `~/.a3s/skills`    |
+
+From a Box repository checkout, run `integrations/skills/install.sh` directly.
+Checkout installs use symlinks by default so every agent reads one source file;
+pass `--copy` when the checkout may move.
+
+## Reload and invoke
+
+Restart the agent session or refresh its Skill list after installation. In an
+interface that exposes skills as slash commands, start with `/a3s-box`:
+
+```text
+/a3s-box Build this repository and run its tests in an isolated MicroVM.
+Preserve failing logs and clean up the temporary Box when finished.
+```
+
+Agents without a slash-command UI can activate the same Skill from a natural
+request:
+
+```text
+Use the A3S Box Skill to run this generated script safely in a disposable
+MicroVM, report its exit code, and remove the Box afterward.
+```
+
+The Skill guides the agent through a repeatable sequence:
+
+1. Run `a3s-box info` before the first workload.
+2. Choose an explicit Box name instead of parsing human CLI output.
+3. Keep the guest command after `--`.
+4. Verify detached workloads with `a3s-box ps -a`.
+5. Inspect status and logs on failure, then stop and remove temporary state.
+
+## What the Skill covers
+
+- One-shot and long-running MicroVM workloads.
+- Image builds, registry operations, volumes, networks, and published ports.
+- `exec`, shell access, copy, logs, health checks, and lifecycle recovery.
+- Filesystem snapshots and restored workload startup.
+- Command timeouts, detached monitoring, and common guest-channel failures.
+
+The Skill preserves Box's fail-closed model. It does not request a weaker
+isolation backend when the host cannot satisfy a workload, and it does not
+bypass agent approval or workspace policy. Where an agent enforces the
+`allowed-tools` declaration, shell access is limited to `a3s-box` and `curl`.
+
+## Update or remove
+
+Run the same streamed command again to replace the installed copy with the
+current Skill. Remove only the target directory to uninstall it, for example:
+
+```bash
+rm -rf ~/.a3s/skills/a3s-box
+```
+
+Removing a Skill does not remove A3S Box, running workloads, images, volumes,
+or runtime state.

--- a/website/docs/v3/zh/_nav.json
+++ b/website/docs/v3/zh/_nav.json
@@ -10,6 +10,10 @@
     "activeMatch": "^/sdk/"
   },
   {
+    "text": "Agent Skill",
+    "link": "/guide/agent-skill.html"
+  },
+  {
     "text": "参考",
     "link": "/reference/",
     "activeMatch": "^/reference/"

--- a/website/docs/v3/zh/guide/_meta.json
+++ b/website/docs/v3/zh/guide/_meta.json
@@ -2,6 +2,7 @@
   "index",
   "installation",
   "quick-start",
+  "agent-skill",
   "architecture",
   "images-builds",
   "networking-compose",

--- a/website/docs/v3/zh/guide/agent-skill.mdx
+++ b/website/docs/v3/zh/guide/agent-skill.mdx
@@ -1,0 +1,135 @@
+---
+title: Agent Skill
+description: 在 A3S Code、Codex、Claude Code 及其他支持 Skill 的 Agent 中安装并使用 A3S Box Skill。
+---
+
+# A3S Box Agent Skill
+
+A3S Box Skill 会教会编码 Agent 通过 Box CLI 运行 OCI 工作负载，并正确处理生命周期、
+隔离、网络和清理规则。所有 Agent 共用同一份 `SKILL.md`，无需为每个产品维护一套集成。
+
+Skill 不负责安装 Box 运行时。请先完成[安装指南](./installation/)，再检查当前主机：
+
+```bash
+a3s-box --version
+a3s-box info
+```
+
+## 为你的 Agent 安装
+
+下面的命令会把当前 Skill 安装到用户级目录。通过网络执行时，安装器会下载并保存一份
+持久副本，不会留下指向临时文件的符号链接。
+
+### A3S Code
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home a3s-code
+```
+
+目标：`~/.a3s/skills/a3s-box/SKILL.md`
+
+### Codex
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home codex
+```
+
+目标：`~/.codex/skills/a3s-box/SKILL.md`
+
+### Claude Code
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home claude
+```
+
+目标：`~/.claude/skills/a3s-box/SKILL.md`
+
+### 安装到所有受支持目录
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- --home all
+```
+
+`all` 会把同一份文件安装到所选作用域下的 `.agents`、`.claude`、`.codex` 和
+`.a3s` 目录，适合同一台机器同时使用多个 Agent 的场景。
+
+> [!TIP]
+> 网络管道会执行 `main` 分支上的安装器。如果环境要求固定版本或先审计脚本，请先下载
+> 并检查安装器，再在本地执行。
+
+## 用户级与项目级作用域
+
+`--home` 表示用户级安装；去掉它即可只为当前项目安装：
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh |
+  sh -s -- a3s-code
+```
+
+| Agent 目标  | 项目级目录       | 用户级目录         |
+| ----------- | ---------------- | ------------------ |
+| 跨工具标准  | `.agents/skills` | `~/.agents/skills` |
+| Claude Code | `.claude/skills` | `~/.claude/skills` |
+| Codex       | `.codex/skills`  | `~/.codex/skills`  |
+| A3S Code    | `.a3s/skills`    | `~/.a3s/skills`    |
+
+如果已经检出 Box 仓库，可以直接运行 `integrations/skills/install.sh`。仓库内安装
+默认使用符号链接，使多个 Agent 始终读取同一个源文件；如果仓库之后可能移动，请增加
+`--copy`。
+
+## 重新加载并调用
+
+安装后请重启 Agent 会话或刷新 Skill 列表。支持斜杠命令的界面可直接使用
+`/a3s-box`：
+
+```text
+/a3s-box 在隔离的 MicroVM 中构建这个仓库并运行测试，保留失败日志，
+完成后清理临时 Box。
+```
+
+没有斜杠命令界面的 Agent 也可以通过自然语言激活同一个 Skill：
+
+```text
+使用 A3S Box Skill 在一次性 MicroVM 中安全运行这段生成脚本，报告退出码，
+然后删除 Box。
+```
+
+Skill 会引导 Agent 使用可重复的执行顺序：
+
+1. 首次运行工作负载前执行 `a3s-box info`。
+2. 为 Box 指定明确名称，不从面向用户的 CLI 输出中解析 ID。
+3. 将来宾命令放在 `--` 之后。
+4. 使用 `a3s-box ps -a` 验证后台工作负载。
+5. 失败时检查状态和日志，然后停止并删除临时状态。
+
+## Skill 覆盖的能力
+
+- 一次性与长时间运行的 MicroVM 工作负载。
+- 镜像构建、仓库操作、存储卷、网络和端口发布。
+- `exec`、Shell、文件复制、日志、健康检查和生命周期恢复。
+- 文件系统快照，以及恢复后的工作负载启动流程。
+- 命令超时、后台监控和常见来宾通道故障。
+
+Skill 会保留 Box 的失败关闭模型：主机无法满足请求时，不会改用更弱的隔离后端；
+它也不会绕过 Agent 的确认或工作区权限。在执行 `allowed-tools` 声明的 Agent 中，
+Shell 调用会限制为 `a3s-box` 和 `curl`。
+
+## 更新或删除
+
+再次运行相同的网络安装命令，即可用当前版本替换已安装副本。卸载时只删除对应 Skill
+目录，例如：
+
+```bash
+rm -rf ~/.a3s/skills/a3s-box
+```
+
+删除 Skill 不会卸载 A3S Box，也不会删除正在运行的工作负载、镜像、存储卷或运行时状态。

--- a/website/scripts/check-built-site.mjs
+++ b/website/scripts/check-built-site.mjs
@@ -14,6 +14,7 @@ const routeFiles = [
   'guide/index.html',
   'guide/installation.html',
   'guide/quick-start.html',
+  'guide/agent-skill.html',
   'guide/architecture.html',
   'guide/images-builds.html',
   'guide/networking-compose.html',
@@ -81,6 +82,10 @@ for (const [homepagePath, html] of [
   ['en/index.html', englishHomepage],
 ]) {
   for (const marker of [
+    'id="agent-skill"',
+    'box-global-grid-canvas',
+    'a3s-box · skill installer',
+    'integrations/skills/install.sh',
     'id="sdk-code-tour"',
     'id="homepage-code-hike"',
     'href="#homepage-code-hike"',
@@ -104,6 +109,7 @@ for (const [homepagePath, html] of [
   }
 }
 for (const route of [
+  `${base}en/guide/agent-skill.html`,
   `${base}en/guide/quick-start.html`,
   `${base}en/sdk/rust.html`,
   `${base}en/sdk/typescript.html`,
@@ -118,6 +124,34 @@ for (const route of [
 }
 
 for (const localePrefix of ['', 'en/']) {
+  const agentSkillPath = `${localePrefix}guide/agent-skill.html`;
+  const agentSkillHtml = await readFile(
+    path.join(outputRoot, agentSkillPath),
+    'utf8',
+  );
+  const agentSkillText = agentSkillHtml
+    .replace(/<[^>]+>/g, '')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&')
+    .replace(/\s+/g, ' ');
+
+  for (const marker of [
+    'integrations/skills/install.sh',
+    'sh -s -- --home a3s-code',
+    'sh -s -- --home codex',
+    'sh -s -- --home claude',
+    'sh -s -- --home all',
+    '/a3s-box',
+    'allowed-tools',
+  ]) {
+    if (!agentSkillText.includes(marker)) {
+      throw new Error(
+        `${agentSkillPath} is missing its Skill integration marker: ${marker}`,
+      );
+    }
+  }
+
   const quickStartPath = `${localePrefix}guide/quick-start.html`;
   const quickStartHtml = await readFile(
     path.join(outputRoot, quickStartPath),
@@ -237,5 +271,5 @@ if (brokenReferences.length > 0) {
 }
 
 console.log(
-  `Bilingual Tabs, Code Hike walkthroughs, references, and ACL highlighting verified across ${htmlFiles.length} HTML pages.`,
+  `Bilingual Agent Skill, Tabs, Code Hike walkthroughs, references, and ACL highlighting verified across ${htmlFiles.length} HTML pages.`,
 );

--- a/website/scripts/check-docs.mjs
+++ b/website/scripts/check-docs.mjs
@@ -14,6 +14,7 @@ const requiredPages = [
   'guide/index.mdx',
   'guide/installation.mdx',
   'guide/quick-start.mdx',
+  'guide/agent-skill.mdx',
   'guide/architecture.mdx',
   'guide/images-builds.mdx',
   'guide/networking-compose.mdx',
@@ -204,6 +205,10 @@ for (const language of languages) {
     path.join(docsRoot, language, 'guide', 'quick-start.mdx'),
     'utf8',
   );
+  const agentSkill = await readFile(
+    path.join(docsRoot, language, 'guide', 'agent-skill.mdx'),
+    'utf8',
+  );
   const networking = await readFile(
     path.join(docsRoot, language, 'guide', 'networking-compose.mdx'),
     'utf8',
@@ -254,6 +259,22 @@ for (const language of languages) {
     programFailures.push(
       `${language}/guide/networking-compose.mdx: ACL example must use an acl fence`,
     );
+  }
+
+  for (const marker of [
+    'integrations/skills/install.sh',
+    'sh -s -- --home a3s-code',
+    'sh -s -- --home codex',
+    'sh -s -- --home claude',
+    'sh -s -- --home all',
+    '/a3s-box',
+    'allowed-tools',
+  ]) {
+    if (!agentSkill.includes(marker)) {
+      experienceFailures.push(
+        `${language}/guide/agent-skill.mdx: missing Skill integration marker ${marker}`,
+      );
+    }
   }
 
   const tabsContract = [
@@ -352,5 +373,5 @@ if (experienceFailures.length > 0) {
 }
 
 console.log(
-  `Documentation contract verified: ${requiredPages.length} routes × ${languages.length} languages, complete Rust/TypeScript/Python/Go programs in Tabs, Code Hike walkthroughs, and ACL fences.`,
+  `Documentation contract verified: ${requiredPages.length} routes × ${languages.length} languages, Agent Skill integration, complete Rust/TypeScript/Python/Go programs in Tabs, Code Hike walkthroughs, and ACL fences.`,
 );

--- a/website/theme/agent-skill.css
+++ b/website/theme/agent-skill.css
@@ -1,0 +1,468 @@
+.box-agent-skill {
+  scroll-margin-top: calc(var(--rp-nav-height) + 16px);
+  background:
+    radial-gradient(
+      circle at 8% 12%,
+      rgba(98, 215, 139, 0.11),
+      transparent 31rem
+    ),
+    radial-gradient(
+      circle at 94% 82%,
+      rgba(245, 185, 95, 0.055),
+      transparent 27rem
+    ),
+    rgba(8, 12, 9, 0.94);
+}
+
+.box-agent-skill-intro p {
+  margin: 0;
+}
+
+.box-agent-skill-intro .box-inline-link {
+  margin-top: 22px;
+}
+
+.box-agent-skill-stage {
+  display: grid;
+  margin-top: 64px;
+  align-items: stretch;
+  gap: 26px;
+  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.7fr);
+}
+
+.box-agent-skill-console {
+  overflow: hidden;
+  min-width: 0;
+  min-height: 482px;
+  border: 1px solid rgba(98, 215, 139, 0.28);
+  border-radius: 14px;
+  background:
+    linear-gradient(rgba(98, 215, 139, 0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(98, 215, 139, 0.022) 1px, transparent 1px),
+    #0a0f0c;
+  background-size: 28px 28px;
+  box-shadow:
+    0 32px 88px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(98, 215, 139, 0.025),
+    inset 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.box-agent-skill-console > header {
+  display: grid;
+  min-height: 52px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--box-line);
+  background: rgba(8, 12, 9, 0.94);
+  align-items: center;
+  grid-template-columns: 1fr auto 1fr;
+}
+
+.box-agent-skill-console > header > div {
+  display: flex;
+  gap: 6px;
+}
+
+.box-agent-skill-console > header > div span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #506058;
+}
+
+.box-agent-skill-console > header > div span:first-child {
+  background: #d9695f;
+}
+
+.box-agent-skill-console > header > div span:nth-child(2) {
+  background: #d6a64f;
+}
+
+.box-agent-skill-console > header > div span:last-child {
+  background: #58b878;
+}
+
+.box-agent-skill-console > header strong,
+.box-agent-skill-console > header small,
+.box-agent-skill-console > footer {
+  font-family: var(--box-mono);
+  letter-spacing: 0.045em;
+}
+
+.box-agent-skill-console > header strong {
+  color: #cbd4ce;
+  font-size: 11px;
+  font-weight: 620;
+}
+
+.box-agent-skill-console > header small {
+  justify-self: end;
+  color: var(--box-green);
+  font-size: 8px;
+  text-transform: uppercase;
+}
+
+.box-agent-skill-tabs {
+  display: grid;
+  border-bottom: 1px solid var(--box-line);
+  background: rgba(9, 13, 10, 0.92);
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.box-agent-skill-tabs button {
+  position: relative;
+  min-width: 0;
+  min-height: 55px;
+  padding: 0 12px;
+  border: 0;
+  border-right: 1px solid var(--box-line);
+  background: transparent;
+  color: var(--box-faint);
+  cursor: pointer;
+  font-family: var(--box-mono);
+  font-size: 10px;
+  font-weight: 650;
+  transition:
+    background 180ms ease,
+    color 180ms ease;
+}
+
+.box-agent-skill-tabs button:last-child {
+  border-right: 0;
+}
+
+.box-agent-skill-tabs button::after {
+  position: absolute;
+  right: 16px;
+  bottom: -1px;
+  left: 16px;
+  height: 2px;
+  background: transparent;
+  content: '';
+  transition:
+    background 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.box-agent-skill-tabs button:hover,
+.box-agent-skill-tabs button.is-active {
+  background: rgba(98, 215, 139, 0.055);
+  color: var(--box-text);
+}
+
+.box-agent-skill-tabs button.is-active::after {
+  background: var(--box-green);
+  box-shadow: 0 0 15px rgba(98, 215, 139, 0.56);
+}
+
+.box-agent-skill-tabs button:focus-visible,
+.box-agent-skill-command > button:focus-visible {
+  outline: 2px solid var(--box-green);
+  outline-offset: -3px;
+}
+
+.box-agent-skill-command {
+  position: relative;
+  display: flex;
+  min-height: 302px;
+  padding: 34px 132px 34px 30px;
+  align-items: center;
+}
+
+.box-agent-skill-command::before {
+  margin-right: 13px;
+  color: var(--box-green);
+  content: '$';
+  font-family: var(--box-mono);
+  font-size: 13px;
+}
+
+.box-agent-skill-command pre {
+  overflow: auto;
+  min-width: 0;
+  max-width: 100%;
+  margin: 0;
+  background: transparent;
+  color: #dbe5de;
+  font-family: var(--box-mono);
+  font-size: 12px;
+  line-height: 1.75;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.box-agent-skill-command code {
+  color: inherit;
+  font: inherit;
+}
+
+.box-agent-skill-command > button {
+  position: absolute;
+  top: 24px;
+  right: 22px;
+  display: inline-flex;
+  min-width: 88px;
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--box-line);
+  border-radius: 6px;
+  background: #141b16;
+  color: var(--box-muted);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-family: inherit;
+  font-size: 12px;
+  transition:
+    border-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.box-agent-skill-command > button:hover {
+  border-color: rgba(98, 215, 139, 0.46);
+  color: var(--box-text);
+  transform: translateY(-1px);
+}
+
+.box-agent-skill-command > button svg {
+  width: 14px;
+  height: 14px;
+}
+
+.box-agent-skill-console > footer {
+  display: grid;
+  min-height: 72px;
+  padding: 0 22px;
+  border-top: 1px solid var(--box-line);
+  background: rgba(8, 12, 9, 0.94);
+  align-items: center;
+  gap: 18px;
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.box-agent-skill-console > footer span {
+  color: var(--box-faint);
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.box-agent-skill-console > footer code {
+  overflow: hidden;
+  color: #91a098;
+  font-size: 10px;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.box-agent-skill-flow {
+  display: flex;
+  min-width: 0;
+  padding: 4px 0;
+  flex-direction: column;
+}
+
+.box-agent-skill-flow > span {
+  color: var(--box-green);
+  font-family: var(--box-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.box-agent-skill-flow ol {
+  display: grid;
+  min-height: 0;
+  margin: 18px 0 0;
+  padding: 0;
+  flex: 1;
+  gap: 10px;
+  grid-template-rows: repeat(3, 1fr);
+  list-style: none;
+}
+
+.box-agent-skill-flow li {
+  display: flex;
+  overflow: hidden;
+  min-height: 0;
+  padding: 22px 24px;
+  border: 1px solid var(--box-line);
+  border-radius: 9px;
+  background:
+    linear-gradient(135deg, rgba(98, 215, 139, 0.035), transparent 58%),
+    rgba(13, 18, 15, 0.92);
+  flex-direction: column;
+  justify-content: center;
+}
+
+.box-agent-skill-flow li > span {
+  color: var(--box-faint);
+  font-family: var(--box-mono);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+}
+
+.box-agent-skill-flow h3 {
+  margin: 8px 0 0;
+  color: var(--box-text);
+  font-size: 17px;
+  font-weight: 660;
+  letter-spacing: -0.025em;
+}
+
+.box-agent-skill-flow p {
+  margin: 7px 0 0;
+  color: var(--box-muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.box-agent-skill-example {
+  display: grid;
+  margin-top: 26px;
+  border: 1px solid var(--box-line);
+  border-radius: 11px;
+  background: rgba(9, 13, 10, 0.86);
+  grid-template-columns: minmax(0, 1.3fr) minmax(300px, 0.7fr);
+}
+
+.box-agent-skill-example > div {
+  min-width: 0;
+  padding: 26px 28px;
+}
+
+.box-agent-skill-example > div + div {
+  border-left: 1px solid var(--box-line);
+  background: rgba(98, 215, 139, 0.025);
+}
+
+.box-agent-skill-example span {
+  display: block;
+  color: var(--box-faint);
+  font-family: var(--box-mono);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.box-agent-skill-example code {
+  display: inline-block;
+  margin-top: 14px;
+  padding: 7px 10px;
+  border: 1px solid rgba(98, 215, 139, 0.22);
+  border-radius: 5px;
+  background: rgba(98, 215, 139, 0.065);
+  color: var(--box-green-soft);
+  font-family: var(--box-mono);
+  font-size: 11px;
+}
+
+.box-agent-skill-example p {
+  margin: 13px 0 0;
+  color: var(--box-muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+@media (max-width: 1020px) {
+  .box-agent-skill-stage {
+    grid-template-columns: 1fr;
+  }
+
+  .box-agent-skill-flow ol {
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: none;
+  }
+
+  .box-agent-skill-flow li {
+    min-height: 190px;
+  }
+}
+
+@media (max-width: 760px) {
+  .box-agent-skill-tabs {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .box-agent-skill-tabs button:nth-child(2) {
+    border-right: 0;
+  }
+
+  .box-agent-skill-tabs button:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--box-line);
+  }
+
+  .box-agent-skill-flow ol,
+  .box-agent-skill-example {
+    grid-template-columns: 1fr;
+  }
+
+  .box-agent-skill-flow li {
+    min-height: 155px;
+  }
+
+  .box-agent-skill-example > div + div {
+    border-top: 1px solid var(--box-line);
+    border-left: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .box-agent-skill-stage {
+    margin-top: 46px;
+  }
+
+  .box-agent-skill-console {
+    min-height: 540px;
+    border-radius: 11px;
+  }
+
+  .box-agent-skill-console > header {
+    padding: 0 13px;
+    grid-template-columns: auto 1fr auto;
+  }
+
+  .box-agent-skill-console > header strong {
+    padding-left: 12px;
+    font-size: 9px;
+  }
+
+  .box-agent-skill-console > header small {
+    font-size: 7px;
+  }
+
+  .box-agent-skill-command {
+    min-height: 322px;
+    padding: 30px 20px 88px;
+    align-items: flex-start;
+  }
+
+  .box-agent-skill-command::before {
+    padding-top: 2px;
+  }
+
+  .box-agent-skill-command > button {
+    top: auto;
+    right: 18px;
+    bottom: 22px;
+  }
+
+  .box-agent-skill-console > footer {
+    min-height: 72px;
+    padding: 12px 17px;
+    align-content: center;
+    gap: 6px;
+    grid-template-columns: 1fr;
+  }
+
+  .box-agent-skill-console > footer code {
+    text-align: left;
+  }
+
+  .box-agent-skill-example > div {
+    padding: 24px 22px;
+  }
+}

--- a/website/theme/components/AgentSkillSection.tsx
+++ b/website/theme/components/AgentSkillSection.tsx
@@ -1,0 +1,264 @@
+import { useState } from 'react';
+
+type Locale = 'zh' | 'en';
+
+type AgentSkillSectionProps = {
+  guideHref: string;
+  locale: Locale;
+};
+
+const installerUrl =
+  'https://raw.githubusercontent.com/A3S-Lab/Box/main/integrations/skills/install.sh';
+
+const installTargets = [
+  {
+    id: 'a3s-code',
+    label: 'A3S Code',
+    root: '~/.a3s/skills/a3s-box',
+    command: `curl --proto '=https' --tlsv1.2 -fsSL ${installerUrl} | sh -s -- --home a3s-code`,
+  },
+  {
+    id: 'codex',
+    label: 'Codex',
+    root: '~/.codex/skills/a3s-box',
+    command: `curl --proto '=https' --tlsv1.2 -fsSL ${installerUrl} | sh -s -- --home codex`,
+  },
+  {
+    id: 'claude',
+    label: 'Claude Code',
+    root: '~/.claude/skills/a3s-box',
+    command: `curl --proto '=https' --tlsv1.2 -fsSL ${installerUrl} | sh -s -- --home claude`,
+  },
+  {
+    id: 'all',
+    label: 'All agents',
+    root: '~/{.agents,.claude,.codex,.a3s}/skills/a3s-box',
+    command: `curl --proto '=https' --tlsv1.2 -fsSL ${installerUrl} | sh -s -- --home all`,
+  },
+] as const;
+
+const copy = {
+  zh: {
+    kicker: 'AGENT SKILL',
+    title: '让 Agent 把不受信任的执行交给 Box。',
+    body: '安装一次，即可让 A3S Code、Codex、Claude Code 等支持 Skill 的 Agent 理解 Box 的隔离模型、生命周期、网络、快照与故障恢复。',
+    guide: '阅读完整 Skill 指南',
+    consoleTitle: 'a3s-box · skill installer',
+    consoleStatus: '远程副本',
+    targetLabel: '安装目标',
+    copyCommand: '复制 Skill 安装命令',
+    copy: '复制',
+    copied: '已复制',
+    flowLabel: '三步接入',
+    steps: [
+      {
+        label: '01 / INSTALL',
+        title: '选择 Agent',
+        body: '命令会将同一份 SKILL.md 写入所选用户级技能目录。',
+      },
+      {
+        label: '02 / RELOAD',
+        title: '重新加载 Agent',
+        body: '重启会话或刷新 Skill 列表，让 Agent 发现 /a3s-box。',
+      },
+      {
+        label: '03 / RUN',
+        title: '描述隔离任务',
+        body: 'Agent 会先检查主机能力，再使用明确的 Box 生命周期完成任务和清理。',
+      },
+    ],
+    promptLabel: '示例请求',
+    prompt:
+      '在隔离的 MicroVM 中构建这个仓库并运行测试，保留失败日志，完成后清理临时 Box。',
+    boundaryLabel: '工具边界',
+    boundary:
+      '在 Agent 执行 allowed-tools 的环境中，Skill 仅开放 a3s-box 与 curl 的 Shell 调用；文件读取仍由 Agent 自身权限控制。',
+  },
+  en: {
+    kicker: 'AGENT SKILL',
+    title: 'Give agents a safe place to execute untrusted work.',
+    body: 'Install once so A3S Code, Codex, Claude Code, and other skill-aware agents understand Box isolation, lifecycle, networking, snapshots, and recovery.',
+    guide: 'Read the complete Skill guide',
+    consoleTitle: 'a3s-box · skill installer',
+    consoleStatus: 'remote copy',
+    targetLabel: 'INSTALL TARGET',
+    copyCommand: 'Copy the Skill install command',
+    copy: 'Copy',
+    copied: 'Copied',
+    flowLabel: 'THREE-STEP SETUP',
+    steps: [
+      {
+        label: '01 / INSTALL',
+        title: 'Choose an agent',
+        body: 'The command writes the same SKILL.md into the selected user-level skill root.',
+      },
+      {
+        label: '02 / RELOAD',
+        title: 'Reload the agent',
+        body: 'Restart the session or refresh skills so the agent discovers /a3s-box.',
+      },
+      {
+        label: '03 / RUN',
+        title: 'Describe isolated work',
+        body: 'The agent checks host capabilities, then uses an explicit Box lifecycle and cleanup path.',
+      },
+    ],
+    promptLabel: 'EXAMPLE REQUEST',
+    prompt:
+      'Build this repository and run its tests in an isolated MicroVM. Preserve failing logs and clean up the temporary Box.',
+    boundaryLabel: 'TOOL BOUNDARY',
+    boundary:
+      'Where an agent enforces allowed-tools, the Skill limits shell calls to a3s-box and curl. File reads remain governed by the agent policy.',
+  },
+} as const;
+
+function ArrowIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M5 12h14M13 6l6 6-6 6" />
+    </svg>
+  );
+}
+
+function CopyIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <rect x="8" y="8" width="11" height="11" rx="2" />
+      <path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="m5 12 4 4L19 6" />
+    </svg>
+  );
+}
+
+export function AgentSkillSection({
+  guideHref,
+  locale,
+}: AgentSkillSectionProps) {
+  const labels = copy[locale];
+  const [selectedTarget, setSelectedTarget] =
+    useState<(typeof installTargets)[number]['id']>('a3s-code');
+  const [copied, setCopied] = useState(false);
+  const activeTarget =
+    installTargets.find((target) => target.id === selectedTarget) ??
+    installTargets[0];
+
+  async function copyInstallCommand() {
+    try {
+      await navigator.clipboard.writeText(activeTarget.command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1_400);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <section className="box-section box-agent-skill" id="agent-skill">
+      <div className="box-section-heading box-section-heading--split">
+        <div>
+          <span>{labels.kicker}</span>
+          <h2>{labels.title}</h2>
+        </div>
+        <div className="box-agent-skill-intro">
+          <p>{labels.body}</p>
+          <a className="box-inline-link" href={guideHref}>
+            {labels.guide}
+            <ArrowIcon />
+          </a>
+        </div>
+      </div>
+
+      <div className="box-agent-skill-stage">
+        <div className="box-agent-skill-console box-premium-surface">
+          <header>
+            <div aria-hidden="true">
+              <span />
+              <span />
+              <span />
+            </div>
+            <strong>{labels.consoleTitle}</strong>
+            <small>{labels.consoleStatus}</small>
+          </header>
+
+          <div className="box-agent-skill-tabs" role="tablist">
+            {installTargets.map((target) => (
+              <button
+                aria-controls="box-agent-skill-command"
+                aria-selected={selectedTarget === target.id}
+                className={
+                  selectedTarget === target.id ? 'is-active' : undefined
+                }
+                id={`box-agent-skill-tab-${target.id}`}
+                key={target.id}
+                onClick={() => {
+                  setSelectedTarget(target.id);
+                  setCopied(false);
+                }}
+                role="tab"
+                type="button"
+              >
+                {target.label}
+              </button>
+            ))}
+          </div>
+
+          <div
+            aria-labelledby={`box-agent-skill-tab-${activeTarget.id}`}
+            className="box-agent-skill-command"
+            id="box-agent-skill-command"
+            role="tabpanel"
+          >
+            <pre>
+              <code>{activeTarget.command}</code>
+            </pre>
+            <button
+              aria-label={labels.copyCommand}
+              onClick={copyInstallCommand}
+              type="button"
+            >
+              {copied ? <CheckIcon /> : <CopyIcon />}
+              {copied ? labels.copied : labels.copy}
+            </button>
+          </div>
+
+          <footer>
+            <span>{labels.targetLabel}</span>
+            <code>{activeTarget.root}</code>
+          </footer>
+        </div>
+
+        <div className="box-agent-skill-flow">
+          <span>{labels.flowLabel}</span>
+          <ol>
+            {labels.steps.map((step) => (
+              <li className="box-premium-surface" key={step.label}>
+                <span>{step.label}</span>
+                <h3>{step.title}</h3>
+                <p>{step.body}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+
+      <div className="box-agent-skill-example">
+        <div>
+          <span>{labels.promptLabel}</span>
+          <code>/a3s-box</code>
+          <p>{labels.prompt}</p>
+        </div>
+        <div>
+          <span>{labels.boundaryLabel}</span>
+          <p>{labels.boundary}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/theme/components/CanvasGridEffect.tsx
+++ b/website/theme/components/CanvasGridEffect.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useRef } from 'react';
+
+type CanvasGridEffectProps = {
+  cellSize?: number;
+  className?: string;
+  intensity?: number;
+  interactionScope?: 'host' | 'page';
+};
+
+type GridWave = {
+  bornAt: number;
+  strength: number;
+  x: number;
+  y: number;
+};
+
+const GRID_TINT = [98, 215, 139] as const;
+const WAVE_LIFETIME = 1_650;
+
+function clamp(value: number, minimum: number, maximum: number) {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+/**
+ * A lightweight interpretation of Canvas UI's Grid interaction.
+ *
+ * The effect preserves the cursor-driven tile wave without relying on the
+ * experimental HTML-in-canvas API, so it remains reliable on static hosting.
+ * https://canvasui.dev/docs/components/grid
+ */
+export function CanvasGridEffect({
+  cellSize = 34,
+  className,
+  intensity = 1,
+  interactionScope = 'host',
+}: CanvasGridEffectProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const host = canvas?.parentElement;
+    const context = canvas?.getContext('2d');
+    if (!canvas || !host || !context) return undefined;
+    const drawingContext = context;
+    const interactionTarget =
+      interactionScope === 'page'
+        ? (canvas.closest<HTMLElement>('.box-home') ?? host)
+        : host;
+
+    const motionPreference = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    );
+    let reducedMotion = motionPreference.matches;
+    let frame = 0;
+    let isVisible = true;
+    let isPointerInside = false;
+    let lastWaveAt = 0;
+    let previousPointer = { x: -cellSize, y: -cellSize };
+    let pointer = { x: -cellSize * 4, y: -cellSize * 4 };
+    let waves: GridWave[] = [];
+    let width = 1;
+    let height = 1;
+    let pixelRatio = 1;
+
+    const scheduleDraw = () => {
+      if (frame || !isVisible) return;
+      frame = window.requestAnimationFrame(draw);
+    };
+
+    const resize = () => {
+      const bounds = host.getBoundingClientRect();
+      width = Math.max(bounds.width, 1);
+      height = Math.max(bounds.height, 1);
+      pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = Math.round(width * pixelRatio);
+      canvas.height = Math.round(height * pixelRatio);
+      scheduleDraw();
+    };
+
+    function draw(now: number) {
+      frame = 0;
+      drawingContext.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+      drawingContext.clearRect(0, 0, width, height);
+
+      const activeWaves = reducedMotion
+        ? []
+        : waves.filter((wave) => now - wave.bornAt < WAVE_LIFETIME);
+      waves = activeWaves;
+      const columnCount = Math.ceil(width / cellSize) + 1;
+      const rowCount = Math.ceil(height / cellSize) + 1;
+      const maxDimension = Math.max(width, height);
+
+      for (let row = 0; row < rowCount; row += 1) {
+        for (let column = 0; column < columnCount; column += 1) {
+          const centerX = column * cellSize + cellSize / 2;
+          const centerY = row * cellSize + cellSize / 2;
+          const pointerDistance = Math.hypot(
+            centerX - pointer.x,
+            centerY - pointer.y,
+          );
+          const pointerLift = isPointerInside
+            ? Math.exp(-pointerDistance / (cellSize * 2.25))
+            : 0;
+          let waveLift = 0;
+
+          for (const wave of activeWaves) {
+            const progress = clamp((now - wave.bornAt) / WAVE_LIFETIME, 0, 1);
+            const radius = progress * maxDimension * 0.78;
+            const distance = Math.hypot(centerX - wave.x, centerY - wave.y);
+            const ring = Math.exp(
+              -Math.pow((distance - radius) / (cellSize * 1.5), 2),
+            );
+            waveLift = Math.max(
+              waveLift,
+              ring * (1 - progress) * wave.strength,
+            );
+          }
+
+          const lift = clamp(pointerLift * 0.66 + waveLift, 0, 1);
+          const inset = 4 - lift * 2.35;
+          const offsetY = -lift * 7;
+          const alpha = intensity * (0.035 + lift * 0.22);
+          const fillAlpha = intensity * (0.004 + lift * 0.045);
+          const tileX = column * cellSize + inset;
+          const tileY = row * cellSize + inset + offsetY;
+          const tileWidth = cellSize - inset * 2;
+          const depth = lift * 5;
+
+          if (depth > 0.25) {
+            drawingContext.fillStyle = `rgba(${GRID_TINT.join(', ')}, ${intensity * lift * 0.055})`;
+            drawingContext.beginPath();
+            drawingContext.moveTo(tileX, tileY + tileWidth);
+            drawingContext.lineTo(tileX + tileWidth, tileY + tileWidth);
+            drawingContext.lineTo(tileX + tileWidth, tileY + tileWidth + depth);
+            drawingContext.lineTo(tileX, tileY + tileWidth + depth);
+            drawingContext.closePath();
+            drawingContext.fill();
+
+            drawingContext.fillStyle = `rgba(${GRID_TINT.join(', ')}, ${intensity * lift * 0.035})`;
+            drawingContext.beginPath();
+            drawingContext.moveTo(tileX + tileWidth, tileY);
+            drawingContext.lineTo(tileX + tileWidth, tileY + tileWidth);
+            drawingContext.lineTo(tileX + tileWidth, tileY + tileWidth + depth);
+            drawingContext.lineTo(tileX + tileWidth + depth, tileY + depth);
+            drawingContext.closePath();
+            drawingContext.fill();
+          }
+
+          drawingContext.fillStyle = `rgba(${GRID_TINT.join(', ')}, ${fillAlpha})`;
+          drawingContext.fillRect(tileX, tileY, tileWidth, tileWidth);
+
+          drawingContext.strokeStyle = `rgba(${GRID_TINT.join(', ')}, ${alpha})`;
+          drawingContext.lineWidth = 1;
+          drawingContext.strokeRect(tileX, tileY, tileWidth, tileWidth);
+        }
+      }
+
+      if (activeWaves.length > 0) scheduleDraw();
+    }
+
+    const addWave = (x: number, y: number, now: number, strength = 1) => {
+      waves = [...waves.slice(-4), { bornAt: now, strength, x, y }];
+      lastWaveAt = now;
+      scheduleDraw();
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (reducedMotion || event.pointerType === 'touch') return;
+      const bounds = host.getBoundingClientRect();
+      const x = event.clientX - bounds.left;
+      const y = event.clientY - bounds.top;
+      const now = performance.now();
+      const distance = Math.hypot(x - previousPointer.x, y - previousPointer.y);
+
+      pointer = { x, y };
+      isPointerInside = true;
+      if (distance > cellSize * 1.25 && now - lastWaveAt > 90) {
+        addWave(x, y, now, 1);
+        previousPointer = { x, y };
+      }
+      scheduleDraw();
+    };
+
+    const handlePointerLeave = () => {
+      isPointerInside = false;
+      pointer = { x: -cellSize * 4, y: -cellSize * 4 };
+      scheduleDraw();
+    };
+
+    const handleMotionChange = () => {
+      reducedMotion = motionPreference.matches;
+      if (reducedMotion) waves = [];
+      scheduleDraw();
+    };
+
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(host);
+    const intersectionObserver = new IntersectionObserver(([entry]) => {
+      isVisible = entry?.isIntersecting ?? true;
+      if (isVisible) scheduleDraw();
+    });
+    intersectionObserver.observe(host);
+    motionPreference.addEventListener('change', handleMotionChange);
+    interactionTarget.addEventListener('pointermove', handlePointerMove);
+    interactionTarget.addEventListener('pointerleave', handlePointerLeave);
+    resize();
+    if (!reducedMotion) {
+      addWave(width * 0.72, height * 0.32, performance.now(), 0.62);
+    }
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+      motionPreference.removeEventListener('change', handleMotionChange);
+      interactionTarget.removeEventListener('pointermove', handlePointerMove);
+      interactionTarget.removeEventListener('pointerleave', handlePointerLeave);
+    };
+  }, [cellSize, intensity, interactionScope]);
+
+  return <canvas aria-hidden="true" className={className} ref={canvasRef} />;
+}

--- a/website/theme/components/HomeLayout.tsx
+++ b/website/theme/components/HomeLayout.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
 import { Content, useLang, withBase } from '@rspress/core/runtime';
+import { AgentSkillSection } from './AgentSkillSection';
+import { CanvasGridEffect } from './CanvasGridEffect';
+import { PremiumInteractions } from './PremiumInteractions';
 
 const installCommands = [
   {
@@ -49,6 +52,7 @@ const content = {
     heroSubtitle:
       'A3S Box 是一个本地 OCI 运行时，将隔离策略作为每次请求的一部分。默认使用独立来宾内核；共享内核执行必须显式启用，并通过能力检查。',
     getStarted: '快速开始',
+    installSkill: '安装 Agent Skill',
     exploreCode: '代码漫游',
     copy: '复制',
     copied: '已复制',
@@ -75,8 +79,8 @@ const content = {
     signals: [
       ['独立内核', '默认隔离'],
       ['OCI 原生', '镜像与构建'],
-      ['4 种 SDK', '统一运行时契约'],
-      ['3 类主机', 'KVM · HVF · WHPX'],
+      ['Agent Skill', 'A3S Code · Codex · Claude'],
+      ['4 种 SDK', 'Rust · Go · Python · TypeScript'],
     ],
     principleKicker: '将隔离作为数据',
     principleTitle: '让执行边界在代码中清晰可见。',
@@ -181,6 +185,7 @@ const content = {
     heroSubtitle:
       'A3S Box is a local OCI runtime that makes isolation part of every request. Dedicated guest kernels are the default. Shared-kernel execution is an explicit, capability-checked opt-in.',
     getStarted: 'Get started',
+    installSkill: 'Install Agent Skill',
     exploreCode: 'Code walkthrough',
     copy: 'Copy',
     copied: 'Copied',
@@ -207,8 +212,8 @@ const content = {
     signals: [
       ['Dedicated kernel', 'default isolation'],
       ['OCI-native', 'images and builds'],
-      ['4 SDKs', 'one runtime contract'],
-      ['3 hosts', 'KVM · HVF · WHPX'],
+      ['Agent Skill', 'A3S Code · Codex · Claude'],
+      ['4 SDKs', 'Rust · Go · Python · TypeScript'],
     ],
     principleKicker: 'ISOLATION AS DATA',
     principleTitle: 'Make the execution boundary visible in code.',
@@ -365,18 +370,6 @@ function ArrowIcon() {
   );
 }
 
-function GithubIcon() {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true">
-      <path
-        fill="currentColor"
-        stroke="none"
-        d="M12 .8a11.4 11.4 0 0 0-3.6 22.2c.6.1.8-.2.8-.5v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.6.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.6.8.5A11.4 11.4 0 0 0 12 .8Z"
-      />
-    </svg>
-  );
-}
-
 function CopyIcon() {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -419,6 +412,15 @@ export function HomeLayout() {
 
   return (
     <main className="box-home">
+      <PremiumInteractions />
+      <div className="box-global-grid" aria-hidden="true">
+        <CanvasGridEffect
+          cellSize={54}
+          className="box-global-grid-canvas"
+          intensity={0.62}
+          interactionScope="page"
+        />
+      </div>
       <section className="box-hero" aria-labelledby="box-hero-title">
         <div className="box-hero-copy">
           <div className="box-eyebrow">
@@ -438,6 +440,10 @@ export function HomeLayout() {
               {copy.getStarted}
               <ArrowIcon />
             </a>
+            <a className="box-button box-button--secondary" href="#agent-skill">
+              {copy.installSkill}
+              <ArrowIcon />
+            </a>
             <a
               className="box-button box-button--secondary"
               href="#homepage-code-hike"
@@ -445,18 +451,9 @@ export function HomeLayout() {
               {copy.exploreCode}
               <ArrowIcon />
             </a>
-            <a
-              className="box-button box-button--secondary"
-              href="https://github.com/A3S-Lab/Box"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <GithubIcon />
-              GitHub
-            </a>
           </div>
 
-          <div className="box-install">
+          <div className="box-install box-premium-surface">
             <div className="box-install-tabs" role="tablist">
               {installCommands.map((option) => (
                 <button
@@ -492,7 +489,7 @@ export function HomeLayout() {
         </div>
 
         <div className="box-hero-visual" aria-label={copy.isolationAria}>
-          <div className="box-runtime-window">
+          <div className="box-runtime-window box-premium-surface">
             <header>
               <span className="box-runtime-status" />
               {copy.visual.resolver}
@@ -552,6 +549,11 @@ export function HomeLayout() {
         ))}
       </section>
 
+      <AgentSkillSection
+        guideHref={docLink('/guide/agent-skill.html')}
+        locale={isChinese ? 'zh' : 'en'}
+      />
+
       <section id="sdk-code-tour" className="box-section box-home-code-tour">
         <Content />
       </section>
@@ -564,7 +566,7 @@ export function HomeLayout() {
         </div>
         <div className="box-principle-grid">
           {copy.principles.map((principle) => (
-            <article key={principle.label}>
+            <article className="box-premium-surface" key={principle.label}>
               <span>{principle.label}</span>
               <h3>{principle.title}</h3>
               <p>{principle.body}</p>
@@ -584,7 +586,10 @@ export function HomeLayout() {
         </div>
         <div className="box-capability-grid">
           {copy.capabilities.map((card) => (
-            <article key={card.index} className={card.className}>
+            <article
+              key={card.index}
+              className={`${card.className} box-premium-surface`}
+            >
               <div className="box-card-index">{card.index}</div>
               <span>{card.eyebrow}</span>
               <h3>{card.title}</h3>
@@ -607,7 +612,11 @@ export function HomeLayout() {
         </div>
         <div className="box-sdk-grid">
           {sdkCards.map((sdk) => (
-            <a key={sdk.language} href={docLink(sdk.href)}>
+            <a
+              className="box-premium-surface"
+              key={sdk.language}
+              href={docLink(sdk.href)}
+            >
               <header>
                 <span>{sdk.language}</span>
                 <ArrowIcon />

--- a/website/theme/components/PremiumInteractions.tsx
+++ b/website/theme/components/PremiumInteractions.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef } from 'react';
+
+type PointerPosition = {
+  clientX: number;
+  clientY: number;
+  target: EventTarget | null;
+};
+
+/**
+ * Coordinates pointer lighting for Box surfaces. Layout and presentation stay
+ * in CSS; this component only publishes local pointer coordinates.
+ */
+export function PremiumInteractions() {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const host = anchorRef.current?.closest<HTMLElement>('.box-home');
+    if (!host) return undefined;
+
+    const hero = host.querySelector<HTMLElement>('.box-hero');
+    const motionPreference = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    );
+    let activeSurface: HTMLElement | null = null;
+    let animationFrame = 0;
+    let latestPointer: PointerPosition | null = null;
+
+    const clearActiveSurface = () => {
+      activeSurface?.classList.remove('is-pointer-active');
+      activeSurface = null;
+    };
+
+    const paintPointer = () => {
+      animationFrame = 0;
+      const pointer = latestPointer;
+      if (!pointer || motionPreference.matches) {
+        clearActiveSurface();
+        return;
+      }
+
+      const target =
+        pointer.target instanceof Element ? pointer.target : undefined;
+      const surface =
+        target?.closest<HTMLElement>('.box-premium-surface') ?? null;
+
+      if (surface && host.contains(surface)) {
+        if (surface !== activeSurface) {
+          clearActiveSurface();
+          activeSurface = surface;
+          surface.classList.add('is-pointer-active');
+        }
+
+        const bounds = surface.getBoundingClientRect();
+        surface.style.setProperty(
+          '--box-spot-x',
+          `${pointer.clientX - bounds.left}px`,
+        );
+        surface.style.setProperty(
+          '--box-spot-y',
+          `${pointer.clientY - bounds.top}px`,
+        );
+      } else {
+        clearActiveSurface();
+      }
+
+      if (hero && target && hero.contains(target)) {
+        const bounds = hero.getBoundingClientRect();
+        const x = ((pointer.clientX - bounds.left) / bounds.width) * 100;
+        const y = ((pointer.clientY - bounds.top) / bounds.height) * 100;
+        hero.style.setProperty(
+          '--box-hero-x',
+          `${Math.max(0, Math.min(x, 100))}%`,
+        );
+        hero.style.setProperty(
+          '--box-hero-y',
+          `${Math.max(0, Math.min(y, 100))}%`,
+        );
+      } else {
+        hero?.style.removeProperty('--box-hero-x');
+        hero?.style.removeProperty('--box-hero-y');
+      }
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (event.pointerType === 'touch') return;
+      latestPointer = {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        target: event.target,
+      };
+      if (!animationFrame) {
+        animationFrame = window.requestAnimationFrame(paintPointer);
+      }
+    };
+
+    const handlePointerLeave = () => {
+      latestPointer = null;
+      clearActiveSurface();
+      hero?.style.removeProperty('--box-hero-x');
+      hero?.style.removeProperty('--box-hero-y');
+    };
+
+    const handleMotionChange = () => {
+      if (motionPreference.matches) handlePointerLeave();
+    };
+
+    host.dataset.premiumEffects = 'ready';
+    host.addEventListener('pointermove', handlePointerMove);
+    host.addEventListener('pointerleave', handlePointerLeave);
+    motionPreference.addEventListener('change', handleMotionChange);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      clearActiveSurface();
+      delete host.dataset.premiumEffects;
+      host.removeEventListener('pointermove', handlePointerMove);
+      host.removeEventListener('pointerleave', handlePointerLeave);
+      motionPreference.removeEventListener('change', handleMotionChange);
+    };
+  }, []);
+
+  return (
+    <span
+      aria-hidden="true"
+      className="box-premium-effects-anchor"
+      ref={anchorRef}
+    />
+  );
+}

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,4 +1,6 @@
 import './index.css';
+import './agent-skill.css';
+import './premium-effects.css';
 
 export { HomeLayout } from './components/HomeLayout';
 export * from '@rspress/core/theme-original';

--- a/website/theme/premium-effects.css
+++ b/website/theme/premium-effects.css
@@ -1,0 +1,257 @@
+/* Canvas UI-inspired interaction layer, aligned with the A3S Code website. */
+
+.box-premium-effects-anchor {
+  position: absolute;
+  overflow: hidden;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.rp-nav {
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.28);
+}
+
+.rp-nav::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(98, 215, 139, 0.08) 22%,
+    rgba(98, 215, 139, 0.58) 48%,
+    rgba(245, 185, 95, 0.18) 68%,
+    transparent 100%
+  );
+  content: '';
+  opacity: 0.56;
+  pointer-events: none;
+}
+
+.box-home {
+  --box-premium-green: 98, 215, 139;
+  --box-premium-amber: 245, 185, 95;
+  isolation: isolate;
+}
+
+.box-global-grid {
+  position: fixed;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+  inset: var(--rp-nav-height, 72px) 0 0;
+}
+
+.box-global-grid-canvas {
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+  inset: 0;
+  mix-blend-mode: screen;
+  opacity: 0.68;
+}
+
+.box-signal-strip {
+  position: relative;
+  z-index: 1;
+}
+
+.box-home::after {
+  position: fixed;
+  z-index: 3;
+  background-image: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.16) 0.4px,
+    transparent 0.68px
+  );
+  background-size: 4px 4px;
+  content: '';
+  inset: 0;
+  mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.52),
+    rgba(0, 0, 0, 0.13) 38%,
+    rgba(0, 0, 0, 0.36)
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.075;
+  pointer-events: none;
+}
+
+.box-hero {
+  --box-hero-x: 72%;
+  --box-hero-y: 34%;
+  isolation: isolate;
+}
+
+.box-hero::before {
+  position: absolute;
+  z-index: 0;
+  background:
+    radial-gradient(
+      circle 350px at var(--box-hero-x) var(--box-hero-y),
+      rgba(var(--box-premium-green), 0.15),
+      rgba(var(--box-premium-green), 0.045) 40%,
+      transparent 72%
+    ),
+    conic-gradient(
+      from 205deg at 70% 42%,
+      transparent 0deg,
+      rgba(var(--box-premium-green), 0.075) 48deg,
+      transparent 112deg,
+      rgba(var(--box-premium-amber), 0.03) 184deg,
+      transparent 250deg
+    );
+  content: '';
+  filter: blur(22px);
+  inset: -16%;
+  opacity: 0.82;
+  pointer-events: none;
+}
+
+.box-hero-copy,
+.box-hero-visual {
+  position: relative;
+  z-index: 1;
+}
+
+.box-hero h1 {
+  text-shadow: 0 18px 54px rgba(0, 0, 0, 0.42);
+}
+
+.box-hero h1 > span {
+  filter: drop-shadow(0 12px 28px rgba(75, 180, 111, 0.14));
+}
+
+.box-button--primary {
+  box-shadow:
+    0 12px 34px rgba(34, 136, 71, 0.17),
+    inset 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.box-premium-surface {
+  --box-spot-x: 50%;
+  --box-spot-y: 50%;
+  position: relative;
+  isolation: isolate;
+}
+
+.box-premium-surface::before {
+  position: absolute;
+  z-index: 0;
+  background: radial-gradient(
+    380px circle at var(--box-spot-x) var(--box-spot-y),
+    rgba(var(--box-premium-green), 0.12),
+    rgba(var(--box-premium-amber), 0.025) 38%,
+    transparent 69%
+  );
+  content: '';
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 260ms ease;
+}
+
+.box-premium-surface.is-pointer-active::before,
+.box-premium-surface:focus-within::before {
+  opacity: 1;
+}
+
+.box-premium-surface > * {
+  position: relative;
+  z-index: 1;
+}
+
+.box-card-index {
+  position: absolute;
+  z-index: 1;
+}
+
+.box-install {
+  border-color: rgba(98, 215, 139, 0.24);
+  box-shadow:
+    0 24px 70px rgba(0, 0, 0, 0.22),
+    0 0 0 1px rgba(98, 215, 139, 0.018);
+}
+
+.box-runtime-window,
+.box-agent-skill-console {
+  transition:
+    border-color 300ms ease,
+    box-shadow 300ms ease;
+}
+
+.box-runtime-window:hover,
+.box-agent-skill-console:hover,
+.box-agent-skill-console:focus-within {
+  border-color: rgba(98, 215, 139, 0.48);
+  box-shadow:
+    0 38px 112px rgba(0, 0, 0, 0.47),
+    0 0 0 1px rgba(98, 215, 139, 0.045),
+    0 0 86px rgba(48, 150, 85, 0.09),
+    inset 0 1px rgba(255, 255, 255, 0.055);
+}
+
+.box-section-heading {
+  position: relative;
+}
+
+.box-section-heading::after {
+  position: absolute;
+  bottom: -22px;
+  left: 0;
+  width: min(34%, 320px);
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    rgba(var(--box-premium-green), 0.48),
+    transparent
+  );
+  content: '';
+  pointer-events: none;
+}
+
+.box-principle-grid article,
+.box-capability-grid article,
+.box-sdk-grid > a,
+.box-agent-skill-flow li {
+  transition:
+    border-color 220ms ease,
+    background 220ms ease,
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.box-principle-grid article:hover,
+.box-capability-grid article:hover,
+.box-agent-skill-flow li:hover {
+  border-color: rgba(98, 215, 139, 0.33);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.035);
+  transform: translateY(-2px);
+}
+
+.box-sdk-grid > a:hover {
+  border-color: rgba(98, 215, 139, 0.33);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .box-global-grid-canvas {
+    opacity: 0.42;
+  }
+
+  .box-hero::before {
+    background: radial-gradient(
+      circle at 72% 34%,
+      rgba(var(--box-premium-green), 0.09),
+      transparent 44%
+    );
+  }
+
+  .box-premium-surface::before {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- align the Box homepage with A3S Code through a Canvas UI-inspired grid and pointer lighting
- add a first-class bilingual Agent Skill installer and complete usage guide
- support durable streamed Skill installs for A3S Code, Codex, Claude Code, and shared agent roots
- extend documentation and built-site contracts for the new routes and install commands

## Validation
- npm run format
- npm run lint
- npm run build
- npm run check:site
- local symlink, streamed copy, and all-agent installer matrix
- desktop/mobile browser QA in Chinese and English, including reduced motion