### PR TITLE
feat(runtime): materialize transient Runtime Secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 0bd7929b9842184b3cf98986bfe1b6ef79ca5282
+  A3S_OCI_RUNTIME_REV: 6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,13 @@ jobs:
             echo 'root:100000:65536' | sudo tee -a /etc/subuid
           grep -q '^root:' /etc/subgid ||
             echo 'root:100000:65536' | sudo tee -a /etc/subgid
+      - name: Mount private Runtime Secret tmpfs
+        run: |
+          sudo install -d -m 700 "$A3S_HOME/runtime-secrets"
+          sudo mount -t tmpfs \
+            -o size=16m,mode=0700,nosuid,nodev,noexec \
+            a3s-runtime-secrets "$A3S_HOME/runtime-secrets"
+          mountpoint -q "$A3S_HOME/runtime-secrets"
       - name: Certify all advertised A3S Runtime R17 profiles
         run: |
           cd src
@@ -309,11 +316,16 @@ jobs:
       - name: Verify cleanup
         if: always()
         run: |
+          cleanup_status=0
           if pgrep -f 'a3s-box-shim|a3s-oci.*native-linux-service|a3s-oci-agent' >/dev/null; then
             ps aux | grep -E 'a3s-box-shim|a3s-oci.*native-linux-service|a3s-oci-agent' | grep -v grep
-            exit 1
+            cleanup_status=1
+          fi
+          if mountpoint -q "$A3S_HOME/runtime-secrets"; then
+            sudo umount "$A3S_HOME/runtime-secrets" || cleanup_status=1
           fi
           sudo rm -rf "$A3S_HOME"
+          exit "$cleanup_status"
 
   # ── Build check (compile only, no artifacts) ────────────────────
   build-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,16 @@ jobs:
             -o size=16m,mode=0700,nosuid,nodev,noexec \
             a3s-runtime-secrets "$A3S_HOME/runtime-secrets"
           mountpoint -q "$A3S_HOME/runtime-secrets"
-      - name: Certify all advertised A3S Runtime R17 profiles
+      - name: Cache the pinned public R17 image over HTTPS
+        run: |
+          sudo env \
+              PATH="$PATH" \
+              HOME="$HOME" \
+              A3S_DEPS_STUB=1 \
+              A3S_HOME="$A3S_HOME" \
+              "$GITHUB_WORKSPACE/src/target/debug/a3s-box" pull \
+                'docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc'
+      - name: Certify all advertised R17 profiles and private registry pull
         run: |
           cd src
           sudo env \
@@ -291,6 +300,7 @@ jobs:
               A3S_BOX_RUNTIME_CONFORMANCE=1 \
               A3S_BOX_RUNTIME_CONFORMANCE_IMAGE='docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc' \
               A3S_BOX_RUNTIME_CONFORMANCE_MEDIA_TYPE='application/vnd.oci.image.index.v1+json' \
+              A3S_REGISTRY_PROTOCOL=http \
               RUST_MIN_STACK=33554432 \
               cargo test --locked -p a3s-box-runtime --lib \
                 box_runtime_passes_all_advertised_profiles \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 0bd7929b9842184b3cf98986bfe1b6ef79ca5282
+  A3S_OCI_RUNTIME_REV: 6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ All notable changes to A3S Box will be documented in this file.
   provider-neutral A3S Runtime Tasks through Fleet; Box retains only node-local
   Runtime provider mechanics.
 
+### Added
+
+- **Caller-authorized Runtime Secret materialization.** The shared
+  `BoxRuntimeDriver` can compose one `BoxSecretMaterializer` and advertise
+  environment and file `SecretReferences` only when a canonical private Linux
+  tmpfs root is ready. Material is mounted read-only, recovered without
+  rematerializing a live generation, retained across stop/restart, removed with
+  stale or deleted generations, zeroized at the provider boundary, and redacted
+  after per-read reauthorization before log cursor construction. Plaintext is
+  excluded from durable Box state, creation intent, and OCI configuration;
+  registry credentials remain explicitly unsupported.
+
 ### Changed
 
 - **Single-owner Sandbox resource contract.** `linux.resources` now carries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,16 @@ All notable changes to A3S Box will be documented in this file.
 
 - **Caller-authorized Runtime Secret materialization.** The shared
   `BoxRuntimeDriver` can compose one `BoxSecretMaterializer` and advertise
-  environment and file `SecretReferences` only when a canonical private Linux
-  tmpfs root is ready. Material is mounted read-only, recovered without
-  rematerializing a live generation, retained across stop/restart, removed with
-  stale or deleted generations, zeroized at the provider boundary, and redacted
-  after per-read reauthorization before log cursor construction. Plaintext is
-  excluded from durable Box state, creation intent, and OCI configuration;
-  registry credentials remain explicitly unsupported.
+  environment, file, and registry-credential `SecretReferences`. Environment
+  and file material requires a canonical private Linux tmpfs root, is mounted
+  read-only, survives an explicit restart, and is removed with stale or deleted
+  generations. Registry credentials resolve only at an uncached image-pull
+  boundary, pass through a token-fenced in-memory handoff, override every
+  persistent credential source (including with explicit anonymous auth), and
+  are zeroized immediately after the pull. Running-generation recovery never
+  rematerializes Secrets. Log reads reauthorize and redact only material that
+  can enter the workload. Plaintext is excluded from durable Box state,
+  creation intent, OCI configuration, logs, cursors, and credential stores.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ runtime state changes instead of being silently stored or weakened.
   build leases, one-shot pool routing, and opt-in Linux/KVM snapshot-fork.
 - **Security and operations** — resource and syscall controls, audit evidence,
   stats, events, Prometheus metrics, health monitoring, SEV-SNP-oriented TEE
-  workflows, sealing, and secret injection.
+  workflows, sealing, TEE secret injection, and caller-authorized transient
+  Runtime Secret materialization.
 
 A few common workflows:
 
@@ -319,7 +320,7 @@ or go directly to the [Rust](src/sdk/README.md),
 | Execution path | Real-runtime evidence | Remaining boundary |
 | --- | --- | --- |
 | Default MicroVM on Windows/WHPX | [`scripts/windows-whpx-soak.ps1`](scripts/windows-whpx-soak.ps1) covers lifecycle and foreground exit, published-port networking, read-only bind mounts, named volumes, volume-backed initialization success and failure, metadata-preserving commit, filesystem commit/snapshot restore, and repeated virtio-fs traversal. The current qualification completed all 12 cases and returned the start and final runtime inventories to zero. | This proves the tested x86_64 Windows/WHPX host and workload matrix, not KVM, HVF, or TEE hardware. |
-| Explicit Linux Sandbox | The required `SDK Local Sandbox (A3S OCI Runtime)` CI job runs the pinned runtime's native Linux network, storage, and initialization profiles; certifies every advertised R17 Base, Recovery, Networking, Mounts, Health, Resources, Logs, Exec, and Security profile; then exercises the Rust, Python, TypeScript, and Go local SDKs and verifies process/cgroup cleanup. | Sandbox remains a shared-kernel preview and intentionally rejects VM-only features. |
+| Explicit Linux Sandbox | The required `SDK Local Sandbox (A3S OCI Runtime)` CI job runs the pinned runtime's native Linux network, storage, and initialization profiles; certifies every advertised R17 Base, Recovery, Networking, Mounts, Health, Resources, Logs, Exec, and Security profile, including transient Secret nondisclosure, restart recovery, log reauthorization and redaction, and cleanup; then exercises the Rust, Python, TypeScript, and Go local SDKs and verifies process/cgroup cleanup. | Sandbox remains a shared-kernel preview and intentionally rejects VM-only features. |
 | Linux/KVM MicroVM | A self-hosted real-KVM workflow covers the core lifecycle, SDK, CRI, leak, race, snapshot-fork, and soak paths when `KVM_CI=true`. | The job is conditionally skipped without the enrolled runner; a green hosted build alone is not real-KVM evidence. |
 | macOS/HVF MicroVM | Hosted macOS arm64 compilation checks the supported target. | A real Apple Silicon/HVF boot and soak are separate release evidence. |
 | SEV-SNP-oriented TEE | Unit and simulation tests cover application flow and protocol behavior. | No hardware security claim is made without a qualifying SEV-SNP host and attestation evidence. |
@@ -342,7 +343,16 @@ evidence. Review [Host Integration](docs/host-integration.md),
   CLI monitor policy, so Box creates no second lifecycle store, durable endpoint
   registry, health registry, or health worker for the same Service. The artifact
   contract accepts OCI image manifests and multi-platform OCI image indexes; it
-  does not advertise a Docker manifest media type.
+  does not advertise a Docker manifest media type. A caller can compose this
+  same driver with one `BoxSecretMaterializer`; Box then advertises
+  `SecretReferences`, resolves shared Runtime references through that caller,
+  and mounts environment or file material read-only from a pre-mounted private
+  Linux tmpfs. Secret bytes never enter durable Box state, creation intent, or
+  OCI configuration. Recovery validates the existing generation without
+  rematerializing it, stop retains restartable material, and remove or stale
+  generation retirement cleans it. Log reads reauthorize every reference and
+  redact exact material before cursor construction. Registry credentials remain
+  an explicit unsupported capability rather than a silent downgrade.
 - **Kubernetes RuntimeClass** — The CRI server and containerd shim let selected
   Linux/KVM pods use `runtimeClassName: a3s-box`; installers and soak manifests
   live under [`deploy/`](deploy/).

--- a/README.md
+++ b/README.md
@@ -351,8 +351,11 @@ evidence. Review [Host Integration](docs/host-integration.md),
   OCI configuration. Recovery validates the existing generation without
   rematerializing it, stop retains restartable material, and remove or stale
   generation retirement cleans it. Log reads reauthorize every reference and
-  redact exact material before cursor construction. Registry credentials remain
-  an explicit unsupported capability rather than a silent downgrade.
+  redact exact workload material before cursor construction. A registry target
+  is resolved only for an uncached pull, handed to the image boundary in memory,
+  and zeroized after use; cached images do not request it. The Runtime driver
+  passes explicit anonymous auth when no registry target is present, so it never
+  falls back to a Box-local or process-environment credential source.
 - **Kubernetes RuntimeClass** — The CRI server and containerd shim let selected
   Linux/KVM pods use `runtimeClassName: a3s-box`; installers and soak manifests
   live under [`deploy/`](deploy/).

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -43,8 +43,9 @@ Box now:
 - rejects any reintroduction of the removed integration symbols in CI.
 
 The exact integration revision is
-`0bd7929b9842184b3cf98986bfe1b6ef79ca5282`, which implements the versioned
-control/workload cgroup layout and retains the earlier cross-platform
+`6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2`, which implements the versioned
+control/workload cgroup layout, prepares parent-namespace read-only bind mounts
+before user-namespace entry, and retains the earlier cross-platform
 qualification.
 
 ## Upgrade behavior

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0bd7929b9842184b3cf98986bfe1b6ef79ca5282#0bd7929b9842184b3cf98986bfe1b6ef79ca5282"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2#6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0bd7929b9842184b3cf98986bfe1b6ef79ca5282#0bd7929b9842184b3cf98986bfe1b6ef79ca5282"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2#6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1137,7 +1137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2254,7 +2254,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3057,7 +3057,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3578,10 +3578,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]
@@ -183,6 +184,7 @@ dependencies = [
  "x509-cert",
  "xattr",
  "xz2",
+ "zeroize",
  "zstd",
 ]
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -68,6 +68,7 @@ notify = "6.1"
 # Cryptography (for integrity checks)
 sha2 = "0.10"
 hex = "0.4"
+zeroize = "1"
 
 # Cryptography (for TEE attestation verification)
 p256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,7 +125,7 @@ ring = "0.17"
 a3s-acl = { version = "0.2.2", git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "25caf65ffed7ff9b82cedc4e7156c79f396896f7" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "0bd7929b9842184b3cf98986bfe1b6ef79ca5282" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -156,6 +156,7 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         stop_timeout: args.common.stop_timeout,
         oom_kill_disable: args.common.oom_kill_disable,
         oom_score_adj: args.common.oom_score_adj,
+        managed_secret_root: None,
     };
     let operation_id = OperationId::new(format!("cli-create-{}", uuid::Uuid::new_v4()))?;
     let request = CreateExecutionRequest {

--- a/src/cli/src/commands/run/setup.rs
+++ b/src/cli/src/commands/run/setup.rs
@@ -342,6 +342,7 @@ pub(super) fn build_execution_request(
             stop_timeout: args.common.stop_timeout,
             oom_kill_disable: args.common.oom_kill_disable,
             oom_score_adj: args.common.oom_score_adj,
+            managed_secret_root: None,
         },
         rootfs_snapshot_id: None,
     }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod port;
 pub mod pty;
 pub mod rootfs_metadata;
 pub mod scale;
+pub mod secret;
 pub mod security;
 pub mod snapshot;
 pub mod tee;

--- a/src/core/src/secret.rs
+++ b/src/core/src/secret.rs
@@ -1,0 +1,76 @@
+//! Non-sensitive control metadata for transient Secret environment bindings.
+
+use serde::{Deserialize, Serialize};
+
+/// Runtime control key carrying only environment names and guest file paths.
+pub const SECRET_ENVIRONMENT_MANIFEST: &str = "A3S_BOX_SECRET_ENV_V1";
+
+/// One non-sensitive environment binding consumed by guest-init immediately
+/// before it launches the workload process.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretEnvironmentBinding {
+    pub variable: String,
+    pub path: String,
+}
+
+impl SecretEnvironmentBinding {
+    pub fn validate(&self) -> Result<(), String> {
+        let mut bytes = self.variable.bytes();
+        let Some(first) = bytes.next() else {
+            return Err("Secret environment variable name must not be empty".into());
+        };
+        if !(first.is_ascii_alphabetic() || first == b'_')
+            || !bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+            || self.variable.len() > 255
+        {
+            return Err("Secret environment variable name is invalid".into());
+        }
+        let normalized_path = self.path.strip_prefix('/').is_some_and(|relative| {
+            !relative.is_empty()
+                && relative
+                    .split('/')
+                    .all(|segment| !segment.is_empty() && !matches!(segment, "." | ".."))
+        });
+        if !normalized_path
+            || self.path.len() > 4096
+            || self.path.contains([':', '\0'])
+            || self.path.bytes().any(|byte| byte.is_ascii_control())
+        {
+            return Err("Secret environment file path is invalid".into());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn environment_binding_accepts_only_canonical_linux_paths_and_names() {
+        let binding = SecretEnvironmentBinding {
+            variable: "A3S_PROVIDER_TOKEN".into(),
+            path: format!("/.a3s-box-secrets/{}/000.secret", "a".repeat(64)),
+        };
+        binding.validate().unwrap();
+
+        for variable in ["", "9TOKEN", "TOKEN-NAME"] {
+            let mut invalid = binding.clone();
+            invalid.variable = variable.into();
+            assert!(invalid.validate().is_err(), "accepted {variable:?}");
+        }
+
+        for path in [
+            "relative/000.secret",
+            "/.a3s-box-secrets//000.secret",
+            "/.a3s-box-secrets/./000.secret",
+            "/.a3s-box-secrets/../000.secret",
+            "/.a3s-box-secrets/value:000.secret",
+        ] {
+            let mut invalid = binding.clone();
+            invalid.path = path.into();
+            assert!(invalid.validate().is_err(), "accepted {path:?}");
+        }
+    }
+}

--- a/src/core/src/traits/execution.rs
+++ b/src/core/src/traits/execution.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::num::NonZeroU16;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
 
@@ -287,6 +288,14 @@ pub struct ExecutionRecordPolicy {
     /// Requested host OOM score adjustment.
     #[serde(default)]
     pub oom_score_adj: Option<i32>,
+    /// Runtime-owned Linux tmpfs root containing transient Secret files.
+    ///
+    /// This path is persisted only so a reconstructed backend can distinguish
+    /// caller-owned bind mounts from transient files that A3S Box is allowed to
+    /// prepare for the Sandbox user namespace. Secret values never enter this
+    /// policy or the creation request.
+    #[serde(default)]
+    pub managed_secret_root: Option<PathBuf>,
 }
 
 impl Default for ExecutionRecordPolicy {
@@ -309,6 +318,7 @@ impl Default for ExecutionRecordPolicy {
             stop_timeout: None,
             oom_kill_disable: false,
             oom_score_adj: None,
+            managed_secret_root: None,
         }
     }
 }

--- a/src/cri/src/image_service.rs
+++ b/src/cri/src/image_service.rs
@@ -742,9 +742,12 @@ mod tests {
             password: "secret".into(),
             ..Default::default()
         });
-        assert!(ra.is_some());
-        let dbg = format!("{ra:?}");
-        assert!(dbg.contains("alice") && dbg.contains("secret"), "got {dbg}");
+        let ra = ra.expect("username/password auth");
+        assert_eq!(
+            ra.basic_credentials(),
+            Some(("alice".into(), "secret".into()))
+        );
+        assert_eq!(format!("{ra:?}"), "<redacted-registry-auth>");
 
         // Docker-config base64 "user:pass" auth field -> basic
         use base64::Engine;
