### PR TITLE
feat(runtime): add Artifact, Volume, and Task-output storage ports

### DIFF
--- a/src/runtime/src/a3s_runtime_driver/artifact.rs
+++ b/src/runtime/src/a3s_runtime_driver/artifact.rs
@@ -1,10 +1,8 @@
 //! Runtime Artifact, persistent Volume, and Task-output storage bindings.
 
-use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
-use a3s_box_core::volume::VolumeConfig;
 use a3s_box_core::CreateExecutionRequest;
 use a3s_runtime::contract::{
     RuntimeMount, RuntimeMountSource, RuntimeOutputArtifact, RuntimeOutputSpec, RuntimeUnitSpec,
@@ -12,16 +10,13 @@ use a3s_runtime::contract::{
 };
 use a3s_runtime::{RuntimeError, RuntimeResult};
 use async_trait::async_trait;
-use sha2::{Digest, Sha256};
 
-use crate::{BoxRecord, VolumeStore};
+use crate::BoxRecord;
 
-const VOLUME_ROLE_LABEL: &str = "a3s.runtime.volume-role";
-const VOLUME_ID_LABEL: &str = "a3s.runtime.volume-id";
-const SPEC_DIGEST_LABEL: &str = "a3s.runtime.spec-digest";
-const OUTPUT_NAME_LABEL: &str = "a3s.runtime.output-name";
-const PERSISTENT_VOLUME_ROLE: &str = "persistent";
-const OUTPUT_VOLUME_ROLE: &str = "task-output";
+use super::volume_storage::{
+    cleanup_output_volumes, require_output_volume, reset_output_volumes, resolve_output_volume,
+    resolve_persistent_volume,
+};
 
 /// Caller-owned Artifact boundary composed into the shared Box Runtime driver.
 ///
@@ -331,171 +326,6 @@ impl ArtifactStorageOwner {
     }
 }
 
