### PR TITLE
feat(website): showcase runtime isolation and startup

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -17,6 +17,8 @@ Language parity, complete SDK programs, the shared language Tabs, scroll-driven
 line-focus tutorials, Agent Skill install routes, and the custom ACL grammar are
 checked during every build. Run `npm run generate:tutorial` after changing the
 TypeScript tutorial source; `npm run build` does this automatically. The
-homepage uses a Canvas UI-inspired 2D grid with reduced-motion behavior;
-attribution lives in `THIRD_PARTY_NOTICES.md`. All internal links must remain
-valid when the site is hosted below the `/Box/` GitHub Pages base path.
+homepage uses a Canvas UI-inspired 2D grid and includes dedicated-kernel escape,
+copy-on-write fork, and warm-pool lease animations. Their platform boundaries,
+server-rendered markers, and reduced-motion behavior are part of the build
+contract. Attribution lives in `THIRD_PARTY_NOTICES.md`. All internal links must
+remain valid when the site is hosted below the `/Box/` GitHub Pages base path.

--- a/website/scripts/check-built-site.mjs
+++ b/website/scripts/check-built-site.mjs
@@ -68,13 +68,13 @@ const englishHomepage = await readFile(
   'utf8',
 );
 
-if (!rootHomepage.includes('在本机运行')) {
+if (!rootHomepage.includes('给每个任务')) {
   throw new Error('The default homepage is not rendered in Chinese.');
 }
 if (!rootHomepage.includes(`${base}en/`)) {
   throw new Error('The Chinese homepage does not expose the English locale.');
 }
-if (!englishHomepage.includes('Run OCI workloads')) {
+if (!englishHomepage.includes('Give every task')) {
   throw new Error('The /en/ homepage is not rendered in English.');
 }
 for (const [homepagePath, html] of [
@@ -95,6 +95,12 @@ for (const [homepagePath, html] of [
     'data-tutorial-step="create"',
     'data-tutorial-step="cleanup"',
     'data-focus="true"',
+    'id="runtime-features"',
+    'box-agent-probe',
+    'box-vm-barrier',
+    'box-cow-scene',
+    'box-pool-scene',
+    '--snapshot-fork',
   ]) {
     if (!html.includes(marker)) {
       throw new Error(
@@ -271,5 +277,5 @@ if (brokenReferences.length > 0) {
 }
 
 console.log(
-  `Bilingual Agent Skill, Tabs, line-focus tutorials, references, and ACL highlighting verified across ${htmlFiles.length} HTML pages.`,
+  `Bilingual runtime features, Agent Skill, Tabs, line-focus tutorials, references, and ACL highlighting verified across ${htmlFiles.length} HTML pages.`,
 );

--- a/website/scripts/check-docs.mjs
+++ b/website/scripts/check-docs.mjs
@@ -12,6 +12,17 @@ const tutorialComponent = await readFile(
   path.join(websiteRoot, 'theme', 'components', 'RuntimeTutorial.tsx'),
   'utf8',
 );
+const featureComponent = await readFile(
+  path.join(websiteRoot, 'theme', 'components', 'RuntimeFeatureShowcase.tsx'),
+  'utf8',
+);
+const featureStyles = (
+  await Promise.all(
+    ['runtime-features.css', 'runtime-features-responsive.css'].map((file) =>
+      readFile(path.join(websiteRoot, 'theme', file), 'utf8'),
+    ),
+  )
+).join('\n');
 const tutorialSteps = JSON.parse(
   await readFile(
     path.join(websiteRoot, 'theme', 'generated', 'runtime-tutorial.json'),
@@ -183,6 +194,37 @@ for (const marker of [
   if (!tutorialComponent.includes(marker)) {
     experienceFailures.push(
       `RuntimeTutorial.tsx: missing scroll-and-focus contract ${marker}`,
+    );
+  }
+}
+
+for (const marker of [
+  'id="runtime-features"',
+  'className="box-agent-probe"',
+  'className="box-vm-barrier"',
+  'className="box-cow-scene"',
+  'className="box-pool-scene"',
+  'MAP_PRIVATE',
+  '--snapshot-fork',
+  'Linux/KVM',
+  'not a universal performance guarantee',
+]) {
+  if (!featureComponent.includes(marker)) {
+    experienceFailures.push(
+      `RuntimeFeatureShowcase.tsx: missing runtime feature contract ${marker}`,
+    );
+  }
+}
+
+for (const marker of [
+  '@keyframes box-agent-escape',
+  '@keyframes box-dirty-page',
+  '@keyframes box-pool-request',
+  '@media (prefers-reduced-motion: reduce)',
+]) {
+  if (!featureStyles.includes(marker)) {
+    experienceFailures.push(
+      `runtime-features.css: missing animation or accessibility contract ${marker}`,
     );
   }
 }
@@ -382,5 +424,5 @@ if (experienceFailures.length > 0) {
 }
 
 console.log(
-  `Documentation contract verified: ${requiredPages.length} routes × ${languages.length} languages, Agent Skill integration, complete Rust/TypeScript/Python/Go programs in Tabs, the five-step line-focus tutorial, and ACL fences.`,
+  `Documentation contract verified: ${requiredPages.length} routes × ${languages.length} languages, runtime feature animations, Agent Skill integration, complete Rust/TypeScript/Python/Go programs in Tabs, the five-step line-focus tutorial, and ACL fences.`,
 );

--- a/website/theme/components/HomeLayout.tsx
+++ b/website/theme/components/HomeLayout.tsx
@@ -3,6 +3,7 @@ import { Content, useLang, withBase } from '@rspress/core/runtime';
 import { AgentSkillSection } from './AgentSkillSection';
 import { CanvasGridEffect } from './CanvasGridEffect';
 import { PremiumInteractions } from './PremiumInteractions';
+import { RuntimeFeatureShowcase } from './RuntimeFeatureShowcase';
 
 const installCommands = [
   {
@@ -47,12 +48,12 @@ const installCommands = [
 const content = {
   zh: {
     eyebrow: '本地 OCI 运行时 · v3',
-    heroLineOne: '在本机运行',
-    heroLineTwo: 'OCI 工作负载。',
+    heroLineOne: '给每个任务',
+    heroLineTwo: '一个独立内核。',
     heroSubtitle:
-      'A3S Box 在本机创建和管理 OCI 工作负载。默认使用独立内核 MicroVM；Linux 共享内核 Sandbox 需要显式选择，并通过主机能力检查。',
+      'A3S Box 默认在独立内核 MicroVM 中运行 OCI 工作负载。Linux/KVM 可用 CoW snapshot-fork 填充暖池，让重复任务直接从已就绪的 VM 开始。',
     getStarted: '快速开始',
-    installSkill: '安装 Agent Skill',
+    exploreFeatures: '查看核心特性',
     exploreCode: '代码漫游',
     copy: '复制',
     copied: '已复制',
@@ -78,8 +79,8 @@ const content = {
     },
     signals: [
       ['独立内核', '默认隔离'],
-      ['OCI 原生', '镜像与构建'],
-      ['Agent Skill', 'A3S Code · Codex · Claude'],
+      ['写时复制', 'ROOTFS · RAM'],
+      ['暖池', '预启动 MicroVM'],
       ['4 种 SDK', 'Rust · Go · Python · TypeScript'],
     ],
     principleKicker: '隔离模式',
@@ -180,12 +181,12 @@ const content = {
   },
   en: {
     eyebrow: 'LOCAL OCI RUNTIME · v3',
-    heroLineOne: 'Run OCI workloads',
-    heroLineTwo: 'on your machine.',
+    heroLineOne: 'Give every task',
+    heroLineTwo: 'a dedicated kernel.',
     heroSubtitle:
-      'A3S Box creates and manages OCI workloads locally. It uses dedicated-kernel MicroVMs by default. The shared-kernel Linux Sandbox must be selected explicitly and pass host capability checks.',
+      'A3S Box runs OCI workloads in dedicated-kernel MicroVMs by default. On Linux/KVM, CoW snapshot-fork can fill warm pools so repeated tasks start from ready VMs.',
     getStarted: 'Get started',
-    installSkill: 'Install Agent Skill',
+    exploreFeatures: 'Explore core features',
     exploreCode: 'Code walkthrough',
     copy: 'Copy',
     copied: 'Copied',
@@ -211,8 +212,8 @@ const content = {
     },
     signals: [
       ['Dedicated kernel', 'default isolation'],
-      ['OCI-native', 'images and builds'],
-      ['Agent Skill', 'A3S Code · Codex · Claude'],
+      ['Copy on write', 'ROOTFS · RAM'],
+      ['Warm pool', 'pre-booted MicroVMs'],
       ['4 SDKs', 'Rust · Go · Python · TypeScript'],
     ],
     principleKicker: 'ISOLATION MODES',
@@ -441,8 +442,11 @@ export function HomeLayout() {
               {copy.getStarted}
               <ArrowIcon />
             </a>
-            <a className="box-button box-button--secondary" href="#agent-skill">
-              {copy.installSkill}
+            <a
+              className="box-button box-button--secondary"
+              href="#runtime-features"
+            >
+              {copy.exploreFeatures}
               <ArrowIcon />
             </a>
             <a
@@ -549,6 +553,11 @@ export function HomeLayout() {
           </div>
         ))}
       </section>
+
+      <RuntimeFeatureShowcase
+        locale={isChinese ? 'zh' : 'en'}
+        platformHref={docLink('/reference/platforms.html')}
+      />
 
       <AgentSkillSection
         guideHref={docLink('/guide/agent-skill.html')}

--- a/website/theme/components/RuntimeFeatureShowcase.tsx
+++ b/website/theme/components/RuntimeFeatureShowcase.tsx
@@ -1,0 +1,356 @@
+type Locale = 'zh' | 'en';
+
+type KernelSceneLabels = {
+  host: string;
+  hostKernel: string;
+  hostData: string;
+  vmBoundary: string;
+  guestKernel: string;
+  agent: string;
+  attempt: string;
+  blocked: string;
+};
+
+type CowSceneLabels = {
+  template: string;
+  readonlyPages: string;
+  fork: string;
+  shared: string;
+  privateWrite: string;
+};
+
+type PoolSceneLabels = {
+  requests: string;
+  ready: string;
+  running: string;
+  replenish: string;
+  idle: string;
+  active: string;
+  leased: string;
+};
+
+const benchmarkHref =
+  'https://github.com/A3S-Lab/Box/blob/main/docs/ANNOUNCEMENT-v2.1.0.md';
+
+const content = {
+  zh: {
+    kicker: '核心实现',
+    title: '每个任务一个内核；重复任务不必每次冷启动。',
+    body: '默认 MicroVM、写时复制和暖池是三套可以组合使用的机制。隔离负责挡住共享内核攻击面，CoW 减少重复数据，暖池把启动移出任务热路径。',
+    kernel: {
+      label: '01 / 独立内核',
+      title: 'Agent 与宿主机不共享内核',
+      body: '每个 Box 默认运行在自己的来宾 Linux 内核中。Agent 即使利用了来宾内核漏洞，仍需跨过硬件虚拟机边界才能接触宿主机；没有显式挂载的宿主目录也不会出现在来宾中。',
+      boundary:
+        'MicroVM 降低共享内核风险，但不能替代 Hypervisor、硬件和挂载策略本身的安全审查。',
+      command: 'a3s-box run --rm alpine:3.20 -- uname -a',
+      scene: {
+        host: 'HOST',
+        hostKernel: '宿主机内核',
+        hostData: '宿主机数据',
+        vmBoundary: '硬件 VM 边界',
+        guestKernel: '来宾 Linux 内核',
+        agent: 'AGENT',
+        attempt: '内核越界尝试',
+        blocked: '被 VM 边界阻断',
+      },
+    },
+    cow: {
+      label: '02 / 写时复制',
+      title: '只为修改过的数据分配新页',
+      body: 'Linux 文件系统恢复把同一份快照作为只读 lower，每个 Box 只保存自己的 upper。启用 Linux/KVM snapshot-fork 后，来宾 RAM 也从同一模板按 MAP_PRIVATE 恢复；未修改页继续共享，脏页才进入分叉副本。',
+      boundary:
+        '文件系统 CoW 依赖 Linux overlay；RAM CoW 需要支持原生快照的 Linux/KVM 主机，其他情况会使用完整复制或冷启动。',
+      command: 'a3s-box snapshot restore checkpoint-1 --name test-2',
+      scene: {
+        template: '模板快照',
+        readonlyPages: '只读 RAM + ROOTFS',
+        fork: 'FORK',
+        shared: '共享模板页',
+        privateWrite: '自己的修改',
+      },
+    },
+    pool: {
+      label: '03 / 暖池',
+      title: '任务到来时直接领取已就绪的 MicroVM',
+      body: 'pool daemon 按镜像、CPU、内存和卷配置维护空闲实例。pool run 优先领取已启动的 VM；没有空闲实例时按需启动，后台再补到 min_idle。Linux/KVM 还可用 snapshot-fork 加快池填充。',
+      boundary:
+        '一次特定 /dev/kvm 主机实测中，预热池约 73 ms，冷启动约 1688 ms；这是历史实测，不是跨机器性能承诺。',
+      command: 'a3s-box pool start --image node:24 --size 4 --snapshot-fork',
+      benchmark: '查看实测条件',
+      scene: {
+        requests: '任务队列',
+        ready: '已就绪',
+        running: '执行中',
+        replenish: '后台补池',
+        idle: '空闲 3',
+        active: '活跃 1',
+        leased: '租约 0',
+      },
+    },
+    platformLink: '查看平台支持范围',
+    moreLabel: '同时提供',
+    more: [
+      ['OCI 构建', '多阶段 · 缓存 · save/load'],
+      ['持久存储', '命名卷 · tmpfs · 快照'],
+      ['网络', 'TSI · Bridge · TCP 端口'],
+      ['可编程 CI/CD', '镜像 · 脚本 · 并行分叉'],
+      ['Kubernetes', 'CRI · containerd shim'],
+      ['机密计算', 'SEV-SNP · 证明 · 密钥注入'],
+    ],
+  },
+  en: {
+    kicker: 'CORE MECHANISMS',
+    title: 'One kernel per task, without a cold boot for every repeat run.',
+    body: 'Default MicroVMs, copy-on-write forks, and warm pools solve different parts of the runtime path. Isolation removes the shared-kernel attack surface, CoW avoids duplicate data, and the pool moves boot work out of the request path.',
+    kernel: {
+      label: '01 / DEDICATED KERNEL',
+      title: 'The agent does not share the host kernel',
+      body: 'Every Box runs with its own guest Linux kernel by default. Exploiting that guest kernel still leaves the hardware VM boundary between the agent and the host. Host directories are absent unless they are mounted explicitly.',
+      boundary:
+        'A MicroVM reduces shared-kernel risk; it does not replace review of the hypervisor, hardware, or mount policy.',
+      command: 'a3s-box run --rm alpine:3.20 -- uname -a',
+      scene: {
+        host: 'HOST',
+        hostKernel: 'host kernel',
+        hostData: 'host data',
+        vmBoundary: 'hardware VM boundary',
+        guestKernel: 'guest Linux kernel',
+        agent: 'AGENT',
+        attempt: 'kernel escape attempt',
+        blocked: 'stopped at VM boundary',
+      },
+    },
+    cow: {
+      label: '02 / COPY ON WRITE',
+      title: 'Allocate new pages only for changed data',
+      body: 'On Linux, filesystem restores share one read-only snapshot lower while each Box keeps its own upper. With Linux/KVM snapshot-fork enabled, guest RAM also restores from one MAP_PRIVATE template: untouched pages remain shared and dirty pages belong to the fork.',
+      boundary:
+        'Filesystem CoW requires Linux overlay. RAM CoW requires a snapshot-capable Linux/KVM host; other paths use a full copy or a cold boot.',
+      command: 'a3s-box snapshot restore checkpoint-1 --name test-2',
+      scene: {
+        template: 'template snapshot',
+        readonlyPages: 'read-only RAM + ROOTFS',
+        fork: 'FORK',
+        shared: 'shared template pages',
+        privateWrite: 'private writes',
+      },
+    },
+    pool: {
+      label: '03 / WARM POOL',
+      title: 'Lease a ready MicroVM when work arrives',
+      body: 'The pool daemon keeps idle instances by image, CPU, memory, and volume shape. pool run takes a ready VM first, boots on demand after a miss, and replenishes min_idle in the background. Linux/KVM can also use snapshot-fork to fill the pool.',
+      boundary:
+        'One historical /dev/kvm host measured about 73 ms from a warm pool versus about 1688 ms cold. This is host-specific evidence, not a universal performance guarantee.',
+      command: 'a3s-box pool start --image node:24 --size 4 --snapshot-fork',
+      benchmark: 'Read the benchmark conditions',
+      scene: {
+        requests: 'request queue',
+        ready: 'ready',
+        running: 'running',
+        replenish: 'replenish',
+        idle: 'idle 3',
+        active: 'active 1',
+        leased: 'leased 0',
+      },
+    },
+    platformLink: 'Check platform support',
+    moreLabel: 'ALSO INCLUDED',
+    more: [
+      ['OCI builds', 'multi-stage · cache · save/load'],
+      ['Persistent storage', 'volumes · tmpfs · snapshots'],
+      ['Networking', 'TSI · bridge · TCP ports'],
+      ['Programmable CI/CD', 'images · scripts · parallel forks'],
+      ['Kubernetes', 'CRI · containerd shim'],
+      ['Confidential workloads', 'SEV-SNP · attestation · secrets'],
+    ],
+  },
+} as const;
+
+function KernelBoundaryScene({ labels }: { labels: KernelSceneLabels }) {
+  return (
+    <div className="box-kernel-scene" aria-hidden="true">
+      <header>
+        <span>{labels.host}</span>
+        <small>KVM · HVF · WHPX</small>
+      </header>
+      <div className="box-host-target">
+        <span>{labels.hostKernel}</span>
+        <strong>{labels.hostData}</strong>
+        <i />
+      </div>
+      <div className="box-microvm-boundary">
+        <span>{labels.vmBoundary}</span>
+        <div className="box-guest-kernel">{labels.guestKernel}</div>
+        <div className="box-agent-probe">
+          <i />
+          <strong>{labels.agent}</strong>
+        </div>
+        <div className="box-escape-trace">
+          <span>{labels.attempt}</span>
+          <i />
+        </div>
+        <div className="box-vm-barrier">
+          <i />
+          <strong>{labels.blocked}</strong>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CowPageGrid({ dirty = [] }: { dirty?: number[] }) {
+  return (
+    <div className="box-cow-pages">
+      {Array.from({ length: 12 }, (_, index) => (
+        <i className={dirty.includes(index) ? 'is-dirty' : ''} key={index} />
+      ))}
+    </div>
+  );
+}
+
+function CowForkScene({ labels }: { labels: CowSceneLabels }) {
+  return (
+    <div className="box-cow-scene" aria-hidden="true">
+      <div className="box-cow-template">
+        <header>
+          <span>{labels.template}</span>
+          <small>{labels.readonlyPages}</small>
+        </header>
+        <CowPageGrid />
+      </div>
+      <div className="box-cow-branches">
+        <span>{labels.fork}</span>
+        <i />
+        <i />
+        <i />
+      </div>
+      <div className="box-cow-forks">
+        {[[1, 8], [4], [2, 6, 10]].map((dirty, index) => (
+          <div key={index}>
+            <header>
+              <strong>BOX {String(index + 1).padStart(2, '0')}</strong>
+              <small>{labels.shared}</small>
+            </header>
+            <CowPageGrid dirty={dirty} />
+            <span>{labels.privateWrite}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WarmPoolScene({ labels }: { labels: PoolSceneLabels }) {
+  return (
+    <div className="box-pool-scene" aria-hidden="true">
+      <header>
+        <span>pool.sock</span>
+        <small>min_idle=3 · max=8</small>
+      </header>
+      <div className="box-pool-flow">
+        <div className="box-pool-queue">
+          <span>{labels.requests}</span>
+          <i />
+          <i />
+          <i />
+        </div>
+        <div className="box-pool-request-packet">JOB</div>
+        <div className="box-pool-slots">
+          <span>{labels.ready}</span>
+          {[0, 1, 2, 3].map((index) => (
+            <div className={index === 1 ? 'is-active' : ''} key={index}>
+              <i />
+              <strong>VM {index + 1}</strong>
+              <small>{index === 1 ? labels.running : labels.ready}</small>
+            </div>
+          ))}
+          <div className="box-pool-replenish">{labels.replenish}</div>
+        </div>
+        <div className="box-pool-result">EXIT 0</div>
+      </div>
+      <footer>
+        <span>{labels.idle}</span>
+        <span>{labels.active}</span>
+        <span>{labels.leased}</span>
+      </footer>
+    </div>
+  );
+}
+
+export function RuntimeFeatureShowcase({
+  locale,
+  platformHref,
+}: {
+  locale: Locale;
+  platformHref: string;
+}) {
+  const copy = content[locale];
+
+  return (
+    <section
+      className="box-section box-runtime-features"
+      id="runtime-features"
+      aria-labelledby="runtime-features-title"
+    >
+      <div className="box-section-heading box-feature-heading">
+        <span>{copy.kicker}</span>
+        <h2 id="runtime-features-title">{copy.title}</h2>
+        <p>{copy.body}</p>
+      </div>
+
+      <div className="box-feature-list">
+        <article className="box-feature-row box-feature-row--kernel">
+          <div className="box-feature-copy">
+            <span>{copy.kernel.label}</span>
+            <h3>{copy.kernel.title}</h3>
+            <p>{copy.kernel.body}</p>
+            <small>{copy.kernel.boundary}</small>
+            <code>{copy.kernel.command}</code>
+          </div>
+          <KernelBoundaryScene labels={copy.kernel.scene} />
+        </article>
+
+        <article className="box-feature-row box-feature-row--cow">
+          <div className="box-feature-copy">
+            <span>{copy.cow.label}</span>
+            <h3>{copy.cow.title}</h3>
+            <p>{copy.cow.body}</p>
+            <small>{copy.cow.boundary}</small>
+            <code>{copy.cow.command}</code>
+          </div>
+          <CowForkScene labels={copy.cow.scene} />
+        </article>
+
+        <article className="box-feature-row box-feature-row--pool">
+          <div className="box-feature-copy">
+            <span>{copy.pool.label}</span>
+            <h3>{copy.pool.title}</h3>
+            <p>{copy.pool.body}</p>
+            <small>{copy.pool.boundary}</small>
+            <div className="box-feature-links">
+              <a href={benchmarkHref} target="_blank" rel="noreferrer">
+                {copy.pool.benchmark}
+              </a>
+              <a href={platformHref}>{copy.platformLink}</a>
+            </div>
+            <code>{copy.pool.command}</code>
+          </div>
+          <WarmPoolScene labels={copy.pool.scene} />
+        </article>
+      </div>
+
+      <div className="box-feature-more">
+        <header>{copy.moreLabel}</header>
+        <div>
+          {copy.more.map(([title, detail]) => (
+            <article key={title}>
+              <strong>{title}</strong>
+              <span>{detail}</span>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,6 +1,8 @@
 import './index.css';
 import './agent-skill.css';
 import './premium-effects.css';
+import './runtime-features.css';
+import './runtime-features-responsive.css';
 
 export { HomeLayout } from './components/HomeLayout';
 export * from '@rspress/core/theme-original';

--- a/website/theme/runtime-features-responsive.css
+++ b/website/theme/runtime-features-responsive.css
@@ -1,0 +1,321 @@
+.box-feature-more {
+  margin-top: 34px;
+  border: 1px solid var(--box-line);
+  background: rgba(10, 14, 12, 0.88);
+}
+
+.box-feature-more > header {
+  padding: 13px 18px;
+  border-bottom: 1px solid var(--box-line);
+  color: #59665e;
+  font-family: var(--box-mono);
+  font-size: 8px;
+  letter-spacing: 0.1em;
+}
+
+.box-feature-more > div {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.box-feature-more article {
+  display: flex;
+  min-height: 92px;
+  padding: 19px;
+  border-right: 1px solid var(--box-line);
+  border-bottom: 1px solid var(--box-line);
+  justify-content: center;
+  flex-direction: column;
+}
+
+.box-feature-more article:nth-child(3n) {
+  border-right: 0;
+}
+
+.box-feature-more article:nth-last-child(-n + 3) {
+  border-bottom: 0;
+}
+
+.box-feature-more strong {
+  color: #c9d0cc;
+  font-size: 13px;
+  font-weight: 640;
+}
+
+.box-feature-more span {
+  margin-top: 7px;
+  color: #5f6c64;
+  font-family: var(--box-mono);
+  font-size: 8px;
+  line-height: 1.5;
+}
+
+@media (max-width: 1100px) {
+  .box-feature-row,
+  .box-feature-row--cow {
+    grid-template-columns: minmax(300px, 0.85fr) minmax(0, 1.15fr);
+  }
+
+  .box-feature-copy {
+    padding-right: 35px;
+    padding-left: 35px;
+  }
+
+  .box-feature-row--cow .box-feature-copy {
+    grid-column: 1;
+  }
+
+  .box-feature-row--cow .box-cow-scene {
+    grid-column: 2;
+  }
+
+  .box-kernel-scene,
+  .box-cow-scene,
+  .box-pool-scene {
+    margin: 24px;
+  }
+
+  .box-host-target {
+    right: 17px;
+    min-width: 88px;
+  }
+
+  .box-pool-flow {
+    gap: 14px;
+    grid-template-columns: 0.32fr minmax(190px, 1fr) 0.25fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .box-feature-row,
+  .box-feature-row--cow {
+    grid-template-columns: 1fr;
+  }
+
+  .box-feature-copy,
+  .box-feature-row--cow .box-feature-copy {
+    min-height: 470px;
+    border-right: 0;
+    border-bottom: 1px solid var(--box-line);
+    border-left: 0;
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .box-kernel-scene,
+  .box-feature-row--cow .box-cow-scene,
+  .box-pool-scene {
+    min-height: 520px;
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .box-feature-more > div {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .box-feature-more article:nth-child(3n) {
+    border-right: 1px solid var(--box-line);
+  }
+
+  .box-feature-more article:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .box-feature-more article:nth-last-child(-n + 3) {
+    border-bottom: 1px solid var(--box-line);
+  }
+
+  .box-feature-more article:nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .box-feature-list {
+    margin-top: 44px;
+  }
+
+  .box-feature-copy,
+  .box-feature-row--cow .box-feature-copy {
+    min-height: 0;
+    padding: 35px 24px 28px;
+  }
+
+  .box-feature-copy h3 {
+    margin-top: 37px;
+    font-size: 33px;
+  }
+
+  .box-feature-copy > code {
+    overflow-wrap: anywhere;
+    margin-top: 30px;
+    text-overflow: unset;
+    white-space: normal;
+  }
+
+  .box-kernel-scene,
+  .box-cow-scene,
+  .box-pool-scene,
+  .box-feature-row--cow .box-cow-scene {
+    min-height: 440px;
+    margin: 12px;
+  }
+
+  .box-kernel-scene {
+    padding: 62px 18px 18px;
+  }
+
+  .box-host-target {
+    top: 80px;
+    right: 12px;
+    width: 25%;
+    min-width: 70px;
+    height: 300px;
+    padding-right: 6px;
+    padding-left: 6px;
+  }
+
+  .box-host-target > strong {
+    font-size: 8px;
+  }
+
+  .box-microvm-boundary {
+    width: calc(75% - 10px);
+    min-height: 360px;
+  }
+
+  .box-escape-trace > span,
+  .box-vm-barrier > strong {
+    display: none;
+  }
+
+  .box-agent-probe {
+    width: 48px;
+    height: 48px;
+  }
+
+  .box-cow-scene {
+    padding: 58px 13px 18px;
+  }
+
+  .box-cow-template {
+    width: 86%;
+  }
+
+  .box-cow-branches {
+    width: 83%;
+    height: 70px;
+  }
+
+  .box-cow-forks {
+    gap: 5px;
+  }
+
+  .box-cow-forks > div {
+    padding: 8px;
+  }
+
+  .box-cow-forks header small,
+  .box-cow-forks > div > span {
+    display: none;
+  }
+
+  .box-cow-pages {
+    gap: 3px;
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .box-cow-pages > i {
+    height: 12px;
+  }
+
+  .box-pool-scene {
+    padding-right: 12px;
+    padding-left: 12px;
+  }
+
+  .box-pool-flow {
+    gap: 8px;
+    grid-template-columns: 0.22fr minmax(185px, 1fr) 0.2fr;
+  }
+
+  .box-pool-queue > span,
+  .box-pool-slots > span {
+    display: none;
+  }
+
+  .box-pool-queue > i {
+    width: 22px;
+  }
+
+  .box-pool-slots {
+    padding: 13px;
+    gap: 6px;
+  }
+
+  .box-pool-slots > div:not(.box-pool-replenish) {
+    min-height: 72px;
+    padding: 7px;
+  }
+
+  .box-pool-result {
+    width: 42px;
+    font-size: 6px;
+  }
+
+  .box-feature-more > div {
+    grid-template-columns: 1fr;
+  }
+
+  .box-feature-more article,
+  .box-feature-more article:nth-child(2n),
+  .box-feature-more article:nth-child(3n),
+  .box-feature-more article:nth-last-child(-n + 2),
+  .box-feature-more article:nth-last-child(-n + 3) {
+    min-height: 82px;
+    border-right: 0;
+    border-bottom: 1px solid var(--box-line);
+  }
+
+  .box-feature-more article:last-child {
+    border-bottom: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .box-agent-probe,
+  .box-escape-trace > i,
+  .box-vm-barrier,
+  .box-vm-barrier > strong,
+  .box-cow-pages > i.is-dirty,
+  .box-pool-request-packet,
+  .box-pool-slots > div.is-active,
+  .box-pool-replenish,
+  .box-pool-result {
+    animation: none !important;
+  }
+
+  .box-agent-probe {
+    top: 42%;
+    left: calc(100% - 74px);
+    border-color: #dc756c;
+  }
+
+  .box-escape-trace > i {
+    left: 100%;
+  }
+
+  .box-vm-barrier {
+    border-color: #f18a80;
+  }
+
+  .box-vm-barrier > strong,
+  .box-pool-result {
+    opacity: 1;
+  }
+
+  .box-pool-result {
+    transform: none;
+  }
+}

--- a/website/theme/runtime-features.css
+++ b/website/theme/runtime-features.css
@@ -1,0 +1,944 @@
+.box-runtime-features {
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at 92% 8%,
+      rgba(98, 215, 139, 0.09),
+      transparent 26%
+    ),
+    radial-gradient(
+      circle at 10% 62%,
+      rgba(245, 185, 95, 0.045),
+      transparent 26%
+    ),
+    rgba(7, 10, 8, 0.96);
+}
+
+.box-feature-heading {
+  max-width: 930px;
+}
+
+.box-feature-list {
+  margin-top: 64px;
+  border-top: 1px solid var(--box-line);
+  border-left: 1px solid var(--box-line);
+}
+
+.box-feature-row {
+  display: grid;
+  min-height: 570px;
+  border-right: 1px solid var(--box-line);
+  border-bottom: 1px solid var(--box-line);
+  background: rgba(12, 17, 14, 0.9);
+  grid-template-columns: minmax(320px, 0.84fr) minmax(0, 1.16fr);
+}
+
+.box-feature-copy {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  min-width: 0;
+  padding: 50px 46px 44px;
+  border-right: 1px solid var(--box-line);
+  flex-direction: column;
+}
+
+.box-feature-copy > span {
+  color: var(--box-green);
+  font-family: var(--box-mono);
+  font-size: 10px;
+  font-weight: 680;
+  letter-spacing: 0.11em;
+}
+
+.box-feature-copy h3 {
+  max-width: 520px;
+  margin: 56px 0 0;
+  color: var(--box-text);
+  font-size: clamp(31px, 3vw, 45px);
+  font-weight: 665;
+  letter-spacing: -0.05em;
+  line-height: 1.07;
+}
+
+.box-feature-copy p {
+  max-width: 600px;
+  margin: 22px 0 0;
+  color: var(--box-muted);
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+.box-feature-copy > small {
+  display: block;
+  max-width: 590px;
+  margin-top: 18px;
+  padding-left: 13px;
+  border-left: 2px solid #4a574f;
+  color: #717e76;
+  font-size: 11px;
+  line-height: 1.65;
+}
+
+.box-feature-copy > code {
+  display: block;
+  overflow: hidden;
+  margin-top: auto;
+  padding: 14px 15px;
+  border: 1px solid var(--box-line);
+  background: #080c09;
+  color: #93a198;
+  font-family: var(--box-mono);
+  font-size: 10px;
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.box-feature-links {
+  display: flex;
+  margin-top: 17px;
+  flex-wrap: wrap;
+  gap: 9px 17px;
+}
+
+.box-feature-links a {
+  color: #82dda2;
+  font-family: var(--box-mono);
+  font-size: 10px;
+  text-decoration: underline;
+  text-decoration-color: rgba(130, 221, 162, 0.35);
+  text-underline-offset: 4px;
+}
+
+.box-feature-row--cow {
+  grid-template-columns: minmax(0, 1.16fr) minmax(320px, 0.84fr);
+}
+
+.box-feature-row--cow .box-feature-copy {
+  border-right: 0;
+  border-left: 1px solid var(--box-line);
+  grid-column: 2;
+}
+
+.box-feature-row--cow .box-cow-scene {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.box-feature-row--cow .box-feature-copy > span {
+  color: var(--box-amber);
+}
+
+.box-kernel-scene,
+.box-cow-scene,
+.box-pool-scene {
+  position: relative;
+  overflow: hidden;
+  min-width: 0;
+  margin: 34px;
+  border: 1px solid #303b35;
+  background:
+    linear-gradient(rgba(98, 215, 139, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(98, 215, 139, 0.025) 1px, transparent 1px),
+    #0a0f0c;
+  background-size: 26px 26px;
+  box-shadow:
+    0 25px 70px rgba(0, 0, 0, 0.34),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.015);
+}
+
+/* Dedicated-kernel boundary animation */
+
+.box-kernel-scene {
+  min-height: 500px;
+  padding: 63px 31px 31px;
+}
+
+.box-kernel-scene > header,
+.box-pool-scene > header {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: flex;
+  height: 48px;
+  padding: 0 17px;
+  border-bottom: 1px solid var(--box-line);
+  background: rgba(8, 12, 9, 0.94);
+  color: #9aa79f;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--box-mono);
+  font-size: 9px;
+  letter-spacing: 0.09em;
+}
+
+.box-kernel-scene > header small,
+.box-pool-scene > header small {
+  color: #505c55;
+  font-size: 8px;
+}
+
+.box-host-target {
+  position: absolute;
+  top: 91px;
+  right: 27px;
+  display: flex;
+  width: 22%;
+  min-width: 112px;
+  height: 330px;
+  padding: 18px 13px;
+  border: 1px solid #3b4740;
+  background: rgba(15, 20, 17, 0.96);
+  align-items: center;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.box-host-target > span {
+  color: #717f76;
+  font-family: var(--box-mono);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.box-host-target > strong {
+  margin-top: auto;
+  color: #aab4ae;
+  font-size: 11px;
+  font-weight: 620;
+}
+
+.box-host-target > i {
+  position: relative;
+  width: 34px;
+  height: 29px;
+  margin-bottom: auto;
+  border: 1px solid #657269;
+  border-radius: 3px;
+}
+
+.box-host-target > i::before {
+  position: absolute;
+  top: -14px;
+  left: 7px;
+  width: 18px;
+  height: 18px;
+  border: 1px solid #657269;
+  border-bottom: 0;
+  border-radius: 10px 10px 0 0;
+  content: '';
+}
+
+.box-host-target > i::after {
+  position: absolute;
+  top: 10px;
+  left: 14px;
+  width: 4px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--box-green);
+  content: '';
+  box-shadow: 0 0 9px rgba(98, 215, 139, 0.55);
+}
+
+.box-microvm-boundary {
+  position: relative;
+  width: calc(78% - 24px);
+  height: 100%;
+  min-height: 405px;
+  border: 2px solid #4c8c61;
+  background:
+    radial-gradient(
+      circle at 30% 42%,
+      rgba(98, 215, 139, 0.1),
+      transparent 38%
+    ),
+    rgba(10, 16, 12, 0.93);
+  box-shadow:
+    0 0 0 5px rgba(98, 215, 139, 0.025),
+    inset 0 0 40px rgba(98, 215, 139, 0.03);
+}
+
+.box-microvm-boundary > span {
+  position: absolute;
+  top: 14px;
+  left: 16px;
+  color: #73bd89;
+  font-family: var(--box-mono);
+  font-size: 8px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.box-guest-kernel {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  left: 18px;
+  display: flex;
+  height: 48px;
+  border: 1px solid #386047;
+  background: #101a13;
+  color: #90bf9e;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--box-mono);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+}
+
+.box-agent-probe {
+  position: absolute;
+  z-index: 4;
+  top: 56%;
+  left: 18%;
+  display: flex;
+  width: 56px;
+  height: 56px;
+  border: 1px solid #73bd89;
+  border-radius: 50%;
+  background: #14251a;
+  color: #c5ebd0;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  animation: box-agent-escape 5.2s cubic-bezier(0.45, 0, 0.32, 1) infinite;
+  box-shadow: 0 0 22px rgba(98, 215, 139, 0.17);
+}
+
+.box-agent-probe > i {
+  width: 16px;
+  height: 11px;
+  border: 1px solid currentcolor;
+  border-radius: 2px;
+}
+
+.box-agent-probe > i::before,
+.box-agent-probe > i::after {
+  display: inline-block;
+  width: 2px;
+  height: 2px;
+  margin: 2px 1px 0 3px;
+  border-radius: 50%;
+  background: currentcolor;
+  content: '';
+  vertical-align: top;
+}
+
+.box-agent-probe > strong {
+  margin-top: 5px;
+  font-family: var(--box-mono);
+  font-size: 7px;
+  letter-spacing: 0.08em;
+}
+
+.box-escape-trace {
+  position: absolute;
+  z-index: 2;
+  top: 49%;
+  left: 30%;
+  width: 39%;
+  height: 1px;
+  border-top: 1px dashed #804d49;
+  transform: rotate(-19deg);
+  transform-origin: left center;
+}
+
+.box-escape-trace > span {
+  position: absolute;
+  top: -22px;
+  left: 18%;
+  color: #925d57;
+  font-family: var(--box-mono);
+  font-size: 7px;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.box-escape-trace > i {
+  position: absolute;
+  top: -3px;
+  left: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #e07168;
+  animation: box-escape-packet 5.2s ease-in-out infinite;
+  box-shadow: 0 0 10px rgba(224, 113, 104, 0.76);
+}
+
+.box-vm-barrier {
+  position: absolute;
+  z-index: 5;
+  top: 25%;
+  right: -2px;
+  display: flex;
+  width: 24px;
+  height: 118px;
+  border: 1px solid #ab5a52;
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(224, 113, 104, 0.15) 0 6px,
+      rgba(224, 113, 104, 0.025) 6px 12px
+    ),
+    #1b1110;
+  align-items: center;
+  justify-content: center;
+  animation: box-barrier-pulse 5.2s ease-in-out infinite;
+}
+
+.box-vm-barrier > i::before,
+.box-vm-barrier > i::after {
+  position: absolute;
+  top: 57px;
+  left: 5px;
+  width: 13px;
+  height: 1px;
+  background: #f18a80;
+  content: '';
+}
+
+.box-vm-barrier > i::before {
+  transform: rotate(45deg);
+}
+
+.box-vm-barrier > i::after {
+  transform: rotate(-45deg);
+}
+
+.box-vm-barrier > strong {
+  position: absolute;
+  top: 50%;
+  left: 31px;
+  width: 92px;
+  color: #d9867e;
+  font-family: var(--box-mono);
+  font-size: 7px;
+  font-weight: 650;
+  line-height: 1.45;
+  opacity: 0;
+  transform: translateY(-50%);
+  animation: box-blocked-label 5.2s ease-in-out infinite;
+}
+
+@keyframes box-agent-escape {
+  0%,
+  18% {
+    top: 56%;
+    left: 18%;
+    border-color: #73bd89;
+  }
+  58%,
+  66% {
+    top: 33%;
+    left: calc(100% - 66px);
+    border-color: #dc756c;
+    background: #271715;
+  }
+  74% {
+    top: 38%;
+    left: calc(100% - 82px);
+  }
+  100% {
+    top: 56%;
+    left: 18%;
+  }
+}
+
+@keyframes box-escape-packet {
+  0%,
+  18% {
+    left: 0;
+    opacity: 0;
+  }
+  28% {
+    opacity: 1;
+  }
+  60%,
+  69% {
+    left: 100%;
+    opacity: 1;
+  }
+  76%,
+  100% {
+    left: 88%;
+    opacity: 0;
+  }
+}
+
+@keyframes box-barrier-pulse {
+  0%,
+  52%,
+  76%,
+  100% {
+    border-color: #6f3d39;
+    box-shadow: none;
+  }
+  60%,
+  69% {
+    border-color: #f18a80;
+    box-shadow: 0 0 28px rgba(224, 113, 104, 0.35);
+  }
+}
+
+@keyframes box-blocked-label {
+  0%,
+  53%,
+  76%,
+  100% {
+    opacity: 0;
+    transform: translate(-5px, -50%);
+  }
+  60%,
+  70% {
+    opacity: 1;
+    transform: translate(0, -50%);
+  }
+}
+
+/* Copy-on-write fork animation */
+
+.box-cow-scene {
+  display: flex;
+  min-height: 500px;
+  padding: 70px 30px 30px;
+  flex-direction: column;
+}
+
+.box-cow-template {
+  width: min(76%, 430px);
+  margin: 0 auto;
+  padding: 17px;
+  border: 1px solid #577662;
+  background:
+    linear-gradient(130deg, rgba(98, 215, 139, 0.09), transparent 54%), #101713;
+  box-shadow: 0 0 34px rgba(98, 215, 139, 0.055);
+}
+
+.box-cow-template header,
+.box-cow-forks header {
+  display: flex;
+  margin-bottom: 13px;
+  color: #afbbb3;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--box-mono);
+  font-size: 8px;
+  letter-spacing: 0.05em;
+}
+
+.box-cow-template header small,
+.box-cow-forks header small {
+  color: #5f6c64;
+  font-size: 7px;
+}
+
+.box-cow-pages {
+  display: grid;
+  gap: 5px;
+  grid-template-columns: repeat(6, 1fr);
+}
+
+.box-cow-pages > i {
+  height: 18px;
+  border: 1px solid #33423a;
+  background: #18221c;
+}
+
+.box-cow-pages > i.is-dirty {
+  border-color: #d79d52;
+  background: #735028;
+  animation: box-dirty-page 4.8s ease-in-out infinite;
+  box-shadow: 0 0 14px rgba(245, 185, 95, 0.16);
+}
+
+.box-cow-pages > i.is-dirty:nth-child(2n) {
+  animation-delay: 260ms;
+}
+
+.box-cow-pages > i.is-dirty:nth-child(3n) {
+  animation-delay: 520ms;
+}
+
+.box-cow-branches {
+  position: relative;
+  width: 74%;
+  height: 88px;
+  margin: 0 auto;
+}
+
+.box-cow-branches > span {
+  position: absolute;
+  z-index: 2;
+  top: 22px;
+  left: 50%;
+  padding: 4px 8px;
+  background: #0a0f0c;
+  color: var(--box-amber);
+  font-family: var(--box-mono);
+  font-size: 7px;
+  letter-spacing: 0.08em;
+  transform: translateX(-50%);
+}
+
+.box-cow-branches::before {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 1px;
+  height: 48px;
+  background: #4c5b52;
+  content: '';
+}
+
+.box-cow-branches::after {
+  position: absolute;
+  right: 11%;
+  bottom: 0;
+  left: 11%;
+  height: 40px;
+  border-top: 1px solid #4c5b52;
+  border-right: 1px solid #4c5b52;
+  border-left: 1px solid #4c5b52;
+  content: '';
+}
+
+.box-cow-branches > i {
+  position: absolute;
+  bottom: 0;
+  width: 1px;
+  height: 17px;
+  background: #4c5b52;
+}
+
+.box-cow-branches > i:nth-of-type(1) {
+  left: 11%;
+}
+
+.box-cow-branches > i:nth-of-type(2) {
+  left: 50%;
+}
+
+.box-cow-branches > i:nth-of-type(3) {
+  right: 11%;
+}
+
+.box-cow-forks {
+  display: grid;
+  margin-top: 0;
+  gap: 10px;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.box-cow-forks > div {
+  min-width: 0;
+  padding: 13px;
+  border: 1px solid #343e38;
+  background: rgba(14, 20, 16, 0.96);
+}
+
+.box-cow-forks > div:nth-child(2) {
+  border-color: #5b5038;
+}
+
+.box-cow-forks header {
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.box-cow-forks > div > span {
+  display: block;
+  margin-top: 9px;
+  color: #a57439;
+  font-family: var(--box-mono);
+  font-size: 7px;
+  text-align: right;
+}
+
+@keyframes box-dirty-page {
+  0%,
+  22%,
+  100% {
+    border-color: #465049;
+    background: #18221c;
+    transform: scale(1);
+  }
+  42%,
+  75% {
+    border-color: #d79d52;
+    background: #735028;
+    transform: scale(0.92);
+  }
+}
+
+/* Warm-pool lease animation */
+
+.box-pool-scene {
+  min-height: 500px;
+  padding: 75px 28px 66px;
+}
+
+.box-pool-flow {
+  position: relative;
+  display: grid;
+  min-height: 350px;
+  align-items: center;
+  gap: 27px;
+  grid-template-columns: 0.45fr minmax(200px, 1fr) 0.38fr;
+}
+
+.box-pool-queue {
+  display: flex;
+  height: 260px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.box-pool-queue > span,
+.box-pool-slots > span {
+  margin-bottom: 8px;
+  color: #66736b;
+  font-family: var(--box-mono);
+  font-size: 7px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.box-pool-queue > i {
+  width: 34px;
+  height: 26px;
+  border: 1px solid #3c4841;
+  background: #111713;
+}
+
+.box-pool-queue > i::before {
+  display: block;
+  width: 12px;
+  height: 3px;
+  margin: 7px auto 0;
+  background: #58655d;
+  content: '';
+  box-shadow: 0 6px #39443e;
+}
+
+.box-pool-request-packet {
+  position: absolute;
+  z-index: 5;
+  top: 49%;
+  left: 12%;
+  display: flex;
+  width: 42px;
+  height: 30px;
+  border: 1px solid var(--box-amber);
+  background: #2b2113;
+  color: #f1c77e;
+  align-items: center;
+  justify-content: center;
+  animation: box-pool-request 5.4s ease-in-out infinite;
+  font-family: var(--box-mono);
+  font-size: 7px;
+  box-shadow: 0 0 16px rgba(245, 185, 95, 0.15);
+}
+
+.box-pool-slots {
+  position: relative;
+  display: grid;
+  padding: 21px;
+  border: 1px solid #42614d;
+  background:
+    linear-gradient(145deg, rgba(98, 215, 139, 0.07), transparent 54%), #101713;
+  gap: 9px;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.box-pool-slots > span {
+  grid-column: 1 / -1;
+}
+
+.box-pool-slots > div:not(.box-pool-replenish) {
+  display: flex;
+  min-height: 82px;
+  padding: 12px;
+  border: 1px solid #33443a;
+  background: #0d130f;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.box-pool-slots > div.is-active {
+  animation: box-pool-slot 5.4s ease-in-out infinite;
+}
+
+.box-pool-slots > div > i {
+  width: 24px;
+  height: 17px;
+  border: 1px solid #668070;
+  border-radius: 2px;
+  background: #17231b;
+}
+
+.box-pool-slots > div > i::after {
+  display: block;
+  width: 10px;
+  height: 1px;
+  margin: 21px auto 0;
+  background: #526159;
+  content: '';
+}
+
+.box-pool-slots strong {
+  margin-top: 12px;
+  color: #acb8b0;
+  font-family: var(--box-mono);
+  font-size: 8px;
+}
+
+.box-pool-slots small {
+  margin-top: 3px;
+  color: #526159;
+  font-family: var(--box-mono);
+  font-size: 6px;
+}
+
+.box-pool-replenish {
+  position: absolute;
+  right: 11px;
+  bottom: -28px;
+  color: #67756d;
+  font-family: var(--box-mono);
+  font-size: 7px;
+  animation: box-pool-refill 5.4s ease-in-out infinite;
+}
+
+.box-pool-replenish::before {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 6px;
+  border: 1px solid var(--box-green);
+  border-top-color: transparent;
+  border-radius: 50%;
+  content: '';
+  vertical-align: -1px;
+}
+
+.box-pool-result {
+  display: flex;
+  width: 58px;
+  height: 38px;
+  border: 1px solid #42664f;
+  background: #122018;
+  color: #88cb9b;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  animation: box-pool-result 5.4s ease-in-out infinite;
+  font-family: var(--box-mono);
+  font-size: 7px;
+}
+
+.box-pool-scene > footer {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: grid;
+  height: 45px;
+  border-top: 1px solid var(--box-line);
+  background: #090d0a;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.box-pool-scene > footer span {
+  display: flex;
+  border-right: 1px solid var(--box-line);
+  color: #68756d;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--box-mono);
+  font-size: 8px;
+}
+
+.box-pool-scene > footer span:last-child {
+  border-right: 0;
+}
+
+@keyframes box-pool-request {
+  0%,
+  12% {
+    left: 12%;
+    opacity: 0;
+    transform: translateY(-50%);
+  }
+  20% {
+    opacity: 1;
+  }
+  48%,
+  56% {
+    left: 52%;
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+  65%,
+  100% {
+    left: 52%;
+    opacity: 0;
+    transform: translate(-50%, -50%);
+  }
+}
+
+@keyframes box-pool-slot {
+  0%,
+  40%,
+  82%,
+  100% {
+    border-color: #33443a;
+    background: #0d130f;
+    box-shadow: none;
+  }
+  49%,
+  72% {
+    border-color: #d39b52;
+    background: #251c11;
+    box-shadow: 0 0 20px rgba(245, 185, 95, 0.12);
+  }
+}
+
+@keyframes box-pool-result {
+  0%,
+  56%,
+  100% {
+    opacity: 0;
+    transform: translateX(-14px);
+  }
+  68%,
+  82% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes box-pool-refill {
+  0%,
+  68%,
+  100% {
+    opacity: 0.36;
+  }
+  78%,
+  92% {
+    color: #84ba94;
+    opacity: 1;
+  }
+  78%,
+  92% {
+    transform: translateY(-2px);
+  }
+}


### PR DESCRIPTION
## Summary

- make dedicated-kernel MicroVMs, copy-on-write forks, and warm pools visible from the hero
- add an agent escape-attempt animation that stops at the hardware VM boundary
- visualize shared CoW pages/private writes and warm-pool lease/replenishment flow
- state Linux/KVM limits, fallback behavior, and benchmark scope next to the visuals
- add bilingual SSR, responsive, and reduced-motion build contracts

## Validation

- npm run format:check
- npm run lint
- npm run build
- npm run check:site
- browser QA at 1440x900 and 390x844 in Chinese and English
- animation recording and reduced-motion verification