@@ -752,9 +755,10 @@ mod tests {
         let ra = auth_config_to_registry_auth(&AuthConfig {
             auth: encoded,
             ..Default::default()
-        });
-        let dbg = format!("{ra:?}");
-        assert!(dbg.contains("bob") && dbg.contains("pw123"), "got {dbg}");
+        })
+        .expect("encoded username/password auth");
+        assert_eq!(ra.basic_credentials(), Some(("bob".into(), "pw123".into())));
+        assert_eq!(format!("{ra:?}"), "<redacted-registry-auth>");
 
         // Bearer-token-only AuthConfig -> None (no RegistryAuth bearer support yet)
         assert!(auth_config_to_registry_auth(&AuthConfig {

--- a/src/guest/init/Cargo.toml
+++ b/src/guest/init/Cargo.toml
@@ -35,6 +35,7 @@ sha2 = { workspace = true }
 # Sealed storage
 ring = { workspace = true }
 base64 = { workspace = true }
+zeroize = { workspace = true }
 tar = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/guest/init/src/main.rs
+++ b/src/guest/init/src/main.rs
@@ -14,12 +14,14 @@ mod linux {
     use a3s_box_core::guest_exec::{
         GuestExecConfig, MAX_RUNTIME_EXEC_CONFIG_BYTES, RUNTIME_EXEC_CONFIG_PATH,
     };
+    use a3s_box_core::secret::{SecretEnvironmentBinding, SECRET_ENVIRONMENT_MANIFEST};
     use a3s_box_guest_init::{
         attest_server, exec_server, host_config, namespace, network, port_forward, pty_server,
     };
     use std::process;
     use std::sync::atomic::{AtomicI32, Ordering};
     use tracing::{error, info, warn};
+    use zeroize::{Zeroize, Zeroizing};
 
     /// Signal forwarded to the container process group during graceful shutdown.
     /// Zero means no shutdown has been requested.
@@ -276,6 +278,14 @@ mod linux {
         stdin_null: bool,
     }
 
+    impl Drop for ExecConfig {
+        fn drop(&mut self) {
+            for (_, value) in &mut self.env {
+                value.zeroize();
+            }
+        }
+    }
+
     impl ExecConfig {
         /// Parse container entrypoint configuration from environment variables.
         ///
@@ -387,6 +397,113 @@ mod linux {
                 user,
                 stdin_null,
             })
+        }
+
+        /// Replace the non-sensitive Runtime binding manifest with exact
+        /// values read from read-only files that Box mounted from node tmpfs.
+        /// The manifest itself never reaches the workload environment.
+        fn materialize_secret_environment(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+            self.materialize_secret_environment_from(std::path::Path::new("/.a3s-box-secrets"))
+        }
+
+        fn materialize_secret_environment_from(
+            &mut self,
+            internal_root: &std::path::Path,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let manifests = self
+                .env
+                .iter()
+                .enumerate()
+                .filter(|(_, (key, _))| key == SECRET_ENVIRONMENT_MANIFEST)
+                .map(|(index, _)| index)
+                .collect::<Vec<_>>();
+            if manifests.is_empty() {
+                return Ok(());
+            }
+            if manifests.len() != 1 {
+                return Err("duplicate Box Secret environment manifests".into());
+            }
+            let (_, encoded) = self.env.remove(manifests[0]);
+            let encoded = Zeroizing::new(encoded);
+            let bindings: Vec<SecretEnvironmentBinding> = serde_json::from_str(&encoded)
+                .map_err(|_| "Box Secret environment manifest is not valid version-1 JSON")?;
+            if bindings.is_empty() || bindings.len() > 128 {
+                return Err("Box Secret environment manifest has an invalid binding count".into());
+            }
+
+            let mut variables = std::collections::BTreeSet::new();
+            let mut paths = std::collections::BTreeSet::new();
+            for binding in bindings {
+                binding.validate()?;
+                if !variables.insert(binding.variable.clone())
+                    || !paths.insert(binding.path.clone())
+                {
+                    return Err(
+                        "Box Secret environment manifest contains duplicate bindings".into(),
+                    );
+                }
+                let path = std::path::Path::new(&binding.path);
+                let relative = path.strip_prefix(internal_root).map_err(|_| {
+                    "Box Secret environment file escaped the reserved guest directory"
+                })?;
+                let components = relative
+                    .components()
+                    .filter_map(|component| match component {
+                        std::path::Component::Normal(value) => value.to_str(),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                if components.len() != 2
+                    || components[0].len() != 64
+                    || !components[0].bytes().all(|byte| byte.is_ascii_hexdigit())
+                    || components[1].len() != 10
+                    || !components[1].as_bytes()[..3]
+                        .iter()
+                        .all(|byte| byte.is_ascii_digit())
+                    || &components[1].as_bytes()[3..] != b".secret"
+                    || components[1][..3]
+                        .parse::<usize>()
+                        .ok()
+                        .is_none_or(|index| index >= 128)
+                {
+                    return Err(
+                        "Box Secret environment file has an invalid reserved identity".into(),
+                    );
+                }
+                let metadata = std::fs::symlink_metadata(path)?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+                    if !metadata.file_type().is_file()
+                        || metadata.file_type().is_symlink()
+                        || metadata.nlink() != 1
+                        || metadata.len() == 0
+                        || metadata.len() > 1024 * 1024
+                        || metadata.permissions().mode() & 0o777 != 0o400
+                    {
+                        return Err("Box Secret environment file violates its regular-file, size, or mode contract".into());
+                    }
+                }
+                let bytes = Zeroizing::new(std::fs::read(path)?);
+                if bytes.is_empty() || bytes.len() > 1024 * 1024 {
+                    return Err("Box Secret environment value has an invalid size".into());
+                }
+                let mut value = std::str::from_utf8(bytes.as_slice())
+                    .map_err(|_| "Box Secret environment value is not UTF-8")?
+                    .to_owned();
+                if value.contains('\0') {
+                    value.zeroize();
+                    return Err("Box Secret environment value contains a NUL byte".into());
+                }
+                if self.env.iter().any(|(key, _)| key == &binding.variable) {
+                    value.zeroize();
+                    return Err(
+                        "Box Secret environment binding conflicts with an existing value".into(),
+                    );
+                }
+                self.env.push((binding.variable, value));
+            }
+            Ok(())
         }
     }
 
@@ -732,7 +849,7 @@ mod linux {
         // the process file before a later read-only remount. An OCI runtime may
         // mount a Sandbox root read-only before PID 1 starts, so retain that copy;
         // runtime-internal paths are excluded from snapshots and commits.
-        let exec_config = if bootstrap_mode.is_host_sandbox() {
+        let mut exec_config = if bootstrap_mode.is_host_sandbox() {
             ExecConfig::from_env_without_consuming_staged_file()?
         } else {
             ExecConfig::from_env()?
@@ -757,6 +874,11 @@ mod linux {
             #[cfg(target_os = "linux")]
             let _ = a3s_box_guest_init::cgroup::ensure_cgroup2_ready();
         }
+
+        // Host Sandbox mounts are already installed by the OCI runtime before
+        // PID 1 starts. Resolve Secret environment values only now, after all
+        // backend-owned mount setup and immediately before process creation.
+        exec_config.materialize_secret_environment()?;
 
         // Step 2.6: Bind the exec (vsock 4089) and PTY (vsock 4090) listening sockets
         // NOW, before the slower network bring-up and container spawn below. These are
@@ -2007,6 +2129,17 @@ mod linux {
     mod tests {
         use super::*;
 
+        fn test_exec_config(env: Vec<(String, String)>) -> ExecConfig {
+            ExecConfig {
+                executable: "/bin/sh".into(),
+                args: Vec::new(),
+                env,
+                workdir: "/".into(),
+                user: None,
+                stdin_null: true,
+            }
+        }
+
         #[test]
         fn bootstrap_mode_is_explicit_and_fail_closed() {
             assert_eq!(
@@ -2030,6 +2163,81 @@ mod linux {
                 console_handoff_delay(BootstrapMode::Microvm),
                 std::time::Duration::from_millis(250)
             );
+        }
+
+        #[test]
+        fn secret_environment_manifest_is_validated_consumed_and_injected() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let directory = tempfile::tempdir().unwrap();
+            let internal_root = directory.path().join(".a3s-box-secrets");
+            let digest = "a".repeat(64);
+            let secret_directory = internal_root.join(&digest);
+            std::fs::create_dir_all(&secret_directory).unwrap();
+            let secret_path = secret_directory.join("000.secret");
+            std::fs::write(&secret_path, b"guest-secret-value").unwrap();
+            std::fs::set_permissions(&secret_path, std::fs::Permissions::from_mode(0o400)).unwrap();
+            let manifest = serde_json::to_string(&vec![SecretEnvironmentBinding {
+                variable: "A3S_PROVIDER_TOKEN".into(),
+                path: secret_path.to_string_lossy().into_owned(),
+            }])
+            .unwrap();
+            let mut config = test_exec_config(vec![
+                ("LANG".into(), "C.UTF-8".into()),
+                (SECRET_ENVIRONMENT_MANIFEST.into(), manifest),
+            ]);
+
+            config
+                .materialize_secret_environment_from(&internal_root)
+                .unwrap();
+
+            assert_eq!(
+                config
+                    .env
+                    .iter()
+                    .find(|(key, _)| key == "A3S_PROVIDER_TOKEN")
+                    .map(|(_, value)| value.as_str()),
+                Some("guest-secret-value")
+            );
+            assert!(config
+                .env
+                .iter()
+                .all(|(key, _)| key != SECRET_ENVIRONMENT_MANIFEST));
+            assert!(config.env.contains(&("LANG".into(), "C.UTF-8".into())));
+        }
+
+        #[test]
+        fn secret_environment_manifest_fails_closed_on_tamper() {
+            let directory = tempfile::tempdir().unwrap();
+            let internal_root = directory.path().join(".a3s-box-secrets");
+            std::fs::create_dir_all(&internal_root).unwrap();
+
+            let mut invalid_json = test_exec_config(vec![(
+                SECRET_ENVIRONMENT_MANIFEST.into(),
+                "not-json".into(),
+            )]);
+            assert!(invalid_json
+                .materialize_secret_environment_from(&internal_root)
+                .unwrap_err()
+                .to_string()
+                .contains("version-1 JSON"));
+            assert!(invalid_json
+                .env
+                .iter()
+                .all(|(key, _)| key != SECRET_ENVIRONMENT_MANIFEST));
+
+            let escaped = serde_json::to_string(&vec![SecretEnvironmentBinding {
+                variable: "A3S_PROVIDER_TOKEN".into(),
+                path: "/etc/passwd".into(),
+            }])
+            .unwrap();
+            let mut escaped_path =
+                test_exec_config(vec![(SECRET_ENVIRONMENT_MANIFEST.into(), escaped)]);
+            assert!(escaped_path
+                .materialize_secret_environment_from(&internal_root)
+                .unwrap_err()
+                .to_string()
+                .contains("escaped"));
         }
 
         #[test]

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -47,6 +47,7 @@ tracing = { workspace = true }
 # Cryptography
 sha2 = { workspace = true }
 hex = { workspace = true }
+zeroize = { workspace = true }
 
 # Image signature verification
 p256 = { workspace = true }

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -1,6 +1,7 @@
 # A3S Box Runtime
 
-MicroVM runtime implementation for A3S Box.
+Local MicroVM, Sandbox, and shared A3S Runtime provider implementation for A3S
+Box.
 
 ## Overview
 
@@ -12,6 +13,10 @@ This package provides the actual runtime implementation for A3S Box, including:
 - **gRPC Communication**: Guest agent health checking over Unix socket
 - **Filesystem Operations**: virtio-fs mount management
 - **Metrics Collection**: Runtime metrics and monitoring
+- **A3S Runtime Provider**: generation-fenced Tasks and Services over the
+  explicit Linux Sandbox backend
+- **Transient Secrets**: caller-authorized environment and file Secret
+  materialization without durable plaintext
 
 ## Architecture
 
@@ -29,6 +34,49 @@ The runtime package builds on top of `a3s-box-core` which provides foundational 
 │  (Config, Error, Event)            │
 └─────────────────────────────────────┘
 ```
+
+## Shared A3S Runtime provider
+
+`BoxRuntimeDriver` implements the shared `a3s-runtime` contract. It maps
+digest-pinned OCI Tasks and Services onto the canonical local execution manager
+instead of creating a second Box lifecycle path. The driver owns provider
+identity, generation fencing, recovery, Service endpoints, health observations,
+logs, exec, resource controls, and cleanup.
+
+Callers that need Runtime Secrets compose the driver with exactly one
+`BoxSecretMaterializer`:
+
+```rust
+use std::sync::Arc;
+
+use a3s_box_runtime::{BoxRuntimeDriver, BoxRuntimeDriverConfig};
+
+let config = BoxRuntimeDriverConfig {
+    secret_root: "/run/a3s-box/runtime-secrets".into(),
+    ..Default::default()
+};
+let driver = BoxRuntimeDriver::with_secret_materializer(
+    config,
+    Arc::new(node_secret_materializer),
+)?;
+```
+
+The configured `secret_root` must already be a canonical provider-owned `0700`
+Linux tmpfs mount. Box never creates it and never falls back to disk. The caller
+owns reference authorization and transport; Box owns only node-local
+materialization, deterministic read-only Sandbox mounts, recovery validation,
+log redaction, and lifecycle cleanup.
+
+Environment and file targets are supported. Environment values use a
+non-sensitive `A3S_BOX_SECRET_ENV_V1` binding manifest that Guest Init validates
+and consumes immediately before process creation. Registry credential targets
+remain unsupported. Secret bytes are zeroized in memory where they cross the
+materializer boundary and never enter durable Box records, creation intent, or
+OCI configuration. Stopping retains material for an explicit restart; removal
+and stale-generation retirement remove it. A reconstructed driver validates the
+existing live generation without rematerializing it. Every log read reauthorizes
+the references, redacts exact values longest-first, and hashes only redacted
+content into its cursor.
 
 ## Components
 

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -49,16 +49,15 @@ Callers that need Runtime Secrets compose the driver with exactly one
 ```rust
 use std::sync::Arc;
 
+use a3s_box_core::ExecutionIsolation;
 use a3s_box_runtime::{BoxRuntimeDriver, BoxRuntimeDriverConfig};
 
 let config = BoxRuntimeDriverConfig {
     secret_root: "/run/a3s-box/runtime-secrets".into(),
     ..Default::default()
 };
-let driver = BoxRuntimeDriver::with_secret_materializer(
-    config,
-    Arc::new(node_secret_materializer),
-)?;
+let driver = BoxRuntimeDriver::new_with_isolation(config, ExecutionIsolation::Sandbox)?
+    .with_secret_materializer(Arc::new(node_secret_materializer));
 ```
 
 The configured `secret_root` must already be a canonical provider-owned `0700`
@@ -67,16 +66,24 @@ owns reference authorization and transport; Box owns only node-local
 materialization, deterministic read-only Sandbox mounts, recovery validation,
 log redaction, and lifecycle cleanup.
 
-Environment and file targets are supported. Environment values use a
-non-sensitive `A3S_BOX_SECRET_ENV_V1` binding manifest that Guest Init validates
-and consumes immediately before process creation. Registry credential targets
-remain unsupported. Secret bytes are zeroized in memory where they cross the
-materializer boundary and never enter durable Box records, creation intent, or
-OCI configuration. Stopping retains material for an explicit restart; removal
-and stale-generation retirement remove it. A reconstructed driver validates the
-existing live generation without rematerializing it. Every log read reauthorizes
-the references, redacts exact values longest-first, and hashes only redacted
-content into its cursor.
+Environment, file, and registry credential targets are supported. Environment
+values use a non-sensitive `A3S_BOX_SECRET_ENV_V1` binding manifest that Guest
+Init validates and consumes immediately before process creation. File material
+uses the exact requested mode. A registry credential is resolved only when the
+image is absent from the local cache, handed through a per-execution in-memory
+broker, consumed at the image-pull boundary, and zeroized before rootfs
+preparation continues. Cache hits do not call the resolver. With no registry
+target the Runtime driver supplies explicit anonymous auth, preventing fallback
+to persistent Box-local or process-environment credentials.
+
+Secret bytes never enter durable Box records, creation intent, OCI
+configuration, logs, cursors, or the image credential store. Stopping retains
+environment and file material for an explicit restart; removal and stale-
+generation retirement remove it. A reconstructed driver validates the existing
+live generation without rematerializing it. Every log read reauthorizes only
+workload-visible references, redacts exact values longest-first, and hashes only
+redacted content into its cursor. Registry credentials are never injected into
+the workload and therefore never become log-redaction inputs.
 
 ## Components
 

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests.rs
@@ -12,6 +12,7 @@ mod health_profile;
 mod logs_profile;
 mod mounts_profile;
 mod networking_profile;
+mod private_registry_profile;
 mod recovery_profile;
 mod resources_profile;
 mod security_profile;
@@ -29,6 +30,9 @@ type Result<T> = RuntimeResult<T>;
 
 const R17_RUNNER_STACK_BYTES: usize = 32 * 1024 * 1024;
 const R17_WORKER_STACK_BYTES: usize = 8 * 1024 * 1024;
+pub(super) const PRIVATE_REGISTRY_SECRET_REFERENCE: &str = "secret://r17/registry-credential/v1";
+pub(super) const PRIVATE_REGISTRY_USERNAME: &str = "r17-registry-user";
+pub(super) const PRIVATE_REGISTRY_PASSWORD: &str = "r17-registry-password-long";
 
 fn failure(message: impl Into<String>) -> RuntimeError {
     RuntimeError::ProviderUnavailable(message.into())
@@ -114,4 +118,8 @@ async fn run_all_advertised_profiles() {
             .collect::<std::collections::BTreeSet<_>>(),
         expected
     );
+
+    private_registry_profile::run(&fixture)
+        .await
+        .expect("R17 authenticated private-registry pull must pass");
 }

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -1,10 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use a3s_runtime::contract::{
-    RuntimeCapabilities, RuntimeInspection, RuntimeUnitSpec, RuntimeUnitState,
+    RuntimeCapabilities, RuntimeInspection, RuntimeUnitSpec, RuntimeUnitState, SecretReference,
 };
 use a3s_runtime::{
     runtime_profile_requirements, FileRuntimeStateStore, ManagedRuntimeClient, RuntimeClient,
@@ -14,9 +15,56 @@ use a3s_runtime::{
 use async_trait::async_trait;
 
 use super::super::metadata::{local_identity, UNIT_LABEL};
-use super::super::{BoxRuntimeDriver, BoxRuntimeDriverConfig};
+use super::super::{
+    BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial, BoxSecretMaterializationError,
+    BoxSecretMaterializer,
+};
 use super::cases::CaseFactory;
 use super::{external, failure, require, Result};
+
+pub(super) const SECRET_ENV_REFERENCE: &str = "secret://r17/provider-token/v1";
+pub(super) const SECRET_ENV_VALUE: &str = "r17-secret-alpha-long";
+pub(super) const SECRET_FILE_REFERENCE: &str = "secret://r17/provider-file/v1";
+pub(super) const SECRET_FILE_VALUE: &str = "secret-alpha";
+
+struct ConformanceSecretMaterializer {
+    calls: AtomicUsize,
+    authorized: AtomicBool,
+}
+
+impl Default for ConformanceSecretMaterializer {
+    fn default() -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            authorized: AtomicBool::new(true),
+        }
+    }
+}
+
+#[async_trait]
+impl BoxSecretMaterializer for ConformanceSecretMaterializer {
+    async fn materialize(
+        &self,
+        reference: &SecretReference,
+    ) -> std::result::Result<BoxSecretMaterial, BoxSecretMaterializationError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if !self.authorized.load(Ordering::SeqCst) {
+            return Err(BoxSecretMaterializationError::Rejected(
+                "R17 fixture authorization was revoked".into(),
+            ));
+        }
+        let value = match reference.reference.as_str() {
+            SECRET_ENV_REFERENCE => SECRET_ENV_VALUE,
+            SECRET_FILE_REFERENCE => SECRET_FILE_VALUE,
+            _ => {
+                return Err(BoxSecretMaterializationError::Rejected(
+                    "R17 fixture reference is not registered".into(),
+                ))
+            }
+        };
+        BoxSecretMaterial::new(value.as_bytes().to_vec())
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 struct SeenResource {
@@ -35,6 +83,7 @@ pub(super) struct BoxRuntimeConformanceFixture {
     pub(super) state: Arc<FileRuntimeStateStore>,
     pub(super) cases: CaseFactory,
     base_case: a3s_runtime::RuntimeBaseConformanceCase,
+    secret_materializer: Arc<ConformanceSecretMaterializer>,
     drivers: Mutex<Vec<Arc<BoxRuntimeDriver>>>,
     state_roots: Mutex<BTreeSet<PathBuf>>,
     removable_homes: Mutex<BTreeSet<PathBuf>>,
@@ -77,10 +126,17 @@ impl BoxRuntimeConformanceFixture {
         let base_case = cases.base_case();
         base_case.validate().map_err(super::invalid)?;
 
+        let secret_root = home_dir.join("runtime-secrets");
+        require(
+            secret_root.is_dir(),
+            "A3S_HOME/runtime-secrets must be a pre-mounted private tmpfs directory",
+        )?;
         let config = driver_config(home_dir.clone());
-        let driver = Arc::new(BoxRuntimeDriver::new_with_isolation(
+        let secret_materializer = Arc::new(ConformanceSecretMaterializer::default());
+        let driver = Arc::new(BoxRuntimeDriver::with_secret_materializer(
             config,
             a3s_box_core::ExecutionIsolation::Sandbox,
+            secret_materializer.clone(),
         )?);
         let state = Arc::new(FileRuntimeStateStore::new(&state_root));
         Ok(Self {
@@ -89,6 +145,7 @@ impl BoxRuntimeConformanceFixture {
             state,
             cases,
             base_case,
+            secret_materializer,
             drivers: Mutex::new(vec![driver]),
             state_roots: Mutex::new(BTreeSet::from([state_root])),
             removable_homes: Mutex::new(BTreeSet::new()),
@@ -109,12 +166,23 @@ impl BoxRuntimeConformanceFixture {
     }
 
     pub(super) fn restarted_driver(&self) -> Result<Arc<BoxRuntimeDriver>> {
-        let driver = Arc::new(BoxRuntimeDriver::new_with_isolation(
+        let driver = Arc::new(BoxRuntimeDriver::with_secret_materializer(
             driver_config(self.home_dir.clone()),
             a3s_box_core::ExecutionIsolation::Sandbox,
+            self.secret_materializer.clone(),
         )?);
         self.register_driver(driver.clone());
         Ok(driver)
+    }
+
+    pub(super) fn secret_materialization_calls(&self) -> usize {
+        self.secret_materializer.calls.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn set_secret_authorized(&self, authorized: bool) {
+        self.secret_materializer
+            .authorized
+            .store(authorized, Ordering::SeqCst);
     }
 
     pub(super) fn register_driver(&self, driver: Arc<BoxRuntimeDriver>) {
@@ -436,6 +504,7 @@ impl RuntimeConformanceFixture for BoxRuntimeConformanceFixture {
 
 fn driver_config(home_dir: PathBuf) -> BoxRuntimeDriverConfig {
     BoxRuntimeDriverConfig {
+        secret_root: home_dir.join("runtime-secrets"),
         home_dir,
         control_timeout: Duration::from_secs(120),
         task_poll_interval: Duration::from_millis(25),

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -16,11 +16,14 @@ use async_trait::async_trait;
 
 use super::super::metadata::{local_identity, UNIT_LABEL};
 use super::super::{
-    BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial, BoxSecretMaterializationError,
-    BoxSecretMaterializer,
+    BoxRegistryCredential, BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial,
+    BoxSecretMaterializationError, BoxSecretMaterializer,
 };
 use super::cases::CaseFactory;
-use super::{external, failure, require, Result};
+use super::{
+    external, failure, require, Result, PRIVATE_REGISTRY_PASSWORD,
+    PRIVATE_REGISTRY_SECRET_REFERENCE, PRIVATE_REGISTRY_USERNAME,
+};
 
 pub(super) const SECRET_ENV_REFERENCE: &str = "secret://r17/provider-token/v1";
 pub(super) const SECRET_ENV_VALUE: &str = "r17-secret-alpha-long";
@@ -63,6 +66,27 @@ impl BoxSecretMaterializer for ConformanceSecretMaterializer {
             }
         };
         BoxSecretMaterial::new(value.as_bytes().to_vec())
+    }
+
+    async fn materialize_registry_credential(
+        &self,
+        reference: &SecretReference,
+        registry: &str,
+    ) -> std::result::Result<BoxRegistryCredential, BoxSecretMaterializationError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if !self.authorized.load(Ordering::SeqCst) {
+            return Err(BoxSecretMaterializationError::Rejected(
+                "R17 fixture authorization was revoked".into(),
+            ));
+        }
+        if reference.reference != PRIVATE_REGISTRY_SECRET_REFERENCE
+            || !registry.starts_with("127.0.0.1:")
+        {
+            return Err(BoxSecretMaterializationError::Rejected(
+                "R17 fixture registry reference is not registered for this registry".into(),
+            ));
+        }
+        BoxRegistryCredential::new(PRIVATE_REGISTRY_USERNAME, PRIVATE_REGISTRY_PASSWORD)
     }
 }
 
@@ -133,11 +157,13 @@ impl BoxRuntimeConformanceFixture {
         )?;
         let config = driver_config(home_dir.clone());
         let secret_materializer = Arc::new(ConformanceSecretMaterializer::default());
-        let driver = Arc::new(BoxRuntimeDriver::with_secret_materializer(
-            config,
-            a3s_box_core::ExecutionIsolation::Sandbox,
-            secret_materializer.clone(),
-        )?);
+        let driver = Arc::new(
+            BoxRuntimeDriver::new_with_isolation(
+                config,
+                a3s_box_core::ExecutionIsolation::Sandbox,
+            )?
+            .with_secret_materializer(secret_materializer.clone()),
+        );
         let state = Arc::new(FileRuntimeStateStore::new(&state_root));
         Ok(Self {
             home_dir,
@@ -166,11 +192,13 @@ impl BoxRuntimeConformanceFixture {
     }
 
     pub(super) fn restarted_driver(&self) -> Result<Arc<BoxRuntimeDriver>> {
-        let driver = Arc::new(BoxRuntimeDriver::with_secret_materializer(
-            driver_config(self.home_dir.clone()),
-            a3s_box_core::ExecutionIsolation::Sandbox,
-            self.secret_materializer.clone(),
-        )?);
+        let driver = Arc::new(
+            BoxRuntimeDriver::new_with_isolation(
+                driver_config(self.home_dir.clone()),
+                a3s_box_core::ExecutionIsolation::Sandbox,
+            )?
+            .with_secret_materializer(self.secret_materializer.clone()),
+        );
         self.register_driver(driver.clone());
         Ok(driver)
     }
@@ -195,6 +223,30 @@ impl BoxRuntimeConformanceFixture {
 
     pub(super) fn register_removable_home(&self, home: PathBuf) {
         self.removable_homes.lock().unwrap().insert(home);
+    }
+
+    pub(super) fn private_registry_driver(
+        &self,
+        home_dir: PathBuf,
+    ) -> Result<Arc<BoxRuntimeDriver>> {
+        let driver = Arc::new(
+            BoxRuntimeDriver::new_with_isolation(
+                BoxRuntimeDriverConfig {
+                    secret_root: self.home_dir.join("runtime-secrets"),
+                    home_dir,
+                    control_timeout: Duration::from_secs(120),
+                    task_poll_interval: Duration::from_millis(25),
+                },
+                a3s_box_core::ExecutionIsolation::Sandbox,
+            )?
+            .with_secret_materializer(self.secret_materializer.clone()),
+        );
+        self.register_driver(driver.clone());
+        Ok(driver)
+    }
+
+    pub(super) async fn cleanup_registered(&self) -> Result<()> {
+        self.cleanup_all().await
     }
 
     pub(super) async fn record_for(&self, spec: &RuntimeUnitSpec) -> Result<crate::BoxRecord> {

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/private_registry_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/private_registry_profile.rs
@@ -1,0 +1,562 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use a3s_runtime::contract::{
+    ArtifactRef, RuntimeInspection, RuntimeUnitState, SecretReference, SecretTarget,
+};
+use a3s_runtime::{FileRuntimeStateStore, RuntimeClient};
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Method, Request, Response, StatusCode};
+use axum::routing::any;
+use axum::Router;
+use base64::Engine as _;
+use serde_json::json;
+use sha2::Digest as _;
+
+use super::fixture::BoxRuntimeConformanceFixture;
+use super::{
+    external, protocol, require, Result, PRIVATE_REGISTRY_PASSWORD,
+    PRIVATE_REGISTRY_SECRET_REFERENCE, PRIVATE_REGISTRY_USERNAME,
+};
+
+const REPOSITORY: &str = "a3s/private-runtime";
+const OCI_IMAGE_INDEX: &str = "application/vnd.oci.image.index.v1+json";
+
+#[derive(Clone)]
+struct RegistryContent {
+    bytes: Vec<u8>,
+    digest: String,
+    media_type: String,
+}
+
+#[derive(Clone, Debug)]
+struct RecordedRequest {
+    authorized: bool,
+    path: String,
+}
+
+#[derive(Clone)]
+struct RegistryState {
+    expected_authorization: String,
+    manifests: Arc<HashMap<String, RegistryContent>>,
+    blobs: Arc<HashMap<String, RegistryContent>>,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+}
+
+struct PrivateRegistry {
+    authority: String,
+    index_digest: String,
+    manifest_digest: String,
+    config_digest: String,
+    layer_digests: Vec<String>,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl PrivateRegistry {
+    async fn start(source_layout: &Path) -> Result<Self> {
+        let source_index = read_json(&source_layout.join("index.json"), "source OCI index")?;
+        let selected = source_index
+            .get("manifests")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|manifests| manifests.first())
+            .ok_or_else(|| protocol("cached source OCI index has no selected manifest"))?;
+        let manifest_digest = descriptor_digest(selected, "selected manifest")?;
+        let manifest_media_type = descriptor_media_type(selected, "selected manifest")?;
+        let manifest_bytes = read_blob(source_layout, &manifest_digest)?;
+        let manifest = serde_json::from_slice::<serde_json::Value>(&manifest_bytes)
+            .map_err(|error| external("decode cached source image manifest", error))?;
+
+        let config = manifest
+            .get("config")
+            .ok_or_else(|| protocol("cached source image manifest has no config descriptor"))?;
+        let config_digest = descriptor_digest(config, "image config")?;
+        let config_media_type = descriptor_media_type(config, "image config")?;
+        let config_bytes = read_blob(source_layout, &config_digest)?;
+
+        let layers = manifest
+            .get("layers")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| protocol("cached source image manifest has no layer descriptors"))?;
+        require(
+            !layers.is_empty(),
+            "cached source image has no filesystem layers",
+        )?;
+        let mut blobs = HashMap::from([(
+            config_digest.clone(),
+            RegistryContent {
+                bytes: config_bytes,
+                digest: config_digest.clone(),
+                media_type: config_media_type,
+            },
+        )]);
+        let mut layer_digests = Vec::with_capacity(layers.len());
+        for layer in layers {
+            let digest = descriptor_digest(layer, "image layer")?;
+            let media_type = descriptor_media_type(layer, "image layer")?;
+            let bytes = read_blob(source_layout, &digest)?;
+            blobs.insert(
+                digest.clone(),
+                RegistryContent {
+                    bytes,
+                    digest: digest.clone(),
+                    media_type,
+                },
+            );
+            layer_digests.push(digest);
+        }
+
+        let index_bytes = serde_json::to_vec(&json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_IMAGE_INDEX,
+            "manifests": [{
+                "mediaType": manifest_media_type,
+                "digest": manifest_digest,
+                "size": manifest_bytes.len(),
+                "platform": {
+                    "architecture": oci_architecture(),
+                    "os": "linux"
+                }
+            }]
+        }))
+        .map_err(|error| external("encode private-registry image index", error))?;
+        let index_digest = digest(&index_bytes);
+        let manifests = HashMap::from([
+            (
+                index_digest.clone(),
+                RegistryContent {
+                    bytes: index_bytes,
+                    digest: index_digest.clone(),
+                    media_type: OCI_IMAGE_INDEX.into(),
+                },
+            ),
+            (
+                manifest_digest.clone(),
+                RegistryContent {
+                    bytes: manifest_bytes,
+                    digest: manifest_digest.clone(),
+                    media_type: manifest_media_type,
+                },
+            ),
+        ]);
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let state = RegistryState {
+            expected_authorization: format!(
+                "Basic {}",
+                base64::engine::general_purpose::STANDARD.encode(format!(
+                    "{PRIVATE_REGISTRY_USERNAME}:{PRIVATE_REGISTRY_PASSWORD}"
+                ))
+            ),
+            manifests: Arc::new(manifests),
+            blobs: Arc::new(blobs),
+            requests: Arc::clone(&requests),
+        };
+        let app = Router::new()
+            .route("/*path", any(registry_handler))
+            .with_state(state);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .map_err(|error| external("bind private OCI registry", error))?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|error| external("configure private OCI registry listener", error))?;
+        let authority = listener
+            .local_addr()
+            .map_err(|error| external("inspect private OCI registry listener", error))?
+            .to_string();
+        let task = tokio::spawn(async move {
+            if let Err(error) = axum::Server::from_tcp(listener)
+                .expect("private registry listener must remain valid")
+                .serve(app.into_make_service())
+                .await
+            {
+                tracing::error!(%error, "Private registry conformance server failed");
+            }
+        });
+
+        Ok(Self {
+            authority,
+            index_digest,
+            manifest_digest,
+            config_digest,
+            layer_digests,
+            requests,
+            task,
+        })
+    }
+
+    fn requests(&self) -> Vec<RecordedRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl Drop for PrivateRegistry {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub(super) async fn run(fixture: &BoxRuntimeConformanceFixture) -> Result<()> {
+    require(
+        std::env::var("A3S_REGISTRY_PROTOCOL").as_deref() == Ok("http"),
+        "set A3S_REGISTRY_PROTOCOL=http only for the loopback private-registry gate",
+    )?;
+
+    let result = run_inner(fixture).await;
+    let cleanup = fixture.cleanup_registered().await;
+    match (result, cleanup) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(cleanup_error)) => Err(protocol(format!(
+            "private-registry gate failed: {error}; cleanup also failed: {cleanup_error}"
+        ))),
+    }
+}
+
+async fn run_inner(fixture: &BoxRuntimeConformanceFixture) -> Result<()> {
+    let source_reference = std::env::var("A3S_BOX_RUNTIME_CONFORMANCE_IMAGE")
+        .map_err(|error| external("read cached R17 image reference", error))?;
+    let source_store = crate::ImageStore::new(
+        &fixture.home_dir.join("images"),
+        crate::DEFAULT_IMAGE_CACHE_SIZE,
+    )
+    .map_err(|error| external("open cached R17 image store", error))?;
+    let source = source_store
+        .get(&source_reference)
+        .await
+        .ok_or_else(|| protocol("pinned R17 source image was not cached before the HTTP gate"))?;
+    let registry = PrivateRegistry::start(&source.path).await?;
+
+    let private_home = fixture
+        .home_dir
+        .parent()
+        .ok_or_else(|| protocol("R17 home has no parent for private-registry isolation"))?
+        .join(format!(
+            "a3s-runtime-conformance-private-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+    std::fs::create_dir(&private_home)
+        .map_err(|error| external("create private-registry provider home", error))?;
+    fixture.register_removable_home(private_home.clone());
+    let state_root = private_home.join("runtime-state");
+    fixture.register_state_root(state_root.clone());
+    let driver = fixture.private_registry_driver(private_home.clone())?;
+    let client = fixture.client_with(
+        driver.clone(),
+        Arc::new(FileRuntimeStateStore::new(&state_root)),
+    );
+
+    let image_reference = format!(
+        "{}/{REPOSITORY}@{}",
+        registry.authority, registry.index_digest
+    );
+    let mut request = fixture.cases.service(
+        "security-private-registry",
+        "printf 'r17-private-registry-ready\\n'; exec sleep 3600",
+    );
+    request.spec.artifact = ArtifactRef {
+        uri: format!("oci://{image_reference}"),
+        digest: registry.index_digest.clone(),
+        media_type: OCI_IMAGE_INDEX.into(),
+    };
+    request.spec.secrets = vec![SecretReference {
+        name: "private-registry-credential".into(),
+        reference: PRIVATE_REGISTRY_SECRET_REFERENCE.into(),
+        target: SecretTarget::RegistryCredential,
+    }];
+    request.validate().map_err(super::invalid)?;
+
+    let calls_before = fixture.secret_materialization_calls();
+    let running = client.apply(&request).await?;
+    require(
+        running.state == RuntimeUnitState::Running,
+        "private-registry Service did not reach running",
+    )?;
+    require(
+        fixture.secret_materialization_calls() == calls_before + 1,
+        "private-registry credential was not resolved exactly once",
+    )?;
+    require(
+        driver
+            .transient_registry_auth
+            .as_ref()
+            .is_some_and(|broker| broker.pending() == 0),
+        "private-registry authorization remained in the transient broker after pull",
+    )?;
+
+    let requests = registry.requests();
+    let protected = requests
+        .iter()
+        .filter(|request| request.path != "/v2/")
+        .collect::<Vec<_>>();
+    require(
+        protected.iter().any(|request| request.authorized),
+        "private registry never observed an authorized protected request",
+    )?;
+    for path in [
+        format!("/v2/{REPOSITORY}/manifests/{}", registry.index_digest),
+        format!("/v2/{REPOSITORY}/manifests/{}", registry.manifest_digest),
+        format!("/v2/{REPOSITORY}/blobs/{}", registry.config_digest),
+    ] {
+        require(
+            protected
+                .iter()
+                .any(|request| request.path == path && request.authorized),
+            format!("private-registry pull omitted {path}"),
+        )?;
+    }
+    for digest in &registry.layer_digests {
+        let path = format!("/v2/{REPOSITORY}/blobs/{digest}");
+        require(
+            protected
+                .iter()
+                .any(|request| request.path == path && request.authorized),
+            format!("private-registry pull omitted layer {digest}"),
+        )?;
+    }
+
+    let record = driver
+        .manager
+        .managed_records()
+        .await
+        .map_err(|error| external("load private-registry Box record", error))?
+        .into_iter()
+        .find(|record| {
+            record.labels.get(super::super::metadata::UNIT_LABEL) == Some(&request.spec.unit_id)
+        })
+        .ok_or_else(|| protocol("private-registry execution record was not retained"))?;
+    let creation_intent = serde_json::to_vec(
+        &record
+            .managed_execution
+            .as_ref()
+            .ok_or_else(|| protocol("private-registry record lost creation intent"))?
+            .request,
+    )
+    .map_err(|error| external("encode private-registry creation intent", error))?;
+    require(
+        !contains_registry_plaintext(&creation_intent),
+        "private-registry creation intent persisted credential plaintext",
+    )?;
+    require(
+        !private_home.join("auth/credentials.json").exists(),
+        "Runtime Secret credential was copied into the Box credential store",
+    )?;
+    if let Some(path) = find_plaintext_file(&private_home)? {
+        return Err(protocol(format!(
+            "private-registry credential plaintext persisted in {}",
+            path.display()
+        )));
+    }
+
+    let stopped = client
+        .stop(
+            &fixture
+                .cases
+                .action("security-private-registry-stop", &request.spec),
+        )
+        .await?;
+    require(
+        matches!(
+            stopped,
+            RuntimeInspection::Found { ref observation, .. }
+                if observation.state == RuntimeUnitState::Stopped
+        ),
+        "private-registry Service did not stop cleanly",
+    )?;
+    client
+        .remove(
+            &fixture
+                .cases
+                .action("security-private-registry-remove", &request.spec),
+        )
+        .await?;
+    require(
+        driver
+            .manager
+            .managed_records()
+            .await
+            .map_err(|error| external("load removed private-registry inventory", error))?
+            .is_empty(),
+        "private-registry removal retained a Box execution record",
+    )?;
+    require(
+        driver
+            .transient_registry_auth
+            .as_ref()
+            .is_some_and(|broker| broker.pending() == 0),
+        "private-registry removal left a transient authorization",
+    )?;
+    if let Some(path) = find_plaintext_file(&private_home)? {
+        return Err(protocol(format!(
+            "private-registry removal left credential plaintext in {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+async fn registry_handler(
+    State(state): State<RegistryState>,
+    request: Request<Body>,
+) -> Response<Body> {
+    let path = request.uri().path().to_string();
+    let authorized = request
+        .headers()
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        == Some(state.expected_authorization.as_str());
+    state.requests.lock().unwrap().push(RecordedRequest {
+        authorized,
+        path: path.clone(),
+    });
+
+    if request.method() != Method::GET {
+        return response(StatusCode::METHOD_NOT_ALLOWED, None, None, Vec::new());
+    }
+    if path == "/v2/" {
+        return response(StatusCode::OK, None, None, Vec::new());
+    }
+    if !authorized {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header("www-authenticate", "Basic realm=\"A3S R17 Registry\"")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":{}}]}"#,
+            ))
+            .expect("static private-registry rejection response must be valid");
+    }
+
+    let manifest_prefix = format!("/v2/{REPOSITORY}/manifests/");
+    if let Some(reference) = path.strip_prefix(&manifest_prefix) {
+        return state.manifests.get(reference).map_or_else(
+            || response(StatusCode::NOT_FOUND, None, None, Vec::new()),
+            |content| {
+                response(
+                    StatusCode::OK,
+                    Some(&content.media_type),
+                    Some(&content.digest),
+                    content.bytes.clone(),
+                )
+            },
+        );
+    }
+    let blob_prefix = format!("/v2/{REPOSITORY}/blobs/");
+    if let Some(reference) = path.strip_prefix(&blob_prefix) {
+        return state.blobs.get(reference).map_or_else(
+            || response(StatusCode::NOT_FOUND, None, None, Vec::new()),
+            |content| {
+                response(
+                    StatusCode::OK,
+                    Some(&content.media_type),
+                    Some(&content.digest),
+                    content.bytes.clone(),
+                )
+            },
+        );
+    }
+    response(StatusCode::NOT_FOUND, None, None, Vec::new())
+}
+
+fn response(
+    status: StatusCode,
+    media_type: Option<&str>,
+    digest: Option<&str>,
+    bytes: Vec<u8>,
+) -> Response<Body> {
+    let mut builder = Response::builder().status(status);
+    if let Some(media_type) = media_type {
+        builder = builder.header("content-type", media_type);
+    }
+    if let Some(digest) = digest {
+        builder = builder.header("docker-content-digest", digest);
+    }
+    builder
+        .body(Body::from(bytes))
+        .expect("private-registry fixture response must be valid")
+}
+
+fn read_json(path: &Path, label: &str) -> Result<serde_json::Value> {
+    let bytes = std::fs::read(path).map_err(|error| external(label, error))?;
+    serde_json::from_slice(&bytes).map_err(|error| external(label, error))
+}
+
+fn read_blob(layout: &Path, digest: &str) -> Result<Vec<u8>> {
+    let digest = digest
+        .strip_prefix("sha256:")
+        .ok_or_else(|| protocol("source OCI descriptor is not a SHA-256 digest"))?;
+    require(
+        digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "source OCI descriptor has an invalid SHA-256 digest",
+    )?;
+    std::fs::read(layout.join("blobs/sha256").join(digest))
+        .map_err(|error| external("read cached source OCI blob", error))
+}
+
+fn descriptor_digest(value: &serde_json::Value, label: &str) -> Result<String> {
+    value
+        .get("digest")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| protocol(format!("{label} has no digest")))
+}
+
+fn descriptor_media_type(value: &serde_json::Value, label: &str) -> Result<String> {
+    value
+        .get("mediaType")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| protocol(format!("{label} has no media type")))
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", sha2::Sha256::digest(bytes))
+}
+
+fn oci_architecture() -> &'static str {
+    match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        architecture => architecture,
+    }
+}
+
+fn contains_registry_plaintext(bytes: &[u8]) -> bool {
+    [PRIVATE_REGISTRY_USERNAME, PRIVATE_REGISTRY_PASSWORD]
+        .iter()
+        .any(|secret| {
+            bytes
+                .windows(secret.len())
+                .any(|window| window == secret.as_bytes())
+        })
+}
+
+fn find_plaintext_file(root: &Path) -> Result<Option<PathBuf>> {
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        let metadata = std::fs::symlink_metadata(&path)
+            .map_err(|error| external("inspect private-registry persistence path", error))?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            for entry in std::fs::read_dir(&path)
+                .map_err(|error| external("scan private-registry persistence directory", error))?
+            {
+                pending.push(
+                    entry
+                        .map_err(|error| external("read private-registry directory entry", error))?
+                        .path(),
+                );
+            }
+        } else if metadata.is_file() {
+            let bytes = std::fs::read(&path)
+                .map_err(|error| external("scan private-registry persistence file", error))?;
+            if contains_registry_plaintext(&bytes) {
+                return Ok(Some(path));
+            }
+        }
+    }
+    Ok(None)
+}

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use a3s_box_core::rootfs_metadata::RUNTIME_ENV_PATH;
+use a3s_box_core::secret::SECRET_ENVIRONMENT_MANIFEST;
 use a3s_runtime::contract::{
     NetworkMode, RuntimeInspection, RuntimeMount, RuntimeMountSource, RuntimeUnitState,
     SecretReference, SecretTarget,
@@ -225,12 +227,28 @@ async fn secret_nondisclosure(
     .map_err(|error| super::external("encode Secret creation intent", error))?;
     let boxes = std::fs::read(fixture.home_dir.join("boxes.json"))
         .map_err(|error| super::external("read Box state for Secret nondisclosure", error))?;
-    let oci = std::fs::read(record.box_dir.join("sandbox/bundle/config.json"))
+    let bundle_directory = record.box_dir.join("sandbox/bundle");
+    let oci = std::fs::read(bundle_directory.join("config.json"))
         .map_err(|error| super::external("read Secret Sandbox OCI configuration", error))?;
+    let oci_spec: serde_json::Value = serde_json::from_slice(&oci)
+        .map_err(|error| super::external("decode Secret Sandbox OCI configuration", error))?;
+    let rootfs_path = oci_spec
+        .pointer("/root/path")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| super::protocol("Secret Sandbox OCI configuration omitted root.path"))?;
+    let rootfs_path = if Path::new(rootfs_path).is_absolute() {
+        Path::new(rootfs_path).to_path_buf()
+    } else {
+        bundle_directory.join(rootfs_path)
+    };
+    let staged_environment =
+        std::fs::read(rootfs_path.join(RUNTIME_ENV_PATH.trim_start_matches('/')))
+            .map_err(|error| super::external("read Secret Sandbox staged environment", error))?;
     for (label, bytes) in [
         ("managed creation intent", creation_intent.as_slice()),
         ("boxes.json", boxes.as_slice()),
         ("Sandbox OCI configuration", oci.as_slice()),
+        ("Sandbox staged environment", staged_environment.as_slice()),
     ] {
         let value = String::from_utf8_lossy(bytes);
         require(
@@ -239,8 +257,14 @@ async fn secret_nondisclosure(
         )?;
     }
     require(
-        String::from_utf8_lossy(&oci).contains("A3S_BOX_SECRET_ENV_V1"),
-        "Sandbox OCI configuration omitted the non-secret environment binding manifest",
+        String::from_utf8_lossy(&oci).contains(&format!("BOX_EXEC_ENV_FILE={RUNTIME_ENV_PATH}")),
+        "Sandbox OCI configuration omitted the protected environment staging pointer",
+    )?;
+    require(
+        String::from_utf8_lossy(&staged_environment)
+            .lines()
+            .any(|line| line.starts_with(&format!("{SECRET_ENVIRONMENT_MANIFEST}="))),
+        "Sandbox staged environment omitted the non-secret environment binding manifest",
     )?;
 
     let calls_before_reconstruction = fixture.secret_materialization_calls();

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -17,6 +17,7 @@ use super::fixture::{
     BoxRuntimeConformanceFixture, SECRET_ENV_REFERENCE, SECRET_ENV_VALUE, SECRET_FILE_REFERENCE,
     SECRET_FILE_VALUE,
 };
+use super::PRIVATE_REGISTRY_SECRET_REFERENCE;
 use super::{require, Result};
 
 pub(super) async fn run(
@@ -149,23 +150,6 @@ async fn reject_hostile_inputs(
         "Box accepted an unadvertised volume mount",
     )?;
 
-    let mut registry_secret = template.clone();
-    registry_secret.request_id = fixture.cases.request_id("security-registry-secret");
-    registry_secret.spec.unit_id = fixture.cases.unit_id("security-registry-secret");
-    registry_secret.spec.secrets = vec![SecretReference {
-        name: "registry-credential".into(),
-        reference: "secret://r17/registry/v1".into(),
-        target: SecretTarget::RegistryCredential,
-    }];
-    require(
-        matches!(
-            client.apply(&registry_secret).await,
-            Err(RuntimeError::UnsupportedCapabilities(missing))
-                if missing == vec!["feature:RegistryCredentials"]
-        ),
-        "Box accepted an unadvertised registry credential",
-    )?;
-
     let after = fixture
         .driver
         .manager
@@ -204,6 +188,11 @@ async fn secret_nondisclosure(
                 mode: 0o400,
             },
         },
+        SecretReference {
+            name: "registry-credential".into(),
+            reference: PRIVATE_REGISTRY_SECRET_REFERENCE.into(),
+            target: SecretTarget::RegistryCredential,
+        },
     ];
     let secret_directory = super::super::secret::secret_directory(
         &fixture.home_dir.join("runtime-secrets"),
@@ -218,7 +207,7 @@ async fn secret_nondisclosure(
     )?;
     require(
         fixture.secret_materialization_calls() == calls_before_apply + 2,
-        "Secret materialization did not resolve each reference exactly once before start",
+        "Secret materialization did not resolve container references exactly once or resolved a cached registry credential",
     )?;
     require(
         secret_directory.is_dir(),

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use a3s_runtime::contract::{
     NetworkMode, RuntimeInspection, RuntimeMount, RuntimeMountSource, RuntimeUnitState,
@@ -13,7 +13,10 @@ use a3s_runtime::{
 
 use super::super::metadata::GENERATION_LABEL;
 use super::super::{BoxRuntimeDriver, BoxRuntimeDriverConfig};
-use super::fixture::BoxRuntimeConformanceFixture;
+use super::fixture::{
+    BoxRuntimeConformanceFixture, SECRET_ENV_REFERENCE, SECRET_ENV_VALUE, SECRET_FILE_REFERENCE,
+    SECRET_FILE_VALUE,
+};
 use super::{require, Result};
 
 pub(super) async fn run(
@@ -43,6 +46,7 @@ pub(super) async fn run(
     verify_workload_least_privilege(fixture, client, &service.spec).await?;
     metadata_tamper_fails_closed(fixture, client, &service.spec, &record.id).await?;
     namespace_separation(fixture).await?;
+    secret_nondisclosure(fixture, client).await?;
 
     fixture
         .remove_unit(client, &service.spec, "security-service")
@@ -145,23 +149,21 @@ async fn reject_hostile_inputs(
         "Box accepted an unadvertised volume mount",
     )?;
 
-    let mut secret = template.clone();
-    secret.request_id = fixture.cases.request_id("security-secret");
-    secret.spec.unit_id = fixture.cases.unit_id("security-secret");
-    secret.spec.secrets = vec![SecretReference {
-        name: "provider-token".into(),
-        reference: "secret://r17/provider-token".into(),
-        target: SecretTarget::Environment {
-            variable: "R17_PROVIDER_TOKEN".into(),
-        },
+    let mut registry_secret = template.clone();
+    registry_secret.request_id = fixture.cases.request_id("security-registry-secret");
+    registry_secret.spec.unit_id = fixture.cases.unit_id("security-registry-secret");
+    registry_secret.spec.secrets = vec![SecretReference {
+        name: "registry-credential".into(),
+        reference: "secret://r17/registry/v1".into(),
+        target: SecretTarget::RegistryCredential,
     }];
     require(
         matches!(
-            client.apply(&secret).await,
+            client.apply(&registry_secret).await,
             Err(RuntimeError::UnsupportedCapabilities(missing))
-                if missing == vec!["feature:SecretReferences"]
+                if missing == vec!["feature:RegistryCredentials"]
         ),
-        "Box accepted an unadvertised secret reference",
+        "Box accepted an unadvertised registry credential",
     )?;
 
     let after = fixture
@@ -176,6 +178,191 @@ async fn reject_hostile_inputs(
         after.len() == baseline_records,
         "hostile input mutated provider inventory before rejection",
     )
+}
+
+async fn secret_nondisclosure(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    let mut request = fixture.cases.service(
+        "security-secret-nondisclosure",
+        "test -n \"$R17_PROVIDER_TOKEN\"; test -s /run/a3s-secrets/provider-token; printf 'secret-env=%s\\n' \"$R17_PROVIDER_TOKEN\"; printf 'secret-file=%s\\n' \"$(cat /run/a3s-secrets/provider-token)\"; printf 'secret-mode=%s\\n' \"$(stat -c %a /run/a3s-secrets/provider-token)\"; exec sleep 3600",
+    );
+    request.spec.secrets = vec![
+        SecretReference {
+            name: "provider-token".into(),
+            reference: SECRET_ENV_REFERENCE.into(),
+            target: SecretTarget::Environment {
+                variable: "R17_PROVIDER_TOKEN".into(),
+            },
+        },
+        SecretReference {
+            name: "provider-token-file".into(),
+            reference: SECRET_FILE_REFERENCE.into(),
+            target: SecretTarget::File {
+                path: "/run/a3s-secrets/provider-token".into(),
+                mode: 0o400,
+            },
+        },
+    ];
+    let secret_directory = super::super::secret::secret_directory(
+        &fixture.home_dir.join("runtime-secrets"),
+        &request.spec,
+    )?;
+    let calls_before_apply = fixture.secret_materialization_calls();
+
+    let running = client.apply(&request).await?;
+    require(
+        running.state == RuntimeUnitState::Running,
+        "Secret nondisclosure Service did not reach running",
+    )?;
+    require(
+        fixture.secret_materialization_calls() == calls_before_apply + 2,
+        "Secret materialization did not resolve each reference exactly once before start",
+    )?;
+    require(
+        secret_directory.is_dir(),
+        "Secret materialization directory was not retained for the running generation",
+    )?;
+
+    let record = fixture.record_for(&request.spec).await?;
+    let creation_intent = serde_json::to_vec(
+        &record
+            .managed_execution
+            .as_ref()
+            .ok_or_else(|| super::protocol("Secret execution lost managed creation intent"))?
+            .request,
+    )
+    .map_err(|error| super::external("encode Secret creation intent", error))?;
+    let boxes = std::fs::read(fixture.home_dir.join("boxes.json"))
+        .map_err(|error| super::external("read Box state for Secret nondisclosure", error))?;
+    let oci = std::fs::read(record.box_dir.join("sandbox/bundle/config.json"))
+        .map_err(|error| super::external("read Secret Sandbox OCI configuration", error))?;
+    for (label, bytes) in [
+        ("managed creation intent", creation_intent.as_slice()),
+        ("boxes.json", boxes.as_slice()),
+        ("Sandbox OCI configuration", oci.as_slice()),
+    ] {
+        let value = String::from_utf8_lossy(bytes);
+        require(
+            !value.contains(SECRET_ENV_VALUE) && !value.contains(SECRET_FILE_VALUE),
+            format!("{label} persisted Secret plaintext"),
+        )?;
+    }
+    require(
+        String::from_utf8_lossy(&oci).contains("A3S_BOX_SECRET_ENV_V1"),
+        "Sandbox OCI configuration omitted the non-secret environment binding manifest",
+    )?;
+
+    let calls_before_reconstruction = fixture.secret_materialization_calls();
+    let restarted_driver = fixture.restarted_driver()?;
+    let restarted = fixture.client_with(restarted_driver, fixture.state.clone());
+    require(
+        matches!(
+            restarted.inspect(&request.spec.unit_id).await?,
+            RuntimeInspection::Found { observation, .. }
+                if observation.state == RuntimeUnitState::Running
+        ),
+        "reconstructed Box driver did not adopt the running Secret generation",
+    )?;
+    require(
+        fixture.secret_materialization_calls() == calls_before_reconstruction,
+        "driver reconstruction rematerialized a live Secret generation",
+    )?;
+
+    let chunks = wait_for_redacted_secret_logs(fixture, &restarted, &request.spec).await?;
+    require(
+        chunks.iter().all(|chunk| {
+            !chunk.data.contains(SECRET_ENV_VALUE) && !chunk.data.contains(SECRET_FILE_VALUE)
+        }),
+        "Runtime log projection exposed Secret plaintext",
+    )?;
+    require(
+        chunks
+            .iter()
+            .map(|chunk| chunk.data.matches("[REDACTED]").count())
+            .sum::<usize>()
+            >= 2,
+        "Runtime log projection did not redact both Secret values",
+    )?;
+    require(
+        chunks
+            .iter()
+            .any(|chunk| chunk.data.contains("secret-mode=400")),
+        "file Secret did not preserve its requested mode",
+    )?;
+    require(
+        fixture.secret_materialization_calls() >= calls_before_reconstruction + 2,
+        "Runtime log read did not reauthorize Secret references",
+    )?;
+
+    fixture.set_secret_authorized(false);
+    let denied = restarted
+        .logs(&fixture.cases.logs(&request.spec, None, 100, None))
+        .await;
+    fixture.set_secret_authorized(true);
+    require(
+        matches!(denied, Err(RuntimeError::InvalidRequest(_))),
+        "Runtime log read ignored revoked Secret authorization",
+    )?;
+
+    let stopped = restarted
+        .stop(&fixture.cases.action("security-secret-stop", &request.spec))
+        .await?;
+    require(
+        matches!(
+            stopped,
+            RuntimeInspection::Found { ref observation, .. }
+                if observation.state == RuntimeUnitState::Stopped
+        ),
+        "Secret Service did not stop cleanly",
+    )?;
+    require(
+        secret_directory.is_dir(),
+        "stop removed Secret material needed for an explicit restart",
+    )?;
+
+    restarted
+        .remove(
+            &fixture
+                .cases
+                .action("security-secret-remove", &request.spec),
+        )
+        .await?;
+    require(
+        !secret_directory.exists(),
+        "removal left Secret material behind",
+    )
+}
+
+async fn wait_for_redacted_secret_logs(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+    spec: &a3s_runtime::contract::RuntimeUnitSpec,
+) -> Result<Vec<a3s_runtime::contract::RuntimeLogChunk>> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let chunks = client
+            .logs(&fixture.cases.logs(spec, None, 100, None))
+            .await?;
+        if chunks
+            .iter()
+            .any(|chunk| chunk.data.contains("secret-mode=400"))
+            && chunks
+                .iter()
+                .map(|chunk| chunk.data.matches("[REDACTED]").count())
+                .sum::<usize>()
+                >= 2
+        {
+            return Ok(chunks);
+        }
+        if Instant::now() >= deadline {
+            return Err(super::protocol(
+                "Secret workload logs did not converge within five seconds",
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
 }
 
 fn verify_digest_pin(
@@ -408,6 +595,7 @@ async fn namespace_separation(fixture: &BoxRuntimeConformanceFixture) -> Result<
     fixture.register_state_root(sibling_state_root.clone());
     let sibling_driver = Arc::new(BoxRuntimeDriver::new_with_isolation(
         BoxRuntimeDriverConfig {
+            secret_root: sibling_home.join("runtime-secrets"),
             home_dir: sibling_home,
             control_timeout: Duration::from_secs(120),
             task_poll_interval: Duration::from_millis(25),

--- a/src/runtime/src/a3s_runtime_driver/exec.rs
+++ b/src/runtime/src/a3s_runtime_driver/exec.rs
@@ -41,7 +41,12 @@ impl BoxRuntimeDriver {
                     unit_id: unit.spec.unit_id.clone(),
                 })?;
         provider_identity_matches(&unit.observation, &record)?;
-        validate_record_for_spec(&record, &unit.spec, self.execution_isolation)?;
+        validate_record_for_spec(
+            &record,
+            &unit.spec,
+            self.execution_isolation,
+            &self.config.secret_root,
+        )?;
         let (execution_id, generation, _) = local_identity(&record)?;
 
         // Refresh provider state before crossing the exec boundary. The
@@ -63,7 +68,12 @@ impl BoxRuntimeDriver {
             .ok_or_else(|| RuntimeError::NotFound {
                 unit_id: unit.spec.unit_id.clone(),
             })?;
-        validate_record_for_spec(&record, &unit.spec, self.execution_isolation)?;
+        validate_record_for_spec(
+            &record,
+            &unit.spec,
+            self.execution_isolation,
+            &self.config.secret_root,
+        )?;
         let (_, refreshed_generation, state) = local_identity(&record)?;
         if state != ManagedExecutionState::Running {
             return Err(RuntimeError::InvalidRequest(format!(
@@ -115,7 +125,12 @@ impl BoxRuntimeDriver {
             .ok_or_else(|| RuntimeError::NotFound {
                 unit_id: unit.spec.unit_id.clone(),
             })?;
-        validate_record_for_spec(&record, &unit.spec, self.execution_isolation)?;
+        validate_record_for_spec(
+            &record,
+            &unit.spec,
+            self.execution_isolation,
+            &self.config.secret_root,
+        )?;
         let observation = self.observe_service_health(&unit.spec, &record).await?;
         let result = RuntimeExecResult {
             schema: RuntimeExecResult::SCHEMA.into(),

--- a/src/runtime/src/a3s_runtime_driver/lifecycle.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle.rs
@@ -217,6 +217,15 @@ impl BoxRuntimeDriver {
             ManagedExecutionState::Creating
             | ManagedExecutionState::Created
             | ManagedExecutionState::Starting => {
+                let _registry_auth = self
+                    .secret_materialization
+                    .prepare_registry_auth_for_start(
+                        spec,
+                        &record,
+                        &self.config.home_dir,
+                        self.transient_registry_auth.as_ref(),
+                    )
+                    .await?;
                 let result = self
                     .bounded("startup", async {
                         self.manager
@@ -263,14 +272,16 @@ impl BoxRuntimeDriver {
         if matches!(
             state,
             ManagedExecutionState::Creating | ManagedExecutionState::Created
-        ) || matches!(
+        ) {
+            self.secret_materialization
+                .materialize_for_start(spec)
+                .await
+        } else if matches!(
             state,
             ManagedExecutionState::Stopped | ManagedExecutionState::Failed
         ) && should_restart(spec, record)?
         {
-            self.secret_materialization
-                .materialize_for_start(spec)
-                .await
+            Ok(())
         } else {
             self.secret_materialization.require_materialized(spec).await
         }
@@ -399,6 +410,18 @@ impl BoxRuntimeDriver {
         spec: &RuntimeUnitSpec,
         record: BoxRecord,
     ) -> RuntimeResult<BoxRecord> {
+        self.secret_materialization
+            .materialize_for_start(spec)
+            .await?;
+        let _registry_auth = self
+            .secret_materialization
+            .prepare_registry_auth_for_start(
+                spec,
+                &record,
+                &self.config.home_dir,
+                self.transient_registry_auth.as_ref(),
+            )
+            .await?;
         let (execution_id, generation, _) = local_identity(&record)?;
         let operation_id = restart_operation(spec, generation)?;
         let result = self

--- a/src/runtime/src/a3s_runtime_driver/lifecycle.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle.rs
@@ -12,10 +12,10 @@ use sha2::{Digest, Sha256};
 
 use crate::{BoxRecord, ManagedExecutionState};
 
-use super::mapping::{creation_request, operation};
+use super::mapping::{creation_request_for, operation};
 use super::metadata::{
     local_identity, map_execution_error, now_ms, provider_identity_matches, timestamp_ms,
-    validate_record_for_spec,
+    validate_record_for_spec, SPEC_DIGEST_LABEL,
 };
 use super::BoxRuntimeDriver;
 
@@ -27,7 +27,9 @@ impl BoxRuntimeDriver {
     ) -> RuntimeResult<RuntimeObservation> {
         // Complete validation and conversion before any Box state or provider
         // mutation. The returned request is reused for identity comparison.
-        let request = creation_request(spec, self.execution_isolation)?;
+        let request =
+            creation_request_for(spec, self.execution_isolation, &self.config.secret_root)?;
+        self.secret_materialization.require_configured_for(spec)?;
         let mut record = self.find_generation(spec).await?;
 
         if let Some(existing) = record.as_ref() {
@@ -39,7 +41,7 @@ impl BoxRuntimeDriver {
         }
 
         let record = match record {
-            Some(record) => self.ensure_started(spec, record).await?,
+            Some(record) => record,
             None => {
                 let operation_id = operation(spec)?;
                 let reservation = self
@@ -60,10 +62,17 @@ impl BoxRuntimeDriver {
                             "Box lost a durable execution immediately after reservation".into(),
                         )
                     })?;
-                validate_record_for_spec(&record, spec, self.execution_isolation)?;
-                self.ensure_started(spec, record).await?
+                validate_record_for_spec(
+                    &record,
+                    spec,
+                    self.execution_isolation,
+                    &self.config.secret_root,
+                )?;
+                record
             }
         };
+        self.prepare_secret_material(spec, &record).await?;
+        let record = self.ensure_started(spec, record).await?;
 
         // Retire older Runtime generations as soon as the current generation
         // has a durable provider identity. A retry resumes any partial cleanup.
@@ -87,6 +96,7 @@ impl BoxRuntimeDriver {
             self.service_endpoints
                 .remove_runtime(&unit.spec.unit_id, unit.spec.generation)
                 .await;
+            self.secret_materialization.cleanup_spec(&unit.spec).await?;
             return Ok(not_found(&unit.spec));
         };
         provider_identity_matches(&unit.observation, &record)?;
@@ -98,6 +108,8 @@ impl BoxRuntimeDriver {
                 .await;
             return Ok(not_found(&unit.spec));
         }
+
+        self.prepare_secret_material(&unit.spec, &record).await?;
 
         let record = if should_restart(&unit.spec, &record)? {
             self.restart_record(&unit.spec, record).await?
@@ -176,6 +188,7 @@ impl BoxRuntimeDriver {
         self.service_endpoints
             .remove_runtime(&unit.spec.unit_id, unit.spec.generation)
             .await;
+        self.secret_materialization.cleanup_spec(&unit.spec).await?;
         let removal = RuntimeRemoval {
             schema: RuntimeRemoval::SCHEMA.into(),
             request_id: request.request_id.clone(),
@@ -193,7 +206,12 @@ impl BoxRuntimeDriver {
         spec: &RuntimeUnitSpec,
         record: BoxRecord,
     ) -> RuntimeResult<BoxRecord> {
-        validate_record_for_spec(&record, spec, self.execution_isolation)?;
+        validate_record_for_spec(
+            &record,
+            spec,
+            self.execution_isolation,
+            &self.config.secret_root,
+        )?;
         let (execution_id, generation, state) = local_identity(&record)?;
         match state {
             ManagedExecutionState::Creating
@@ -230,6 +248,31 @@ impl BoxRuntimeDriver {
                 "Box execution {} cannot be applied while in state {state}",
                 record.id
             ))),
+        }
+    }
+
+    async fn prepare_secret_material(
+        &self,
+        spec: &RuntimeUnitSpec,
+        record: &BoxRecord,
+    ) -> RuntimeResult<()> {
+        if spec.secrets.is_empty() {
+            return Ok(());
+        }
+        let state = local_identity(record)?.2;
+        if matches!(
+            state,
+            ManagedExecutionState::Creating | ManagedExecutionState::Created
+        ) || matches!(
+            state,
+            ManagedExecutionState::Stopped | ManagedExecutionState::Failed
+        ) && should_restart(spec, record)?
+        {
+            self.secret_materialization
+                .materialize_for_start(spec)
+                .await
+        } else {
+            self.secret_materialization.require_materialized(spec).await
         }
     }
 
@@ -328,7 +371,12 @@ impl BoxRuntimeDriver {
             .ok_or_else(|| RuntimeError::NotFound {
                 unit_id: spec.unit_id.clone(),
             })?;
-        validate_record_for_spec(&record, spec, self.execution_isolation)?;
+        validate_record_for_spec(
+            &record,
+            spec,
+            self.execution_isolation,
+            &self.config.secret_root,
+        )?;
         Ok(record)
     }
 
@@ -394,7 +442,12 @@ impl BoxRuntimeDriver {
                 remaining.len()
             )));
         }
-        validate_record_for_spec(&remaining[0], spec, self.execution_isolation)
+        validate_record_for_spec(
+            &remaining[0],
+            spec,
+            self.execution_isolation,
+            &self.config.secret_root,
+        )
     }
 
     pub(super) async fn retire_record(
@@ -402,6 +455,16 @@ impl BoxRuntimeDriver {
         mut record: BoxRecord,
         unit_id: &str,
     ) -> RuntimeResult<()> {
+        let secret_digest = record
+            .labels
+            .get(SPEC_DIGEST_LABEL)
+            .cloned()
+            .ok_or_else(|| {
+                RuntimeError::Protocol(format!(
+                    "Box execution {} has no Runtime specification digest",
+                    record.id
+                ))
+            })?;
         let (execution_id, mut generation, mut state) = local_identity(&record)?;
         if matches!(
             state,
@@ -424,6 +487,9 @@ impl BoxRuntimeDriver {
             {
                 Ok(ReconcileOutcome::Absent) => {
                     self.service_endpoints.remove_provider(&execution_id).await;
+                    self.secret_materialization
+                        .cleanup_digest(&secret_digest)
+                        .await?;
                     return Ok(());
                 }
                 Ok(_) => {}
@@ -471,6 +537,9 @@ impl BoxRuntimeDriver {
         }
 
         self.service_endpoints.remove_provider(&execution_id).await;
+        self.secret_materialization
+            .cleanup_digest(&secret_digest)
+            .await?;
 
         self.bounded("generation retirement removal", async {
             self.manager
@@ -501,7 +570,12 @@ impl BoxRuntimeDriver {
         state_override: Option<RuntimeUnitState>,
         failure_override: Option<RuntimeFailure>,
     ) -> RuntimeResult<RuntimeObservation> {
-        validate_record_for_spec(record, spec, self.execution_isolation)?;
+        validate_record_for_spec(
+            record,
+            spec,
+            self.execution_isolation,
+            &self.config.secret_root,
+        )?;
         let state = state_override.unwrap_or(runtime_state(spec, record)?);
         let terminal = state.is_terminal();
         let metadata = record.managed_execution.as_ref().ok_or_else(|| {

--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -1,14 +1,174 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use a3s_runtime::contract::{RestartPolicy, RuntimeInspection, RuntimeUnitClass, RuntimeUnitState};
+use a3s_runtime::contract::{
+    RestartPolicy, RuntimeFeature, RuntimeInspection, RuntimeUnitClass, RuntimeUnitState,
+    SecretReference, SecretTarget,
+};
 use a3s_runtime::{RuntimeDriver, RuntimeError};
 
 use super::metadata::GENERATION_LABEL;
 use super::test_support::{
-    accepted, action, fake_driver, fake_driver_with_backend, runtime_spec, unit, unknown,
-    DriverFakeBackend,
+    accepted, action, fake_driver, fake_driver_with_backend,
+    fake_driver_with_backend_and_secret_materializer, fake_driver_with_secret_materializer,
+    runtime_spec, unit, unknown, DriverFakeBackend, DriverFakeSecretMaterializer,
 };
+
+fn tmpfs_secret_root() -> (tempfile::TempDir, std::path::PathBuf) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mount = tempfile::tempdir_in("/dev/shm")
+        .expect("Linux Runtime Secret tests require the standard /dev/shm tmpfs");
+    let root = mount.path().join("runtime-secrets");
+    std::fs::create_dir(&root).unwrap();
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700)).unwrap();
+    (mount, root)
+}
+
+fn environment_secret(reference: &str) -> SecretReference {
+    SecretReference {
+        name: "provider-token".into(),
+        reference: reference.into(),
+        target: SecretTarget::Environment {
+            variable: "A3S_PROVIDER_TOKEN".into(),
+        },
+    }
+}
+
+#[tokio::test]
+async fn unconfigured_secret_port_rejects_before_provider_mutation() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, backend) = fake_driver(&directory);
+    let mut spec = runtime_spec("secret-unconfigured", 1, RuntimeUnitClass::Service);
+    spec.secrets
+        .push(environment_secret("secret://provider/token/v1"));
+
+    assert!(matches!(
+        driver.apply(&spec, &accepted(&spec)).await,
+        Err(RuntimeError::UnsupportedCapabilities(missing))
+            if missing == vec!["feature:SecretReferences"]
+    ));
+    assert_eq!(backend.starts(), 0);
+    assert!(driver.manager.managed_records().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn secret_materialization_recovers_without_persisting_plaintext_and_cleans_on_remove() {
+    let directory = tempfile::tempdir().unwrap();
+    let (_secret_mount, secret_root) = tmpfs_secret_root();
+    let materializer = Arc::new(DriverFakeSecretMaterializer::default());
+    let reference = "secret://provider/token/v7";
+    let plaintext = "box-fixture-secret-plaintext";
+    materializer.insert(reference, plaintext.as_bytes().to_vec());
+    let (driver, backend) =
+        fake_driver_with_secret_materializer(&directory, secret_root.clone(), materializer.clone());
+    let mut spec = runtime_spec("secret-retry", 1, RuntimeUnitClass::Service);
+    spec.secrets.push(environment_secret(reference));
+
+    let capabilities = driver.capabilities().await.unwrap();
+    assert!(capabilities
+        .features
+        .contains(&RuntimeFeature::SecretReferences));
+
+    materializer.fail_next();
+    assert!(matches!(
+        driver.apply(&spec, &accepted(&spec)).await,
+        Err(RuntimeError::ProviderUnavailable(message))
+            if message.contains("temporarily unavailable")
+    ));
+    assert_eq!(backend.starts(), 0);
+    assert_eq!(driver.manager.managed_records().await.unwrap().len(), 1);
+    let materialized_directory = super::secret::secret_directory(&secret_root, &spec).unwrap();
+    assert!(!materialized_directory.exists());
+
+    let running = driver.apply(&spec, &accepted(&spec)).await.unwrap();
+    assert_eq!(running.state, RuntimeUnitState::Running);
+    assert_eq!(backend.starts(), 1);
+    let materialized = super::secret::secret_file(&secret_root, &spec, 0).unwrap();
+    assert_eq!(std::fs::read(&materialized).unwrap(), plaintext.as_bytes());
+
+    let state = std::fs::read_to_string(driver.manager.state_path()).unwrap();
+    assert!(!state.contains(plaintext));
+    let record = driver.manager.managed_records().await.unwrap().remove(0);
+    let creation_intent =
+        serde_json::to_string(&record.managed_execution.unwrap().request).unwrap();
+    assert!(!creation_intent.contains(plaintext));
+
+    let calls_before_reconstruction = materializer.calls();
+    let reopened = fake_driver_with_backend_and_secret_materializer(
+        &directory,
+        backend.clone(),
+        secret_root.clone(),
+        materializer.clone(),
+    );
+    let replayed = reopened.apply(&spec, &running).await.unwrap();
+    assert_eq!(replayed.provider_resource_id, running.provider_resource_id);
+    assert_eq!(backend.starts(), 1);
+    assert_eq!(materializer.calls(), calls_before_reconstruction);
+    assert!(materialized.exists());
+
+    let running_unit = unit(spec.clone(), replayed);
+    let stopped = reopened
+        .stop(&running_unit, &action("secret-stop", &spec))
+        .await
+        .unwrap();
+    assert_eq!(stopped.state, RuntimeUnitState::Stopped);
+    assert!(materialized.exists(), "stop must retain restart material");
+
+    reopened
+        .remove(
+            &unit(spec.clone(), stopped),
+            &action("secret-remove", &spec),
+        )
+        .await
+        .unwrap();
+    assert!(!materialized_directory.exists());
+    assert!(reopened.manager.managed_records().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn stale_generation_retirement_removes_only_its_secret_material() {
+    let directory = tempfile::tempdir().unwrap();
+    let (_secret_mount, secret_root) = tmpfs_secret_root();
+    let materializer = Arc::new(DriverFakeSecretMaterializer::default());
+    materializer.insert("secret://provider/token/v1", b"generation-one".to_vec());
+    materializer.insert("secret://provider/token/v2", b"generation-two".to_vec());
+    let (driver, _backend) =
+        fake_driver_with_secret_materializer(&directory, secret_root.clone(), materializer);
+    let mut first = runtime_spec("secret-handoff", 1, RuntimeUnitClass::Service);
+    first
+        .secrets
+        .push(environment_secret("secret://provider/token/v1"));
+    driver.apply(&first, &accepted(&first)).await.unwrap();
+    let first_directory = super::secret::secret_directory(&secret_root, &first).unwrap();
+    assert!(first_directory.exists());
+
+    let mut second = runtime_spec("secret-handoff", 2, RuntimeUnitClass::Service);
+    second.process.args = vec!["-c".into(), "echo generation-two".into()];
+    second
+        .secrets
+        .push(environment_secret("secret://provider/token/v2"));
+    let second_running = driver.apply(&second, &accepted(&second)).await.unwrap();
+    let second_directory = super::secret::secret_directory(&secret_root, &second).unwrap();
+
+    assert!(!first_directory.exists());
+    assert!(second_directory.exists());
+    let records = driver.manager.managed_records().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        second_running.provider_resource_id.as_deref(),
+        Some(records[0].id.as_str())
+    );
+
+    driver
+        .remove(
+            &unit(second.clone(), second_running),
+            &action("secret-handoff-remove", &second),
+        )
+        .await
+        .unwrap();
+    assert!(!second_directory.exists());
+}
 
 #[tokio::test]
 async fn service_replay_reopens_the_same_identity_and_stop_remove_are_idempotent() {

--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -35,6 +35,14 @@ fn environment_secret(reference: &str) -> SecretReference {
     }
 }
 
+fn registry_secret(reference: &str) -> SecretReference {
+    SecretReference {
+        name: "registry-credential".into(),
+        reference: reference.into(),
+        target: SecretTarget::RegistryCredential,
+    }
+}
+
 #[tokio::test]
 async fn unconfigured_secret_port_rejects_before_provider_mutation() {
     let directory = tempfile::tempdir().unwrap();
@@ -168,6 +176,112 @@ async fn stale_generation_retirement_removes_only_its_secret_material() {
         .await
         .unwrap();
     assert!(!second_directory.exists());
+}
+
+#[tokio::test]
+async fn registry_credentials_resolve_only_for_an_uncached_start_and_never_persist() {
+    let directory = tempfile::tempdir().unwrap();
+    let secret_root = directory.path().join("runtime-secrets");
+    let materializer = Arc::new(DriverFakeSecretMaterializer::default());
+    let reference = "secret://registry/credential/v7";
+    materializer.insert_registry_credential(
+        reference,
+        "box-registry-user",
+        "box-registry-password",
+    );
+    let (driver, backend) =
+        fake_driver_with_secret_materializer(&directory, secret_root.clone(), materializer.clone());
+    let mut spec = runtime_spec("registry-secret", 1, RuntimeUnitClass::Service);
+    spec.secrets.push(registry_secret(reference));
+
+    materializer.fail_next();
+    assert!(matches!(
+        driver.apply(&spec, &accepted(&spec)).await,
+        Err(RuntimeError::ProviderUnavailable(message))
+            if message.contains("temporarily unavailable")
+    ));
+    assert_eq!(backend.starts(), 0);
+    assert_eq!(
+        driver.transient_registry_auth.as_ref().unwrap().pending(),
+        0
+    );
+
+    backend.fail_next_start_response();
+    let running = driver.apply(&spec, &accepted(&spec)).await.unwrap();
+    assert_eq!(running.state, RuntimeUnitState::Running);
+    assert_eq!(backend.starts(), 1);
+    assert_eq!(materializer.calls(), 2);
+    assert_eq!(
+        driver.transient_registry_auth.as_ref().unwrap().pending(),
+        0
+    );
+    assert!(!secret_root.exists());
+
+    let state = std::fs::read_to_string(driver.manager.state_path()).unwrap();
+    assert!(!state.contains("box-registry-user"));
+    assert!(!state.contains("box-registry-password"));
+    assert!(state.contains(reference));
+
+    let reopened = fake_driver_with_backend_and_secret_materializer(
+        &directory,
+        backend.clone(),
+        secret_root,
+        materializer.clone(),
+    );
+    let replayed = reopened.apply(&spec, &running).await.unwrap();
+    assert_eq!(replayed.provider_resource_id, running.provider_resource_id);
+    assert_eq!(materializer.calls(), 2);
+
+    let provider_id = replayed.provider_resource_id.clone().unwrap();
+    backend.finish(&provider_id, 9);
+    let inspection = reopened
+        .inspect(&unit(spec.clone(), replayed))
+        .await
+        .unwrap();
+    assert!(matches!(
+        inspection,
+        RuntimeInspection::Found { ref observation, .. }
+            if observation.state == RuntimeUnitState::Running
+    ));
+    assert_eq!(backend.starts(), 2);
+    assert_eq!(materializer.calls(), 3);
+    assert_eq!(
+        reopened.transient_registry_auth.as_ref().unwrap().pending(),
+        0
+    );
+
+    let state = std::fs::read_to_string(reopened.manager.state_path()).unwrap();
+    assert!(!state.contains("box-registry-user"));
+    assert!(!state.contains("box-registry-password"));
+}
+
+#[tokio::test]
+async fn cached_registry_artifact_does_not_resolve_its_credential() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = directory.path().join("home");
+    let images = home.join("images");
+    let source = directory.path().join("cached-image");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::write(source.join("fixture"), b"cached").unwrap();
+    let digest = format!("sha256:{}", "a".repeat(64));
+    let reference = format!("registry.example/a3s/runtime@{digest}");
+    let store = crate::ImageStore::new(&images, crate::DEFAULT_IMAGE_CACHE_SIZE).unwrap();
+    store.put(&reference, &digest, &source).await.unwrap();
+
+    let materializer = Arc::new(DriverFakeSecretMaterializer::default());
+    let (driver, backend) = fake_driver_with_secret_materializer(
+        &directory,
+        directory.path().join("runtime-secrets"),
+        materializer.clone(),
+    );
+    let mut spec = runtime_spec("cached-registry-secret", 1, RuntimeUnitClass::Service);
+    spec.secrets
+        .push(registry_secret("secret://registry/credential/unregistered"));
+
+    let running = driver.apply(&spec, &accepted(&spec)).await.unwrap();
+    assert_eq!(running.state, RuntimeUnitState::Running);
+    assert_eq!(backend.starts(), 1);
+    assert_eq!(materializer.calls(), 0);
 }
 
 #[tokio::test]

--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -220,7 +220,7 @@ async fn registry_credentials_resolve_only_for_an_uncached_start_and_never_persi
     let state = std::fs::read_to_string(driver.manager.state_path()).unwrap();
     assert!(!state.contains("box-registry-user"));
     assert!(!state.contains("box-registry-password"));
-    assert!(state.contains(reference));
+    assert!(!state.contains(reference));
 
     let reopened = fake_driver_with_backend_and_secret_materializer(
         &directory,

--- a/src/runtime/src/a3s_runtime_driver/logs.rs
+++ b/src/runtime/src/a3s_runtime_driver/logs.rs
@@ -5,8 +5,10 @@ use a3s_runtime::contract::{RuntimeLogChunk, RuntimeLogQuery, RuntimeLogStream};
 use a3s_runtime::{RuntimeError, RuntimeResult, RuntimeUnitRecord};
 use chrono::DateTime;
 use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
 
 use super::metadata::{local_identity, map_execution_error, provider_identity_matches};
+use super::secret::BoxSecretMaterial;
 use super::BoxRuntimeDriver;
 
 const RECORDS_PER_SECOND: u64 = 1_000_000;
@@ -31,19 +33,25 @@ impl BoxRuntimeDriver {
                 })?;
         provider_identity_matches(&unit.observation, &record)?;
         let (execution_id, local_generation, _) = local_identity(&record)?;
+        let secret_material = self
+            .secret_materialization
+            .resolve_for_redaction(&unit.spec)
+            .await?;
         let entries = self
             .manager
             .read_logs(&execution_id, local_generation)
             .await
             .map_err(|error| map_execution_error(&unit.spec.unit_id, error))?;
-        project_logs(entries, query)
+        project_logs(entries, query, &secret_material)
     }
 }
 
 fn project_logs(
     entries: Vec<a3s_box_core::log::LogEntry>,
     query: &RuntimeLogQuery,
+    secret_material: &[BoxSecretMaterial],
 ) -> RuntimeResult<Vec<RuntimeLogChunk>> {
+    let redactions = redaction_values(secret_material);
     let requested_cursor = query.cursor.as_deref().map(LogCursor::parse).transpose()?;
     if requested_cursor
         .as_ref()
@@ -100,10 +108,11 @@ fn project_logs(
             timestamp_ns,
             ordinal,
             stream,
-            data: entry.log,
+            data: Zeroizing::new(entry.log),
         };
         ordinal += 1;
-        let cursor = LogCursor::new(&raw).encode();
+        let redacted = Zeroizing::new(redact_log(raw.data.as_str(), &redactions));
+        let cursor = LogCursor::new(&raw, redacted.as_str()).encode();
         let sequence = log_sequence(second, ordinal)?;
 
         if !cursor_found {
@@ -123,7 +132,7 @@ fn project_logs(
             sequence,
             observed_at_ms,
             stream,
-            data: raw.data,
+            data: redacted.as_str().to_owned(),
         };
         chunk.validate().map_err(RuntimeError::Protocol)?;
         chunks.push(chunk);
@@ -154,7 +163,41 @@ struct RawLogRecord {
     timestamp_ns: i64,
     ordinal: u64,
     stream: RuntimeLogStream,
-    data: String,
+    data: Zeroizing<String>,
+}
+
+fn redaction_values(material: &[BoxSecretMaterial]) -> Vec<&str> {
+    let mut values = material
+        .iter()
+        .filter_map(|material| std::str::from_utf8(material.as_bytes()).ok())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    values
+        .sort_unstable_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+    values.dedup();
+    values
+}
+
+fn redact_log(value: &str, redactions: &[&str]) -> String {
+    let mut redacted = String::with_capacity(value.len());
+    let mut offset = 0;
+    while offset < value.len() {
+        if let Some(secret) = redactions
+            .iter()
+            .copied()
+            .find(|secret| value[offset..].starts_with(secret))
+        {
+            redacted.push_str("[REDACTED]");
+            offset += secret.len();
+            continue;
+        }
+        let Some(character) = value[offset..].chars().next() else {
+            break;
+        };
+        redacted.push(character);
+        offset += character.len_utf8();
+    }
+    redacted
 }
 
 struct LogCursor {
@@ -166,7 +209,7 @@ struct LogCursor {
 }
 
 impl LogCursor {
-    fn new(record: &RawLogRecord) -> Self {
+    fn new(record: &RawLogRecord, redacted_data: &str) -> Self {
         let mut hash = Sha256::new();
         hash.update(b"a3s-box-log-cursor-v1\0");
         hash.update(record.generation.to_be_bytes());
@@ -176,7 +219,9 @@ impl LogCursor {
             RuntimeLogStream::Stdout => b"stdout".as_slice(),
             RuntimeLogStream::Stderr => b"stderr".as_slice(),
         });
-        hash.update(record.data.as_bytes());
+        // A cursor must never become an offline verifier for low-entropy
+        // Secret material that a workload wrote to its raw provider log.
+        hash.update(redacted_data.as_bytes());
         let digest = format!("{:x}", hash.finalize());
         Self {
             generation: record.generation,
@@ -290,13 +335,14 @@ mod tests {
                 time: "2026-07-17T00:00:01Z".into(),
             },
         ];
-        let all = project_logs(entries.clone(), &query(None, None)).unwrap();
+        let all = project_logs(entries.clone(), &query(None, None), &[]).unwrap();
         assert_eq!(all.len(), 3);
         assert!(all[0].sequence < all[1].sequence && all[1].sequence < all[2].sequence);
 
         let resumed = project_logs(
             entries,
             &query(Some(all[0].cursor.clone()), Some(RuntimeLogStream::Stdout)),
+            &[],
         )
         .unwrap();
         assert_eq!(resumed.len(), 1);
@@ -313,7 +359,61 @@ mod tests {
             digest: "0123456789abcdef".into(),
         }
         .encode();
-        let error = project_logs(Vec::new(), &query(Some(cursor), None)).unwrap_err();
+        let error = project_logs(Vec::new(), &query(Some(cursor), None), &[]).unwrap_err();
         assert!(error.to_string().contains("rotation gap"));
+    }
+
+    #[test]
+    fn exact_overlapping_secret_values_are_redacted_longest_first() {
+        let entries = vec![LogEntry {
+            log: "token=abc123 fallback=abc untouched=abcd\n".into(),
+            stream: "stdout".into(),
+            time: "2026-07-17T00:00:00Z".into(),
+        }];
+        let secrets = [
+            BoxSecretMaterial::new(b"abc".to_vec()).unwrap(),
+            BoxSecretMaterial::new(b"abc123".to_vec()).unwrap(),
+        ];
+        let chunks = project_logs(entries, &query(None, None), &secrets).unwrap();
+        assert_eq!(
+            chunks[0].data,
+            "token=[REDACTED] fallback=[REDACTED] untouched=[REDACTED]d\n"
+        );
+        assert!(!chunks[0].data.contains("abc"));
+    }
+
+    #[test]
+    fn replacement_markers_are_not_reprocessed_as_secret_material() {
+        assert_eq!(
+            redact_log("abc123 RED", &["abc123", "RED"]),
+            "[REDACTED] [REDACTED]"
+        );
+    }
+
+    #[test]
+    fn cursor_digest_uses_redacted_data_instead_of_secret_plaintext() {
+        let first = project_logs(
+            vec![LogEntry {
+                log: "token=alpha\n".into(),
+                stream: "stdout".into(),
+                time: "2026-07-17T00:00:00Z".into(),
+            }],
+            &query(None, None),
+            &[BoxSecretMaterial::new(b"alpha".to_vec()).unwrap()],
+        )
+        .unwrap();
+        let second = project_logs(
+            vec![LogEntry {
+                log: "token=bravo\n".into(),
+                stream: "stdout".into(),
+                time: "2026-07-17T00:00:00Z".into(),
+            }],
+            &query(None, None),
+            &[BoxSecretMaterial::new(b"bravo".to_vec()).unwrap()],
+        )
+        .unwrap();
+
+        assert_eq!(first[0].data, "token=[REDACTED]\n");
+        assert_eq!(first[0].cursor, second[0].cursor);
     }
 }

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -235,17 +235,6 @@ fn compile_secret_inputs(
             "Runtime process environment cannot use reserved Box key {SECRET_ENVIRONMENT_MANIFEST:?}"
         )));
     }
-    if spec
-        .secrets
-        .iter()
-        .filter(|secret| matches!(secret.target, SecretTarget::RegistryCredential))
-        .count()
-        > 1
-    {
-        return Err(RuntimeError::InvalidRequest(
-            "Box Runtime specification has multiple registry credential Secrets".into(),
-        ));
-    }
     let digest = spec_digest.strip_prefix("sha256:").ok_or_else(|| {
         RuntimeError::Protocol("Box Secret compilation requires a SHA-256 spec digest".into())
     })?;

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -1,29 +1,33 @@
 //! Lossless Runtime protocol to Box execution creation mapping.
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use a3s_box_core::log::LogConfig;
+use a3s_box_core::secret::{SecretEnvironmentBinding, SECRET_ENVIRONMENT_MANIFEST};
 use a3s_box_core::{
     BoxConfig, CreateExecutionRequest, ExecutionIsolation, ExecutionRecordPolicy,
     ExecutionRestartPolicy, NetworkMode, ResourceConfig, ResourceLimits,
 };
 use a3s_runtime::contract::{
     ArtifactRef, MountKind, NetworkMode as RuntimeNetworkMode, RestartPolicy, RuntimeMountSource,
-    RuntimeUnitClass, RuntimeUnitSpec, TransportProtocol,
+    RuntimeUnitClass, RuntimeUnitSpec, SecretTarget, TransportProtocol,
 };
 use a3s_runtime::{RuntimeError, RuntimeResult};
 use url::Position;
 
 use super::metadata::{managed_labels, operation_id};
+use super::secret::secret_file;
 use super::{OCI_IMAGE_INDEX, OCI_IMAGE_MANIFEST};
 
 const CPU_PERIOD_US: u64 = 100_000;
 const BYTES_PER_MIB: u64 = 1024 * 1024;
+const SECRET_GUEST_ROOT: &str = "/.a3s-box-secrets";
 
-pub(super) fn creation_request(
+pub(super) fn creation_request_for(
     spec: &RuntimeUnitSpec,
     execution_isolation: ExecutionIsolation,
+    secret_root: &Path,
 ) -> RuntimeResult<CreateExecutionRequest> {
     spec.validate().map_err(RuntimeError::InvalidRequest)?;
     validate_provider_unit_id(&spec.unit_id)?;
@@ -60,6 +64,17 @@ pub(super) fn creation_request(
         )
     };
     let tmpfs = compile_tmpfs_mounts(spec)?;
+    let (secret_volumes, secret_environment_manifest) =
+        compile_secret_inputs(spec, secret_root, &spec_digest)?;
+    let mut extra_env = spec
+        .process
+        .environment
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<Vec<_>>();
+    if let Some(manifest) = secret_environment_manifest {
+        extra_env.push((SECRET_ENVIRONMENT_MANIFEST.into(), manifest));
+    }
 
     let config = BoxConfig {
         image: image_reference(&spec.artifact)?,
@@ -73,12 +88,8 @@ pub(super) fn creation_request(
         cmd,
         entrypoint_override,
         workdir: spec.process.working_directory.clone(),
-        extra_env: spec
-            .process
-            .environment
-            .iter()
-            .map(|(key, value)| (key.clone(), value.clone()))
-            .collect(),
+        volumes: secret_volumes,
+        extra_env,
         network: NetworkMode::None,
         tmpfs,
         resource_limits: ResourceLimits {
@@ -108,10 +119,23 @@ pub(super) fn creation_request(
             healthcheck_disabled: true,
             log_config: LogConfig::default(),
             init: true,
+            managed_secret_root: (!spec.secrets.is_empty()).then(|| secret_root.to_path_buf()),
             ..Default::default()
         },
         rootfs_snapshot_id: None,
     })
+}
+
+#[cfg(test)]
+pub(super) fn creation_request(
+    spec: &RuntimeUnitSpec,
+    execution_isolation: ExecutionIsolation,
+) -> RuntimeResult<CreateExecutionRequest> {
+    creation_request_for(
+        spec,
+        execution_isolation,
+        Path::new("/run/a3s-box/runtime-secrets"),
+    )
 }
 
 pub(super) fn operation(spec: &RuntimeUnitSpec) -> RuntimeResult<a3s_box_core::OperationId> {
@@ -171,11 +195,6 @@ fn validate_supported_shape(spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
                 .collect(),
         ));
     }
-    if !spec.secrets.is_empty() {
-        return Err(RuntimeError::UnsupportedCapabilities(vec![
-            "feature:SecretReferences".into(),
-        ]));
-    }
     if !spec.outputs.is_empty() {
         return Err(RuntimeError::UnsupportedCapabilities(vec![
             "feature:OutputArtifacts".into(),
@@ -193,6 +212,132 @@ fn validate_supported_shape(spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
             "Runtime Tasks cannot use an always restart policy".into(),
         )),
     }
+}
+
+fn compile_secret_inputs(
+    spec: &RuntimeUnitSpec,
+    secret_root: &Path,
+    spec_digest: &str,
+) -> RuntimeResult<(Vec<String>, Option<String>)> {
+    if spec.secrets.is_empty() {
+        return Ok((Vec::new(), None));
+    }
+    if spec
+        .process
+        .environment
+        .contains_key(SECRET_ENVIRONMENT_MANIFEST)
+    {
+        return Err(RuntimeError::InvalidRequest(format!(
+            "Runtime process environment cannot use reserved Box key {SECRET_ENVIRONMENT_MANIFEST:?}"
+        )));
+    }
+    let digest = spec_digest.strip_prefix("sha256:").ok_or_else(|| {
+        RuntimeError::Protocol("Box Secret compilation requires a SHA-256 spec digest".into())
+    })?;
+    let internal_root = PathBuf::from(format!("{SECRET_GUEST_ROOT}/{digest}"));
+    let mut destinations = spec
+        .mounts
+        .iter()
+        .map(|mount| PathBuf::from(&mount.target))
+        .collect::<Vec<_>>();
+    let mut volumes = Vec::with_capacity(spec.secrets.len());
+    let mut environment = Vec::new();
+
+    for (index, secret) in spec.secrets.iter().enumerate() {
+        let host = secret_file(secret_root, spec, index)?;
+        let host = host.to_str().filter(|value| {
+            !value.contains([':', '\0']) && !value.bytes().any(|byte| byte.is_ascii_control())
+        });
+        let host = host.ok_or_else(|| {
+            RuntimeError::InvalidRequest(
+                "Box Runtime Secret root cannot be encoded as a bind-mount source".into(),
+            )
+        })?;
+        let destination = match &secret.target {
+            SecretTarget::Environment { variable } => {
+                if spec.process.environment.contains_key(variable) {
+                    return Err(RuntimeError::InvalidRequest(format!(
+                        "Runtime Secret environment target {variable:?} conflicts with a literal process value"
+                    )));
+                }
+                let path = internal_root.join(format!("{index:03}.secret"));
+                let binding = SecretEnvironmentBinding {
+                    variable: variable.clone(),
+                    path: path.to_string_lossy().into_owned(),
+                };
+                binding.validate().map_err(RuntimeError::Protocol)?;
+                environment.push(binding);
+                path
+            }
+            SecretTarget::File { path, .. } => {
+                validate_secret_file_target(path)?;
+                PathBuf::from(path)
+            }
+            SecretTarget::RegistryCredential => {
+                return Err(RuntimeError::UnsupportedCapabilities(vec![
+                    "feature:RegistryCredentials".into(),
+                ]))
+            }
+        };
+        if destinations
+            .iter()
+            .any(|existing| paths_overlap(existing, &destination))
+        {
+            return Err(RuntimeError::InvalidRequest(format!(
+                "Runtime Secret target {:?} overlaps another mount or Secret target",
+                destination
+            )));
+        }
+        destinations.push(destination.clone());
+        volumes.push(format!("{host}:{}:ro", destination.display()));
+    }
+
+    let manifest = if environment.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&environment).map_err(|error| {
+            RuntimeError::Protocol(format!(
+                "Box could not encode the non-secret environment binding manifest: {error}"
+            ))
+        })?)
+    };
+    Ok((volumes, manifest))
+}
+
+fn paths_overlap(left: &Path, right: &Path) -> bool {
+    left == right || left.starts_with(right) || right.starts_with(left)
+}
+
+fn validate_secret_file_target(target: &str) -> RuntimeResult<()> {
+    let path = Path::new(target);
+    let normalized = target.strip_prefix('/').is_some_and(|relative| {
+        !relative.is_empty()
+            && relative
+                .split('/')
+                .all(|segment| !segment.is_empty() && !matches!(segment, "." | ".."))
+    });
+    let is_or_below = |root: &Path| {
+        path == root
+            || path
+                .strip_prefix(root)
+                .is_ok_and(|suffix| !suffix.as_os_str().is_empty())
+    };
+    let protected = path == Path::new("/")
+        || is_or_below(Path::new("/proc"))
+        || is_or_below(Path::new("/sys"))
+        || is_or_below(Path::new("/dev"))
+        || is_or_below(Path::new("/run/a3s-box"))
+        || is_or_below(Path::new(SECRET_GUEST_ROOT));
+    if !normalized
+        || target.contains([':', '\0'])
+        || target.bytes().any(|byte| byte.is_ascii_control())
+        || protected
+    {
+        return Err(RuntimeError::InvalidRequest(format!(
+            "Box Sandbox Secret file target must be an encodable normalized unprotected absolute path: {target:?}"
+        )));
+    }
+    Ok(())
 }
 
 fn validate_provider_unit_id(unit_id: &str) -> RuntimeResult<()> {

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -119,7 +119,11 @@ pub(super) fn creation_request_for(
             healthcheck_disabled: true,
             log_config: LogConfig::default(),
             init: true,
-            managed_secret_root: (!spec.secrets.is_empty()).then(|| secret_root.to_path_buf()),
+            managed_secret_root: spec
+                .secrets
+                .iter()
+                .any(|reference| !matches!(reference.target, SecretTarget::RegistryCredential))
+                .then(|| secret_root.to_path_buf()),
             ..Default::default()
         },
         rootfs_snapshot_id: None,
@@ -231,6 +235,17 @@ fn compile_secret_inputs(
             "Runtime process environment cannot use reserved Box key {SECRET_ENVIRONMENT_MANIFEST:?}"
         )));
     }
+    if spec
+        .secrets
+        .iter()
+        .filter(|secret| matches!(secret.target, SecretTarget::RegistryCredential))
+        .count()
+        > 1
+    {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Runtime specification has multiple registry credential Secrets".into(),
+        ));
+    }
     let digest = spec_digest.strip_prefix("sha256:").ok_or_else(|| {
         RuntimeError::Protocol("Box Secret compilation requires a SHA-256 spec digest".into())
     })?;
@@ -273,11 +288,7 @@ fn compile_secret_inputs(
                 validate_secret_file_target(path)?;
                 PathBuf::from(path)
             }
-            SecretTarget::RegistryCredential => {
-                return Err(RuntimeError::UnsupportedCapabilities(vec![
-                    "feature:RegistryCredentials".into(),
-                ]))
-            }
+            SecretTarget::RegistryCredential => continue,
         };
         if destinations
             .iter()

--- a/src/runtime/src/a3s_runtime_driver/metadata.rs
+++ b/src/runtime/src/a3s_runtime_driver/metadata.rs
@@ -1,6 +1,7 @@
 //! Stable provider ownership metadata and fail-closed record discovery.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use a3s_box_core::{ExecutionGeneration, ExecutionId, ExecutionIsolation, OperationId};
@@ -10,7 +11,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{BoxRecord, ManagedExecutionState};
 
-use super::mapping::{creation_request, labels_as_hash_map};
+use super::mapping::{creation_request_for, labels_as_hash_map};
 use super::BoxRuntimeDriver;
 
 pub(super) const MANAGED_LABEL: &str = "a3s.runtime.managed";
@@ -82,7 +83,12 @@ impl BoxRuntimeDriver {
         let Some(record) = matches.into_iter().next() else {
             return Ok(None);
         };
-        validate_record_for_spec(&record, spec, self.execution_isolation)?;
+        validate_record_for_spec(
+            &record,
+            spec,
+            self.execution_isolation,
+            &self.config.secret_root,
+        )?;
         Ok(Some(record))
     }
 
@@ -150,9 +156,10 @@ pub(super) fn validate_record_for_spec(
     record: &BoxRecord,
     spec: &RuntimeUnitSpec,
     execution_isolation: ExecutionIsolation,
+    secret_root: &Path,
 ) -> RuntimeResult<()> {
     validate_owned_record(record, &spec.unit_id)?;
-    let expected_request = creation_request(spec, execution_isolation)?;
+    let expected_request = creation_request_for(spec, execution_isolation, secret_root)?;
     let metadata = record.managed_execution.as_ref().ok_or_else(|| {
         RuntimeError::Protocol(format!("Box execution {} lost managed metadata", record.id))
     })?;

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -6,6 +6,7 @@ mod lifecycle;
 mod logs;
 mod mapping;
 mod metadata;
+mod secret;
 mod service_endpoints;
 
 use std::future::Future;
@@ -26,7 +27,10 @@ use tokio::sync::OnceCell;
 
 use crate::{ExecutionIsolation, LocalExecutionManager};
 
+use self::secret::SecretMaterializationOwner;
 use self::service_endpoints::ServiceEndpointOwner;
+
+pub use self::secret::{BoxSecretMaterial, BoxSecretMaterializationError, BoxSecretMaterializer};
 
 pub(super) const OCI_IMAGE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
 pub(super) const OCI_IMAGE_INDEX: &str = "application/vnd.oci.image.index.v1+json";
@@ -41,12 +45,18 @@ pub struct BoxRuntimeDriverConfig {
     pub control_timeout: Duration,
     /// Poll cadence while waiting for a finite Task to reach a terminal state.
     pub task_poll_interval: Duration,
+    /// Existing private Linux tmpfs mount used only for transient Runtime
+    /// Secret files. The provider never creates or silently downgrades this
+    /// mount to disk-backed storage.
+    pub secret_root: PathBuf,
 }
 
 impl Default for BoxRuntimeDriverConfig {
     fn default() -> Self {
+        let home_dir = a3s_box_core::dirs_home();
         Self {
-            home_dir: a3s_box_core::dirs_home(),
+            secret_root: home_dir.join("runtime-secrets"),
+            home_dir,
             control_timeout: Duration::from_secs(60),
             task_poll_interval: Duration::from_millis(50),
         }
@@ -61,6 +71,7 @@ pub struct BoxRuntimeDriver {
     port_connector: Arc<dyn ExecutionPortConnector>,
     service_endpoints: ServiceEndpointOwner,
     execution_isolation: ExecutionIsolation,
+    secret_materialization: SecretMaterializationOwner,
     provider_build: OnceCell<String>,
 }
 
@@ -86,6 +97,31 @@ impl BoxRuntimeDriver {
         Self::with_manager(config, manager, execution_isolation)
     }
 
+    /// Compose the shared Box driver with one caller-owned Secret resolver.
+    ///
+    /// The resolver is normally backed by the node agent's existing
+    /// authenticated control channel. It is not a second lifecycle or Secret
+    /// store, and Box never persists the returned bytes.
+    pub fn with_secret_materializer(
+        config: BoxRuntimeDriverConfig,
+        execution_isolation: ExecutionIsolation,
+        materializer: Arc<dyn BoxSecretMaterializer>,
+    ) -> RuntimeResult<Self> {
+        validate_config(&config)?;
+        let manager = LocalExecutionManager::with_vm_backend(
+            config.home_dir.join("boxes.json"),
+            &config.home_dir,
+        );
+        let connector: Arc<dyn ExecutionPortConnector> = Arc::new(manager.clone());
+        Self::with_manager_connector_and_materializer(
+            config,
+            manager,
+            connector,
+            execution_isolation,
+            Some(materializer),
+        )
+    }
+
     fn with_manager(
         config: BoxRuntimeDriverConfig,
         manager: LocalExecutionManager,
@@ -101,8 +137,26 @@ impl BoxRuntimeDriver {
         connector: Arc<dyn ExecutionPortConnector>,
         execution_isolation: ExecutionIsolation,
     ) -> RuntimeResult<Self> {
+        Self::with_manager_connector_and_materializer(
+            config,
+            manager,
+            connector,
+            execution_isolation,
+            None,
+        )
+    }
+
+    fn with_manager_connector_and_materializer(
+        config: BoxRuntimeDriverConfig,
+        manager: LocalExecutionManager,
+        connector: Arc<dyn ExecutionPortConnector>,
+        execution_isolation: ExecutionIsolation,
+        materializer: Option<Arc<dyn BoxSecretMaterializer>>,
+    ) -> RuntimeResult<Self> {
         validate_config(&config)?;
         let endpoint_connector = Arc::clone(&connector);
+        let secret_materialization =
+            SecretMaterializationOwner::new(config.secret_root.clone(), materializer);
         Ok(Self {
             provider_id: ProviderId::parse("a3s-box")?,
             config,
@@ -110,6 +164,7 @@ impl BoxRuntimeDriver {
             port_connector: connector,
             service_endpoints: ServiceEndpointOwner::new(endpoint_connector),
             execution_isolation,
+            secret_materialization,
             provider_build: OnceCell::new(),
         })
     }
@@ -203,6 +258,36 @@ fn validate_config(config: &BoxRuntimeDriverConfig) -> RuntimeResult<()> {
             "Box Runtime timeout and poll interval must be positive".into(),
         ));
     }
+    let secret_root = config.secret_root.to_str().ok_or_else(|| {
+        RuntimeError::InvalidRequest(
+            "Box Runtime Secret root must be an encodable UTF-8 Linux path".into(),
+        )
+    })?;
+    let normalized_secret_root = secret_root.strip_prefix('/').is_some_and(|relative| {
+        !relative.is_empty()
+            && relative
+                .split('/')
+                .all(|segment| !segment.is_empty() && !matches!(segment, "." | ".."))
+    });
+    if !normalized_secret_root
+        || secret_root.contains([':', '\0'])
+        || secret_root.bytes().any(|byte| byte.is_ascii_control())
+        || !config.secret_root.is_absolute()
+        || config.secret_root.parent().is_none()
+        || config.secret_root.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::CurDir
+                    | std::path::Component::ParentDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Runtime Secret root must be an encodable absolute normalized non-root Linux path"
+                .into(),
+        ));
+    }
     Ok(())
 }
 
@@ -213,6 +298,20 @@ impl RuntimeDriver for BoxRuntimeDriver {
     }
 
     async fn capabilities(&self) -> RuntimeResult<RuntimeCapabilities> {
+        if self.secret_materialization.configured() {
+            self.secret_materialization.require_ready().await?;
+        }
+        let mut features = vec![
+            RuntimeFeature::DurableIdentity,
+            RuntimeFeature::Stop,
+            RuntimeFeature::Remove,
+            RuntimeFeature::ServiceTcp,
+            RuntimeFeature::Logs,
+            RuntimeFeature::Exec,
+        ];
+        if self.secret_materialization.configured() {
+            features.push(RuntimeFeature::SecretReferences);
+        }
         let capabilities = RuntimeCapabilities {
             schema: RuntimeCapabilities::SCHEMA.into(),
             provider_id: self.provider_id.clone(),
@@ -235,14 +334,7 @@ impl RuntimeDriver for BoxRuntimeDriver {
                 ResourceControl::Pids,
                 ResourceControl::ExecutionTimeout,
             ],
-            features: vec![
-                RuntimeFeature::DurableIdentity,
-                RuntimeFeature::Stop,
-                RuntimeFeature::Remove,
-                RuntimeFeature::ServiceTcp,
-                RuntimeFeature::Logs,
-                RuntimeFeature::Exec,
-            ],
+            features,
         };
         capabilities.validate().map_err(RuntimeError::Protocol)?;
         Ok(capabilities)

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -25,12 +25,15 @@ use a3s_runtime::{ProviderId, RuntimeDriver, RuntimeError, RuntimeResult, Runtim
 use async_trait::async_trait;
 use tokio::sync::OnceCell;
 
-use crate::{ExecutionIsolation, LocalExecutionManager};
+use crate::local_execution::TransientRegistryAuthBroker;
+use crate::{ExecutionIsolation, LocalExecutionManager, VmLocalExecutionBackend};
 
 use self::secret::SecretMaterializationOwner;
 use self::service_endpoints::ServiceEndpointOwner;
 
-pub use self::secret::{BoxSecretMaterial, BoxSecretMaterializationError, BoxSecretMaterializer};
+pub use self::secret::{
+    BoxRegistryCredential, BoxSecretMaterial, BoxSecretMaterializationError, BoxSecretMaterializer,
+};
 
 pub(super) const OCI_IMAGE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
 pub(super) const OCI_IMAGE_INDEX: &str = "application/vnd.oci.image.index.v1+json";
@@ -72,6 +75,7 @@ pub struct BoxRuntimeDriver {
     service_endpoints: ServiceEndpointOwner,
     execution_isolation: ExecutionIsolation,
     secret_materialization: SecretMaterializationOwner,
+    transient_registry_auth: Option<TransientRegistryAuthBroker>,
     provider_build: OnceCell<String>,
 }
 
@@ -90,11 +94,16 @@ impl BoxRuntimeDriver {
         execution_isolation: ExecutionIsolation,
     ) -> RuntimeResult<Self> {
         validate_config(&config)?;
-        let manager = LocalExecutionManager::with_vm_backend(
-            config.home_dir.join("boxes.json"),
-            &config.home_dir,
-        );
-        Self::with_manager(config, manager, execution_isolation)
+        let (manager, broker) = production_manager(&config);
+        let connector: Arc<dyn ExecutionPortConnector> = Arc::new(manager.clone());
+        Self::with_manager_connector_and_materializer(
+            config,
+            manager,
+            connector,
+            execution_isolation,
+            None,
+            Some(broker),
+        )
     }
 
     /// Compose the shared Box driver with one caller-owned Secret resolver.
@@ -103,23 +112,12 @@ impl BoxRuntimeDriver {
     /// authenticated control channel. It is not a second lifecycle or Secret
     /// store, and Box never persists the returned bytes.
     pub fn with_secret_materializer(
-        config: BoxRuntimeDriverConfig,
-        execution_isolation: ExecutionIsolation,
+        mut self,
         materializer: Arc<dyn BoxSecretMaterializer>,
-    ) -> RuntimeResult<Self> {
-        validate_config(&config)?;
-        let manager = LocalExecutionManager::with_vm_backend(
-            config.home_dir.join("boxes.json"),
-            &config.home_dir,
-        );
-        let connector: Arc<dyn ExecutionPortConnector> = Arc::new(manager.clone());
-        Self::with_manager_connector_and_materializer(
-            config,
-            manager,
-            connector,
-            execution_isolation,
-            Some(materializer),
-        )
+    ) -> Self {
+        self.secret_materialization =
+            SecretMaterializationOwner::new(self.config.secret_root.clone(), Some(materializer));
+        self
     }
 
     fn with_manager(
@@ -143,6 +141,7 @@ impl BoxRuntimeDriver {
             connector,
             execution_isolation,
             None,
+            None,
         )
     }
 
@@ -152,6 +151,7 @@ impl BoxRuntimeDriver {
         connector: Arc<dyn ExecutionPortConnector>,
         execution_isolation: ExecutionIsolation,
         materializer: Option<Arc<dyn BoxSecretMaterializer>>,
+        transient_registry_auth: Option<TransientRegistryAuthBroker>,
     ) -> RuntimeResult<Self> {
         validate_config(&config)?;
         let endpoint_connector = Arc::clone(&connector);
@@ -165,6 +165,7 @@ impl BoxRuntimeDriver {
             service_endpoints: ServiceEndpointOwner::new(endpoint_connector),
             execution_isolation,
             secret_materialization,
+            transient_registry_auth,
             provider_build: OnceCell::new(),
         })
     }
@@ -212,6 +213,20 @@ impl BoxRuntimeDriver {
                 ))
             })?
     }
+}
+
+fn production_manager(
+    config: &BoxRuntimeDriverConfig,
+) -> (LocalExecutionManager, TransientRegistryAuthBroker) {
+    let broker = TransientRegistryAuthBroker::default();
+    let backend =
+        VmLocalExecutionBackend::new(&config.home_dir).with_transient_registry_auth(broker.clone());
+    let manager = LocalExecutionManager::new(
+        config.home_dir.join("boxes.json"),
+        &config.home_dir,
+        Arc::new(backend),
+    );
+    (manager, broker)
 }
 
 fn probe_provider_build(execution_isolation: ExecutionIsolation) -> Result<String, String> {

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -120,31 +120,6 @@ impl BoxRuntimeDriver {
         self
     }
 
-    fn with_manager(
-        config: BoxRuntimeDriverConfig,
-        manager: LocalExecutionManager,
-        execution_isolation: ExecutionIsolation,
-    ) -> RuntimeResult<Self> {
-        let connector: Arc<dyn ExecutionPortConnector> = Arc::new(manager.clone());
-        Self::with_manager_and_connector(config, manager, connector, execution_isolation)
-    }
-
-    fn with_manager_and_connector(
-        config: BoxRuntimeDriverConfig,
-        manager: LocalExecutionManager,
-        connector: Arc<dyn ExecutionPortConnector>,
-        execution_isolation: ExecutionIsolation,
-    ) -> RuntimeResult<Self> {
-        Self::with_manager_connector_and_materializer(
-            config,
-            manager,
-            connector,
-            execution_isolation,
-            None,
-            None,
-        )
-    }
-
     fn with_manager_connector_and_materializer(
         config: BoxRuntimeDriverConfig,
         manager: LocalExecutionManager,

--- a/src/runtime/src/a3s_runtime_driver/secret.rs
+++ b/src/runtime/src/a3s_runtime_driver/secret.rs
@@ -12,7 +12,12 @@ use async_trait::async_trait;
 use tokio::io::AsyncWriteExt;
 use zeroize::{Zeroize, Zeroizing};
 
+use crate::local_execution::{TransientRegistryAuthBroker, TransientRegistryAuthLease};
+use crate::{BoxRecord, ImagePuller, ImageReference, ImageStore, RegistryAuth};
+
 const MAX_SECRET_BYTES: usize = 1024 * 1024;
+const MAX_REGISTRY_USERNAME_BYTES: usize = 255;
+const MAX_REGISTRY_PASSWORD_BYTES: usize = 16 * 1024;
 const TMPFS_MAGIC: libc::c_long = 0x0102_1994;
 
 /// Provider-neutral Secret resolver supplied by the authenticated caller.
@@ -28,6 +33,13 @@ pub trait BoxSecretMaterializer: Send + Sync {
         &self,
         reference: &SecretReference,
     ) -> Result<BoxSecretMaterial, BoxSecretMaterializationError>;
+
+    /// Resolve one registry credential immediately before an uncached pull.
+    async fn materialize_registry_credential(
+        &self,
+        reference: &SecretReference,
+        registry: &str,
+    ) -> Result<BoxRegistryCredential, BoxSecretMaterializationError>;
 }
 
 /// Zeroizing Secret bytes returned across the Box materialization port.
@@ -53,6 +65,50 @@ impl BoxSecretMaterial {
 impl fmt::Debug for BoxSecretMaterial {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("<redacted-box-secret-material>")
+    }
+}
+
+/// Zeroizing Basic-auth material used only for one registry pull boundary.
+pub struct BoxRegistryCredential {
+    username: Zeroizing<String>,
+    password: Zeroizing<String>,
+}
+
+impl BoxRegistryCredential {
+    pub fn new(
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Result<Self, BoxSecretMaterializationError> {
+        let mut username = username.into();
+        let mut password = password.into();
+        let valid_username =
+            valid_registry_field(&username, MAX_REGISTRY_USERNAME_BYTES) && !username.contains(':');
+        let valid_password = valid_registry_field(&password, MAX_REGISTRY_PASSWORD_BYTES);
+        if !valid_username || !valid_password {
+            username.zeroize();
+            password.zeroize();
+            return Err(BoxSecretMaterializationError::Rejected(
+                "Registry credential material is invalid".into(),
+            ));
+        }
+        Ok(Self {
+            username: Zeroizing::new(username),
+            password: Zeroizing::new(password),
+        })
+    }
+
+    pub fn username(&self) -> &str {
+        self.username.as_str()
+    }
+
+    pub fn password(&self) -> &str {
+        self.password.as_str()
+    }
+}
+
+impl fmt::Debug for BoxRegistryCredential {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("<redacted-box-registry-credential>")
     }
 }
 
@@ -101,7 +157,13 @@ impl SecretMaterializationOwner {
     }
 
     pub(super) async fn materialize_for_start(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
-        if spec.secrets.is_empty() {
+        let container_secrets = spec
+            .secrets
+            .iter()
+            .enumerate()
+            .filter(|(_, reference)| !matches!(reference.target, SecretTarget::RegistryCredential))
+            .collect::<Vec<_>>();
+        if container_secrets.is_empty() {
             return Ok(());
         }
         let materializer = self.materializer.as_ref().ok_or_else(|| {
@@ -111,13 +173,7 @@ impl SecretMaterializationOwner {
         let directory = secret_directory(&self.root, spec)?;
         ensure_private_directory(&directory).await?;
 
-        for (index, reference) in spec.secrets.iter().enumerate() {
-            if matches!(reference.target, SecretTarget::RegistryCredential) {
-                self.cleanup_directory(&directory).await?;
-                return Err(RuntimeError::UnsupportedCapabilities(vec![
-                    "feature:RegistryCredentials".into(),
-                ]));
-            }
+        for (index, reference) in container_secrets {
             let material = match materializer.materialize(reference).await {
                 Ok(material) => material,
                 Err(error) => {
@@ -143,15 +199,17 @@ impl SecretMaterializationOwner {
     }
 
     pub(super) async fn require_materialized(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
-        if spec.secrets.is_empty() {
+        if !spec
+            .secrets
+            .iter()
+            .any(|reference| !matches!(reference.target, SecretTarget::RegistryCredential))
+        {
             return Ok(());
         }
         self.require_ready().await?;
         for (index, reference) in spec.secrets.iter().enumerate() {
             if matches!(reference.target, SecretTarget::RegistryCredential) {
-                return Err(RuntimeError::UnsupportedCapabilities(vec![
-                    "feature:RegistryCredentials".into(),
-                ]));
+                continue;
             }
             let path = secret_file(&self.root, spec, index)?;
             let expected_mode = secret_mode(&reference.target);
@@ -179,9 +237,7 @@ impl SecretMaterializationOwner {
         })?;
         for reference in &spec.secrets {
             if matches!(reference.target, SecretTarget::RegistryCredential) {
-                return Err(RuntimeError::UnsupportedCapabilities(vec![
-                    "feature:RegistryCredentials".into(),
-                ]));
+                continue;
             }
             let material = materializer
                 .materialize(reference)
@@ -191,6 +247,53 @@ impl SecretMaterializationOwner {
             materials.push(material);
         }
         Ok(materials)
+    }
+
+    pub(super) async fn prepare_registry_auth_for_start(
+        &self,
+        spec: &RuntimeUnitSpec,
+        record: &BoxRecord,
+        home_dir: &Path,
+        broker: Option<&TransientRegistryAuthBroker>,
+    ) -> RuntimeResult<Option<TransientRegistryAuthLease>> {
+        let registry_reference = registry_reference(spec)?;
+        let Some(broker) = broker else {
+            if registry_reference.is_some() {
+                return Err(RuntimeError::UnsupportedCapabilities(vec![
+                    "feature:RegistryCredentials".into(),
+                ]));
+            }
+            return Ok(None);
+        };
+        let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+            RuntimeError::Protocol("Box execution lost managed creation metadata".into())
+        })?;
+        let image = &metadata.request.config.image;
+        let auth = match registry_reference {
+            Some(reference) if !image_is_cached(home_dir, image).await? => {
+                let registry = ImageReference::parse(image)
+                    .map_err(|_| {
+                        RuntimeError::Protocol(
+                            "Box managed artifact has an invalid registry identity".into(),
+                        )
+                    })?
+                    .registry;
+                let materializer = self.materializer.as_ref().ok_or_else(|| {
+                    RuntimeError::UnsupportedCapabilities(vec!["feature:SecretReferences".into()])
+                })?;
+                let credential = materializer
+                    .materialize_registry_credential(reference, &registry)
+                    .await
+                    .map_err(map_materialization_error)?;
+                RegistryAuth::basic(credential.username(), credential.password())
+            }
+            Some(_) | None => RegistryAuth::anonymous(),
+        };
+        broker.bind(&record.id, auth).map(Some).map_err(|error| {
+            RuntimeError::ProviderUnavailable(format!(
+                "Box transient registry credential handoff failed: {error}"
+            ))
+        })
     }
 
     pub(super) async fn cleanup_spec(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
@@ -262,6 +365,36 @@ fn validate_material_for_target(bytes: &[u8], target: &SecretTarget) -> RuntimeR
         ));
     }
     Ok(())
+}
+
+fn valid_registry_field(value: &str, maximum: usize) -> bool {
+    !value.is_empty() && value.len() <= maximum && !value.chars().any(char::is_control)
+}
+
+fn registry_reference(spec: &RuntimeUnitSpec) -> RuntimeResult<Option<&SecretReference>> {
+    let mut references = spec
+        .secrets
+        .iter()
+        .filter(|reference| matches!(reference.target, SecretTarget::RegistryCredential));
+    let first = references.next();
+    if references.next().is_some() {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Runtime specification has multiple registry credential Secrets".into(),
+        ));
+    }
+    Ok(first)
+}
+
+async fn image_is_cached(home_dir: &Path, reference: &str) -> RuntimeResult<bool> {
+    let images = home_dir.join("images");
+    let store = ImageStore::new(&images, crate::DEFAULT_IMAGE_CACHE_SIZE).map_err(|error| {
+        RuntimeError::ProviderUnavailable(format!(
+            "Box image cache could not be inspected before registry authorization: {error}"
+        ))
+    })?;
+    Ok(ImagePuller::new(Arc::new(store), RegistryAuth::anonymous())
+        .is_cached(reference)
+        .await)
 }
 
 fn map_materialization_error(error: BoxSecretMaterializationError) -> RuntimeError {
@@ -465,5 +598,26 @@ mod tests {
     fn material_debug_output_never_contains_plaintext() {
         let material = BoxSecretMaterial::new(b"box-secret-fixture".to_vec()).unwrap();
         assert_eq!(format!("{material:?}"), "<redacted-box-secret-material>");
+    }
+
+    #[test]
+    fn registry_credential_is_bounded_and_redacted() {
+        let credential = BoxRegistryCredential::new("registry-user", "registry-password").unwrap();
+        assert_eq!(credential.username(), "registry-user");
+        assert_eq!(credential.password(), "registry-password");
+        assert_eq!(
+            format!("{credential:?}"),
+            "<redacted-box-registry-credential>"
+        );
+
+        for (username, password) in [
+            ("", "password"),
+            ("user:name", "password"),
+            ("username", ""),
+            ("username", "password\nleak"),
+            ("username", "password\tleak"),
+        ] {
+            assert!(BoxRegistryCredential::new(username, password).is_err());
+        }
     }
 }

--- a/src/runtime/src/a3s_runtime_driver/secret.rs
+++ b/src/runtime/src/a3s_runtime_driver/secret.rs
@@ -1,0 +1,469 @@
+//! Transient Runtime Secret material owned by the Box provider boundary.
+
+use std::fmt;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use a3s_runtime::contract::{RuntimeUnitSpec, SecretReference, SecretTarget};
+use a3s_runtime::{RuntimeError, RuntimeResult};
+use async_trait::async_trait;
+use tokio::io::AsyncWriteExt;
+use zeroize::{Zeroize, Zeroizing};
+
+const MAX_SECRET_BYTES: usize = 1024 * 1024;
+const TMPFS_MAGIC: libc::c_long = 0x0102_1994;
+
+/// Provider-neutral Secret resolver supplied by the authenticated caller.
+///
+/// Box deliberately accepts the shared Runtime [`SecretReference`] rather than
+/// a Cloud type. The caller owns authorization and remote transport; Box owns
+/// only transient node-local materialization and cleanup. A reference must
+/// resolve to the same bytes for the lifetime of one Runtime specification;
+/// rotation uses a new reference and therefore a new specification digest.
+#[async_trait]
+pub trait BoxSecretMaterializer: Send + Sync {
+    async fn materialize(
+        &self,
+        reference: &SecretReference,
+    ) -> Result<BoxSecretMaterial, BoxSecretMaterializationError>;
+}
+
+/// Zeroizing Secret bytes returned across the Box materialization port.
+pub struct BoxSecretMaterial(Zeroizing<Vec<u8>>);
+
+impl BoxSecretMaterial {
+    pub fn new(value: impl Into<Vec<u8>>) -> Result<Self, BoxSecretMaterializationError> {
+        let mut value = value.into();
+        if value.is_empty() || value.len() > MAX_SECRET_BYTES {
+            value.zeroize();
+            return Err(BoxSecretMaterializationError::Rejected(
+                "Secret material must contain between 1 byte and 1 MiB".into(),
+            ));
+        }
+        Ok(Self(Zeroizing::new(value)))
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl fmt::Debug for BoxSecretMaterial {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("<redacted-box-secret-material>")
+    }
+}
+
+/// Stable, non-sensitive failure categories for caller-provided resolvers.
+#[derive(Debug, thiserror::Error)]
+pub enum BoxSecretMaterializationError {
+    #[error("Secret reference was rejected: {0}")]
+    Rejected(String),
+    #[error("Secret material is temporarily unavailable: {0}")]
+    Unavailable(String),
+}
+
+#[derive(Clone)]
+pub(super) struct SecretMaterializationOwner {
+    root: PathBuf,
+    materializer: Option<Arc<dyn BoxSecretMaterializer>>,
+}
+
+impl SecretMaterializationOwner {
+    pub(super) fn new(root: PathBuf, materializer: Option<Arc<dyn BoxSecretMaterializer>>) -> Self {
+        Self { root, materializer }
+    }
+
+    pub(super) fn configured(&self) -> bool {
+        self.materializer.is_some()
+    }
+
+    pub(super) fn require_configured_for(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+        if !spec.secrets.is_empty() && self.materializer.is_none() {
+            return Err(RuntimeError::UnsupportedCapabilities(vec![
+                "feature:SecretReferences".into(),
+            ]));
+        }
+        Ok(())
+    }
+
+    pub(super) async fn require_ready(&self) -> RuntimeResult<()> {
+        let root = self.root.clone();
+        tokio::task::spawn_blocking(move || validate_secret_root(&root))
+            .await
+            .map_err(|error| {
+                RuntimeError::ProviderUnavailable(format!(
+                    "Box Secret-root validation task failed: {error}"
+                ))
+            })?
+    }
+
+    pub(super) async fn materialize_for_start(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+        if spec.secrets.is_empty() {
+            return Ok(());
+        }
+        let materializer = self.materializer.as_ref().ok_or_else(|| {
+            RuntimeError::UnsupportedCapabilities(vec!["feature:SecretReferences".into()])
+        })?;
+        self.require_ready().await?;
+        let directory = secret_directory(&self.root, spec)?;
+        ensure_private_directory(&directory).await?;
+
+        for (index, reference) in spec.secrets.iter().enumerate() {
+            if matches!(reference.target, SecretTarget::RegistryCredential) {
+                self.cleanup_directory(&directory).await?;
+                return Err(RuntimeError::UnsupportedCapabilities(vec![
+                    "feature:RegistryCredentials".into(),
+                ]));
+            }
+            let material = match materializer.materialize(reference).await {
+                Ok(material) => material,
+                Err(error) => {
+                    self.cleanup_directory(&directory).await?;
+                    return Err(map_materialization_error(error));
+                }
+            };
+            if let Err(error) = validate_material_for_target(material.as_bytes(), &reference.target)
+            {
+                self.cleanup_directory(&directory).await?;
+                return Err(error);
+            }
+            let path = secret_file(&self.root, spec, index)?;
+            if let Err(error) =
+                write_secret_atomically(&path, material.as_bytes(), secret_mode(&reference.target))
+                    .await
+            {
+                self.cleanup_directory(&directory).await?;
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn require_materialized(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+        if spec.secrets.is_empty() {
+            return Ok(());
+        }
+        self.require_ready().await?;
+        for (index, reference) in spec.secrets.iter().enumerate() {
+            if matches!(reference.target, SecretTarget::RegistryCredential) {
+                return Err(RuntimeError::UnsupportedCapabilities(vec![
+                    "feature:RegistryCredentials".into(),
+                ]));
+            }
+            let path = secret_file(&self.root, spec, index)?;
+            let expected_mode = secret_mode(&reference.target);
+            tokio::task::spawn_blocking(move || validate_materialized_file(&path, expected_mode))
+                .await
+                .map_err(|error| {
+                    RuntimeError::ProviderUnavailable(format!(
+                        "Box Secret-file validation task failed: {error}"
+                    ))
+                })??;
+        }
+        Ok(())
+    }
+
+    pub(super) async fn resolve_for_redaction(
+        &self,
+        spec: &RuntimeUnitSpec,
+    ) -> RuntimeResult<Vec<BoxSecretMaterial>> {
+        if spec.secrets.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut materials = Vec::with_capacity(spec.secrets.len());
+        let materializer = self.materializer.as_ref().ok_or_else(|| {
+            RuntimeError::UnsupportedCapabilities(vec!["feature:SecretReferences".into()])
+        })?;
+        for reference in &spec.secrets {
+            if matches!(reference.target, SecretTarget::RegistryCredential) {
+                return Err(RuntimeError::UnsupportedCapabilities(vec![
+                    "feature:RegistryCredentials".into(),
+                ]));
+            }
+            let material = materializer
+                .materialize(reference)
+                .await
+                .map_err(map_materialization_error)?;
+            validate_material_for_target(material.as_bytes(), &reference.target)?;
+            materials.push(material);
+        }
+        Ok(materials)
+    }
+
+    pub(super) async fn cleanup_spec(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+        let directory = secret_directory(&self.root, spec)?;
+        self.cleanup_directory(&directory).await
+    }
+
+    pub(super) async fn cleanup_digest(&self, digest: &str) -> RuntimeResult<()> {
+        let directory = self.root.join(digest_component(digest)?);
+        self.cleanup_directory(&directory).await
+    }
+
+    async fn cleanup_directory(&self, directory: &Path) -> RuntimeResult<()> {
+        let root = self.root.clone();
+        let directory = directory.to_path_buf();
+        tokio::task::spawn_blocking(move || remove_secret_directory(&root, &directory))
+            .await
+            .map_err(|error| {
+                RuntimeError::ProviderUnavailable(format!(
+                    "Box Secret cleanup task failed: {error}"
+                ))
+            })?
+    }
+}
+
+pub(super) fn secret_file(
+    root: &Path,
+    spec: &RuntimeUnitSpec,
+    index: usize,
+) -> RuntimeResult<PathBuf> {
+    if index >= spec.secrets.len() {
+        return Err(RuntimeError::Protocol(
+            "Box Secret-file index is outside the Runtime specification".into(),
+        ));
+    }
+    Ok(secret_directory(root, spec)?.join(format!("{index:03}.secret")))
+}
+
+pub(super) fn secret_directory(root: &Path, spec: &RuntimeUnitSpec) -> RuntimeResult<PathBuf> {
+    let digest = spec.digest().map_err(RuntimeError::InvalidRequest)?;
+    Ok(root.join(digest_component(&digest)?))
+}
+
+fn digest_component(digest: &str) -> RuntimeResult<&str> {
+    let component = digest.strip_prefix("sha256:").ok_or_else(|| {
+        RuntimeError::Protocol("Box Secret identity requires a SHA-256 specification digest".into())
+    })?;
+    if component.len() != 64 || !component.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(RuntimeError::Protocol(
+            "Box Secret identity contains an invalid specification digest".into(),
+        ));
+    }
+    Ok(component)
+}
+
+fn secret_mode(target: &SecretTarget) -> u32 {
+    match target {
+        SecretTarget::File { mode, .. } => *mode,
+        SecretTarget::Environment { .. } | SecretTarget::RegistryCredential => 0o400,
+    }
+}
+
+fn validate_material_for_target(bytes: &[u8], target: &SecretTarget) -> RuntimeResult<()> {
+    if matches!(target, SecretTarget::Environment { .. })
+        && (std::str::from_utf8(bytes).is_err() || bytes.contains(&0))
+    {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Secret environment material must be non-empty UTF-8 without NUL bytes".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn map_materialization_error(error: BoxSecretMaterializationError) -> RuntimeError {
+    match error {
+        BoxSecretMaterializationError::Rejected(_) => RuntimeError::InvalidRequest(
+            "Box Secret reference was rejected by the caller materializer".into(),
+        ),
+        BoxSecretMaterializationError::Unavailable(_) => RuntimeError::ProviderUnavailable(
+            "Box Secret materializer is temporarily unavailable".into(),
+        ),
+    }
+}
+
+async fn ensure_private_directory(path: &Path) -> RuntimeResult<()> {
+    match tokio::fs::create_dir(path).await {
+        Ok(()) => {
+            tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+                .await
+                .map_err(secret_io_error)?;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(secret_io_error(error)),
+    }
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || validate_private_directory(&path))
+        .await
+        .map_err(|error| {
+            RuntimeError::ProviderUnavailable(format!(
+                "Box Secret-directory validation task failed: {error}"
+            ))
+        })?
+}
+
+async fn write_secret_atomically(path: &Path, bytes: &[u8], mode: u32) -> RuntimeResult<()> {
+    let parent = path.parent().ok_or_else(|| {
+        RuntimeError::Protocol("Box Secret file has no materialization directory".into())
+    })?;
+    let temporary = parent.join(format!(
+        ".{}.{}.tmp",
+        path.file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("secret"),
+        uuid::Uuid::new_v4().simple()
+    ));
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .await
+        .map_err(secret_io_error)?;
+    let result = async {
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .await
+            .map_err(secret_io_error)?;
+        file.write_all(bytes).await.map_err(secret_io_error)?;
+        file.flush().await.map_err(secret_io_error)?;
+        file.sync_all().await.map_err(secret_io_error)?;
+        file.set_permissions(std::fs::Permissions::from_mode(mode))
+            .await
+            .map_err(secret_io_error)?;
+        drop(file);
+        tokio::fs::rename(&temporary, path)
+            .await
+            .map_err(secret_io_error)?;
+        sync_directory(parent).await
+    }
+    .await;
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&temporary).await;
+    }
+    result
+}
+
+async fn sync_directory(path: &Path) -> RuntimeResult<()> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        std::fs::File::open(path)
+            .and_then(|directory| directory.sync_all())
+            .map_err(secret_io_error)
+    })
+    .await
+    .map_err(|error| {
+        RuntimeError::ProviderUnavailable(format!("Box Secret sync task failed: {error}"))
+    })?
+}
+
+fn validate_secret_root(root: &Path) -> RuntimeResult<()> {
+    validate_absolute_normalized(root, "Secret root")?;
+    let metadata = std::fs::symlink_metadata(root).map_err(secret_io_error)?;
+    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+        return Err(RuntimeError::ProviderUnavailable(
+            "Box Secret root is not a plain directory".into(),
+        ));
+    }
+    let canonical = root.canonicalize().map_err(secret_io_error)?;
+    if canonical != root {
+        return Err(RuntimeError::ProviderUnavailable(
+            "Box Secret root must already be canonical and contain no links".into(),
+        ));
+    }
+    if metadata.uid() != unsafe { libc::geteuid() } || metadata.mode() & 0o077 != 0 {
+        return Err(RuntimeError::ProviderUnavailable(
+            "Box Secret root must be owned by the provider process and inaccessible to group and other users"
+                .into(),
+        ));
+    }
+    let path = std::ffi::CString::new(root.as_os_str().as_bytes())
+        .map_err(|_| RuntimeError::InvalidRequest("Box Secret root contains a NUL byte".into()))?;
+    let mut status = std::mem::MaybeUninit::<libc::statfs>::uninit();
+    if unsafe { libc::statfs(path.as_ptr(), status.as_mut_ptr()) } != 0 {
+        return Err(secret_io_error(std::io::Error::last_os_error()));
+    }
+    let status = unsafe { status.assume_init() };
+    if status.f_type as libc::c_long != TMPFS_MAGIC {
+        return Err(RuntimeError::ProviderUnavailable(
+            "Box Secret root must be a Linux tmpfs mount".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_private_directory(path: &Path) -> RuntimeResult<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(secret_io_error)?;
+    if !metadata.file_type().is_dir()
+        || metadata.file_type().is_symlink()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.mode() & 0o777 != 0o700
+    {
+        return Err(RuntimeError::ProviderUnavailable(
+            "Box Secret materialization directory is not a provider-owned 0700 directory".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_materialized_file(path: &Path, expected_mode: u32) -> RuntimeResult<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(secret_io_error)?;
+    if !metadata.file_type().is_file()
+        || metadata.file_type().is_symlink()
+        || metadata.nlink() != 1
+        || metadata.len() == 0
+        || metadata.len() > MAX_SECRET_BYTES as u64
+        || metadata.mode() & 0o777 != expected_mode
+    {
+        return Err(RuntimeError::ProviderUnavailable(
+            "Box Secret material is missing or violates its regular-file, size, or mode contract"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn remove_secret_directory(root: &Path, directory: &Path) -> RuntimeResult<()> {
+    validate_absolute_normalized(root, "Secret root")?;
+    if directory.parent() != Some(root) {
+        return Err(RuntimeError::Protocol(
+            "Box Secret cleanup target escaped its configured root".into(),
+        ));
+    }
+    match std::fs::symlink_metadata(directory) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(secret_io_error(error)),
+        Ok(metadata) if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() => {}
+        Ok(_) => {
+            return Err(RuntimeError::ProviderUnavailable(
+                "Box Secret cleanup target is not a plain directory".into(),
+            ))
+        }
+    }
+    std::fs::remove_dir_all(directory).map_err(secret_io_error)?;
+    std::fs::File::open(root)
+        .and_then(|directory| directory.sync_all())
+        .map_err(secret_io_error)
+}
+
+fn validate_absolute_normalized(path: &Path, label: &str) -> RuntimeResult<()> {
+    if !path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::CurDir | Component::ParentDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(RuntimeError::InvalidRequest(format!(
+            "Box {label} must be an absolute normalized Linux path"
+        )));
+    }
+    Ok(())
+}
+
+fn secret_io_error(error: std::io::Error) -> RuntimeError {
+    RuntimeError::ProviderUnavailable(format!("Box Secret filesystem operation failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn material_debug_output_never_contains_plaintext() {
+        let material = BoxSecretMaterial::new(b"box-secret-fixture".to_vec()).unwrap();
+        assert_eq!(format!("{material:?}"), "<redacted-box-secret-material>");
+    }
+}

--- a/src/runtime/src/a3s_runtime_driver/secret.rs
+++ b/src/runtime/src/a3s_runtime_driver/secret.rs
@@ -495,9 +495,11 @@ fn validate_secret_root(root: &Path) -> RuntimeResult<()> {
             "Box Secret root must already be canonical and contain no links".into(),
         ));
     }
-    if metadata.uid() != unsafe { libc::geteuid() } || metadata.mode() & 0o077 != 0 {
+    if metadata.uid() != unsafe { libc::geteuid() }
+        || !matches!(metadata.mode() & 0o7777, 0o700 | 0o710)
+    {
         return Err(RuntimeError::ProviderUnavailable(
-            "Box Secret root must be owned by the provider process and inaccessible to group and other users"
+            "Box Secret root must be provider-owned, non-listable, and inaccessible to other users"
                 .into(),
         ));
     }
@@ -521,10 +523,10 @@ fn validate_private_directory(path: &Path) -> RuntimeResult<()> {
     if !metadata.file_type().is_dir()
         || metadata.file_type().is_symlink()
         || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.mode() & 0o777 != 0o700
+        || !matches!(metadata.mode() & 0o7777, 0o700 | 0o710)
     {
         return Err(RuntimeError::ProviderUnavailable(
-            "Box Secret materialization directory is not a provider-owned 0700 directory".into(),
+            "Box Secret materialization directory is not a private provider-owned directory".into(),
         ));
     }
     Ok(())
@@ -594,6 +596,9 @@ fn secret_io_error(error: std::io::Error) -> RuntimeError {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     #[test]
     fn material_debug_output_never_contains_plaintext() {
         let material = BoxSecretMaterial::new(b"box-secret-fixture".to_vec()).unwrap();
@@ -618,6 +623,23 @@ mod tests {
             ("username", "password\tleak"),
         ] {
             assert!(BoxRegistryCredential::new(username, password).is_err());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_directory_allows_only_sandbox_search_access() {
+        let directory = tempfile::tempdir().unwrap();
+        for mode in [0o700, 0o710] {
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(mode))
+                .unwrap();
+            validate_private_directory(directory.path()).unwrap();
+        }
+
+        for mode in [0o711, 0o720, 0o740, 0o770] {
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(mode))
+                .unwrap();
+            assert!(validate_private_directory(directory.path()).is_err());
         }
     }
 }

--- a/src/runtime/src/a3s_runtime_driver/test_support.rs
+++ b/src/runtime/src/a3s_runtime_driver/test_support.rs
@@ -16,14 +16,15 @@ use a3s_runtime::RuntimeUnitRecord;
 use async_trait::async_trait;
 use tokio::sync::{oneshot, Semaphore};
 
+use crate::local_execution::TransientRegistryAuthBroker;
 use crate::{
     BoxRecord, LocalExecutionBackend, LocalExecutionHandle, LocalExecutionManager,
     LocalExecutionObservation,
 };
 
 use super::{
-    BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial, BoxSecretMaterializationError,
-    BoxSecretMaterializer, OCI_IMAGE_MANIFEST,
+    BoxRegistryCredential, BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial,
+    BoxSecretMaterializationError, BoxSecretMaterializer, OCI_IMAGE_MANIFEST,
 };
 
 #[derive(Clone)]
@@ -303,6 +304,7 @@ impl LocalExecutionBackend for DriverFakeBackend {
 #[derive(Default)]
 pub(super) struct DriverFakeSecretMaterializer {
     materials: Mutex<HashMap<String, Vec<u8>>>,
+    registry_credentials: Mutex<HashMap<String, (String, String)>>,
     calls: AtomicUsize,
     failures: AtomicUsize,
 }
@@ -319,8 +321,28 @@ impl DriverFakeSecretMaterializer {
         self.failures.fetch_add(1, Ordering::SeqCst);
     }
 
+    pub(super) fn insert_registry_credential(
+        &self,
+        reference: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) {
+        self.registry_credentials
+            .lock()
+            .unwrap()
+            .insert(reference.into(), (username.into(), password.into()));
+    }
+
     pub(super) fn calls(&self) -> usize {
         self.calls.load(Ordering::SeqCst)
+    }
+
+    fn should_fail(&self) -> bool {
+        self.failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                (remaining > 0).then(|| remaining - 1)
+            })
+            .is_ok()
     }
 }
 
@@ -331,13 +353,7 @@ impl BoxSecretMaterializer for DriverFakeSecretMaterializer {
         reference: &SecretReference,
     ) -> Result<BoxSecretMaterial, BoxSecretMaterializationError> {
         self.calls.fetch_add(1, Ordering::SeqCst);
-        if self
-            .failures
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
-                (remaining > 0).then(|| remaining - 1)
-            })
-            .is_ok()
-        {
+        if self.should_fail() {
             return Err(BoxSecretMaterializationError::Unavailable(
                 "injected retryable fixture failure".into(),
             ));
@@ -354,6 +370,31 @@ impl BoxSecretMaterializer for DriverFakeSecretMaterializer {
                 )
             })?;
         BoxSecretMaterial::new(value)
+    }
+
+    async fn materialize_registry_credential(
+        &self,
+        reference: &SecretReference,
+        _registry: &str,
+    ) -> Result<BoxRegistryCredential, BoxSecretMaterializationError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.should_fail() {
+            return Err(BoxSecretMaterializationError::Unavailable(
+                "injected retryable fixture failure".into(),
+            ));
+        }
+        let (username, password) = self
+            .registry_credentials
+            .lock()
+            .unwrap()
+            .get(&reference.reference)
+            .cloned()
+            .ok_or_else(|| {
+                BoxSecretMaterializationError::Rejected(
+                    "fixture registry reference is not registered".into(),
+                )
+            })?;
+        BoxRegistryCredential::new(username, password)
     }
 }
 
@@ -456,6 +497,7 @@ fn configured_driver_with_materializer(
         connector,
         a3s_box_core::ExecutionIsolation::Microvm,
         materializer,
+        Some(TransientRegistryAuthBroker::default()),
     )
     .unwrap();
     driver

--- a/src/runtime/src/a3s_runtime_driver/test_support.rs
+++ b/src/runtime/src/a3s_runtime_driver/test_support.rs
@@ -10,7 +10,7 @@ use a3s_box_core::{
 use a3s_runtime::contract::{
     ArtifactRef, IsolationLevel, NetworkMode, ResourceLimits, RestartPolicy, RuntimeActionRequest,
     RuntimeNetworkSpec, RuntimeObservation, RuntimeProcessSpec, RuntimeUnitClass, RuntimeUnitSpec,
-    RuntimeUnitState,
+    RuntimeUnitState, SecretReference,
 };
 use a3s_runtime::RuntimeUnitRecord;
 use async_trait::async_trait;
@@ -21,7 +21,10 @@ use crate::{
     LocalExecutionObservation,
 };
 
-use super::{BoxRuntimeDriver, BoxRuntimeDriverConfig, OCI_IMAGE_MANIFEST};
+use super::{
+    BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial, BoxSecretMaterializationError,
+    BoxSecretMaterializer, OCI_IMAGE_MANIFEST,
+};
 
 #[derive(Clone)]
 struct FakeExecution {
@@ -297,6 +300,63 @@ impl LocalExecutionBackend for DriverFakeBackend {
     }
 }
 
+#[derive(Default)]
+pub(super) struct DriverFakeSecretMaterializer {
+    materials: Mutex<HashMap<String, Vec<u8>>>,
+    calls: AtomicUsize,
+    failures: AtomicUsize,
+}
+
+impl DriverFakeSecretMaterializer {
+    pub(super) fn insert(&self, reference: impl Into<String>, value: impl Into<Vec<u8>>) {
+        self.materials
+            .lock()
+            .unwrap()
+            .insert(reference.into(), value.into());
+    }
+
+    pub(super) fn fail_next(&self) {
+        self.failures.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(super) fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl BoxSecretMaterializer for DriverFakeSecretMaterializer {
+    async fn materialize(
+        &self,
+        reference: &SecretReference,
+    ) -> Result<BoxSecretMaterial, BoxSecretMaterializationError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self
+            .failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                (remaining > 0).then(|| remaining - 1)
+            })
+            .is_ok()
+        {
+            return Err(BoxSecretMaterializationError::Unavailable(
+                "injected retryable fixture failure".into(),
+            ));
+        }
+        let value = self
+            .materials
+            .lock()
+            .unwrap()
+            .get(&reference.reference)
+            .cloned()
+            .ok_or_else(|| {
+                BoxSecretMaterializationError::Rejected(
+                    "fixture reference is not registered".into(),
+                )
+            })?;
+        BoxSecretMaterial::new(value)
+    }
+}
+
 pub(super) fn fake_driver(
     directory: &tempfile::TempDir,
 ) -> (BoxRuntimeDriver, Arc<DriverFakeBackend>) {
@@ -333,13 +393,61 @@ where
     configured_driver(home_dir, manager, connector)
 }
 
+pub(super) fn fake_driver_with_secret_materializer(
+    directory: &tempfile::TempDir,
+    secret_root: std::path::PathBuf,
+    materializer: Arc<dyn BoxSecretMaterializer>,
+) -> (BoxRuntimeDriver, Arc<DriverFakeBackend>) {
+    let backend = Arc::new(DriverFakeBackend::default());
+    let driver = fake_driver_with_backend_and_secret_materializer(
+        directory,
+        backend.clone(),
+        secret_root,
+        materializer,
+    );
+    (driver, backend)
+}
+
+pub(super) fn fake_driver_with_backend_and_secret_materializer<B>(
+    directory: &tempfile::TempDir,
+    backend: Arc<B>,
+    secret_root: std::path::PathBuf,
+    materializer: Arc<dyn BoxSecretMaterializer>,
+) -> BoxRuntimeDriver
+where
+    B: LocalExecutionBackend + 'static,
+{
+    let home_dir = directory.path().join("home");
+    let manager = LocalExecutionManager::new(home_dir.join("boxes.json"), &home_dir, backend);
+    let connector: Arc<dyn ExecutionPortConnector> = Arc::new(manager.clone());
+    configured_driver_with_materializer(
+        home_dir,
+        secret_root,
+        manager,
+        connector,
+        Some(materializer),
+    )
+}
+
 fn configured_driver(
     home_dir: std::path::PathBuf,
     manager: LocalExecutionManager,
     connector: Arc<dyn ExecutionPortConnector>,
 ) -> BoxRuntimeDriver {
-    let driver = BoxRuntimeDriver::with_manager_and_connector(
+    let secret_root = home_dir.join("runtime-secrets");
+    configured_driver_with_materializer(home_dir, secret_root, manager, connector, None)
+}
+
+fn configured_driver_with_materializer(
+    home_dir: std::path::PathBuf,
+    secret_root: std::path::PathBuf,
+    manager: LocalExecutionManager,
+    connector: Arc<dyn ExecutionPortConnector>,
+    materializer: Option<Arc<dyn BoxSecretMaterializer>>,
+) -> BoxRuntimeDriver {
+    let driver = BoxRuntimeDriver::with_manager_connector_and_materializer(
         BoxRuntimeDriverConfig {
+            secret_root,
             home_dir,
             control_timeout: Duration::from_secs(2),
             task_poll_interval: Duration::from_millis(5),
@@ -347,6 +455,7 @@ fn configured_driver(
         manager,
         connector,
         a3s_box_core::ExecutionIsolation::Microvm,
+        materializer,
     )
     .unwrap();
     driver

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -446,7 +446,7 @@ fn mapping_rejects_secret_collisions_and_unencodable_targets() {
     });
     assert!(matches!(
         creation_request(&registry, TEST_EXECUTION_ISOLATION),
-        Err(RuntimeError::InvalidRequest(message)) if message.contains("multiple registry")
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("unique")
     ));
 }
 

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -87,6 +87,7 @@ fn driver_allows_explicit_shared_kernel_selection() {
     let driver = BoxRuntimeDriver::new_with_isolation(
         BoxRuntimeDriverConfig {
             home_dir: directory.path().join("home"),
+            secret_root: directory.path().join("runtime-secrets"),
             control_timeout: Duration::from_secs(2),
             task_poll_interval: Duration::from_millis(5),
         },
@@ -618,7 +619,12 @@ async fn metadata_rejects_a_record_created_for_another_box_isolation_backend() {
         .unwrap();
 
     assert!(matches!(
-        validate_record_for_spec(&record, &spec, ExecutionIsolation::Microvm),
+        validate_record_for_spec(
+            &record,
+            &spec,
+            ExecutionIsolation::Microvm,
+            &driver.config.secret_root,
+        ),
         Err(RuntimeError::Protocol(message)) if message.contains("creation intent")
     ));
 }

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -1,12 +1,13 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use a3s_box_core::secret::{SecretEnvironmentBinding, SECRET_ENVIRONMENT_MANIFEST};
 use a3s_box_core::{ExecutionIsolation, ExecutionManager};
 use a3s_runtime::contract::{
     ArtifactRef, HealthCheckKind, HealthProbe, IsolationLevel, MountKind, NetworkMode,
     ResourceControl, ResourceLimits, RestartPolicy, RuntimeFeature, RuntimeHealthCheck,
     RuntimeMount, RuntimeMountSource, RuntimeNetworkSpec, RuntimePort, RuntimeProcessSpec,
-    RuntimeUnitClass, RuntimeUnitSpec, TransportProtocol,
+    RuntimeUnitClass, RuntimeUnitSpec, SecretReference, SecretTarget, TransportProtocol,
 };
 use a3s_runtime::RuntimeDriver;
 
@@ -64,6 +65,7 @@ fn spec(class: RuntimeUnitClass) -> RuntimeUnitSpec {
 fn driver(directory: &tempfile::TempDir) -> BoxRuntimeDriver {
     BoxRuntimeDriver::new(BoxRuntimeDriverConfig {
         home_dir: directory.path().join("home"),
+        secret_root: directory.path().join("runtime-secrets"),
         control_timeout: Duration::from_secs(2),
         task_poll_interval: Duration::from_millis(5),
     })
@@ -296,6 +298,150 @@ fn mapping_compiles_bounded_tmpfs_mounts_and_read_only_intent() {
 }
 
 #[test]
+fn mapping_compiles_deterministic_non_secret_environment_and_file_bindings() {
+    let mut spec = spec(RuntimeUnitClass::Service);
+    spec.secrets = vec![
+        SecretReference {
+            name: "provider-token".into(),
+            reference: "secret://provider/token/v7".into(),
+            target: SecretTarget::Environment {
+                variable: "A3S_PROVIDER_TOKEN".into(),
+            },
+        },
+        SecretReference {
+            name: "provider-certificate".into(),
+            reference: "secret://provider/certificate/v4".into(),
+            target: SecretTarget::File {
+                path: "/run/provider/certificate.pem".into(),
+                mode: 0o440,
+            },
+        },
+    ];
+
+    let request = creation_request(&spec).unwrap();
+    let digest = spec.digest().unwrap();
+    let digest = digest.strip_prefix("sha256:").unwrap();
+    assert_eq!(
+        request.config.volumes,
+        vec![
+            format!(
+                "/run/a3s-box/runtime-secrets/{digest}/000.secret:/.a3s-box-secrets/{digest}/000.secret:ro"
+            ),
+            format!(
+                "/run/a3s-box/runtime-secrets/{digest}/001.secret:/run/provider/certificate.pem:ro"
+            ),
+        ]
+    );
+    assert_eq!(
+        request.policy.managed_secret_root.as_deref(),
+        Some(std::path::Path::new("/run/a3s-box/runtime-secrets"))
+    );
+    let manifest = request
+        .config
+        .extra_env
+        .iter()
+        .find(|(key, _)| key == SECRET_ENVIRONMENT_MANIFEST)
+        .map(|(_, value)| value)
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<Vec<SecretEnvironmentBinding>>(manifest).unwrap(),
+        vec![SecretEnvironmentBinding {
+            variable: "A3S_PROVIDER_TOKEN".into(),
+            path: format!("/.a3s-box-secrets/{digest}/000.secret"),
+        }]
+    );
+    let intent = serde_json::to_string(&request).unwrap();
+    assert!(!intent.contains("fixture-secret-plaintext"));
+}
+
+#[test]
+fn mapping_rejects_secret_collisions_unencodable_targets_and_registry_credentials() {
+    let environment_secret = SecretReference {
+        name: "provider-token".into(),
+        reference: "secret://provider/token/v7".into(),
+        target: SecretTarget::Environment {
+            variable: "A3S_PROVIDER_TOKEN".into(),
+        },
+    };
+
+    let mut literal_collision = spec(RuntimeUnitClass::Service);
+    literal_collision
+        .process
+        .environment
+        .insert("A3S_PROVIDER_TOKEN".into(), "literal".into());
+    literal_collision.secrets.push(environment_secret.clone());
+    assert!(matches!(
+        creation_request(&literal_collision),
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("conflicts")
+    ));
+
+    let mut reserved = spec(RuntimeUnitClass::Service);
+    reserved.process.environment.insert(
+        SECRET_ENVIRONMENT_MANIFEST.into(),
+        "caller-controlled".into(),
+    );
+    reserved.secrets.push(environment_secret);
+    assert!(matches!(
+        creation_request(&reserved),
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("reserved")
+    ));
+
+    for target in [
+        "/run/provider/token:alternate",
+        "/run/provider//token",
+        "/run/provider/./token",
+        "/proc/provider-token",
+        "/.a3s-box-secrets/escape",
+    ] {
+        let mut invalid = spec(RuntimeUnitClass::Service);
+        invalid.secrets.push(SecretReference {
+            name: "provider-token".into(),
+            reference: "secret://provider/token/v7".into(),
+            target: SecretTarget::File {
+                path: target.into(),
+                mode: 0o400,
+            },
+        });
+        assert!(matches!(
+            creation_request(&invalid),
+            Err(RuntimeError::InvalidRequest(message)) if message.contains("Secret file target")
+        ));
+    }
+
+    let mut overlap = spec(RuntimeUnitClass::Service);
+    overlap.mounts.push(RuntimeMount {
+        name: "runtime".into(),
+        source: RuntimeMountSource::Tmpfs { size_bytes: 4096 },
+        target: "/run/provider".into(),
+        read_only: false,
+    });
+    overlap.secrets.push(SecretReference {
+        name: "provider-token".into(),
+        reference: "secret://provider/token/v7".into(),
+        target: SecretTarget::File {
+            path: "/run/provider/token".into(),
+            mode: 0o400,
+        },
+    });
+    assert!(matches!(
+        creation_request(&overlap),
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("overlaps")
+    ));
+
+    let mut registry = spec(RuntimeUnitClass::Service);
+    registry.secrets.push(SecretReference {
+        name: "registry".into(),
+        reference: "secret://registry/credential/v2".into(),
+        target: SecretTarget::RegistryCredential,
+    });
+    assert!(matches!(
+        creation_request(&registry),
+        Err(RuntimeError::UnsupportedCapabilities(missing))
+            if missing == vec!["feature:RegistryCredentials"]
+    ));
+}
+
+#[test]
 fn mapping_rejects_unadvertised_mount_kinds_before_mutation() {
     let mut spec = spec(RuntimeUnitClass::Service);
     spec.mounts.push(RuntimeMount {
@@ -420,13 +566,24 @@ async fn metadata_tamper_is_rejected_fail_closed() {
         .await
         .unwrap()
         .unwrap();
-    validate_record_for_spec(&record, &spec, TEST_EXECUTION_ISOLATION).unwrap();
+    validate_record_for_spec(
+        &record,
+        &spec,
+        TEST_EXECUTION_ISOLATION,
+        &driver.config.secret_root,
+    )
+    .unwrap();
 
     record
         .labels
         .insert(super::metadata::GENERATION_LABEL.into(), "8".into());
     assert!(matches!(
-        validate_record_for_spec(&record, &spec, TEST_EXECUTION_ISOLATION),
+        validate_record_for_spec(
+            &record,
+            &spec,
+            TEST_EXECUTION_ISOLATION,
+            &driver.config.secret_root,
+        ),
         Err(RuntimeError::Protocol(message)) if message.contains("identity") || message.contains("intent")
     ));
 }

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -318,7 +318,7 @@ fn mapping_compiles_deterministic_non_secret_environment_and_file_bindings() {
         },
     ];
 
-    let request = creation_request(&spec).unwrap();
+    let request = creation_request(&spec, TEST_EXECUTION_ISOLATION).unwrap();
     let digest = spec.digest().unwrap();
     let digest = digest.strip_prefix("sha256:").unwrap();
     assert_eq!(
@@ -355,7 +355,7 @@ fn mapping_compiles_deterministic_non_secret_environment_and_file_bindings() {
 }
 
 #[test]
-fn mapping_rejects_secret_collisions_unencodable_targets_and_registry_credentials() {
+fn mapping_rejects_secret_collisions_and_unencodable_targets() {
     let environment_secret = SecretReference {
         name: "provider-token".into(),
         reference: "secret://provider/token/v7".into(),
@@ -371,7 +371,7 @@ fn mapping_rejects_secret_collisions_unencodable_targets_and_registry_credential
         .insert("A3S_PROVIDER_TOKEN".into(), "literal".into());
     literal_collision.secrets.push(environment_secret.clone());
     assert!(matches!(
-        creation_request(&literal_collision),
+        creation_request(&literal_collision, TEST_EXECUTION_ISOLATION),
         Err(RuntimeError::InvalidRequest(message)) if message.contains("conflicts")
     ));
 
@@ -382,7 +382,7 @@ fn mapping_rejects_secret_collisions_unencodable_targets_and_registry_credential
     );
     reserved.secrets.push(environment_secret);
     assert!(matches!(
-        creation_request(&reserved),
+        creation_request(&reserved, TEST_EXECUTION_ISOLATION),
         Err(RuntimeError::InvalidRequest(message)) if message.contains("reserved")
     ));
 
@@ -403,7 +403,7 @@ fn mapping_rejects_secret_collisions_unencodable_targets_and_registry_credential
             },
         });
         assert!(matches!(
-            creation_request(&invalid),
+            creation_request(&invalid, TEST_EXECUTION_ISOLATION),
             Err(RuntimeError::InvalidRequest(message)) if message.contains("Secret file target")
         ));
     }
@@ -424,7 +424,7 @@ fn mapping_rejects_secret_collisions_unencodable_targets_and_registry_credential
         },
     });
     assert!(matches!(
-        creation_request(&overlap),
+        creation_request(&overlap, TEST_EXECUTION_ISOLATION),
         Err(RuntimeError::InvalidRequest(message)) if message.contains("overlaps")
     ));
 
@@ -434,10 +434,18 @@ fn mapping_rejects_secret_collisions_unencodable_targets_and_registry_credential
         reference: "secret://registry/credential/v2".into(),
         target: SecretTarget::RegistryCredential,
     });
+    let request = creation_request(&registry, TEST_EXECUTION_ISOLATION).unwrap();
+    assert!(request.config.volumes.is_empty());
+    assert!(request.policy.managed_secret_root.is_none());
+
+    registry.secrets.push(SecretReference {
+        name: "registry-secondary".into(),
+        reference: "secret://registry/credential/v3".into(),
+        target: SecretTarget::RegistryCredential,
+    });
     assert!(matches!(
-        creation_request(&registry),
-        Err(RuntimeError::UnsupportedCapabilities(missing))
-            if missing == vec!["feature:RegistryCredentials"]
+        creation_request(&registry, TEST_EXECUTION_ISOLATION),
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("multiple registry")
     ));
 }
 

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -61,7 +61,10 @@ pub mod scale;
 pub use audit::{read_audit_log, AuditLog, AuditQuery};
 
 #[cfg(all(feature = "vm", target_os = "linux"))]
-pub use a3s_runtime_driver::{BoxRuntimeDriver, BoxRuntimeDriverConfig};
+pub use a3s_runtime_driver::{
+    BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial, BoxSecretMaterializationError,
+    BoxSecretMaterializer,
+};
 
 // Canonical local execution metadata
 pub use box_record::{

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -62,8 +62,8 @@ pub use audit::{read_audit_log, AuditLog, AuditQuery};
 
 #[cfg(all(feature = "vm", target_os = "linux"))]
 pub use a3s_runtime_driver::{
-    BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial, BoxSecretMaterializationError,
-    BoxSecretMaterializer,
+    BoxRegistryCredential, BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial,
+    BoxSecretMaterializationError, BoxSecretMaterializer,
 };
 
 // Canonical local execution metadata

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -24,6 +24,8 @@ mod session_unsupported;
 mod snapshot;
 mod store;
 mod support;
+#[cfg(all(feature = "vm", target_os = "linux"))]
+mod transient_registry_auth;
 #[cfg(feature = "vm")]
 mod vm_backend;
 #[cfg(feature = "vm")]
@@ -42,6 +44,8 @@ pub use backend::{
 };
 use record::{build_managed_record, status_from_record};
 use store::RuntimeUpdate;
+#[cfg(all(feature = "vm", target_os = "linux"))]
+pub(crate) use transient_registry_auth::{TransientRegistryAuthBroker, TransientRegistryAuthLease};
 #[cfg(feature = "vm")]
 pub use vm_backend::VmLocalExecutionBackend;
 

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -761,6 +761,7 @@ async fn create_preserves_complete_caller_record_policy() {
         stop_timeout: Some(12),
         oom_kill_disable: true,
         oom_score_adj: Some(100),
+        managed_secret_root: None,
     };
 
     let reservation = manager

--- a/src/runtime/src/local_execution/transient_registry_auth.rs
+++ b/src/runtime/src/local_execution/transient_registry_auth.rs
@@ -1,0 +1,98 @@
+//! In-memory handoff for one execution's registry pull credentials.
+
+use std::sync::Arc;
+
+use a3s_box_core::{ExecutionManagerError, ExecutionManagerResult};
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+
+use crate::oci::RegistryAuth;
+
+#[derive(Clone, Default)]
+pub(crate) struct TransientRegistryAuthBroker {
+    entries: Arc<DashMap<String, PendingRegistryAuth>>,
+}
+
+struct PendingRegistryAuth {
+    token: uuid::Uuid,
+    auth: RegistryAuth,
+}
+
+impl TransientRegistryAuthBroker {
+    pub(crate) fn bind(
+        &self,
+        execution_id: &str,
+        auth: RegistryAuth,
+    ) -> ExecutionManagerResult<TransientRegistryAuthLease> {
+        let token = uuid::Uuid::new_v4();
+        match self.entries.entry(execution_id.to_owned()) {
+            Entry::Vacant(entry) => {
+                entry.insert(PendingRegistryAuth { token, auth });
+            }
+            Entry::Occupied(_) => {
+                return Err(ExecutionManagerError::Unavailable(format!(
+                    "execution {execution_id} already has a pending transient registry credential"
+                )));
+            }
+        }
+        Ok(TransientRegistryAuthLease {
+            broker: self.clone(),
+            execution_id: execution_id.to_owned(),
+            token,
+        })
+    }
+
+    pub(crate) fn take(&self, execution_id: &str) -> Option<RegistryAuth> {
+        self.entries
+            .remove(execution_id)
+            .map(|(_, pending)| pending.auth)
+    }
+
+    fn release(&self, execution_id: &str, token: uuid::Uuid) {
+        if let Entry::Occupied(entry) = self.entries.entry(execution_id.to_owned()) {
+            if entry.get().token == token {
+                entry.remove();
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+pub(crate) struct TransientRegistryAuthLease {
+    broker: TransientRegistryAuthBroker,
+    execution_id: String,
+    token: uuid::Uuid,
+}
+
+impl Drop for TransientRegistryAuthLease {
+    fn drop(&mut self) {
+        self.broker.release(&self.execution_id, self.token);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lease_does_not_remove_a_newer_handoff_after_consumption() {
+        let broker = TransientRegistryAuthBroker::default();
+        let first = broker
+            .bind("execution", RegistryAuth::basic("first", "credential"))
+            .unwrap();
+        assert!(broker.take("execution").is_some());
+
+        let second = broker
+            .bind("execution", RegistryAuth::basic("second", "credential"))
+            .unwrap();
+        drop(first);
+
+        assert_eq!(broker.pending(), 1);
+        drop(second);
+        assert_eq!(broker.pending(), 0);
+    }
+}

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -18,6 +18,8 @@ use tokio::sync::Mutex;
 
 use super::resources::ExecutionResourceGuard;
 use super::vm_process::{locate_microvm_process, LocatedProcess};
+#[cfg(target_os = "linux")]
+use super::TransientRegistryAuthBroker;
 use super::{
     LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation,
     LocalExecutionTermination,
@@ -37,6 +39,8 @@ pub struct VmLocalExecutionBackend {
     home_dir: PathBuf,
     managers: Arc<DashMap<String, SharedVm>>,
     pull_progress_fn: Option<crate::PullProgressFn>,
+    #[cfg(target_os = "linux")]
+    transient_registry_auth: Option<TransientRegistryAuthBroker>,
 }
 
 impl VmLocalExecutionBackend {
@@ -45,11 +49,22 @@ impl VmLocalExecutionBackend {
             home_dir: home_dir.into(),
             managers: Arc::new(DashMap::new()),
             pull_progress_fn: None,
+            #[cfg(target_os = "linux")]
+            transient_registry_auth: None,
         }
     }
 
     pub fn with_pull_progress_fn(mut self, pull_progress_fn: crate::PullProgressFn) -> Self {
         self.pull_progress_fn = Some(pull_progress_fn);
+        self
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn with_transient_registry_auth(
+        mut self,
+        broker: TransientRegistryAuthBroker,
+    ) -> Self {
+        self.transient_registry_auth = Some(broker);
         self
     }
 
@@ -121,6 +136,14 @@ impl VmLocalExecutionBackend {
         manager.resolved_execution_plan = Some(metadata.plan.clone());
         manager.managed_secret_root = metadata.request.policy.managed_secret_root.clone();
         Ok(manager)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn claim_transient_registry_auth_for_boot(&self, manager: &mut VmManager) {
+        manager.transient_registry_auth = self
+            .transient_registry_auth
+            .as_ref()
+            .and_then(|broker| broker.take(manager.box_id()));
     }
 
     fn manager(&self, execution_id: &str) -> Option<SharedVm> {
@@ -624,6 +647,8 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
                 )));
             }
         };
+        #[cfg(target_os = "linux")]
+        self.claim_transient_registry_auth_for_boot(&mut guard);
         if let Err(error) = guard.boot().await {
             guard.config.persistent = requested_persistence;
             // Sandbox boot cleanup synchronously asks the authoritative OCI

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -119,6 +119,7 @@ impl VmLocalExecutionBackend {
         manager.anonymous_volumes = record.anonymous_volumes.clone();
         manager.set_log_config(record.log_config.clone());
         manager.resolved_execution_plan = Some(metadata.plan.clone());
+        manager.managed_secret_root = metadata.request.policy.managed_secret_root.clone();
         Ok(manager)
     }
 

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -133,6 +133,59 @@ fn manager_uses_the_backend_pull_progress_callback() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn recovery_manager_does_not_consume_transient_registry_authorization() {
+    let temporary = tempfile::tempdir().unwrap();
+    let broker = TransientRegistryAuthBroker::default();
+    let backend =
+        VmLocalExecutionBackend::new(temporary.path()).with_transient_registry_auth(broker.clone());
+    let record = record(temporary.path(), ExecutionIsolation::Microvm);
+    let lease = broker
+        .bind(
+            &record.id,
+            crate::RegistryAuth::basic("transient-user", "transient-password"),
+        )
+        .unwrap();
+
+    let manager = backend.new_manager(&record).unwrap();
+
+    assert_eq!(broker.pending(), 1);
+    assert!(manager.transient_registry_auth.is_none());
+    drop(lease);
+    assert_eq!(broker.pending(), 0);
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn boot_claim_consumes_only_its_transient_registry_authorization() {
+    let temporary = tempfile::tempdir().unwrap();
+    let broker = TransientRegistryAuthBroker::default();
+    let backend =
+        VmLocalExecutionBackend::new(temporary.path()).with_transient_registry_auth(broker.clone());
+    let record = record(temporary.path(), ExecutionIsolation::Microvm);
+    let lease = broker
+        .bind(
+            &record.id,
+            crate::RegistryAuth::basic("transient-user", "transient-password"),
+        )
+        .unwrap();
+    let mut manager = backend.new_manager(&record).unwrap();
+
+    backend.claim_transient_registry_auth_for_boot(&mut manager);
+
+    assert_eq!(broker.pending(), 0);
+    assert_eq!(
+        manager
+            .transient_registry_auth
+            .as_ref()
+            .and_then(crate::RegistryAuth::basic_credentials),
+        Some(("transient-user".into(), "transient-password".into()))
+    );
+    drop(lease);
+    assert_eq!(broker.pending(), 0);
+}
+
+#[test]
 fn manager_applies_persisted_shared_memory_policy_to_runtime_config() {
     let temporary = tempfile::tempdir().unwrap();
     let backend = VmLocalExecutionBackend::new(temporary.path());

--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -15,6 +15,7 @@ use oci_distribution::manifest::{
 use oci_distribution::secrets::RegistryAuth as OciRegistryAuth;
 use oci_distribution::{Client, Reference};
 use oci_reqwest::header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, LOCATION};
+use zeroize::Zeroize;
 
 use super::credentials::CredentialStore;
 use super::reference::ImageReference;
@@ -100,10 +101,31 @@ struct PulledImageManifest {
 }
 
 /// Authentication credentials for a container registry.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RegistryAuth {
     username: Option<String>,
     password: Option<String>,
+}
+
+impl std::fmt::Debug for RegistryAuth {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(if self.basic_credentials().is_some() {
+            "<redacted-registry-auth>"
+        } else {
+            "<anonymous-registry-auth>"
+        })
+    }
+}
+
+impl Drop for RegistryAuth {
+    fn drop(&mut self) {
+        if let Some(username) = &mut self.username {
+            username.zeroize();
+        }
+        if let Some(password) = &mut self.password {
+            password.zeroize();
+        }
+    }
 }
 
 impl RegistryAuth {
@@ -1583,6 +1605,7 @@ mod tests {
         let auth = RegistryAuth::basic("user", "pass");
         assert_eq!(auth.username, Some("user".to_string()));
         assert_eq!(auth.password, Some("pass".to_string()));
+        assert_eq!(format!("{auth:?}"), "<redacted-registry-auth>");
     }
 
     #[test]

--- a/src/runtime/src/sandbox/mod.rs
+++ b/src/runtime/src/sandbox/mod.rs
@@ -145,5 +145,6 @@ pub use oci::{
 pub use path_access::prepare_sandbox_path_access;
 pub use rootfs::{
     inspect_rootfs_identity_requirements, mapped_root_ids, prepare_managed_mount_source,
-    prepare_rootfs_ownership, validate_external_mount_access, RootfsIdentityRequirements,
+    prepare_managed_secret_mount_source, prepare_rootfs_ownership, validate_external_mount_access,
+    RootfsIdentityRequirements,
 };

--- a/src/runtime/src/sandbox/rootfs.rs
+++ b/src/runtime/src/sandbox/rootfs.rs
@@ -172,6 +172,89 @@ pub fn validate_external_mount_access(
     Ok(())
 }
 
+/// Validate and prepare one Runtime-owned Secret file without granting Box
+/// ownership over any other external bind source.
+#[cfg(target_os = "linux")]
+pub fn prepare_managed_secret_mount_source(
+    root: &Path,
+    path: &Path,
+    plan: &SandboxIdMappingPlan,
+    read_only: bool,
+) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    if !read_only {
+        return Err(BoxError::ConfigError(
+            "Sandbox Secret material must use a read-only bind mount".into(),
+        ));
+    }
+    let root_metadata = std::fs::symlink_metadata(root).map_err(BoxError::IoError)?;
+    let canonical_root = root.canonicalize().map_err(BoxError::IoError)?;
+    if canonical_root != root
+        || !root_metadata.file_type().is_dir()
+        || root_metadata.file_type().is_symlink()
+        || root_metadata.uid() != unsafe { libc::geteuid() }
+        || root_metadata.permissions().mode() & 0o077 != 0
+    {
+        return Err(BoxError::ConfigError(
+            "Sandbox Secret root must be a canonical private provider-owned directory".into(),
+        ));
+    }
+    let root_c = std::ffi::CString::new(root.as_os_str().as_bytes())
+        .map_err(|_| BoxError::ConfigError("Sandbox Secret root contains NUL".into()))?;
+    let mut status = std::mem::MaybeUninit::<libc::statfs>::uninit();
+    if unsafe { libc::statfs(root_c.as_ptr(), status.as_mut_ptr()) } != 0 {
+        return Err(BoxError::IoError(std::io::Error::last_os_error()));
+    }
+    if unsafe { status.assume_init() }.f_type as libc::c_long != 0x0102_1994 {
+        return Err(BoxError::ConfigError(
+            "Sandbox Secret root is not a Linux tmpfs mount".into(),
+        ));
+    }
+
+    let relative = path.strip_prefix(root).map_err(|_| {
+        BoxError::ConfigError("Sandbox Secret file escaped its configured root".into())
+    })?;
+    let components = relative.components().collect::<Vec<_>>();
+    let valid_identity = matches!(components.as_slice(), [Component::Normal(digest), Component::Normal(file)]
+        if digest.as_bytes().len() == 64
+            && digest.as_bytes().iter().all(u8::is_ascii_hexdigit)
+            && file.as_bytes().len() == 10
+            && file.as_bytes()[..3].iter().all(u8::is_ascii_digit)
+            && &file.as_bytes()[3..] == b".secret");
+    if !valid_identity {
+        return Err(BoxError::ConfigError(
+            "Sandbox Secret file has an invalid deterministic identity".into(),
+        ));
+    }
+    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
+    if !metadata.file_type().is_file()
+        || metadata.file_type().is_symlink()
+        || metadata.nlink() != 1
+        || metadata.len() == 0
+        || metadata.len() > 1024 * 1024
+    {
+        return Err(BoxError::ConfigError(
+            "Sandbox Secret source is not a bounded regular file".into(),
+        ));
+    }
+    prepare_managed_mount_source(path, plan)?;
+    validate_external_mount_access(path, plan, true)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn prepare_managed_secret_mount_source(
+    _root: &Path,
+    _path: &Path,
+    _plan: &SandboxIdMappingPlan,
+    _read_only: bool,
+) -> Result<()> {
+    Err(BoxError::ConfigError(
+        "Sandbox Secret preparation requires Linux".into(),
+    ))
+}
+
 #[cfg(not(unix))]
 pub fn validate_external_mount_access(
     _path: &Path,

--- a/src/runtime/src/sandbox/rootfs.rs
+++ b/src/runtime/src/sandbox/rootfs.rs
@@ -195,7 +195,7 @@ pub fn prepare_managed_secret_mount_source(
         || !root_metadata.file_type().is_dir()
         || root_metadata.file_type().is_symlink()
         || root_metadata.uid() != unsafe { libc::geteuid() }
-        || root_metadata.permissions().mode() & 0o077 != 0
+        || !matches!(root_metadata.permissions().mode() & 0o7777, 0o700 | 0o710)
     {
         return Err(BoxError::ConfigError(
             "Sandbox Secret root must be a canonical private provider-owned directory".into(),
@@ -228,6 +228,23 @@ pub fn prepare_managed_secret_mount_source(
             "Sandbox Secret file has an invalid deterministic identity".into(),
         ));
     }
+    let materialization_directory = path.parent().ok_or_else(|| {
+        BoxError::ConfigError("Sandbox Secret file has no materialization directory".into())
+    })?;
+    let directory_metadata =
+        std::fs::symlink_metadata(materialization_directory).map_err(BoxError::IoError)?;
+    if !directory_metadata.file_type().is_dir()
+        || directory_metadata.file_type().is_symlink()
+        || directory_metadata.uid() != unsafe { libc::geteuid() }
+        || !matches!(
+            directory_metadata.permissions().mode() & 0o7777,
+            0o700 | 0o710
+        )
+    {
+        return Err(BoxError::ConfigError(
+            "Sandbox Secret materialization directory is not private and provider-owned".into(),
+        ));
+    }
     let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
     if !metadata.file_type().is_file()
         || metadata.file_type().is_symlink()
@@ -239,8 +256,28 @@ pub fn prepare_managed_secret_mount_source(
             "Sandbox Secret source is not a bounded regular file".into(),
         ));
     }
+    let (root_uid, root_gid) = mapped_root_ids(plan)?;
+    prepare_secret_directory_traversal(root, root_uid, root_gid)?;
+    prepare_secret_directory_traversal(materialization_directory, root_uid, root_gid)?;
     prepare_managed_mount_source(path, plan)?;
     validate_external_mount_access(path, plan, true)
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_secret_directory_traversal(path: &Path, mapped_uid: u32, mapped_gid: u32) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
+    if metadata.uid() == mapped_uid {
+        return Ok(());
+    }
+    lchown_if_needed(path, metadata.uid(), mapped_gid)?;
+    let mode = metadata.permissions().mode() & 0o7777;
+    if mode != 0o710 {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o710))
+            .map_err(BoxError::IoError)?;
+    }
+    Ok(())
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -45,12 +45,15 @@ pub(crate) fn legacy_sandbox_runtime_root(home_dir: &Path, box_id: &str) -> Path
     home_dir.join("run").join("a3s-oci").join(box_id)
 }
 
-fn registry_auth_for_image(home_dir: &Path, reference: &str) -> Result<crate::oci::RegistryAuth> {
+fn registry_auth_for_image(
+    home_dir: &Path,
+    reference: &str,
+    transient: Option<crate::oci::RegistryAuth>,
+) -> Result<crate::oci::RegistryAuth> {
     let parsed = crate::oci::ImageReference::parse(reference)?;
-    Ok(crate::oci::RegistryAuth::from_credential_store_at(
-        home_dir,
-        &parsed.registry,
-    ))
+    Ok(transient.unwrap_or_else(|| {
+        crate::oci::RegistryAuth::from_credential_store_at(home_dir, &parsed.registry)
+    }))
 }
 
 pub(crate) fn persistent_rootfs_generation_exists(box_dir: &Path) -> Result<bool> {
@@ -98,7 +101,8 @@ fn validate_image_health_support(
 }
 
 impl VmManager {
-    pub(crate) async fn prepare_layout(&self) -> Result<BoxLayout> {
+    pub(crate) async fn prepare_layout(&mut self) -> Result<BoxLayout> {
+        let transient_registry_auth = self.transient_registry_auth.take();
         // Create box-specific directories
         let box_dir = self.home_dir.join("boxes").join(&self.box_id);
         let socket_dir = self.socket_dir();
@@ -298,7 +302,7 @@ impl VmManager {
 
         let images_dir = self.home_dir.join("images");
         let store = crate::oci::ImageStore::new(&images_dir, crate::DEFAULT_IMAGE_CACHE_SIZE)?;
-        let auth = registry_auth_for_image(&self.home_dir, reference)?;
+        let auth = registry_auth_for_image(&self.home_dir, reference, transient_registry_auth)?;
         let mut puller = crate::oci::ImagePuller::new(std::sync::Arc::new(store), auth);
         if let Some(ref m) = self.prom {
             puller = puller.set_metrics(m.clone());
@@ -310,6 +314,10 @@ impl VmManager {
         tracing::info!(reference = %reference, "Pulling OCI image from registry");
 
         let oci_image = puller.pull(reference).await?;
+        // The image object owns only the cached OCI layout. Drop the puller as
+        // soon as the registry boundary closes so transient authorization is
+        // zeroized before rootfs extraction or guest preparation begins.
+        drop(puller);
         validate_image_health_support(
             oci_image.config().health_check.as_ref(),
             self.healthcheck_disabled,
@@ -1129,6 +1137,7 @@ mod tests {
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
             managed_secret_root: None,
+            transient_registry_auth: None,
         }
     }
 
@@ -1236,6 +1245,7 @@ mod tests {
         let auth = registry_auth_for_image(
             home.path(),
             "manager-layout.invalid:5443/a3s/private:latest",
+            None,
         )
         .unwrap();
 
@@ -1243,6 +1253,56 @@ mod tests {
             auth.basic_credentials(),
             Some(("layout-user".to_string(), "layout-secret".to_string()))
         );
+    }
+
+    #[test]
+    fn transient_image_auth_overrides_the_persistent_store() {
+        let home = TempDir::new().unwrap();
+        let store = crate::oci::CredentialStore::new(home.path().join("auth/credentials.json"));
+        store
+            .store(
+                "manager-layout.invalid:5443",
+                "persistent-user",
+                "persistent-secret",
+            )
+            .unwrap();
+
+        let auth = registry_auth_for_image(
+            home.path(),
+            "manager-layout.invalid:5443/a3s/private:latest",
+            Some(crate::RegistryAuth::basic(
+                "transient-user",
+                "transient-secret",
+            )),
+        )
+        .unwrap();
+
+        assert_eq!(
+            auth.basic_credentials(),
+            Some(("transient-user".to_string(), "transient-secret".to_string()))
+        );
+    }
+
+    #[test]
+    fn explicit_anonymous_image_auth_disables_the_persistent_store() {
+        let home = TempDir::new().unwrap();
+        let store = crate::oci::CredentialStore::new(home.path().join("auth/credentials.json"));
+        store
+            .store(
+                "manager-layout.invalid:5443",
+                "persistent-user",
+                "persistent-secret",
+            )
+            .unwrap();
+
+        let auth = registry_auth_for_image(
+            home.path(),
+            "manager-layout.invalid:5443/a3s/private:latest",
+            Some(crate::RegistryAuth::anonymous()),
+        )
+        .unwrap();
+
+        assert!(auth.basic_credentials().is_none());
     }
 
     #[test]

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -1128,6 +1128,7 @@ mod tests {
             pull_progress_fn: None,
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
+            managed_secret_root: None,
         }
     }
 

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -360,6 +360,10 @@ pub struct VmManager {
 
     /// Backend-neutral resolution captured before any boot side effects.
     pub(crate) resolved_execution_plan: Option<ResolvedExecutionPlan>,
+
+    /// Runtime-owned tmpfs root whose regular files may be prepared for the
+    /// Sandbox user namespace. Arbitrary external bind mounts remain immutable.
+    pub(crate) managed_secret_root: Option<PathBuf>,
 }
 
 impl VmManager {
@@ -395,6 +399,7 @@ impl VmManager {
             pull_progress_fn: None,
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
+            managed_secret_root: None,
         }
     }
 
@@ -429,6 +434,7 @@ impl VmManager {
             pull_progress_fn: None,
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
+            managed_secret_root: None,
         }
     }
 
@@ -620,6 +626,7 @@ impl VmManager {
             pull_progress_fn: None,
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
+            managed_secret_root: None,
         }
     }
 

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -364,6 +364,10 @@ pub struct VmManager {
     /// Runtime-owned tmpfs root whose regular files may be prepared for the
     /// Sandbox user namespace. Arbitrary external bind mounts remain immutable.
     pub(crate) managed_secret_root: Option<PathBuf>,
+
+    /// One in-memory registry authorization selected for this boot attempt.
+    /// It is consumed and zeroized while preparing the image layout.
+    pub(crate) transient_registry_auth: Option<crate::oci::RegistryAuth>,
 }
 
 impl VmManager {
@@ -400,6 +404,7 @@ impl VmManager {
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
             managed_secret_root: None,
+            transient_registry_auth: None,
         }
     }
 
@@ -435,6 +440,7 @@ impl VmManager {
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
             managed_secret_root: None,
+            transient_registry_auth: None,
         }
     }
 
@@ -627,6 +633,7 @@ impl VmManager {
             log_config: a3s_box_core::log::LogConfig::default(),
             resolved_execution_plan: None,
             managed_secret_root: None,
+            transient_registry_auth: None,
         }
     }
 

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -17,7 +17,8 @@ use crate::sandbox::rootfs::{
 };
 use crate::sandbox::A3sOciController;
 use crate::sandbox::{
-    compile_oci_spec, plan_id_mappings, prepare_managed_mount_source, prepare_sandbox_path_access,
+    compile_oci_spec, plan_id_mappings, prepare_managed_mount_source,
+    prepare_managed_secret_mount_source, prepare_sandbox_path_access,
     probe_sandbox_capabilities_for, validate_external_mount_access, write_bundle,
     SandboxBundleSpec, SandboxLaunchSpec, SandboxMount, SandboxResources, SandboxTmpfs,
 };
@@ -370,7 +371,20 @@ impl VmManager {
         let managed = self.managed_sandbox_mount_sources(&layout.workspace_path, mounts)?;
 
         for mount in mounts {
-            if managed.contains(&mount.source) {
+            if self
+                .managed_secret_root
+                .as_ref()
+                .is_some_and(|root| mount.source.starts_with(root))
+            {
+                prepare_managed_secret_mount_source(
+                    self.managed_secret_root.as_deref().ok_or_else(|| {
+                        BoxError::ConfigError("Sandbox Secret root disappeared".into())
+                    })?,
+                    &mount.source,
+                    id_mappings,
+                    mount.read_only,
+                )?;
+            } else if managed.contains(&mount.source) {
                 prepare_managed_mount_source(&mount.source, id_mappings)?;
             } else {
                 validate_external_mount_access(&mount.source, id_mappings, mount.read_only)?;

--- a/src/sdk/src/client/tests/lifecycle.rs
+++ b/src/sdk/src/client/tests/lifecycle.rs
@@ -159,6 +159,7 @@ async fn lifecycle_calls_preserve_complete_request_and_fencing_identity() {
             stop_timeout: Some(9),
             oom_kill_disable: true,
             oom_score_adj: Some(100),
+            managed_secret_root: None,
         },
         rootfs_snapshot_id: None,
     };


### PR DESCRIPTION
## Summary

- add one provider-neutral `BoxSecretMaterializer` port for environment, file, and registry credential Runtime Secret targets
- keep environment and file material on a caller-provided private Linux tmpfs with deterministic read-only mounts, recovery validation, lifecycle cleanup, and per-read log redaction
- resolve private registry credentials only for uncached pulls, hand them through a token-fenced per-execution broker, override persistent credential sources with explicit auth, and zeroize them after the image boundary
- keep recovery and cleanup paths from consuming pending credentials and retain one canonical `BoxRuntimeDriver` composition path
- add a real authenticated loopback OCI registry gate that boots a Sandbox without Docker and scans durable provider artifacts for plaintext

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p a3s-box-runtime --lib --locked`
- `cargo test -p a3s-box-runtime --lib --locked` (1458 passed, 1 ignored on macOS)
- Linux-only Runtime conformance and private registry coverage run in CI

Tracks #172.