-#[derive(Debug)]
-struct ResolvedVolume {
-    name: String,
-    path: PathBuf,
-}
-
-fn resolve_persistent_volume(
-    home_dir: &Path,
-    volume_id: &str,
-    create: bool,
-) -> RuntimeResult<ResolvedVolume> {
-    let name = format!(
-        "a3s-runtime-volume-{:x}",
-        Sha256::digest(volume_id.as_bytes())
-    );
-    let mut labels = BTreeMap::new();
-    labels.insert(
-        VOLUME_ROLE_LABEL.to_owned(),
-        PERSISTENT_VOLUME_ROLE.to_owned(),
-    );
-    labels.insert(VOLUME_ID_LABEL.to_owned(), volume_id.to_owned());
-    resolve_volume(home_dir, name, labels, create)
-}
-
-fn resolve_output_volume(
-    home_dir: &Path,
-    spec: &RuntimeUnitSpec,
-    output: &RuntimeOutputSpec,
-    create: bool,
-) -> RuntimeResult<ResolvedVolume> {
-    let digest = spec.digest().map_err(RuntimeError::InvalidRequest)?;
-    let hex = digest.strip_prefix("sha256:").ok_or_else(|| {
-        RuntimeError::Protocol("Box Task output requires a SHA-256 spec digest".into())
-    })?;
-    let name = format!(
-        "a3s-runtime-output-{hex}-{:x}",
-        Sha256::digest(output.name.as_bytes())
-    );
-    let mut labels = BTreeMap::new();
-    labels.insert(VOLUME_ROLE_LABEL.to_owned(), OUTPUT_VOLUME_ROLE.to_owned());
-    labels.insert(SPEC_DIGEST_LABEL.to_owned(), digest);
-    labels.insert(OUTPUT_NAME_LABEL.to_owned(), output.name.clone());
-    resolve_volume(home_dir, name, labels, create)
-}
-
-fn resolve_volume(
-    home_dir: &Path,
-    name: String,
-    labels: BTreeMap<String, String>,
-    create: bool,
-) -> RuntimeResult<ResolvedVolume> {
-    let store = volume_store(home_dir);
-    let mut expected = VolumeConfig::new(&name, "");
-    expected.labels.extend(labels.clone());
-    let volume = match store.get(&name).map_err(volume_store_error)? {
-        Some(volume) => volume,
-        None if create => store.get_or_create(expected).map_err(volume_store_error)?,
-        None => {
-            return Err(RuntimeError::ProviderUnavailable(format!(
-                "Box Runtime Volume {name:?} is missing"
-            )))
-        }
-    };
-    let expected_path = home_dir.join("volumes").join(&name);
-    if volume.name != name
-        || volume.driver != "local"
-        || volume.size_limit != 0
-        || labels
-            .iter()
-            .any(|(key, value)| volume.labels.get(key) != Some(value))
-        || Path::new(&volume.mount_point) != expected_path
-    {
-        return Err(RuntimeError::ProviderUnavailable(format!(
-            "Box Runtime Volume {name:?} has conflicting persisted metadata"
-        )));
-    }
-    validate_volume_path(&expected_path)?;
-    Ok(ResolvedVolume {
-        name,
-        path: expected_path,
-    })
-}
-
-fn require_output_volume(
-    home_dir: &Path,
-    spec: &RuntimeUnitSpec,
-    output: &RuntimeOutputSpec,
-) -> RuntimeResult<PathBuf> {
-    let resolved = resolve_output_volume(home_dir, spec, output, false)?;
-    let store = volume_store(home_dir);
-    let volume = store
-        .get(&resolved.name)
-        .map_err(volume_store_error)?
-        .ok_or_else(|| {
-            RuntimeError::ProviderUnavailable("Task output Volume disappeared".into())
-        })?;
-    if !volume.in_use_by.is_empty() {
-        return Err(RuntimeError::ProviderUnavailable(
-            "Box Task output is still attached to a live execution".into(),
-        ));
-    }
-    Ok(resolved.path)
-}
-
-fn reset_output_volumes(home_dir: &Path, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
-    for output in &spec.outputs {
-        let path = require_output_volume(home_dir, spec, output)?;
-        for entry in std::fs::read_dir(&path).map_err(volume_io_error)? {
-            let entry = entry.map_err(volume_io_error)?;
-            let metadata = std::fs::symlink_metadata(entry.path()).map_err(volume_io_error)?;
-            if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
-                std::fs::remove_dir_all(entry.path()).map_err(volume_io_error)?;
-            } else {
-                std::fs::remove_file(entry.path()).map_err(volume_io_error)?;
-            }
-        }
-    }
-    Ok(())
-}
-
-fn cleanup_output_volumes(home_dir: &Path, digest: &str) -> RuntimeResult<()> {
-    let store = volume_store(home_dir);
-    let outputs = store
-        .list()
-        .map_err(volume_store_error)?
-        .into_iter()
-        .filter(|volume| {
-            volume.labels.get(VOLUME_ROLE_LABEL).map(String::as_str) == Some(OUTPUT_VOLUME_ROLE)
-                && volume.labels.get(SPEC_DIGEST_LABEL).map(String::as_str) == Some(digest)
-        })
-        .collect::<Vec<_>>();
-    for volume in outputs {
-        if !volume.in_use_by.is_empty() {
-            return Err(RuntimeError::ProviderUnavailable(format!(
-                "Box Task-output Volume {:?} is still attached",
-                volume.name
-            )));
-        }
-        store
-            .remove(&volume.name, false)
-            .map_err(volume_store_error)?;
-    }
-    Ok(())
-}
-
-fn volume_store(home_dir: &Path) -> VolumeStore {
-    VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"))
-}
-
-fn validate_volume_path(path: &Path) -> RuntimeResult<()> {
-    let metadata = std::fs::symlink_metadata(path).map_err(volume_io_error)?;
-    let canonical = path.canonicalize().map_err(volume_io_error)?;
-    if !path.is_absolute()
-        || metadata.file_type().is_symlink()
-        || !metadata.file_type().is_dir()
-        || canonical != path
-    {
-        return Err(RuntimeError::ProviderUnavailable(format!(
-            "Box Runtime Volume path is not a canonical plain directory: {}",
-            path.display()
-        )));
-    }
-    Ok(())
-}
-
 async fn validate_artifact_mount_path(path: PathBuf) -> RuntimeResult<PathBuf> {
     let display = path.to_str().ok_or_else(|| {
         RuntimeError::InvalidRequest("Box Artifact mount path is not UTF-8".into())
@@ -654,14 +484,6 @@ fn map_port_error(error: BoxArtifactPortError) -> RuntimeError {
             "Box Artifact boundary is temporarily unavailable".into(),
         ),
     }
-}
-
-fn volume_store_error(error: impl std::fmt::Display) -> RuntimeError {
-    RuntimeError::ProviderUnavailable(format!("Box VolumeStore operation failed: {error}"))
-}
-
-fn volume_io_error(error: std::io::Error) -> RuntimeError {
-    RuntimeError::ProviderUnavailable(format!("Box Runtime Volume I/O failed: {error}"))
 }
 
 fn artifact_io_error(error: std::io::Error) -> RuntimeError {

--- a/src/runtime/src/a3s_runtime_driver/artifact.rs
+++ b/src/runtime/src/a3s_runtime_driver/artifact.rs
@@ -313,8 +313,9 @@ impl ArtifactStorageOwner {
             let home_dir = self.home_dir.clone();
             let spec = spec.clone();
             let output = output.clone();
+            let output_for_lookup = output.clone();
             let resolved = tokio::task::spawn_blocking(move || {
-                resolve_output_volume(&home_dir, &spec, &output, create_volumes)
+                resolve_output_volume(&home_dir, &spec, &output_for_lookup, create_volumes)
             })
             .await
             .map_err(|error| {

--- a/src/runtime/src/a3s_runtime_driver/artifact.rs
+++ b/src/runtime/src/a3s_runtime_driver/artifact.rs
@@ -1,0 +1,668 @@
+//! Runtime Artifact, persistent Volume, and Task-output storage bindings.
+
+use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use a3s_box_core::volume::VolumeConfig;
+use a3s_box_core::CreateExecutionRequest;
+use a3s_runtime::contract::{
+    RuntimeMount, RuntimeMountSource, RuntimeOutputArtifact, RuntimeOutputSpec, RuntimeUnitSpec,
+    SecretTarget,
+};
+use a3s_runtime::{RuntimeError, RuntimeResult};
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+use crate::{BoxRecord, VolumeStore};
+
+const VOLUME_ROLE_LABEL: &str = "a3s.runtime.volume-role";
+const VOLUME_ID_LABEL: &str = "a3s.runtime.volume-id";
+const SPEC_DIGEST_LABEL: &str = "a3s.runtime.spec-digest";
+const OUTPUT_NAME_LABEL: &str = "a3s.runtime.output-name";
+const PERSISTENT_VOLUME_ROLE: &str = "persistent";
+const OUTPUT_VOLUME_ROLE: &str = "task-output";
+
+/// Caller-owned Artifact boundary composed into the shared Box Runtime driver.
+///
+/// Box accepts only shared A3S Runtime contract types. The caller remains the
+/// authority for authenticated Artifact transport, admission, hashing, and
+/// publication. Box owns only local mount wiring, execution fencing, and the
+/// lifecycle of its existing VolumeStore entries.
+#[async_trait]
+pub trait BoxArtifactPort: Send + Sync {
+    /// Return the already materialized, read-only host directory for one input.
+    async fn mount_path(
+        &self,
+        spec: &RuntimeUnitSpec,
+        mount: &RuntimeMount,
+    ) -> Result<PathBuf, BoxArtifactPortError>;
+
+    /// Admit one quiescent Task-output directory into the caller's Artifact store.
+    async fn capture_output(
+        &self,
+        spec: &RuntimeUnitSpec,
+        output: &RuntimeOutputSpec,
+        source: &Path,
+    ) -> Result<RuntimeOutputArtifact, BoxArtifactPortError>;
+
+    /// Release caller-owned materialization views for one immutable spec.
+    async fn cleanup_spec(&self, spec_digest: &str) -> Result<(), BoxArtifactPortError>;
+}
+
+/// Stable, non-sensitive failure categories for caller-provided Artifact ports.
+#[derive(Debug, thiserror::Error)]
+pub enum BoxArtifactPortError {
+    #[error("Artifact request was rejected: {0}")]
+    Rejected(String),
+    #[error("Artifact boundary is temporarily unavailable: {0}")]
+    Unavailable(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RuntimeStoragePlan {
+    spec_digest: String,
+    volumes: Vec<String>,
+    volume_names: Vec<String>,
+}
+
+impl RuntimeStoragePlan {
+    pub(super) fn empty(spec: &RuntimeUnitSpec) -> RuntimeResult<Self> {
+        Ok(Self {
+            spec_digest: spec.digest().map_err(RuntimeError::InvalidRequest)?,
+            volumes: Vec::new(),
+            volume_names: Vec::new(),
+        })
+    }
+
+    pub(super) fn from_request(
+        spec: &RuntimeUnitSpec,
+        request: &CreateExecutionRequest,
+    ) -> RuntimeResult<Self> {
+        let secret_mounts = spec
+            .secrets
+            .iter()
+            .filter(|secret| !matches!(secret.target, SecretTarget::RegistryCredential))
+            .count();
+        let storage_mounts = request
+            .config
+            .volumes
+            .len()
+            .checked_sub(secret_mounts)
+            .ok_or_else(|| {
+                RuntimeError::Protocol("Box creation request omitted a Runtime Secret mount".into())
+            })?;
+        Ok(Self {
+            spec_digest: spec.digest().map_err(RuntimeError::Protocol)?,
+            volumes: request.config.volumes[..storage_mounts].to_vec(),
+            volume_names: request.policy.volume_names.clone(),
+        })
+    }
+
+    pub(super) fn volumes(&self) -> &[String] {
+        &self.volumes
+    }
+
+    pub(super) fn volume_names(&self) -> &[String] {
+        &self.volume_names
+    }
+
+    pub(super) fn validate_for(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+        let digest = spec.digest().map_err(RuntimeError::InvalidRequest)?;
+        if self.spec_digest != digest {
+            return Err(RuntimeError::Protocol(
+                "Box Runtime storage plan belongs to another specification".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct ArtifactStorageOwner {
+    home_dir: PathBuf,
+    port: Option<Arc<dyn BoxArtifactPort>>,
+}
+
+impl ArtifactStorageOwner {
+    pub(super) fn new(home_dir: PathBuf, port: Option<Arc<dyn BoxArtifactPort>>) -> Self {
+        Self { home_dir, port }
+    }
+
+    pub(super) fn artifact_configured(&self) -> bool {
+        self.port.is_some()
+    }
+
+    pub(super) fn require_configured_for(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+        let needs_artifacts = spec
+            .mounts
+            .iter()
+            .any(|mount| matches!(mount.source, RuntimeMountSource::Artifact { .. }));
+        let mut missing = Vec::new();
+        if needs_artifacts && self.port.is_none() {
+            missing.push("mount_kind:Artifact".into());
+        }
+        if !spec.outputs.is_empty() && self.port.is_none() {
+            missing.push("feature:OutputArtifacts".into());
+        }
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(RuntimeError::UnsupportedCapabilities(missing))
+        }
+    }
+
+    pub(super) async fn prepare_plan(
+        &self,
+        spec: &RuntimeUnitSpec,
+    ) -> RuntimeResult<RuntimeStoragePlan> {
+        self.build_plan(spec, true).await
+    }
+
+    pub(super) async fn require_plan(
+        &self,
+        spec: &RuntimeUnitSpec,
+    ) -> RuntimeResult<RuntimeStoragePlan> {
+        self.build_plan(spec, false).await
+    }
+
+    pub(super) async fn validate_record(
+        &self,
+        spec: &RuntimeUnitSpec,
+        record: &BoxRecord,
+    ) -> RuntimeResult<()> {
+        let request = &record
+            .managed_execution
+            .as_ref()
+            .ok_or_else(|| RuntimeError::Protocol("Box execution lost metadata".into()))?
+            .request;
+        let actual = RuntimeStoragePlan::from_request(spec, request)?;
+        let expected = self.require_plan(spec).await?;
+        if actual != expected {
+            return Err(RuntimeError::Protocol(format!(
+                "Box execution {} storage bindings do not match the Runtime specification",
+                record.id
+            )));
+        }
+        Ok(())
+    }
+
+    pub(super) async fn reset_outputs_for_start(
+        &self,
+        spec: &RuntimeUnitSpec,
+    ) -> RuntimeResult<()> {
+        if spec.outputs.is_empty() {
+            return Ok(());
+        }
+        let home_dir = self.home_dir.clone();
+        let spec = spec.clone();
+        tokio::task::spawn_blocking(move || reset_output_volumes(&home_dir, &spec))
+            .await
+            .map_err(|error| {
+                RuntimeError::ProviderUnavailable(format!(
+                    "Box Task-output reset task failed: {error}"
+                ))
+            })?
+    }
+
+    pub(super) async fn capture_outputs(
+        &self,
+        spec: &RuntimeUnitSpec,
+    ) -> RuntimeResult<Vec<RuntimeOutputArtifact>> {
+        if spec.outputs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let port = self.port.as_ref().ok_or_else(|| {
+            RuntimeError::UnsupportedCapabilities(vec!["feature:OutputArtifacts".into()])
+        })?;
+        let home_dir = self.home_dir.clone();
+        let spec_for_paths = spec.clone();
+        let sources = tokio::task::spawn_blocking(move || {
+            spec_for_paths
+                .outputs
+                .iter()
+                .map(|output| require_output_volume(&home_dir, &spec_for_paths, output))
+                .collect::<RuntimeResult<Vec<_>>>()
+        })
+        .await
+        .map_err(|error| {
+            RuntimeError::ProviderUnavailable(format!(
+                "Box Task-output lookup task failed: {error}"
+            ))
+        })??;
+
+        let mut captured = Vec::with_capacity(spec.outputs.len());
+        for (output, source) in spec.outputs.iter().zip(sources) {
+            let artifact = port
+                .capture_output(spec, output, &source)
+                .await
+                .map_err(map_port_error)?;
+            validate_captured_output(output, &artifact)?;
+            captured.push(artifact);
+        }
+        Ok(captured)
+    }
+
+    pub(super) async fn cleanup_spec(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+        let digest = spec.digest().map_err(RuntimeError::InvalidRequest)?;
+        self.cleanup_digest(&digest).await
+    }
+
+    pub(super) async fn cleanup_digest(&self, digest: &str) -> RuntimeResult<()> {
+        validate_digest(digest)?;
+        if let Some(port) = &self.port {
+            port.cleanup_spec(digest).await.map_err(map_port_error)?;
+        }
+        let home_dir = self.home_dir.clone();
+        let digest = digest.to_owned();
+        tokio::task::spawn_blocking(move || cleanup_output_volumes(&home_dir, &digest))
+            .await
+            .map_err(|error| {
+                RuntimeError::ProviderUnavailable(format!(
+                    "Box Task-output cleanup task failed: {error}"
+                ))
+            })?
+    }
+
+    async fn build_plan(
+        &self,
+        spec: &RuntimeUnitSpec,
+        create_volumes: bool,
+    ) -> RuntimeResult<RuntimeStoragePlan> {
+        spec.validate().map_err(RuntimeError::InvalidRequest)?;
+        self.require_configured_for(spec)?;
+        validate_storage_targets(spec)?;
+
+        let mut plan = RuntimeStoragePlan::empty(spec)?;
+        for mount in &spec.mounts {
+            match &mount.source {
+                RuntimeMountSource::Artifact { .. } => {
+                    if !mount.read_only {
+                        return Err(RuntimeError::InvalidRequest(
+                            "Box Runtime Artifact mounts must be read-only".into(),
+                        ));
+                    }
+                    let port = self.port.as_ref().ok_or_else(|| {
+                        RuntimeError::UnsupportedCapabilities(vec!["mount_kind:Artifact".into()])
+                    })?;
+                    let source = port.mount_path(spec, mount).await.map_err(map_port_error)?;
+                    let source = validate_artifact_mount_path(source).await?;
+                    plan.volumes.push(bind_mount(&source, &mount.target, true)?);
+                }
+                RuntimeMountSource::Volume { volume_id } => {
+                    let home_dir = self.home_dir.clone();
+                    let volume_id = volume_id.clone();
+                    let resolved = tokio::task::spawn_blocking(move || {
+                        resolve_persistent_volume(&home_dir, &volume_id, create_volumes)
+                    })
+                    .await
+                    .map_err(|error| {
+                        RuntimeError::ProviderUnavailable(format!(
+                            "Box persistent-Volume lookup task failed: {error}"
+                        ))
+                    })??;
+                    plan.volumes
+                        .push(bind_mount(&resolved.path, &mount.target, mount.read_only)?);
+                    plan.volume_names.push(resolved.name);
+                }
+                RuntimeMountSource::Tmpfs { .. } => {}
+            }
+        }
+
+        for output in &spec.outputs {
+            let home_dir = self.home_dir.clone();
+            let spec = spec.clone();
+            let output = output.clone();
+            let resolved = tokio::task::spawn_blocking(move || {
+                resolve_output_volume(&home_dir, &spec, &output, create_volumes)
+            })
+            .await
+            .map_err(|error| {
+                RuntimeError::ProviderUnavailable(format!(
+                    "Box Task-output Volume lookup task failed: {error}"
+                ))
+            })??;
+            plan.volumes
+                .push(bind_mount(&resolved.path, &output.path, false)?);
+            plan.volume_names.push(resolved.name);
+        }
+        Ok(plan)
+    }
+}
+
+#[derive(Debug)]
+struct ResolvedVolume {
+    name: String,
+    path: PathBuf,
+}
+
+fn resolve_persistent_volume(
+    home_dir: &Path,
+    volume_id: &str,
+    create: bool,
+) -> RuntimeResult<ResolvedVolume> {
+    let name = format!(
+        "a3s-runtime-volume-{:x}",
+        Sha256::digest(volume_id.as_bytes())
+    );
+    let mut labels = BTreeMap::new();
+    labels.insert(
+        VOLUME_ROLE_LABEL.to_owned(),
+        PERSISTENT_VOLUME_ROLE.to_owned(),
+    );
+    labels.insert(VOLUME_ID_LABEL.to_owned(), volume_id.to_owned());
+    resolve_volume(home_dir, name, labels, create)
+}
+
+fn resolve_output_volume(
+    home_dir: &Path,
+    spec: &RuntimeUnitSpec,
+    output: &RuntimeOutputSpec,
+    create: bool,
+) -> RuntimeResult<ResolvedVolume> {
+    let digest = spec.digest().map_err(RuntimeError::InvalidRequest)?;
+    let hex = digest.strip_prefix("sha256:").ok_or_else(|| {
+        RuntimeError::Protocol("Box Task output requires a SHA-256 spec digest".into())
+    })?;
+    let name = format!(
+        "a3s-runtime-output-{hex}-{:x}",
+        Sha256::digest(output.name.as_bytes())
+    );
+    let mut labels = BTreeMap::new();
+    labels.insert(VOLUME_ROLE_LABEL.to_owned(), OUTPUT_VOLUME_ROLE.to_owned());
+    labels.insert(SPEC_DIGEST_LABEL.to_owned(), digest);
+    labels.insert(OUTPUT_NAME_LABEL.to_owned(), output.name.clone());
+    resolve_volume(home_dir, name, labels, create)
+}
+
+fn resolve_volume(
+    home_dir: &Path,
+    name: String,
+    labels: BTreeMap<String, String>,
+    create: bool,
+) -> RuntimeResult<ResolvedVolume> {
+    let store = volume_store(home_dir);
+    let mut expected = VolumeConfig::new(&name, "");
+    expected.labels.extend(labels.clone());
+    let volume = match store.get(&name).map_err(volume_store_error)? {
+        Some(volume) => volume,
+        None if create => store.get_or_create(expected).map_err(volume_store_error)?,
+        None => {
+            return Err(RuntimeError::ProviderUnavailable(format!(
+                "Box Runtime Volume {name:?} is missing"
+            )))
+        }
+    };
+    let expected_path = home_dir.join("volumes").join(&name);
+    if volume.name != name
+        || volume.driver != "local"
+        || volume.size_limit != 0
+        || labels
+            .iter()
+            .any(|(key, value)| volume.labels.get(key) != Some(value))
+        || Path::new(&volume.mount_point) != expected_path
+    {
+        return Err(RuntimeError::ProviderUnavailable(format!(
+            "Box Runtime Volume {name:?} has conflicting persisted metadata"
+        )));
+    }
+    validate_volume_path(&expected_path)?;
+    Ok(ResolvedVolume {
+        name,
+        path: expected_path,
+    })
+}
+
+fn require_output_volume(
+    home_dir: &Path,
+    spec: &RuntimeUnitSpec,
+    output: &RuntimeOutputSpec,
+) -> RuntimeResult<PathBuf> {
+    let resolved = resolve_output_volume(home_dir, spec, output, false)?;
+    let store = volume_store(home_dir);
+    let volume = store
+        .get(&resolved.name)
+        .map_err(volume_store_error)?
+        .ok_or_else(|| {
+            RuntimeError::ProviderUnavailable("Task output Volume disappeared".into())
+        })?;
+    if !volume.in_use_by.is_empty() {
+        return Err(RuntimeError::ProviderUnavailable(
+            "Box Task output is still attached to a live execution".into(),
+        ));
+    }
+    Ok(resolved.path)
+}
+
+fn reset_output_volumes(home_dir: &Path, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+    for output in &spec.outputs {
+        let path = require_output_volume(home_dir, spec, output)?;
+        for entry in std::fs::read_dir(&path).map_err(volume_io_error)? {
+            let entry = entry.map_err(volume_io_error)?;
+            let metadata = std::fs::symlink_metadata(entry.path()).map_err(volume_io_error)?;
+            if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+                std::fs::remove_dir_all(entry.path()).map_err(volume_io_error)?;
+            } else {
+                std::fs::remove_file(entry.path()).map_err(volume_io_error)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cleanup_output_volumes(home_dir: &Path, digest: &str) -> RuntimeResult<()> {
+    let store = volume_store(home_dir);
+    let outputs = store
+        .list()
+        .map_err(volume_store_error)?
+        .into_iter()
+        .filter(|volume| {
+            volume.labels.get(VOLUME_ROLE_LABEL).map(String::as_str) == Some(OUTPUT_VOLUME_ROLE)
+                && volume.labels.get(SPEC_DIGEST_LABEL).map(String::as_str) == Some(digest)
+        })
+        .collect::<Vec<_>>();
+    for volume in outputs {
+        if !volume.in_use_by.is_empty() {
+            return Err(RuntimeError::ProviderUnavailable(format!(
+                "Box Task-output Volume {:?} is still attached",
+                volume.name
+            )));
+        }
+        store
+            .remove(&volume.name, false)
+            .map_err(volume_store_error)?;
+    }
+    Ok(())
+}
+
+fn volume_store(home_dir: &Path) -> VolumeStore {
+    VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"))
+}
+
+fn validate_volume_path(path: &Path) -> RuntimeResult<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(volume_io_error)?;
+    let canonical = path.canonicalize().map_err(volume_io_error)?;
+    if !path.is_absolute()
+        || metadata.file_type().is_symlink()
+        || !metadata.file_type().is_dir()
+        || canonical != path
+    {
+        return Err(RuntimeError::ProviderUnavailable(format!(
+            "Box Runtime Volume path is not a canonical plain directory: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+async fn validate_artifact_mount_path(path: PathBuf) -> RuntimeResult<PathBuf> {
+    let display = path.to_str().ok_or_else(|| {
+        RuntimeError::InvalidRequest("Box Artifact mount path is not UTF-8".into())
+    })?;
+    if !path.is_absolute()
+        || display.contains([':', '\0'])
+        || display.bytes().any(|byte| byte.is_ascii_control())
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::CurDir | Component::ParentDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Artifact mount path must be an encodable normalized absolute path".into(),
+        ));
+    }
+    let metadata = tokio::fs::symlink_metadata(&path)
+        .await
+        .map_err(artifact_io_error)?;
+    let canonical = tokio::fs::canonicalize(&path)
+        .await
+        .map_err(artifact_io_error)?;
+    if metadata.file_type().is_symlink() || !metadata.file_type().is_dir() || canonical != path {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Artifact mount source must be a canonical plain directory".into(),
+        ));
+    }
+    Ok(path)
+}
+
+fn bind_mount(source: &Path, target: &str, read_only: bool) -> RuntimeResult<String> {
+    let source = source.to_str().ok_or_else(|| {
+        RuntimeError::InvalidRequest("Box Runtime mount source is not UTF-8".into())
+    })?;
+    if source.contains([':', '\0']) || source.bytes().any(|byte| byte.is_ascii_control()) {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Runtime mount source cannot be encoded".into(),
+        ));
+    }
+    Ok(format!(
+        "{source}:{target}:{}",
+        if read_only { "ro" } else { "rw" }
+    ))
+}
+
+fn validate_storage_targets(spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+    let mut targets = Vec::new();
+    for mount in &spec.mounts {
+        validate_target(
+            &mount.target,
+            matches!(mount.source, RuntimeMountSource::Tmpfs { .. }),
+        )?;
+        targets.push(PathBuf::from(&mount.target));
+    }
+    for output in &spec.outputs {
+        validate_target(&output.path, false)?;
+        targets.push(PathBuf::from(&output.path));
+    }
+    for secret in &spec.secrets {
+        if let SecretTarget::File { path, .. } = &secret.target {
+            targets.push(PathBuf::from(path));
+        }
+    }
+    for (index, target) in targets.iter().enumerate() {
+        if targets
+            .iter()
+            .skip(index + 1)
+            .any(|other| paths_overlap(target, other))
+        {
+            return Err(RuntimeError::InvalidRequest(
+                "Box Runtime mount, output, and Secret targets must not overlap".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_target(target: &str, tmpfs: bool) -> RuntimeResult<()> {
+    let path = Path::new(target);
+    let normalized = target.strip_prefix('/').is_some_and(|relative| {
+        !relative.is_empty()
+            && !relative.ends_with('/')
+            && relative
+                .split('/')
+                .all(|segment| !segment.is_empty() && !matches!(segment, "." | ".."))
+    });
+    let is_or_below = |root: &Path| {
+        path == root
+            || path
+                .strip_prefix(root)
+                .is_ok_and(|suffix| !suffix.as_os_str().is_empty())
+    };
+    let protected = path == Path::new("/")
+        || is_or_below(Path::new("/proc"))
+        || is_or_below(Path::new("/sys"))
+        || (is_or_below(Path::new("/dev")) && !(tmpfs && path == Path::new("/dev/shm")))
+        || is_or_below(Path::new("/run/a3s-box"))
+        || is_or_below(Path::new("/.a3s-box-secrets"));
+    if !normalized
+        || target.contains([':', '\0'])
+        || target.bytes().any(|byte| byte.is_ascii_control())
+        || protected
+    {
+        return Err(RuntimeError::InvalidRequest(format!(
+            "Box Runtime mount target must be an encodable normalized unprotected absolute path: {target:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn paths_overlap(left: &Path, right: &Path) -> bool {
+    left == right || left.starts_with(right) || right.starts_with(left)
+}
+
+fn validate_captured_output(
+    expected: &RuntimeOutputSpec,
+    actual: &RuntimeOutputArtifact,
+) -> RuntimeResult<()> {
+    actual.artifact.validate().map_err(RuntimeError::Protocol)?;
+    if actual.name != expected.name
+        || actual.artifact.media_type != expected.media_type
+        || actual.size_bytes == 0
+        || actual.size_bytes > expected.max_bytes
+    {
+        return Err(RuntimeError::Protocol(
+            "Box Artifact port returned an output outside its Runtime declaration".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_digest(digest: &str) -> RuntimeResult<()> {
+    let valid = digest.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    });
+    if valid {
+        Ok(())
+    } else {
+        Err(RuntimeError::Protocol(
+            "Box Artifact cleanup requires a lowercase SHA-256 spec digest".into(),
+        ))
+    }
+}
+
+fn map_port_error(error: BoxArtifactPortError) -> RuntimeError {
+    match error {
+        BoxArtifactPortError::Rejected(_) => RuntimeError::InvalidRequest(
+            "Box Artifact request was rejected by the caller boundary".into(),
+        ),
+        BoxArtifactPortError::Unavailable(_) => RuntimeError::ProviderUnavailable(
+            "Box Artifact boundary is temporarily unavailable".into(),
+        ),
+    }
+}
+
+fn volume_store_error(error: impl std::fmt::Display) -> RuntimeError {
+    RuntimeError::ProviderUnavailable(format!("Box VolumeStore operation failed: {error}"))
+}
+
+fn volume_io_error(error: std::io::Error) -> RuntimeError {
+    RuntimeError::ProviderUnavailable(format!("Box Runtime Volume I/O failed: {error}"))
+}
+
+fn artifact_io_error(error: std::io::Error) -> RuntimeError {
+    RuntimeError::ProviderUnavailable(format!("Box Artifact mount I/O failed: {error}"))
+}

--- a/src/runtime/src/a3s_runtime_driver/artifact_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/artifact_tests.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use a3s_box_core::ExecutionManager;
 use a3s_runtime::contract::{
     ArtifactRef, MountKind, RestartPolicy, RuntimeMount, RuntimeMountSource, RuntimeOutputArtifact,
     RuntimeOutputSpec, RuntimeUnitClass, RuntimeUnitSpec, SecretReference, SecretTarget,
@@ -15,7 +14,7 @@ use crate::VolumeStore;
 
 use super::mapping::creation_request_for;
 use super::test_support::{
-    accepted, action, fake_driver, fake_driver_with_backend, runtime_spec, unit, DriverFakeBackend,
+    accepted, action, fake_driver, fake_driver_with_backend, runtime_spec, unit,
 };
 use super::{BoxArtifactPort, BoxArtifactPortError};
 

--- a/src/runtime/src/a3s_runtime_driver/artifact_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/artifact_tests.rs
@@ -1,0 +1,429 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use a3s_box_core::ExecutionManager;
+use a3s_runtime::contract::{
+    ArtifactRef, MountKind, RestartPolicy, RuntimeMount, RuntimeMountSource, RuntimeOutputArtifact,
+    RuntimeOutputSpec, RuntimeUnitClass, RuntimeUnitSpec, SecretReference, SecretTarget,
+};
+use a3s_runtime::{RuntimeDriver, RuntimeError};
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+use crate::VolumeStore;
+
+use super::mapping::creation_request_for;
+use super::test_support::{
+    accepted, action, fake_driver, fake_driver_with_backend, runtime_spec, unit, DriverFakeBackend,
+};
+use super::{BoxArtifactPort, BoxArtifactPortError};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CapturedOutput {
+    spec_digest: String,
+    name: String,
+    files: BTreeMap<String, Vec<u8>>,
+}
+
+#[derive(Default)]
+struct FakeArtifactPort {
+    mounts: Mutex<BTreeMap<String, PathBuf>>,
+    captures: Mutex<Vec<CapturedOutput>>,
+    cleanups: Mutex<Vec<String>>,
+}
+
+impl FakeArtifactPort {
+    fn register_mount(&self, name: impl Into<String>, path: PathBuf) {
+        self.mounts.lock().unwrap().insert(name.into(), path);
+    }
+
+    fn captures(&self) -> Vec<CapturedOutput> {
+        self.captures.lock().unwrap().clone()
+    }
+
+    fn cleanups(&self) -> Vec<String> {
+        self.cleanups.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl BoxArtifactPort for FakeArtifactPort {
+    async fn mount_path(
+        &self,
+        _spec: &RuntimeUnitSpec,
+        mount: &RuntimeMount,
+    ) -> Result<PathBuf, BoxArtifactPortError> {
+        self.mounts
+            .lock()
+            .unwrap()
+            .get(&mount.name)
+            .cloned()
+            .ok_or_else(|| BoxArtifactPortError::Rejected("fixture mount is not registered".into()))
+    }
+
+    async fn capture_output(
+        &self,
+        spec: &RuntimeUnitSpec,
+        output: &RuntimeOutputSpec,
+        source: &Path,
+    ) -> Result<RuntimeOutputArtifact, BoxArtifactPortError> {
+        let mut files = BTreeMap::new();
+        let entries = std::fs::read_dir(source).map_err(|error| {
+            BoxArtifactPortError::Unavailable(format!("fixture output read failed: {error}"))
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                BoxArtifactPortError::Unavailable(format!(
+                    "fixture output entry read failed: {error}"
+                ))
+            })?;
+            let metadata = std::fs::symlink_metadata(entry.path()).map_err(|error| {
+                BoxArtifactPortError::Unavailable(format!(
+                    "fixture output metadata read failed: {error}"
+                ))
+            })?;
+            if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+                return Err(BoxArtifactPortError::Rejected(
+                    "fixture accepts only regular root-level files".into(),
+                ));
+            }
+            let name = entry.file_name().into_string().map_err(|_| {
+                BoxArtifactPortError::Rejected("fixture output name is not UTF-8".into())
+            })?;
+            let value = std::fs::read(entry.path()).map_err(|error| {
+                BoxArtifactPortError::Unavailable(format!(
+                    "fixture output content read failed: {error}"
+                ))
+            })?;
+            files.insert(name, value);
+        }
+        let size_bytes = files.values().try_fold(0_u64, |total, value| {
+            total.checked_add(value.len() as u64).ok_or_else(|| {
+                BoxArtifactPortError::Rejected("fixture output size overflowed".into())
+            })
+        })?;
+        if size_bytes == 0 || size_bytes > output.max_bytes {
+            return Err(BoxArtifactPortError::Rejected(
+                "fixture output violates its declared bound".into(),
+            ));
+        }
+        let mut content_digest = Sha256::new();
+        for (name, value) in &files {
+            content_digest.update((name.len() as u64).to_be_bytes());
+            content_digest.update(name.as_bytes());
+            content_digest.update((value.len() as u64).to_be_bytes());
+            content_digest.update(value);
+        }
+        let digest = format!("sha256:{:x}", content_digest.finalize());
+        self.captures.lock().unwrap().push(CapturedOutput {
+            spec_digest: spec.digest().map_err(BoxArtifactPortError::Rejected)?,
+            name: output.name.clone(),
+            files,
+        });
+        Ok(RuntimeOutputArtifact {
+            name: output.name.clone(),
+            artifact: ArtifactRef {
+                uri: format!("https://artifacts.example/a3s/task-output/{digest}"),
+                digest,
+                media_type: output.media_type.clone(),
+            },
+            size_bytes,
+        })
+    }
+
+    async fn cleanup_spec(&self, spec_digest: &str) -> Result<(), BoxArtifactPortError> {
+        self.cleanups.lock().unwrap().push(spec_digest.into());
+        Ok(())
+    }
+}
+
+fn input_artifact() -> ArtifactRef {
+    let digest = format!("sha256:{}", "b".repeat(64));
+    ArtifactRef {
+        uri: format!("https://artifacts.example/a3s/model/{digest}"),
+        digest,
+        media_type: "application/vnd.a3s.directory.v1+tar".into(),
+    }
+}
+
+fn output_spec() -> RuntimeOutputSpec {
+    RuntimeOutputSpec {
+        name: "result".into(),
+        path: "/outputs/result".into(),
+        media_type: "application/vnd.a3s.directory.v1+tar".into(),
+        max_bytes: 1024,
+    }
+}
+
+fn output_volume_path(
+    home_dir: &Path,
+    spec: &RuntimeUnitSpec,
+    output: &RuntimeOutputSpec,
+) -> PathBuf {
+    let digest = spec.digest().unwrap();
+    let hex = digest.strip_prefix("sha256:").unwrap();
+    let name = format!(
+        "a3s-runtime-output-{hex}-{:x}",
+        Sha256::digest(output.name.as_bytes())
+    );
+    home_dir.join("volumes").join(name)
+}
+
+fn volume_store(home_dir: &Path) -> VolumeStore {
+    VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"))
+}
+
+#[tokio::test]
+async fn artifact_port_advertises_only_the_storage_surface_it_enables() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, _) = fake_driver(&directory);
+    let driver = driver.with_artifact_port(Arc::new(FakeArtifactPort::default()));
+
+    let capabilities = driver.capabilities().await.unwrap();
+    assert_eq!(
+        capabilities.mount_kinds,
+        vec![MountKind::Artifact, MountKind::Volume, MountKind::Tmpfs]
+    );
+    assert!(capabilities
+        .features
+        .contains(&a3s_runtime::contract::RuntimeFeature::OutputArtifacts));
+}
+
+#[tokio::test]
+async fn artifact_and_volume_bindings_precede_secrets_and_artifacts_are_read_only() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, _) = fake_driver(&directory);
+    let port = Arc::new(FakeArtifactPort::default());
+    let input = directory.path().join("materialized-model");
+    std::fs::create_dir(&input).unwrap();
+    let input = input.canonicalize().unwrap();
+    port.register_mount("model", input.clone());
+    let driver = driver.with_artifact_port(port);
+    let mut spec = runtime_spec("storage-order", 1, RuntimeUnitClass::Service);
+    spec.mounts = vec![
+        RuntimeMount {
+            name: "model".into(),
+            source: RuntimeMountSource::Artifact {
+                artifact: input_artifact(),
+            },
+            target: "/models/current".into(),
+            read_only: true,
+        },
+        RuntimeMount {
+            name: "workspace".into(),
+            source: RuntimeMountSource::Volume {
+                volume_id: "workspace-main".into(),
+            },
+            target: "/workspace".into(),
+            read_only: false,
+        },
+    ];
+    spec.secrets.push(SecretReference {
+        name: "token".into(),
+        reference: "secret://storage/token/v1".into(),
+        target: SecretTarget::File {
+            path: "/run/workload/token".into(),
+            mode: 0o400,
+        },
+    });
+
+    let plan = driver.artifact_storage.prepare_plan(&spec).await.unwrap();
+    assert_eq!(plan.volumes().len(), 2);
+    assert_eq!(
+        plan.volumes()[0],
+        format!("{}:/models/current:ro", input.display())
+    );
+    assert!(plan.volumes()[1].ends_with(":/workspace:rw"));
+    assert_eq!(plan.volume_names().len(), 1);
+
+    let request = creation_request_for(
+        &spec,
+        driver.execution_isolation,
+        &driver.config.secret_root,
+        &plan,
+    )
+    .unwrap();
+    assert_eq!(&request.config.volumes[..2], plan.volumes());
+    assert!(request.config.volumes[2].ends_with(":/run/workload/token:ro"));
+    assert_eq!(request.policy.volume_names, plan.volume_names());
+
+    let mut writable = spec;
+    writable.mounts[0].read_only = false;
+    assert!(matches!(
+        driver.artifact_storage.prepare_plan(&writable).await,
+        Err(RuntimeError::InvalidRequest(message)) if message.contains("read-only")
+    ));
+}
+
+#[tokio::test]
+async fn missing_artifact_port_fails_before_box_reservation() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, backend) = fake_driver(&directory);
+    let mut spec = runtime_spec("missing-artifact-port", 1, RuntimeUnitClass::Service);
+    spec.mounts.push(RuntimeMount {
+        name: "model".into(),
+        source: RuntimeMountSource::Artifact {
+            artifact: input_artifact(),
+        },
+        target: "/models/current".into(),
+        read_only: true,
+    });
+
+    assert!(matches!(
+        driver.apply(&spec, &accepted(&spec)).await,
+        Err(RuntimeError::UnsupportedCapabilities(missing))
+            if missing == vec!["mount_kind:Artifact"]
+    ));
+    assert_eq!(backend.starts(), 0);
+    assert!(driver.manager.managed_records().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn persistent_volume_reuses_data_and_detaches_without_becoming_an_artifact_store() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, _) = fake_driver(&directory);
+    let mut first = runtime_spec("persistent-volume", 1, RuntimeUnitClass::Service);
+    first.mounts.push(RuntimeMount {
+        name: "workspace".into(),
+        source: RuntimeMountSource::Volume {
+            volume_id: "workspace-main".into(),
+        },
+        target: "/workspace".into(),
+        read_only: false,
+    });
+
+    let running = driver.apply(&first, &accepted(&first)).await.unwrap();
+    let store = volume_store(&driver.config.home_dir);
+    let volumes = store.list().unwrap();
+    assert_eq!(volumes.len(), 1);
+    assert_eq!(
+        volumes[0].in_use_by,
+        vec![running.provider_resource_id.clone().unwrap()]
+    );
+    let marker = PathBuf::from(&volumes[0].mount_point).join("generation-one");
+    std::fs::write(&marker, b"durable").unwrap();
+
+    let first_unit = unit(first.clone(), running);
+    driver
+        .remove(&first_unit, &action("remove-first-volume", &first))
+        .await
+        .unwrap();
+    let detached = store.list().unwrap();
+    assert_eq!(detached.len(), 1);
+    assert!(detached[0].in_use_by.is_empty());
+    assert_eq!(std::fs::read(&marker).unwrap(), b"durable");
+
+    let mut second = first;
+    second.generation = 2;
+    let running = driver.apply(&second, &accepted(&second)).await.unwrap();
+    let reused = store.list().unwrap();
+    assert_eq!(reused.len(), 1);
+    assert_eq!(std::fs::read(&marker).unwrap(), b"durable");
+    assert_eq!(
+        reused[0].in_use_by,
+        vec![running.provider_resource_id.clone().unwrap()]
+    );
+
+    driver
+        .remove(
+            &unit(second.clone(), running),
+            &action("remove-second-volume", &second),
+        )
+        .await
+        .unwrap();
+    assert!(store.list().unwrap()[0].in_use_by.is_empty());
+}
+
+#[tokio::test]
+async fn task_output_restart_resets_staging_and_replay_recaptures_one_exact_result() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, backend) = fake_driver(&directory);
+    let port = Arc::new(FakeArtifactPort::default());
+    let driver = driver.with_artifact_port(port.clone());
+    let mut spec = runtime_spec("task-output-restart", 1, RuntimeUnitClass::Task);
+    spec.restart = RestartPolicy::OnFailure { max_retries: 1 };
+    spec.outputs.push(output_spec());
+    let output_dir = output_volume_path(&driver.config.home_dir, &spec, &spec.outputs[0]);
+
+    backend.write_on_next_start(output_dir.join("failed-attempt"), b"stale".to_vec());
+    backend.finish_next_start(17);
+    backend.write_on_next_start(output_dir.join("result.json"), b"fresh".to_vec());
+    backend.finish_next_start(0);
+
+    let succeeded = driver.apply(&spec, &accepted(&spec)).await.unwrap();
+    assert_eq!(backend.starts(), 2);
+    assert_eq!(succeeded.outputs.len(), 1);
+    let captures = port.captures();
+    assert_eq!(captures.len(), 1);
+    assert_eq!(captures[0].name, "result");
+    assert_eq!(
+        captures[0].files,
+        BTreeMap::from([("result.json".into(), b"fresh".to_vec())])
+    );
+    assert!(!output_dir.join("failed-attempt").exists());
+    assert!(volume_store(&driver.config.home_dir).list().unwrap()[0]
+        .in_use_by
+        .is_empty());
+
+    let reopened =
+        fake_driver_with_backend(&directory, backend.clone()).with_artifact_port(port.clone());
+    let replayed = reopened.apply(&spec, &succeeded).await.unwrap();
+    assert_eq!(
+        replayed.provider_resource_id,
+        succeeded.provider_resource_id
+    );
+    assert_eq!(backend.starts(), 2);
+    let captures = port.captures();
+    assert_eq!(captures.len(), 2);
+    assert_eq!(
+        captures.iter().cloned().collect::<BTreeSet<_>>().len(),
+        1,
+        "terminal replay must publish byte-identical output identity"
+    );
+
+    reopened
+        .remove(
+            &unit(spec.clone(), replayed),
+            &action("remove-task-output", &spec),
+        )
+        .await
+        .unwrap();
+    assert_eq!(port.cleanups(), vec![spec.digest().unwrap()]);
+    assert!(volume_store(&reopened.config.home_dir)
+        .list()
+        .unwrap()
+        .is_empty());
+    assert!(!output_dir.exists());
+}
+
+#[tokio::test]
+async fn failed_task_never_publishes_output_but_removal_cleans_staging() {
+    let directory = tempfile::tempdir().unwrap();
+    let (driver, backend) = fake_driver(&directory);
+    let port = Arc::new(FakeArtifactPort::default());
+    let driver = driver.with_artifact_port(port.clone());
+    let mut spec = runtime_spec("failed-task-output", 1, RuntimeUnitClass::Task);
+    spec.outputs.push(output_spec());
+    let output_dir = output_volume_path(&driver.config.home_dir, &spec, &spec.outputs[0]);
+    backend.write_on_next_start(output_dir.join("partial"), b"not-published".to_vec());
+    backend.finish_next_start(23);
+
+    let failed = driver.apply(&spec, &accepted(&spec)).await.unwrap();
+    assert_eq!(
+        failed.state,
+        a3s_runtime::contract::RuntimeUnitState::Failed
+    );
+    assert!(failed.outputs.is_empty());
+    assert!(port.captures().is_empty());
+
+    driver
+        .remove(
+            &unit(spec.clone(), failed),
+            &action("remove-failed-output", &spec),
+        )
+        .await
+        .unwrap();
+    assert!(!output_dir.exists());
+    assert_eq!(port.cleanups(), vec![spec.digest().unwrap()]);
+}

--- a/src/runtime/src/a3s_runtime_driver/artifact_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/artifact_tests.rs
@@ -279,7 +279,7 @@ async fn missing_artifact_port_fails_before_box_reservation() {
 }
 
 #[tokio::test]
-async fn persistent_volume_reuses_data_and_detaches_without_becoming_an_artifact_store() {
+async fn persistent_volume_plan_reuses_data_without_becoming_an_artifact_store() {
     let directory = tempfile::tempdir().unwrap();
     let (driver, _) = fake_driver(&directory);
     let mut first = runtime_spec("persistent-volume", 1, RuntimeUnitClass::Service);
@@ -296,9 +296,11 @@ async fn persistent_volume_reuses_data_and_detaches_without_becoming_an_artifact
     let store = volume_store(&driver.config.home_dir);
     let volumes = store.list().unwrap();
     assert_eq!(volumes.len(), 1);
+    let record = driver.find_generation(&first).await.unwrap().unwrap();
     assert_eq!(
-        volumes[0].in_use_by,
-        vec![running.provider_resource_id.clone().unwrap()]
+        record.volume_names,
+        vec![volumes[0].name.clone()],
+        "the Runtime plan must delegate attachment to Box's existing named-Volume lifecycle"
     );
     let marker = PathBuf::from(&volumes[0].mount_point).join("generation-one");
     std::fs::write(&marker, b"durable").unwrap();
@@ -319,9 +321,11 @@ async fn persistent_volume_reuses_data_and_detaches_without_becoming_an_artifact
     let reused = store.list().unwrap();
     assert_eq!(reused.len(), 1);
     assert_eq!(std::fs::read(&marker).unwrap(), b"durable");
+    let record = driver.find_generation(&second).await.unwrap().unwrap();
     assert_eq!(
-        reused[0].in_use_by,
-        vec![running.provider_resource_id.clone().unwrap()]
+        record.volume_names,
+        vec![reused[0].name.clone()],
+        "the second generation must reuse the same Box Volume identity"
     );
 
     driver

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -479,6 +479,33 @@ impl BoxRuntimeConformanceFixture {
             }
         }
         remove_empty_directory(&self.home_dir.join("boxes"));
+        let volume_store = crate::VolumeStore::new(
+            self.home_dir.join("volumes.json"),
+            self.home_dir.join("volumes"),
+        );
+        match volume_store.list() {
+            Ok(volumes) => {
+                for volume in volumes {
+                    if let Err(error) = volume_store.remove(&volume.name, false) {
+                        failures.push(format!(
+                            "remove conformance Volume {:?}: {error}",
+                            volume.name
+                        ));
+                    }
+                }
+            }
+            Err(error) => failures.push(format!("load conformance Volumes: {error}")),
+        }
+        for path in [
+            self.home_dir.join("volumes.json"),
+            self.home_dir.join("volumes.json.lock"),
+            self.home_dir.join("volumes.json.tmp"),
+        ] {
+            if let Err(error) = remove_file(&path) {
+                failures.push(format!("remove Volume state {}: {error}", path.display()));
+            }
+        }
+        remove_empty_directory(&self.home_dir.join("volumes"));
         remove_empty_directory(&self.home_dir.join("run/a3s-oci"));
         remove_empty_directory(&self.home_dir.join("run"));
 

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/mounts_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/mounts_profile.rs
@@ -14,7 +14,103 @@ pub(super) async fn run(
 ) -> Result<()> {
     read_only_enforcement(fixture, client).await?;
     tmpfs_isolation(fixture, client).await?;
+    persistent_volume_reuse(fixture, client).await?;
     mount_cleanup(fixture, client).await
+}
+
+async fn persistent_volume_reuse(
+    fixture: &BoxRuntimeConformanceFixture,
+    client: &dyn RuntimeClient,
+) -> Result<()> {
+    const TARGET: &str = "/mnt/r17-persistent";
+    let mut writer = fixture.cases.service(
+        "mount-persistent-writer",
+        "printf durable > /mnt/r17-persistent/marker; exec sleep 3600",
+    );
+    let volume_id = format!("{}-volume", writer.spec.unit_id);
+    writer.spec.mounts = vec![volume("workspace", &volume_id, TARGET, false)];
+    let running = client.apply(&writer).await?;
+    require(
+        running.state == RuntimeUnitState::Running,
+        "persistent-Volume writer did not reach running",
+    )?;
+    let writer_record = fixture.record_for(&writer.spec).await?;
+    let volume_name = writer_record
+        .volume_names
+        .first()
+        .cloned()
+        .ok_or_else(|| super::protocol("persistent-Volume writer has no named Volume"))?;
+    require(
+        writer_record.volume_names.len() == 1,
+        "persistent-Volume writer attached an unexpected named Volume",
+    )?;
+    require_bind_config(&writer_record, TARGET, false)?;
+    let store = crate::VolumeStore::new(
+        fixture.home_dir.join("volumes.json"),
+        fixture.home_dir.join("volumes"),
+    );
+    let attached = store
+        .get(&volume_name)
+        .map_err(|error| super::external("load attached persistent Volume", error))?
+        .ok_or_else(|| super::protocol("persistent Volume disappeared while attached"))?;
+    require(
+        attached.in_use_by == vec![writer_record.id.clone()],
+        "persistent Volume did not fence its live Box attachment",
+    )?;
+    let marker = Path::new(&attached.mount_point).join("marker");
+    require(
+        std::fs::read(&marker)
+            .map_err(|error| super::external("read persistent-Volume marker", error))?
+            == b"durable",
+        "persistent Volume did not expose the workload write on its canonical host path",
+    )?;
+
+    fixture
+        .remove_unit(client, &writer.spec, "mount-persistent-writer")
+        .await?;
+    let detached = store
+        .get(&volume_name)
+        .map_err(|error| super::external("load detached persistent Volume", error))?
+        .ok_or_else(|| super::protocol("persistent Volume was deleted with its first workload"))?;
+    require(
+        detached.in_use_by.is_empty() && marker.is_file(),
+        "persistent Volume did not detach while retaining its data",
+    )?;
+
+    let mut reader = fixture.cases.task(
+        "mount-persistent-reader",
+        "if sh -c 'printf forbidden > /mnt/r17-persistent/forbidden' 2>/dev/null; then exit 74; fi; test \"$(cat /mnt/r17-persistent/marker)\" = durable",
+        10_000,
+    );
+    reader.spec.mounts = vec![volume("workspace", &volume_id, TARGET, true)];
+    let read = client.apply(&reader).await?;
+    require(
+        read.state == RuntimeUnitState::Succeeded,
+        "persistent Volume was not reused read-only by a second Runtime unit",
+    )?;
+    let reader_record = fixture.record_for(&reader.spec).await?;
+    require(
+        reader_record.volume_names == vec![volume_name.clone()],
+        "persistent Volume identity changed across Runtime units",
+    )?;
+    require_bind_config(&reader_record, TARGET, true)?;
+    fixture
+        .remove_unit(client, &reader.spec, "mount-persistent-reader")
+        .await?;
+    require(
+        store
+            .get(&volume_name)
+            .map_err(|error| super::external("load reused persistent Volume", error))?
+            .is_some_and(|volume| volume.in_use_by.is_empty()),
+        "persistent Volume remained attached after second removal",
+    )?;
+    store
+        .remove(&volume_name, false)
+        .map_err(|error| super::external("remove conformance persistent Volume", error))?;
+    require(
+        !marker.exists(),
+        "persistent-Volume conformance cleanup retained workload data",
+    )
 }
 
 async fn read_only_enforcement(
@@ -195,6 +291,44 @@ fn tmpfs(name: &str, target: &str, read_only: bool) -> RuntimeMount {
         target: target.into(),
         read_only,
     }
+}
+
+fn volume(name: &str, volume_id: &str, target: &str, read_only: bool) -> RuntimeMount {
+    RuntimeMount {
+        name: name.into(),
+        source: RuntimeMountSource::Volume {
+            volume_id: volume_id.into(),
+        },
+        target: target.into(),
+        read_only,
+    }
+}
+
+fn require_bind_config(record: &crate::BoxRecord, target: &str, read_only: bool) -> Result<()> {
+    let bundle = record.box_dir.join("sandbox/bundle/config.json");
+    let value: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&bundle)
+            .map_err(|error| super::external("read Volume Sandbox OCI configuration", error))?,
+    )
+    .map_err(|error| super::external("decode Volume Sandbox OCI configuration", error))?;
+    let mount = value["mounts"]
+        .as_array()
+        .and_then(|mounts| {
+            mounts
+                .iter()
+                .find(|mount| mount["destination"].as_str() == Some(target))
+        })
+        .ok_or_else(|| super::protocol("Sandbox OCI configuration omitted the Runtime Volume"))?;
+    let options = mount["options"]
+        .as_array()
+        .ok_or_else(|| super::protocol("Runtime Volume has no OCI mount options"))?;
+    let expected_mode = if read_only { "ro" } else { "rw" };
+    require(
+        mount["type"] == "bind"
+            && options.iter().any(|option| option == "rbind")
+            && options.iter().any(|option| option == expected_mode),
+        "Sandbox OCI bind mount did not preserve Runtime Volume access mode",
+    )
 }
 
 fn require_tmpfs_config(record: &crate::BoxRecord, target: &str, read_only: bool) -> Result<()> {

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/mounts_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/mounts_profile.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::time::Duration;
 
 use a3s_runtime::contract::{RestartPolicy, RuntimeMount, RuntimeMountSource, RuntimeUnitState};
 use a3s_runtime::RuntimeClient;
@@ -77,21 +78,38 @@ async fn persistent_volume_reuse(
         "persistent Volume did not detach while retaining its data",
     )?;
 
-    let mut reader = fixture.cases.task(
+    let mut reader = fixture.cases.service(
         "mount-persistent-reader",
-        "if sh -c 'printf forbidden > /mnt/r17-persistent/forbidden' 2>/dev/null; then exit 74; fi; test \"$(cat /mnt/r17-persistent/marker)\" = durable",
-        10_000,
+        "if sh -c 'printf forbidden > /mnt/r17-persistent/forbidden' 2>/dev/null; then exit 74; fi; test \"$(cat /mnt/r17-persistent/marker)\" = durable || exit 75; printf ready > /workspace/r17-persistent-reader-ready; exec sleep 3600",
     );
     reader.spec.mounts = vec![volume("workspace", &volume_id, TARGET, true)];
     let read = client.apply(&reader).await?;
     require(
-        read.state == RuntimeUnitState::Succeeded,
-        "persistent Volume was not reused read-only by a second Runtime unit",
+        read.state == RuntimeUnitState::Running,
+        "persistent-Volume reader did not reach running",
     )?;
     let reader_record = fixture.record_for(&reader.spec).await?;
+    wait_for_file(
+        &reader_record
+            .box_dir
+            .join("workspace/r17-persistent-reader-ready"),
+        "persistent-Volume reader did not verify retained read-only data",
+    )
+    .await?;
+    require(
+        !Path::new(&detached.mount_point).join("forbidden").exists(),
+        "persistent Volume accepted a write through its read-only reuse",
+    )?;
     require(
         reader_record.volume_names == vec![volume_name.clone()],
         "persistent Volume identity changed across Runtime units",
+    )?;
+    require(
+        store
+            .get(&volume_name)
+            .map_err(|error| super::external("load reused persistent Volume", error))?
+            .is_some_and(|volume| volume.in_use_by == vec![reader_record.id.clone()]),
+        "persistent Volume did not fence its second live Box attachment",
     )?;
     require_bind_config(&reader_record, TARGET, true)?;
     fixture
@@ -301,6 +319,19 @@ fn volume(name: &str, volume_id: &str, target: &str, read_only: bool) -> Runtime
         },
         target: target.into(),
         read_only,
+    }
+}
+
+async fn wait_for_file(path: &Path, message: &str) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if path.is_file() {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(super::failure(message));
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
     }
 }
 

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/security_profile.rs
@@ -132,26 +132,6 @@ async fn reject_hostile_inputs(
         "Box accepted an unadvertised outbound network",
     )?;
 
-    let mut volume = template.clone();
-    volume.request_id = fixture.cases.request_id("security-volume");
-    volume.spec.unit_id = fixture.cases.unit_id("security-volume");
-    volume.spec.mounts = vec![RuntimeMount {
-        name: "provider-volume".into(),
-        source: RuntimeMountSource::Volume {
-            volume_id: "r17-provider-volume".into(),
-        },
-        target: "/mnt/provider-volume".into(),
-        read_only: false,
-    }];
-    require(
-        matches!(
-            client.apply(&volume).await,
-            Err(RuntimeError::UnsupportedCapabilities(missing))
-                if missing == vec!["mount_kind:Volume"]
-        ),
-        "Box accepted an unadvertised volume mount",
-    )?;
-
     let after = fixture
         .driver
         .manager

--- a/src/runtime/src/a3s_runtime_driver/lifecycle.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle.rs
@@ -12,7 +12,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{BoxRecord, ManagedExecutionState};
 
-use super::mapping::{creation_request_for, operation};
+use super::mapping::{creation_request_for, operation, validate_creation_spec};
 use super::metadata::{
     local_identity, map_execution_error, now_ms, provider_identity_matches, timestamp_ms,
     validate_record_for_spec, SPEC_DIGEST_LABEL,
@@ -25,11 +25,11 @@ impl BoxRuntimeDriver {
         spec: &RuntimeUnitSpec,
         current: &RuntimeObservation,
     ) -> RuntimeResult<RuntimeObservation> {
-        // Complete validation and conversion before any Box state or provider
-        // mutation. The returned request is reused for identity comparison.
-        let request =
-            creation_request_for(spec, self.execution_isolation, &self.config.secret_root)?;
+        // Complete the side-effect-free validation pass before storage
+        // preparation can materialize a caller view or create a named Volume.
+        validate_creation_spec(spec, self.execution_isolation, &self.config.secret_root)?;
         self.secret_materialization.require_configured_for(spec)?;
+        self.artifact_storage.require_configured_for(spec)?;
         let mut record = self.find_generation(spec).await?;
 
         if let Some(existing) = record.as_ref() {
@@ -43,6 +43,13 @@ impl BoxRuntimeDriver {
         let record = match record {
             Some(record) => record,
             None => {
+                let storage = self.artifact_storage.prepare_plan(spec).await?;
+                let request = creation_request_for(
+                    spec,
+                    self.execution_isolation,
+                    &self.config.secret_root,
+                    &storage,
+                )?;
                 let operation_id = operation(spec)?;
                 let reservation = self
                     .bounded("reservation", async {
@@ -68,6 +75,7 @@ impl BoxRuntimeDriver {
                     self.execution_isolation,
                     &self.config.secret_root,
                 )?;
+                self.artifact_storage.validate_record(spec, &record).await?;
                 record
             }
         };
@@ -97,6 +105,7 @@ impl BoxRuntimeDriver {
                 .remove_runtime(&unit.spec.unit_id, unit.spec.generation)
                 .await;
             self.secret_materialization.cleanup_spec(&unit.spec).await?;
+            self.artifact_storage.cleanup_spec(&unit.spec).await?;
             return Ok(not_found(&unit.spec));
         };
         provider_identity_matches(&unit.observation, &record)?;
@@ -184,6 +193,10 @@ impl BoxRuntimeDriver {
         if let Some(record) = record {
             provider_identity_matches(&unit.observation, &record)?;
             self.retire_record(record, &unit.spec.unit_id).await?;
+        } else {
+            // A previous removal may have crossed the durable Box boundary
+            // before caller-owned Artifact cleanup completed.
+            self.artifact_storage.cleanup_spec(&unit.spec).await?;
         }
         self.service_endpoints
             .remove_runtime(&unit.spec.unit_id, unit.spec.generation)
@@ -212,6 +225,7 @@ impl BoxRuntimeDriver {
             self.execution_isolation,
             &self.config.secret_root,
         )?;
+        self.artifact_storage.validate_record(spec, &record).await?;
         let (execution_id, generation, state) = local_identity(&record)?;
         match state {
             ManagedExecutionState::Creating
@@ -226,6 +240,13 @@ impl BoxRuntimeDriver {
                         self.transient_registry_auth.as_ref(),
                     )
                     .await?;
+                // A recovered `Starting` record has already crossed the start
+                // boundary, so resetting it would race a live attachment. For
+                // a fresh `Creating`/`Created` record, clear output staging at
+                // the last safe point before Box attaches and starts it.
+                if state != ManagedExecutionState::Starting {
+                    self.artifact_storage.reset_outputs_for_start(spec).await?;
+                }
                 let result = self
                     .bounded("startup", async {
                         self.manager
@@ -388,6 +409,7 @@ impl BoxRuntimeDriver {
             self.execution_isolation,
             &self.config.secret_root,
         )?;
+        self.artifact_storage.validate_record(spec, &record).await?;
         Ok(record)
     }
 
@@ -422,6 +444,7 @@ impl BoxRuntimeDriver {
                 self.transient_registry_auth.as_ref(),
             )
             .await?;
+        self.artifact_storage.reset_outputs_for_start(spec).await?;
         let (execution_id, generation, _) = local_identity(&record)?;
         let operation_id = restart_operation(spec, generation)?;
         let result = self
@@ -470,7 +493,10 @@ impl BoxRuntimeDriver {
             spec,
             self.execution_isolation,
             &self.config.secret_root,
-        )
+        )?;
+        self.artifact_storage
+            .validate_record(spec, &remaining[0])
+            .await
     }
 
     pub(super) async fn retire_record(
@@ -513,6 +539,7 @@ impl BoxRuntimeDriver {
                     self.secret_materialization
                         .cleanup_digest(&secret_digest)
                         .await?;
+                    self.artifact_storage.cleanup_digest(&secret_digest).await?;
                     return Ok(());
                 }
                 Ok(_) => {}
@@ -583,6 +610,7 @@ impl BoxRuntimeDriver {
                 execution_id
             )));
         }
+        self.artifact_storage.cleanup_digest(&secret_digest).await?;
         Ok(())
     }
 
@@ -599,6 +627,7 @@ impl BoxRuntimeDriver {
             self.execution_isolation,
             &self.config.secret_root,
         )?;
+        self.artifact_storage.validate_record(spec, record).await?;
         let state = state_override.unwrap_or(runtime_state(spec, record)?);
         let terminal = state.is_terminal();
         let metadata = record.managed_execution.as_ref().ok_or_else(|| {
@@ -628,6 +657,11 @@ impl BoxRuntimeDriver {
         } else {
             None
         };
+        let outputs = if state == RuntimeUnitState::Succeeded {
+            self.artifact_storage.capture_outputs(spec).await?
+        } else {
+            Vec::new()
+        };
         let observation = RuntimeObservation {
             schema: RuntimeObservation::SCHEMA.into(),
             unit_id: spec.unit_id.clone(),
@@ -641,7 +675,7 @@ impl BoxRuntimeDriver {
             started_at_ms,
             finished_at_ms,
             health: None,
-            outputs: Vec::new(),
+            outputs,
             usage: None,
             evidence: None,
             provider_attestation: None,

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -10,12 +10,13 @@ use a3s_box_core::{
     ExecutionRestartPolicy, NetworkMode, ResourceConfig, ResourceLimits,
 };
 use a3s_runtime::contract::{
-    ArtifactRef, MountKind, NetworkMode as RuntimeNetworkMode, RestartPolicy, RuntimeMountSource,
+    ArtifactRef, NetworkMode as RuntimeNetworkMode, RestartPolicy, RuntimeMountSource,
     RuntimeUnitClass, RuntimeUnitSpec, SecretTarget, TransportProtocol,
 };
 use a3s_runtime::{RuntimeError, RuntimeResult};
 use url::Position;
 
+use super::artifact::RuntimeStoragePlan;
 use super::metadata::{managed_labels, operation_id};
 use super::secret::secret_file;
 use super::{OCI_IMAGE_INDEX, OCI_IMAGE_MANIFEST};
@@ -28,8 +29,10 @@ pub(super) fn creation_request_for(
     spec: &RuntimeUnitSpec,
     execution_isolation: ExecutionIsolation,
     secret_root: &Path,
+    storage: &RuntimeStoragePlan,
 ) -> RuntimeResult<CreateExecutionRequest> {
     spec.validate().map_err(RuntimeError::InvalidRequest)?;
+    storage.validate_for(spec)?;
     validate_provider_unit_id(&spec.unit_id)?;
     validate_supported_shape(spec)?;
     let spec_digest = spec.digest().map_err(RuntimeError::InvalidRequest)?;
@@ -66,6 +69,8 @@ pub(super) fn creation_request_for(
     let tmpfs = compile_tmpfs_mounts(spec)?;
     let (secret_volumes, secret_environment_manifest) =
         compile_secret_inputs(spec, secret_root, &spec_digest)?;
+    let mut volumes = storage.volumes().to_vec();
+    volumes.extend(secret_volumes);
     let mut extra_env = spec
         .process
         .environment
@@ -88,7 +93,7 @@ pub(super) fn creation_request_for(
         cmd,
         entrypoint_override,
         workdir: spec.process.working_directory.clone(),
-        volumes: secret_volumes,
+        volumes,
         extra_env,
         network: NetworkMode::None,
         tmpfs,
@@ -124,6 +129,7 @@ pub(super) fn creation_request_for(
                 .iter()
                 .any(|reference| !matches!(reference.target, SecretTarget::RegistryCredential))
                 .then(|| secret_root.to_path_buf()),
+            volume_names: storage.volume_names().to_vec(),
             ..Default::default()
         },
         rootfs_snapshot_id: None,
@@ -135,11 +141,25 @@ pub(super) fn creation_request(
     spec: &RuntimeUnitSpec,
     execution_isolation: ExecutionIsolation,
 ) -> RuntimeResult<CreateExecutionRequest> {
+    let storage = RuntimeStoragePlan::empty(spec)?;
     creation_request_for(
         spec,
         execution_isolation,
         Path::new("/run/a3s-box/runtime-secrets"),
+        &storage,
     )
+}
+
+/// Validate every provider-owned creation field before storage preparation can
+/// create a named Volume. The empty plan is replaced by the exact prepared
+/// plan only after this side-effect-free pass succeeds.
+pub(super) fn validate_creation_spec(
+    spec: &RuntimeUnitSpec,
+    execution_isolation: ExecutionIsolation,
+    secret_root: &Path,
+) -> RuntimeResult<()> {
+    let storage = RuntimeStoragePlan::empty(spec)?;
+    creation_request_for(spec, execution_isolation, secret_root, &storage).map(|_| ())
 }
 
 pub(super) fn operation(spec: &RuntimeUnitSpec) -> RuntimeResult<a3s_box_core::OperationId> {
@@ -183,25 +203,6 @@ fn validate_supported_shape(spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
     {
         return Err(RuntimeError::UnsupportedCapabilities(vec![
             "feature:ServiceUdp".into(),
-        ]));
-    }
-    let unsupported_mount_kinds = spec
-        .mounts
-        .iter()
-        .map(|mount| mount.source.kind())
-        .filter(|kind| *kind != MountKind::Tmpfs)
-        .collect::<std::collections::BTreeSet<_>>();
-    if !unsupported_mount_kinds.is_empty() {
-        return Err(RuntimeError::UnsupportedCapabilities(
-            unsupported_mount_kinds
-                .into_iter()
-                .map(|kind| format!("mount_kind:{kind:?}"))
-                .collect(),
-        ));
-    }
-    if !spec.outputs.is_empty() {
-        return Err(RuntimeError::UnsupportedCapabilities(vec![
-            "feature:OutputArtifacts".into(),
         ]));
     }
     if spec.resources.ephemeral_storage_bytes.is_some() {
@@ -355,18 +356,17 @@ fn validate_provider_unit_id(unit_id: &str) -> RuntimeResult<()> {
 fn compile_tmpfs_mounts(spec: &RuntimeUnitSpec) -> RuntimeResult<Vec<String>> {
     spec.mounts
         .iter()
-        .map(|mount| {
+        .filter_map(|mount| {
             let RuntimeMountSource::Tmpfs { size_bytes } = &mount.source else {
-                return Err(RuntimeError::Protocol(
-                    "Box tmpfs compilation received an unsupported mount kind".into(),
-                ));
+                return None;
             };
-            validate_tmpfs_target(&mount.target)?;
-            Ok(format!(
-                "{}:size={size_bytes},{}",
-                mount.target,
-                if mount.read_only { "ro" } else { "rw" }
-            ))
+            Some(validate_tmpfs_target(&mount.target).map(|()| {
+                format!(
+                    "{}:size={size_bytes},{}",
+                    mount.target,
+                    if mount.read_only { "ro" } else { "rw" }
+                )
+            }))
         })
         .collect()
 }

--- a/src/runtime/src/a3s_runtime_driver/metadata.rs
+++ b/src/runtime/src/a3s_runtime_driver/metadata.rs
@@ -11,6 +11,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{BoxRecord, ManagedExecutionState};
 
+use super::artifact::RuntimeStoragePlan;
 use super::mapping::{creation_request_for, labels_as_hash_map};
 use super::BoxRuntimeDriver;
 
@@ -89,6 +90,7 @@ impl BoxRuntimeDriver {
             self.execution_isolation,
             &self.config.secret_root,
         )?;
+        self.artifact_storage.validate_record(spec, &record).await?;
         Ok(Some(record))
     }
 
@@ -159,10 +161,15 @@ pub(super) fn validate_record_for_spec(
     secret_root: &Path,
 ) -> RuntimeResult<()> {
     validate_owned_record(record, &spec.unit_id)?;
-    let expected_request = creation_request_for(spec, execution_isolation, secret_root)?;
     let metadata = record.managed_execution.as_ref().ok_or_else(|| {
         RuntimeError::Protocol(format!("Box execution {} lost managed metadata", record.id))
     })?;
+    // Reconstruct the persisted storage portion first so static intent
+    // validation remains independent of caller I/O. `find_generation` then
+    // compares it with the exact plan required by the live Artifact port and
+    // Box VolumeStore.
+    let storage = RuntimeStoragePlan::from_request(spec, &metadata.request)?;
+    let expected_request = creation_request_for(spec, execution_isolation, secret_root, &storage)?;
     let actual_request = serde_json::to_value(&metadata.request)
         .map_err(|error| RuntimeError::Protocol(error.to_string()))?;
     let expected_request = serde_json::to_value(&expected_request)

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -148,6 +148,7 @@ impl BoxRuntimeDriver {
         let endpoint_connector = Arc::clone(&connector);
         let secret_materialization =
             SecretMaterializationOwner::new(config.secret_root.clone(), materializer);
+        let artifact_storage = ArtifactStorageOwner::new(config.home_dir.clone(), artifact_port);
         Ok(Self {
             provider_id: ProviderId::parse("a3s-box")?,
             config,
@@ -155,7 +156,7 @@ impl BoxRuntimeDriver {
             port_connector: connector,
             service_endpoints: ServiceEndpointOwner::new(endpoint_connector),
             execution_isolation,
-            artifact_storage: ArtifactStorageOwner::new(config.home_dir.clone(), artifact_port),
+            artifact_storage,
             secret_materialization,
             transient_registry_auth,
             provider_build: OnceCell::new(),

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -9,6 +9,7 @@ mod mapping;
 mod metadata;
 mod secret;
 mod service_endpoints;
+mod volume_storage;
 
 use std::future::Future;
 use std::path::PathBuf;

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -1,5 +1,6 @@
 //! A3S Runtime provider adapter for Box isolation backends.
 
+mod artifact;
 mod exec;
 mod health;
 mod lifecycle;
@@ -28,9 +29,11 @@ use tokio::sync::OnceCell;
 use crate::local_execution::TransientRegistryAuthBroker;
 use crate::{ExecutionIsolation, LocalExecutionManager, VmLocalExecutionBackend};
 
+use self::artifact::ArtifactStorageOwner;
 use self::secret::SecretMaterializationOwner;
 use self::service_endpoints::ServiceEndpointOwner;
 
+pub use self::artifact::{BoxArtifactPort, BoxArtifactPortError};
 pub use self::secret::{
     BoxRegistryCredential, BoxSecretMaterial, BoxSecretMaterializationError, BoxSecretMaterializer,
 };
@@ -74,6 +77,7 @@ pub struct BoxRuntimeDriver {
     port_connector: Arc<dyn ExecutionPortConnector>,
     service_endpoints: ServiceEndpointOwner,
     execution_isolation: ExecutionIsolation,
+    artifact_storage: ArtifactStorageOwner,
     secret_materialization: SecretMaterializationOwner,
     transient_registry_auth: Option<TransientRegistryAuthBroker>,
     provider_build: OnceCell<String>,
@@ -102,6 +106,7 @@ impl BoxRuntimeDriver {
             connector,
             execution_isolation,
             None,
+            None,
             Some(broker),
         )
     }
@@ -120,12 +125,23 @@ impl BoxRuntimeDriver {
         self
     }
 
+    /// Compose the shared Box driver with one caller-owned Artifact boundary.
+    ///
+    /// The caller keeps authenticated transport and Artifact admission. Box
+    /// reuses its existing VolumeStore and lifecycle records for mount wiring,
+    /// Task-output staging, generation fencing, and cleanup.
+    pub fn with_artifact_port(mut self, port: Arc<dyn BoxArtifactPort>) -> Self {
+        self.artifact_storage = ArtifactStorageOwner::new(self.config.home_dir.clone(), Some(port));
+        self
+    }
+
     fn with_manager_connector_and_materializer(
         config: BoxRuntimeDriverConfig,
         manager: LocalExecutionManager,
         connector: Arc<dyn ExecutionPortConnector>,
         execution_isolation: ExecutionIsolation,
         materializer: Option<Arc<dyn BoxSecretMaterializer>>,
+        artifact_port: Option<Arc<dyn BoxArtifactPort>>,
         transient_registry_auth: Option<TransientRegistryAuthBroker>,
     ) -> RuntimeResult<Self> {
         validate_config(&config)?;
@@ -139,6 +155,7 @@ impl BoxRuntimeDriver {
             port_connector: connector,
             service_endpoints: ServiceEndpointOwner::new(endpoint_connector),
             execution_isolation,
+            artifact_storage: ArtifactStorageOwner::new(config.home_dir.clone(), artifact_port),
             secret_materialization,
             transient_registry_auth,
             provider_build: OnceCell::new(),
@@ -302,6 +319,13 @@ impl RuntimeDriver for BoxRuntimeDriver {
         if self.secret_materialization.configured() {
             features.push(RuntimeFeature::SecretReferences);
         }
+        if self.artifact_storage.artifact_configured() {
+            features.push(RuntimeFeature::OutputArtifacts);
+        }
+        let mut mount_kinds = vec![MountKind::Volume, MountKind::Tmpfs];
+        if self.artifact_storage.artifact_configured() {
+            mount_kinds.insert(0, MountKind::Artifact);
+        }
         let capabilities = RuntimeCapabilities {
             schema: RuntimeCapabilities::SCHEMA.into(),
             provider_id: self.provider_id.clone(),
@@ -312,7 +336,7 @@ impl RuntimeDriver for BoxRuntimeDriver {
             // class. `execution_isolation` selects Box's concrete backend.
             isolation_levels: vec![IsolationLevel::Sandbox],
             network_modes: vec![NetworkMode::None, NetworkMode::Service],
-            mount_kinds: vec![MountKind::Tmpfs],
+            mount_kinds,
             health_check_kinds: vec![
                 HealthCheckKind::Http,
                 HealthCheckKind::Tcp,
@@ -377,6 +401,8 @@ impl RuntimeDriver for BoxRuntimeDriver {
     }
 }
 
+#[cfg(test)]
+mod artifact_tests;
 #[cfg(test)]
 mod conformance_tests;
 #[cfg(test)]

--- a/src/runtime/src/a3s_runtime_driver/test_support.rs
+++ b/src/runtime/src/a3s_runtime_driver/test_support.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -60,6 +61,7 @@ pub(super) struct DriverFakeBackend {
     fail_start_after_effect: AtomicBool,
     fail_start_after_effect_at: AtomicUsize,
     next_start_terminal: Mutex<VecDeque<(ExecutionState, Option<i32>)>>,
+    next_start_writes: Mutex<VecDeque<(PathBuf, Vec<u8>)>>,
     cancelled_inspection: Mutex<Option<Arc<CancelledInspection>>>,
 }
 
@@ -124,6 +126,13 @@ impl DriverFakeBackend {
             .push_back((state, Some(exit_code)));
     }
 
+    pub(super) fn write_on_next_start(&self, path: PathBuf, value: impl Into<Vec<u8>>) {
+        self.next_start_writes
+            .lock()
+            .unwrap()
+            .push_back((path, value.into()));
+    }
+
     pub(super) fn finish(&self, execution_id: &str, exit_code: i32) {
         let mut executions = self.executions.lock().unwrap();
         let execution = executions.get_mut(execution_id).unwrap();
@@ -181,6 +190,20 @@ impl DriverFakeBackend {
 impl LocalExecutionBackend for DriverFakeBackend {
     async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
         let handle = Self::handle(record)?;
+        if let Some((path, value)) = self.next_start_writes.lock().unwrap().pop_front() {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).map_err(|error| {
+                    ExecutionManagerError::Internal(format!(
+                        "failed to create fake Task-output directory: {error}"
+                    ))
+                })?;
+            }
+            std::fs::write(path, value).map_err(|error| {
+                ExecutionManagerError::Internal(format!(
+                    "failed to write fake Task output: {error}"
+                ))
+            })?;
+        }
         let mut executions = self.executions.lock().unwrap();
         if let Some(execution) = executions.get(&record.id) {
             if matches!(
@@ -497,6 +520,7 @@ fn configured_driver_with_materializer(
         connector,
         a3s_box_core::ExecutionIsolation::Microvm,
         materializer,
+        None,
         Some(TransientRegistryAuthBroker::default()),
     )
     .unwrap();

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -140,7 +140,10 @@ async fn capabilities_claim_only_the_mapped_box_surface() {
         capabilities.network_modes,
         vec![NetworkMode::None, NetworkMode::Service]
     );
-    assert_eq!(capabilities.mount_kinds, vec![MountKind::Tmpfs]);
+    assert_eq!(
+        capabilities.mount_kinds,
+        vec![MountKind::Volume, MountKind::Tmpfs]
+    );
     assert_eq!(
         capabilities.health_check_kinds,
         vec![
@@ -447,25 +450,6 @@ fn mapping_rejects_secret_collisions_and_unencodable_targets() {
     assert!(matches!(
         creation_request(&registry, TEST_EXECUTION_ISOLATION),
         Err(RuntimeError::InvalidRequest(message)) if message.contains("unique")
-    ));
-}
-
-#[test]
-fn mapping_rejects_unadvertised_mount_kinds_before_mutation() {
-    let mut spec = spec(RuntimeUnitClass::Service);
-    spec.mounts.push(RuntimeMount {
-        name: "data".into(),
-        source: RuntimeMountSource::Volume {
-            volume_id: "runtime-data".into(),
-        },
-        target: "/data".into(),
-        read_only: false,
-    });
-
-    assert!(matches!(
-        creation_request(&spec, TEST_EXECUTION_ISOLATION),
-        Err(RuntimeError::UnsupportedCapabilities(missing))
-            if missing == vec!["mount_kind:Volume"]
     ));
 }
 

--- a/src/runtime/src/a3s_runtime_driver/volume_storage.rs
+++ b/src/runtime/src/a3s_runtime_driver/volume_storage.rs
@@ -1,0 +1,193 @@
+//! Runtime-owned bindings over Box's existing named-Volume store.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use a3s_box_core::volume::VolumeConfig;
+use a3s_runtime::contract::{RuntimeOutputSpec, RuntimeUnitSpec};
+use a3s_runtime::{RuntimeError, RuntimeResult};
+use sha2::{Digest, Sha256};
+
+use crate::VolumeStore;
+
+const VOLUME_ROLE_LABEL: &str = "a3s.runtime.volume-role";
+const VOLUME_ID_LABEL: &str = "a3s.runtime.volume-id";
+const SPEC_DIGEST_LABEL: &str = "a3s.runtime.spec-digest";
+const OUTPUT_NAME_LABEL: &str = "a3s.runtime.output-name";
+const PERSISTENT_VOLUME_ROLE: &str = "persistent";
+const OUTPUT_VOLUME_ROLE: &str = "task-output";
+
+#[derive(Debug)]
+pub(super) struct ResolvedVolume {
+    pub(super) name: String,
+    pub(super) path: PathBuf,
+}
+
+pub(super) fn resolve_persistent_volume(
+    home_dir: &Path,
+    volume_id: &str,
+    create: bool,
+) -> RuntimeResult<ResolvedVolume> {
+    let name = format!(
+        "a3s-runtime-volume-{:x}",
+        Sha256::digest(volume_id.as_bytes())
+    );
+    let labels = BTreeMap::from([
+        (
+            VOLUME_ROLE_LABEL.to_owned(),
+            PERSISTENT_VOLUME_ROLE.to_owned(),
+        ),
+        (VOLUME_ID_LABEL.to_owned(), volume_id.to_owned()),
+    ]);
+    resolve_volume(home_dir, name, labels, create)
+}
+
+pub(super) fn resolve_output_volume(
+    home_dir: &Path,
+    spec: &RuntimeUnitSpec,
+    output: &RuntimeOutputSpec,
+    create: bool,
+) -> RuntimeResult<ResolvedVolume> {
+    let digest = spec.digest().map_err(RuntimeError::InvalidRequest)?;
+    let hex = digest.strip_prefix("sha256:").ok_or_else(|| {
+        RuntimeError::Protocol("Box Task output requires a SHA-256 spec digest".into())
+    })?;
+    let name = format!(
+        "a3s-runtime-output-{hex}-{:x}",
+        Sha256::digest(output.name.as_bytes())
+    );
+    let labels = BTreeMap::from([
+        (VOLUME_ROLE_LABEL.to_owned(), OUTPUT_VOLUME_ROLE.to_owned()),
+        (SPEC_DIGEST_LABEL.to_owned(), digest),
+        (OUTPUT_NAME_LABEL.to_owned(), output.name.clone()),
+    ]);
+    resolve_volume(home_dir, name, labels, create)
+}
+
+pub(super) fn require_output_volume(
+    home_dir: &Path,
+    spec: &RuntimeUnitSpec,
+    output: &RuntimeOutputSpec,
+) -> RuntimeResult<PathBuf> {
+    let resolved = resolve_output_volume(home_dir, spec, output, false)?;
+    let volume = volume_store(home_dir)
+        .get(&resolved.name)
+        .map_err(volume_store_error)?
+        .ok_or_else(|| {
+            RuntimeError::ProviderUnavailable("Task output Volume disappeared".into())
+        })?;
+    if !volume.in_use_by.is_empty() {
+        return Err(RuntimeError::ProviderUnavailable(
+            "Box Task output is still attached to a live execution".into(),
+        ));
+    }
+    Ok(resolved.path)
+}
+
+pub(super) fn reset_output_volumes(home_dir: &Path, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {
+    for output in &spec.outputs {
+        let path = require_output_volume(home_dir, spec, output)?;
+        for entry in std::fs::read_dir(&path).map_err(volume_io_error)? {
+            let entry = entry.map_err(volume_io_error)?;
+            let metadata = std::fs::symlink_metadata(entry.path()).map_err(volume_io_error)?;
+            if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+                std::fs::remove_dir_all(entry.path()).map_err(volume_io_error)?;
+            } else {
+                std::fs::remove_file(entry.path()).map_err(volume_io_error)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn cleanup_output_volumes(home_dir: &Path, digest: &str) -> RuntimeResult<()> {
+    let store = volume_store(home_dir);
+    let outputs = store
+        .list()
+        .map_err(volume_store_error)?
+        .into_iter()
+        .filter(|volume| {
+            volume.labels.get(VOLUME_ROLE_LABEL).map(String::as_str) == Some(OUTPUT_VOLUME_ROLE)
+                && volume.labels.get(SPEC_DIGEST_LABEL).map(String::as_str) == Some(digest)
+        })
+        .collect::<Vec<_>>();
+    for volume in outputs {
+        if !volume.in_use_by.is_empty() {
+            return Err(RuntimeError::ProviderUnavailable(format!(
+                "Box Task-output Volume {:?} is still attached",
+                volume.name
+            )));
+        }
+        store
+            .remove(&volume.name, false)
+            .map_err(volume_store_error)?;
+    }
+    Ok(())
+}
+
+fn resolve_volume(
+    home_dir: &Path,
+    name: String,
+    labels: BTreeMap<String, String>,
+    create: bool,
+) -> RuntimeResult<ResolvedVolume> {
+    let store = volume_store(home_dir);
+    let mut expected = VolumeConfig::new(&name, "");
+    expected.labels.extend(labels.clone());
+    let volume = match store.get(&name).map_err(volume_store_error)? {
+        Some(volume) => volume,
+        None if create => store.get_or_create(expected).map_err(volume_store_error)?,
+        None => {
+            return Err(RuntimeError::ProviderUnavailable(format!(
+                "Box Runtime Volume {name:?} is missing"
+            )))
+        }
+    };
+    let expected_path = home_dir.join("volumes").join(&name);
+    if volume.name != name
+        || volume.driver != "local"
+        || volume.size_limit != 0
+        || volume.labels.len() != labels.len()
+        || labels
+            .iter()
+            .any(|(key, value)| volume.labels.get(key) != Some(value))
+        || Path::new(&volume.mount_point) != expected_path
+    {
+        return Err(RuntimeError::ProviderUnavailable(format!(
+            "Box Runtime Volume {name:?} has conflicting persisted metadata"
+        )));
+    }
+    validate_volume_path(&expected_path)?;
+    Ok(ResolvedVolume {
+        name,
+        path: expected_path,
+    })
+}
+
+fn volume_store(home_dir: &Path) -> VolumeStore {
+    VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"))
+}
+
+fn validate_volume_path(path: &Path) -> RuntimeResult<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(volume_io_error)?;
+    let canonical = path.canonicalize().map_err(volume_io_error)?;
+    if !path.is_absolute()
+        || metadata.file_type().is_symlink()
+        || !metadata.file_type().is_dir()
+        || canonical != path
+    {
+        return Err(RuntimeError::ProviderUnavailable(format!(
+            "Box Runtime Volume path is not a canonical plain directory: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn volume_store_error(error: impl std::fmt::Display) -> RuntimeError {
+    RuntimeError::ProviderUnavailable(format!("Box VolumeStore operation failed: {error}"))
+}
+
+fn volume_io_error(error: std::io::Error) -> RuntimeError {
+    RuntimeError::ProviderUnavailable(format!("Box Runtime Volume I/O failed: {error}"))
+}

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -62,8 +62,9 @@ pub use audit::{read_audit_log, AuditLog, AuditQuery};
 
 #[cfg(all(feature = "vm", target_os = "linux"))]
 pub use a3s_runtime_driver::{
-    BoxRegistryCredential, BoxRuntimeDriver, BoxRuntimeDriverConfig, BoxSecretMaterial,
-    BoxSecretMaterializationError, BoxSecretMaterializer,
+    BoxArtifactPort, BoxArtifactPortError, BoxRegistryCredential, BoxRuntimeDriver,
+    BoxRuntimeDriverConfig, BoxSecretMaterial, BoxSecretMaterializationError,
+    BoxSecretMaterializer,
 };
 
 // Canonical local execution metadata


### PR DESCRIPTION
## Summary

- add one caller-owned Artifact port to the shared Box Runtime driver
- reuse Box VolumeStore for persistent Runtime Volumes and deterministic Task-output staging
- preserve tmpfs and Secret paths without introducing another store or lifecycle driver
- fence recovery, restart reset, output capture, and cleanup through existing Box records

## Validation

- formatting and diff checks pass locally
- Linux-only compile and tests are delegated to this PR CI

Tracks A3S-Lab/Box#172.