### PR TITLE
feat(build): add ACL-native Box build plan foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ runtime state changes instead of being silently stored or weakened.
 - **OCI images and builds** — bounded resumable pulls, concurrent verified
   layers, registry credentials, optional cosign verification, save/load,
   multi-stage builds, selected `RUN --mount` forms, and content-addressed
-  caching.
+  caching. Closed A3S ACL build plans add canonical identities, source-root
+  path confinement, and an enforced network-none Linux `RUN` policy over the
+  same native build engine.
 - **Storage** — bind mounts, named volumes, tmpfs, file copy, diff, export,
   commit, filesystem snapshots, copy-on-write restore, and Box-owned read-only
   aliases for caller-provided Artifact trees below private provider roots.

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -362,6 +362,13 @@ Current notes:
   multi-platform requests and non-Linux target platforms fail instead of
   silently producing a single-platform or wrong-OS image. The default output
   platform is Linux with the host architecture, not the host OS.
+- The Cloud-facing foundation is one closed `a3s.box.build-plan.v1` A3S ACL
+  contract compiled into that same `BuildConfig`. Canonical ACL and digest
+  identity, bounded relative POSIX paths, canonical source-root confinement,
+  exact cache/network enums, and symlink-escape rejection pass focused tests.
+  `network = "none"` rejects remote URL `ADD`, changes the native `RUN` cache
+  identity, and adds a private network namespace on Linux. It rejects the warm
+  RUN pool until that path has equivalent isolation evidence.
 - Dockerfile `RUN` no longer has any silent skip path on unsupported hosts.
   Linux uses isolated `chroot`; the built-in engine also has an isolated
   warm-pool VM lease path via `--run-pool`, which mounts each mutable build

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -4,8 +4,12 @@ version = 4
 
 [[package]]
 name = "a3s-acl"
-version = "0.2.2"
-source = "git+https://github.com/A3S-Lab/ACL.git?rev=fc041758758eba89dd5d22a3414d884c158c9ac1#fc041758758eba89dd5d22a3414d884c158c9ac1"
+version = "0.3.0"
+source = "git+https://github.com/A3S-Lab/ACL.git?rev=5317e166222495585909d81f2caffdca90273c99#5317e166222495585909d81f2caffdca90273c99"
+dependencies = [
+ "ryu-js",
+ "sha2",
+]
 
 [[package]]
 name = "a3s-box-cli"
@@ -135,6 +139,7 @@ dependencies = [
 name = "a3s-box-runtime"
 version = "3.2.0"
 dependencies = [
+ "a3s-acl",
  "a3s-box-core",
  "a3s-box-netproxy",
  "a3s-common",
@@ -3115,6 +3120,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "scc"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -122,7 +122,7 @@ base64 = "0.22"
 ring = "0.17"
 
 # Shared types (transport protocol, privacy, tools)
-a3s-acl = { version = "0.2.2", git = "https://github.com/A3S-Lab/ACL.git", rev = "fc041758758eba89dd5d22a3414d884c158c9ac1" }
+a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "25caf65ffed7ff9b82cedc4e7156c79f396896f7" }
 a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2" }

--- a/src/cli/src/commands/build.rs
+++ b/src/cli/src/commands/build.rs
@@ -205,6 +205,7 @@ pub async fn execute(args: BuildArgs) -> Result<(), Box<dyn std::error::Error>> 
         platforms,
         target: args.target.clone(),
         no_cache: args.no_cache,
+        network: a3s_box_runtime::BuildNetworkPolicy::Outbound,
         metrics: None,
         run_pool,
     };

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -23,7 +23,7 @@ pool = ["vm"]
 scale = []
 compose = ["vm"]
 operator = []
-build = []
+build = ["dep:a3s-acl"]
 
 [dependencies]
 a3s-box-core = { version = "3.2", path = "../core" }
@@ -86,6 +86,7 @@ zstd = "0.13"
 
 # Build support
 tempfile = { workspace = true }
+a3s-acl = { workspace = true, optional = true }
 
 # Metrics
 prometheus = { workspace = true }

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -85,6 +85,52 @@ workload-visible references, redacts exact values longest-first, and hashes only
 redacted content into its cursor. Registry credentials are never injected into
 the workload and therefore never become log-redaction inputs.
 
+## Cloud image-build boundary
+
+`BoxBuildPlan` is the closed A3S ACL admission contract for Cloud-owned image
+build intent. It validates one `build "oci"` block, produces canonical ACL
+bytes and a stable SHA-256 digest through `a3s-acl`, confines both the context
+and build file to one canonical source root, and compiles into the existing
+`BuildConfig`. It does not introduce another build engine, cache, scheduler, or
+lifecycle store. Content-changing build arguments are deliberately absent from
+version 1; adding them requires a new closed schema so they cannot alter output
+behind an unchanged plan digest.
+
+```acl
+build "oci" {
+  cache = "content-addressed"
+  context = "."
+  file = "Dockerfile"
+  network = "none"
+  platform = "linux/amd64"
+  schema = "a3s.box.build-plan.v1"
+}
+```
+
+The admitted cache values are `content-addressed` and `disabled`. Network is
+closed to `none` or `outbound`. `none` rejects remote URL `ADD`, binds the
+policy into every `RUN` cache identity, and adds a private Linux network
+namespace to every native `RUN`. Base-image and external-stage resolution stay
+host-side OCI operations; they are not executed inside the build rootfs.
+Network-none plans reject the warm RUN pool until that provider can prove an
+equivalent isolated network boundary.
+
+```rust
+use std::path::Path;
+
+use a3s_box_runtime::{BoxBuildOptions, BoxBuildPlan};
+
+let plan = BoxBuildPlan::parse_acl(plan_acl)?;
+let digest = plan.canonical_digest()?;
+let config = plan.compile(Path::new("/srv/a3s/source"), BoxBuildOptions::default())?;
+let result = a3s_box_runtime::oci::build::build(config, image_store).await?;
+```
+
+This contract is the Box-owned `BX0.4` foundation. Cloud integration must still
+preserve publication, content-addressed cache evidence, SPDX/SLSA evidence,
+signing, cancellation, process-death recovery, and cleanup before the gate can
+be called complete.
+
 ## Components
 
 ### VM Manager

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -146,7 +146,10 @@ pub use volume::VolumeStore;
 // ── Feature-gated re-exports ──
 
 #[cfg(feature = "build")]
-pub use oci::{BuildConfig, BuildRunPoolConfig, Dockerfile, Instruction};
+pub use oci::{
+    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildConfig,
+    BuildNetworkPolicy, BuildRunPoolConfig, Dockerfile, Instruction,
+};
 
 #[cfg(feature = "compose")]
 #[allow(deprecated)]

--- a/src/runtime/src/oci/build/engine/handlers.rs
+++ b/src/runtime/src/oci/build/engine/handlers.rs
@@ -407,6 +407,7 @@ pub(super) fn handle_run(
     cache_mounts: &[RunCacheMount],
     bind_mounts: &[RunBindMount],
     tmpfs_mounts: &[RunTmpfsMount],
+    network: super::BuildNetworkPolicy,
     context_dir: &Path,
     completed_stages: &[(Option<String>, PathBuf)],
     rootfs_dir: &Path,
@@ -420,6 +421,11 @@ pub(super) fn handle_run(
 ) -> Result<Option<LayerInfo>> {
     #[cfg(target_os = "macos")]
     {
+        if network == super::BuildNetworkPolicy::None {
+            return Err(BoxError::BuildError(
+                "network-none Dockerfile RUN requires the isolated Linux build path".to_string(),
+            ));
+        }
         if !unsafe_host_run_enabled() {
             return Err(BoxError::BuildError(format!(
                 "Dockerfile RUN is not supported on macOS yet because isolated Linux build \
@@ -471,7 +477,7 @@ pub(super) fn handle_run(
         let run_mounts =
             run_mounts.with_cache_mounts(rootfs_dir, cache_mounts, completed_stages)?;
 
-        let output = execute_linux_run_command(rootfs_dir, command, workdir, env, shell)?;
+        let output = execute_linux_run_command(rootfs_dir, command, workdir, env, shell, network)?;
 
         if !output.status.success() {
             return Err(run_command_failed_error(
@@ -527,6 +533,7 @@ pub(super) fn handle_run(
             layer_index,
             quiet,
             ignore,
+            network,
         );
         Err(BoxError::BuildError(format!(
             "Dockerfile RUN is not supported on this platform yet because isolated Linux build execution is not implemented: {}",
@@ -890,9 +897,11 @@ fn execute_linux_run_command(
     workdir: &str,
     env: &[(String, String)],
     shell: &[String],
+    network: super::BuildNetworkPolicy,
 ) -> Result<std::process::Output> {
     let unshare = find_linux_run_unshare()?;
-    let mut cmd = isolated_linux_run_command(&unshare, rootfs_dir, command, workdir, env, shell);
+    let mut cmd =
+        isolated_linux_run_command(&unshare, rootfs_dir, command, workdir, env, shell, network);
     cmd.output().map_err(|error| {
         BoxError::BuildError(format!(
             "Failed to execute Dockerfile RUN in an isolated PID namespace with {}: {error}",
@@ -922,7 +931,7 @@ fn find_linux_run_unshare() -> Result<PathBuf> {
         })
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 fn isolated_linux_run_command(
     unshare: &Path,
     rootfs_dir: &Path,
@@ -930,6 +939,7 @@ fn isolated_linux_run_command(
     workdir: &str,
     env: &[(String, String)],
     shell: &[String],
+    network: super::BuildNetworkPolicy,
 ) -> std::process::Command {
     // `--kill-child` plus a PID namespace makes the RUN command namespace PID 1.
     // When it exits, Linux kills every remaining namespace member before
@@ -937,9 +947,11 @@ fn isolated_linux_run_command(
     // from propagating to the host, while a fresh procfs exposes only the
     // namespace-local process tree. Layer capture begins only after return.
     let mut cmd = std::process::Command::new(unshare);
-    cmd.arg("--mount")
-        .arg("--pid")
-        .arg("--fork")
+    cmd.arg("--mount").arg("--pid");
+    if network == super::BuildNetworkPolicy::None {
+        cmd.arg("--net");
+    }
+    cmd.arg("--fork")
         .arg("--kill-child=SIGKILL")
         .arg("--mount-proc")
         .arg("--propagation=private")
@@ -974,7 +986,7 @@ fn isolated_linux_run_command(
     cmd
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 fn configure_run_command_env(cmd: &mut std::process::Command, env: &[(String, String)]) {
     cmd.env_clear();
     cmd.env(
@@ -2859,7 +2871,7 @@ mod tests {
         execute_onbuild_trigger, expand_glob_sources, glob_segment_match, handle_add,
         instruction_to_string, run_command_failed_error, shell_command_in_workdir,
     };
-    use crate::oci::build::engine::{BuildConfig, BuildState};
+    use crate::oci::build::engine::{BuildConfig, BuildNetworkPolicy, BuildState};
     use a3s_box_core::error::BoxError;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -3030,7 +3042,6 @@ mod tests {
         assert_eq!(cmd, vec!["/bin/bash", "-lc", "cd '/app' && echo hi"]);
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
     fn test_linux_run_command_uses_private_pid_and_mount_namespaces() {
         let command = super::isolated_linux_run_command(
@@ -3040,6 +3051,7 @@ mod tests {
             "/app",
             &[],
             &["/bin/bash".to_string(), "-lc".to_string()],
+            BuildNetworkPolicy::Outbound,
         );
         let args = command
             .get_args()
@@ -3070,6 +3082,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_linux_network_none_run_adds_a_private_network_namespace() {
+        let command = super::isolated_linux_run_command(
+            std::path::Path::new("/usr/bin/unshare"),
+            std::path::Path::new("/build/rootfs"),
+            &shell_run("echo hi"),
+            "/app",
+            &[],
+            &["/bin/sh".to_string(), "-c".to_string()],
+            BuildNetworkPolicy::None,
+        );
+        let args = command
+            .get_args()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(&args[..4], ["--mount", "--pid", "--net", "--fork"]);
+        assert_eq!(
+            args.iter().filter(|argument| *argument == "--net").count(),
+            1
+        );
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn test_linux_run_waits_for_detached_descendants_to_be_killed() {
@@ -3085,6 +3120,7 @@ mod tests {
             workdir,
             &[],
             &[],
+            BuildNetworkPolicy::Outbound,
         )
         .expect("util-linux unshare must be installed for Linux RUN");
         if !probe.status.success() {
@@ -3105,6 +3141,7 @@ mod tests {
             workdir,
             &[],
             &[],
+            BuildNetworkPolicy::Outbound,
         )
         .unwrap();
         assert!(
@@ -4315,6 +4352,7 @@ mod tests {
             platforms: vec![],
             target: None,
             no_cache: false,
+            network: BuildNetworkPolicy::Outbound,
             metrics: None,
             run_pool: None,
         };
@@ -4484,6 +4522,7 @@ mod tests {
             &[],
             &[],
             &[],
+            BuildNetworkPolicy::Outbound,
             tmp.path(),
             &[],
             &rootfs,

--- a/src/runtime/src/oci/build/engine/mod.rs
+++ b/src/runtime/src/oci/build/engine/mod.rs
@@ -34,6 +34,38 @@ use handlers::{
 use stages::{global_arg_decls, resolve_stage_rootfs, split_into_stages};
 use utils::{compute_diff_id, expand_args, format_size, resolve_path};
 
+/// Network access available to Dockerfile execution instructions.
+///
+/// Base-image and external-stage resolution remain trusted host-side OCI
+/// operations. `None` isolates every `RUN` network namespace and rejects
+/// remote-URL `ADD`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BuildNetworkPolicy {
+    /// Preserve the existing native engine's outbound network behavior.
+    #[default]
+    Outbound,
+    /// Deny network access from Dockerfile execution instructions.
+    None,
+}
+
+impl BuildNetworkPolicy {
+    /// Stable ACL representation.
+    pub const fn as_acl(self) -> &'static str {
+        match self {
+            Self::Outbound => "outbound",
+            Self::None => "none",
+        }
+    }
+
+    pub(crate) fn parse_acl(value: &str) -> Option<Self> {
+        match value {
+            "outbound" => Some(Self::Outbound),
+            "none" => Some(Self::None),
+            _ => None,
+        }
+    }
+}
+
 /// Configuration for a build operation.
 #[derive(Debug, Clone)]
 pub struct BuildConfig {
@@ -55,6 +87,8 @@ pub struct BuildConfig {
     pub target: Option<String>,
     /// Disable the layer build cache (`--no-cache`): every layer is rebuilt.
     pub no_cache: bool,
+    /// Network policy for Dockerfile execution instructions.
+    pub network: BuildNetworkPolicy,
     /// Prometheus metrics (optional).
     pub metrics: Option<crate::prom::RuntimeMetrics>,
     /// Execute Dockerfile RUN instructions through a warm-pool daemon lease.
@@ -547,6 +581,7 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
         for instruction in &stage.instructions {
             global_step += 1;
             let step = global_step;
+            validate_instruction_network(instruction, config.network)?;
             let run_mount_source_roots = if let Instruction::Run {
                 bind_mounts,
                 cache_mounts,
@@ -594,6 +629,9 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
                             .or_else(|| default.clone())
                             .unwrap_or_default();
                         format!("ARG {}={}", name, effective)
+                    }
+                    Instruction::Run { .. } => {
+                        run_instruction_cache_repr(instruction, config.network)
                     }
                     other => instruction_to_string(other),
                 };
@@ -952,6 +990,7 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
                             cache_mounts,
                             bind_mounts,
                             tmpfs_mounts,
+                            config.network,
                             &config.context_dir,
                             run_mount_source_roots
                                 .as_deref()
@@ -1433,7 +1472,43 @@ fn validate_build_config(config: &BuildConfig) -> Result<()> {
         }
     }
 
+    if config.network == BuildNetworkPolicy::None && config.run_pool.is_some() {
+        return Err(BoxError::BuildError(
+            "network-none builds cannot use a warm RUN pool until the pool provides a generation-bound isolated network namespace"
+                .to_string(),
+        ));
+    }
+
     Ok(())
+}
+
+fn validate_instruction_network(
+    instruction: &Instruction,
+    network: BuildNetworkPolicy,
+) -> Result<()> {
+    if network != BuildNetworkPolicy::None {
+        return Ok(());
+    }
+    if let Instruction::Add { src, .. } = instruction {
+        if src
+            .iter()
+            .any(|source| source.starts_with("http://") || source.starts_with("https://"))
+        {
+            return Err(BoxError::BuildError(
+                "network-none builds reject remote URL ADD; materialize the input as a content-addressed build-context artifact"
+                    .to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn run_instruction_cache_repr(instruction: &Instruction, network: BuildNetworkPolicy) -> String {
+    format!(
+        "{}\n#a3s.box.build.network={}",
+        instruction_to_string(instruction),
+        network.as_acl()
+    )
 }
 
 fn default_target_platform() -> Platform {

--- a/src/runtime/src/oci/build/engine/tests.rs
+++ b/src/runtime/src/oci/build/engine/tests.rs
@@ -5,9 +5,11 @@
 mod tests {
     use super::super::utils::*;
     use super::super::{
-        build, default_target_platform, scratch_config, validate_build_config, BuildConfig,
-        BuildState,
+        build, default_target_platform, run_instruction_cache_repr, scratch_config,
+        validate_build_config, validate_instruction_network, BuildConfig, BuildNetworkPolicy,
+        BuildRunPoolConfig, BuildState,
     };
+    use crate::oci::build::dockerfile::{Instruction, RunCommand};
     use crate::oci::{ImageStore, OciImage};
     use a3s_box_core::platform::Platform;
     use std::collections::HashMap;
@@ -92,9 +94,60 @@ mod tests {
             platforms,
             target: None,
             no_cache: false,
+            network: BuildNetworkPolicy::Outbound,
             metrics: None,
             run_pool: None,
         }
+    }
+
+    #[test]
+    fn test_network_none_rejects_warm_pool_without_isolation_evidence() {
+        let mut config = test_build_config(vec![Platform::linux_amd64()]);
+        config.network = BuildNetworkPolicy::None;
+        config.run_pool = Some(BuildRunPoolConfig {
+            socket: "/tmp/a3s-box-test-pool.sock".to_string(),
+            image: None,
+            vcpus: 1,
+            memory_mb: 256,
+            guest_rootfs: "/run/a3s/build-rootfs".to_string(),
+            timeout_ns: 1_000_000_000,
+            run_cache_dir: PathBuf::from("/tmp/a3s-box-test-run-cache"),
+        });
+
+        let error = validate_build_config(&config).unwrap_err().to_string();
+        assert!(error.contains("network-none builds cannot use a warm RUN pool"));
+    }
+
+    #[test]
+    fn test_network_none_rejects_remote_add_before_cache_or_download() {
+        let instruction = Instruction::Add {
+            src: vec!["https://example.invalid/archive.tar".to_string()],
+            dst: "/src/".to_string(),
+            chown: None,
+        };
+
+        let error = validate_instruction_network(&instruction, BuildNetworkPolicy::None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("network-none builds reject remote URL ADD"));
+        validate_instruction_network(&instruction, BuildNetworkPolicy::Outbound).unwrap();
+    }
+
+    #[test]
+    fn test_run_cache_identity_binds_network_policy() {
+        let instruction = Instruction::Run {
+            command: RunCommand::Shell("make release".to_string()),
+            cache_mounts: Vec::new(),
+            bind_mounts: Vec::new(),
+            tmpfs_mounts: Vec::new(),
+        };
+
+        let outbound = run_instruction_cache_repr(&instruction, BuildNetworkPolicy::Outbound);
+        let isolated = run_instruction_cache_repr(&instruction, BuildNetworkPolicy::None);
+
+        assert_ne!(outbound, isolated);
+        assert!(outbound.ends_with("a3s.box.build.network=outbound"));
+        assert!(isolated.ends_with("a3s.box.build.network=none"));
     }
 
     #[cfg(all(feature = "pool", not(windows)))]
@@ -212,6 +265,7 @@ LABEL org.opencontainers.image.title="scratch-smoke"
                 platforms: vec![],
                 target: None,
                 no_cache: false,
+                network: BuildNetworkPolicy::Outbound,
                 metrics: None,
                 run_pool: None,
             },
@@ -427,6 +481,7 @@ CMD ["cat", "/app/copied.txt"]
                     platforms: vec![],
                     target: None,
                     no_cache: true,
+                    network: BuildNetworkPolicy::Outbound,
                     metrics: None,
                     run_pool: Some(BuildRunPoolConfig {
                         socket: socket.to_string_lossy().to_string(),
@@ -580,6 +635,7 @@ RUN --mount=type=bind,source=src,target=. cat input.txt > /out.txt
                     platforms: vec![],
                     target: None,
                     no_cache: true,
+                    network: BuildNetworkPolicy::Outbound,
                     metrics: None,
                     run_pool: Some(BuildRunPoolConfig {
                         socket: socket.to_string_lossy().to_string(),
@@ -763,6 +819,7 @@ RUN --mount=type=bind,from=builder,source=/artifact.txt,target=artifact.txt cat 
                     platforms: vec![],
                     target: None,
                     no_cache: true,
+                    network: BuildNetworkPolicy::Outbound,
                     metrics: None,
                     run_pool: Some(BuildRunPoolConfig {
                         socket: socket.to_string_lossy().to_string(),
@@ -841,6 +898,7 @@ RUN --mount=type=bind,from=external-bind-source:latest,source=/artifact.txt,targ
                 platforms: vec![],
                 target: None,
                 no_cache: true,
+                network: BuildNetworkPolicy::Outbound,
                 metrics: None,
                 run_pool: None,
             },
@@ -936,6 +994,7 @@ RUN --mount=type=bind,from=external-bind-source:latest,source=/artifact.txt,targ
                     platforms: vec![],
                     target: None,
                     no_cache: true,
+                    network: BuildNetworkPolicy::Outbound,
                     metrics: None,
                     run_pool: Some(BuildRunPoolConfig {
                         socket: socket.to_string_lossy().to_string(),
@@ -1083,6 +1142,7 @@ RUN --mount=type=tmpfs,target=tmp printf ok > /out.txt
                     platforms: vec![],
                     target: None,
                     no_cache: true,
+                    network: BuildNetworkPolicy::Outbound,
                     metrics: None,
                     run_pool: Some(BuildRunPoolConfig {
                         socket: socket.to_string_lossy().to_string(),
@@ -1223,6 +1283,7 @@ RUN --mount=type=cache,id=failed,target=/root/.cache echo before-failure > /root
                     platforms: vec![],
                     target: None,
                     no_cache: true,
+                    network: BuildNetworkPolicy::Outbound,
                     metrics: None,
                     run_pool: Some(BuildRunPoolConfig {
                         socket: socket.to_string_lossy().to_string(),
@@ -1381,6 +1442,7 @@ RUN --mount=type=cache,id=warm,target=/root/.cache cat /root/.cache/cache-only.t
                     platforms: vec![],
                     target: None,
                     no_cache: true,
+                    network: BuildNetworkPolicy::Outbound,
                     metrics: None,
                     run_pool: Some(BuildRunPoolConfig {
                         socket: socket.to_string_lossy().to_string(),
@@ -1532,6 +1594,7 @@ RUN --mount=type=cache,id=seeded,sharing=locked,from=builder,source=/seed-cache,
                     platforms: vec![],
                     target: None,
                     no_cache: true,
+                    network: BuildNetworkPolicy::Outbound,
                     metrics: None,
                     run_pool: Some(BuildRunPoolConfig {
                         socket: socket.to_string_lossy().to_string(),
@@ -1596,6 +1659,7 @@ RUN --mount=type=cache,id=seeded,sharing=locked,from=builder,source=/seed-cache,
                 platforms: vec![],
                 target: Some("builder".to_string()),
                 no_cache: false,
+                network: BuildNetworkPolicy::Outbound,
                 metrics: None,
                 run_pool: None,
             },
@@ -1622,6 +1686,7 @@ RUN --mount=type=cache,id=seeded,sharing=locked,from=builder,source=/seed-cache,
                 platforms: vec![],
                 target: Some("nope".to_string()),
                 no_cache: false,
+                network: BuildNetworkPolicy::Outbound,
                 metrics: None,
                 run_pool: None,
             },
@@ -1665,6 +1730,7 @@ RUN --mount=type=cache,id=seeded,sharing=locked,from=builder,source=/seed-cache,
                 platforms: vec![],
                 target: None,
                 no_cache: true,
+                network: BuildNetworkPolicy::Outbound,
                 metrics: None,
                 run_pool: None,
             },
@@ -1737,6 +1803,7 @@ CMD ["/work/run.sh"]
                 platforms: vec![],
                 target: None,
                 no_cache: false,
+                network: BuildNetworkPolicy::Outbound,
                 metrics: None,
                 run_pool: None,
             },

--- a/src/runtime/src/oci/build/mod.rs
+++ b/src/runtime/src/oci/build/mod.rs
@@ -23,7 +23,9 @@ pub mod dockerfile;
 pub(crate) mod dockerignore;
 pub mod engine;
 pub mod layer;
+pub mod plan;
 
 pub use dockerfile::{Dockerfile, Instruction};
-pub use engine::{build, BuildConfig, BuildResult, BuildRunPoolConfig};
+pub use engine::{build, BuildConfig, BuildNetworkPolicy, BuildResult, BuildRunPoolConfig};
 pub use layer::{DirSnapshot, LayerInfo};
+pub use plan::{BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy};

--- a/src/runtime/src/oci/build/plan.rs
+++ b/src/runtime/src/oci/build/plan.rs
@@ -1,0 +1,443 @@
+//! Closed A3S ACL contract for OCI image builds owned by A3S Box.
+//!
+//! A build plan contains immutable product intent. Invocation-only values such
+//! as the destination tag and output verbosity stay outside the canonical ACL
+//! identity.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use a3s_acl::{
+    canonical_bytes_with_schema, canonical_digest_with_schema, parse_with_limits,
+    validate_document, AttributeSchema, Block, BlockSchema, CanonicalError, Cardinality, Document,
+    ParseLimits, Schema, SchemaDiagnosticCode, Value, ValueSchema,
+};
+use a3s_box_core::platform::Platform;
+use thiserror::Error;
+
+use super::engine::{BuildConfig, BuildNetworkPolicy};
+
+const BUILD_LABEL: &str = "oci";
+const MAX_PLAN_PATH_BYTES: usize = 255;
+const MAX_TARGET_BYTES: usize = 128;
+const BUILD_PLAN_LIMITS: ParseLimits = ParseLimits {
+    max_document_bytes: 16 * 1024,
+    max_nesting_depth: 2,
+    max_collection_items: 16,
+    max_token_bytes: 1024,
+    max_diagnostics: 16,
+};
+
+/// Cache behavior admitted by the Box build-plan contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildCachePolicy {
+    /// Reuse only content-addressed native build-engine cache entries.
+    ContentAddressed,
+    /// Rebuild every layer.
+    Disabled,
+}
+
+impl BuildCachePolicy {
+    fn parse(value: &str) -> Result<Self, BoxBuildPlanError> {
+        match value {
+            "content-addressed" => Ok(Self::ContentAddressed),
+            "disabled" => Ok(Self::Disabled),
+            _ => Err(BoxBuildPlanError::invalid(
+                "cache",
+                "must be content-addressed or disabled",
+            )),
+        }
+    }
+
+    /// Stable ACL representation.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ContentAddressed => "content-addressed",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
+/// Invocation-only options excluded from the canonical build-plan digest.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BoxBuildOptions {
+    /// Optional local image reference assigned by the native image store.
+    pub tag: Option<String>,
+    /// Suppress native build-engine progress output.
+    pub quiet: bool,
+}
+
+/// Immutable, closed Box-owned OCI build plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoxBuildPlan {
+    context: String,
+    file: String,
+    platform: Platform,
+    target: Option<String>,
+    network: BuildNetworkPolicy,
+    cache: BuildCachePolicy,
+}
+
+impl BoxBuildPlan {
+    /// Current closed ACL schema identity.
+    pub const SCHEMA: &'static str = "a3s.box.build-plan.v1";
+
+    /// Parse and validate one bounded A3S ACL build plan.
+    pub fn parse_acl(source: &str) -> Result<Self, BoxBuildPlanError> {
+        let document = parse_with_limits(source, BUILD_PLAN_LIMITS).map_err(|error| {
+            BoxBuildPlanError::AclParse {
+                message: error.message,
+                line: error.line,
+                column: error.column,
+            }
+        })?;
+        let schema = build_plan_schema();
+        let report = validate_document(&document, &schema);
+        if let Some(diagnostic) = report.diagnostics.into_iter().next() {
+            return Err(BoxBuildPlanError::Schema {
+                code: diagnostic.code,
+                path: diagnostic.path,
+            });
+        }
+
+        let block = document.blocks.first().ok_or_else(|| {
+            BoxBuildPlanError::invalid("build", "must contain exactly one build block")
+        })?;
+        if block.labels.first().map(String::as_str) != Some(BUILD_LABEL) {
+            return Err(BoxBuildPlanError::invalid(
+                "label",
+                "must be the exact value oci",
+            ));
+        }
+
+        let schema_value = required_string(block, "schema")?;
+        if schema_value != Self::SCHEMA {
+            return Err(BoxBuildPlanError::invalid(
+                "schema",
+                "is not a supported Box build-plan schema",
+            ));
+        }
+        let context = normalize_repository_path(required_string(block, "context")?, true)
+            .map_err(|reason| BoxBuildPlanError::invalid("context", reason))?;
+        let file = normalize_repository_path(required_string(block, "file")?, false)
+            .map_err(|reason| BoxBuildPlanError::invalid("file", reason))?;
+        let platform = parse_platform(required_string(block, "platform")?)?;
+        let network = BuildNetworkPolicy::parse_acl(required_string(block, "network")?)
+            .ok_or_else(|| BoxBuildPlanError::invalid("network", "must be none or outbound"))?;
+        let cache = BuildCachePolicy::parse(required_string(block, "cache")?)?;
+        let target = block
+            .attributes
+            .get("target")
+            .map(|value| {
+                value
+                    .as_str()
+                    .ok_or_else(|| BoxBuildPlanError::invalid("target", "must be a string"))
+            })
+            .transpose()?
+            .map(normalize_target)
+            .transpose()
+            .map_err(|reason| BoxBuildPlanError::invalid("target", reason))?;
+
+        Ok(Self {
+            context,
+            file,
+            platform,
+            target,
+            network,
+            cache,
+        })
+    }
+
+    /// Canonical A3S ACL bytes represented as UTF-8 text with one final LF.
+    pub fn canonical_acl(&self) -> Result<String, BoxBuildPlanError> {
+        let bytes = canonical_bytes_with_schema(&self.document(), &build_plan_schema())?;
+        String::from_utf8(bytes).map_err(|_| BoxBuildPlanError::CanonicalEncoding)
+    }
+
+    /// Lowercase SHA-256 identity over the canonical ACL bytes.
+    pub fn canonical_digest(&self) -> Result<String, BoxBuildPlanError> {
+        canonical_digest_with_schema(&self.document(), &build_plan_schema())
+            .map_err(BoxBuildPlanError::from)
+    }
+
+    /// Resolve repository-relative paths and compile into Box's existing native
+    /// build engine. Both paths are canonicalized once, so later symlink swaps
+    /// cannot redirect this compiled invocation outside the admitted source.
+    pub fn compile(
+        &self,
+        source_root: &Path,
+        options: BoxBuildOptions,
+    ) -> Result<BuildConfig, BoxBuildPlanError> {
+        let source_root = canonical_source_root(source_root)?;
+        let context_dir = resolve_plan_path(&source_root, &self.context, "context", PathKind::Dir)?;
+        let dockerfile_path = resolve_plan_path(&source_root, &self.file, "file", PathKind::File)?;
+
+        Ok(BuildConfig {
+            context_dir,
+            dockerfile_path,
+            tag: options.tag,
+            build_args: HashMap::new(),
+            quiet: options.quiet,
+            platforms: vec![self.platform.clone()],
+            target: self.target.clone(),
+            no_cache: self.cache == BuildCachePolicy::Disabled,
+            network: self.network,
+            metrics: None,
+            run_pool: None,
+        })
+    }
+
+    /// Repository-relative build context.
+    pub fn context(&self) -> &str {
+        &self.context
+    }
+
+    /// Repository-relative Dockerfile or Containerfile.
+    pub fn file(&self) -> &str {
+        &self.file
+    }
+
+    /// Exact single target platform.
+    pub fn platform(&self) -> &Platform {
+        &self.platform
+    }
+
+    /// Optional multi-stage target.
+    pub fn target(&self) -> Option<&str> {
+        self.target.as_deref()
+    }
+
+    /// Network policy for Dockerfile execution instructions.
+    pub const fn network(&self) -> BuildNetworkPolicy {
+        self.network
+    }
+
+    /// Native build-cache policy.
+    pub const fn cache(&self) -> BuildCachePolicy {
+        self.cache
+    }
+
+    fn document(&self) -> Document {
+        let mut attributes = HashMap::from([
+            (
+                "cache".to_string(),
+                Value::String(self.cache.as_str().to_string()),
+            ),
+            ("context".to_string(), Value::String(self.context.clone())),
+            ("file".to_string(), Value::String(self.file.clone())),
+            (
+                "network".to_string(),
+                Value::String(self.network.as_acl().to_string()),
+            ),
+            (
+                "platform".to_string(),
+                Value::String(self.platform.to_string()),
+            ),
+            (
+                "schema".to_string(),
+                Value::String(Self::SCHEMA.to_string()),
+            ),
+        ]);
+        if let Some(target) = &self.target {
+            attributes.insert("target".to_string(), Value::String(target.clone()));
+        }
+        Document {
+            blocks: vec![Block {
+                name: "build".to_string(),
+                labels: vec![BUILD_LABEL.to_string()],
+                blocks: Vec::new(),
+                attributes,
+            }],
+        }
+    }
+}
+
+/// Stable failures from build-plan admission and source resolution.
+#[derive(Debug, Error)]
+pub enum BoxBuildPlanError {
+    /// The bounded ACL parser rejected the source.
+    #[error("Box build plan ACL is invalid at {line}:{column}: {message}")]
+    AclParse {
+        message: String,
+        line: usize,
+        column: usize,
+    },
+    /// The closed schema rejected an attribute, block, label count, or type.
+    #[error("Box build plan schema rejected {path}: {code}")]
+    Schema {
+        code: SchemaDiagnosticCode,
+        path: String,
+    },
+    /// A closed contract value was invalid.
+    #[error("Box build plan field {field} {reason}")]
+    InvalidValue {
+        field: &'static str,
+        reason: &'static str,
+    },
+    /// The caller did not provide a usable absolute source root.
+    #[error("Box build source root {reason}")]
+    InvalidSourceRoot { reason: &'static str },
+    /// A plan path was missing, the wrong kind, or escaped the source root.
+    #[error("Box build plan {field} path {reason}")]
+    UnsafePath {
+        field: &'static str,
+        reason: &'static str,
+    },
+    /// The validated AST could not be canonicalized.
+    #[error("Box build plan canonicalization failed: {0}")]
+    Canonical(#[from] CanonicalError),
+    /// ACL canonical bytes must always be UTF-8.
+    #[error("Box build plan canonical output was not UTF-8")]
+    CanonicalEncoding,
+}
+
+impl BoxBuildPlanError {
+    fn invalid(field: &'static str, reason: &'static str) -> Self {
+        Self::InvalidValue { field, reason }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PathKind {
+    Dir,
+    File,
+}
+
+fn build_plan_schema() -> Schema {
+    let body = Schema::new()
+        .attribute("schema", AttributeSchema::required(ValueSchema::string()))
+        .attribute("context", AttributeSchema::required(ValueSchema::string()))
+        .attribute("file", AttributeSchema::required(ValueSchema::string()))
+        .attribute("platform", AttributeSchema::required(ValueSchema::string()))
+        .attribute("target", AttributeSchema::optional(ValueSchema::string()))
+        .attribute("network", AttributeSchema::required(ValueSchema::string()))
+        .attribute("cache", AttributeSchema::required(ValueSchema::string()));
+    Schema::new().block(
+        "build",
+        BlockSchema::new(body)
+            .occurrences(Cardinality::exactly(1))
+            .labels(Cardinality::exactly(1)),
+    )
+}
+
+fn required_string<'a>(
+    block: &'a Block,
+    field: &'static str,
+) -> Result<&'a str, BoxBuildPlanError> {
+    block
+        .attributes
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| BoxBuildPlanError::invalid(field, "must be a string"))
+}
+
+fn normalize_repository_path(value: &str, allow_root: bool) -> Result<String, &'static str> {
+    if value.is_empty()
+        || value.len() > MAX_PLAN_PATH_BYTES
+        || value.starts_with('/')
+        || value.contains(['\0', '\\', '%'])
+    {
+        return Err("must be a bounded relative POSIX path");
+    }
+    let value = value.strip_prefix("./").unwrap_or(value);
+    if value == "." {
+        return allow_root
+            .then(|| ".".to_string())
+            .ok_or("cannot be the repository root");
+    }
+    let segments = value.split('/').collect::<Vec<_>>();
+    if segments.iter().any(|segment| {
+        segment.is_empty()
+            || matches!(*segment, "." | "..")
+            || !segment.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'@' | b'+')
+            })
+    }) {
+        return Err("contains an unsafe path segment");
+    }
+    Ok(segments.join("/"))
+}
+
+fn normalize_target(value: &str) -> Result<String, &'static str> {
+    if value.is_empty()
+        || value.len() > MAX_TARGET_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err("must be a bounded Dockerfile stage name");
+    }
+    Ok(value.to_string())
+}
+
+fn parse_platform(value: &str) -> Result<Platform, BoxBuildPlanError> {
+    match value {
+        "linux/amd64" => Ok(Platform::linux_amd64()),
+        "linux/arm64" => Ok(Platform::linux_arm64()),
+        _ => Err(BoxBuildPlanError::invalid(
+            "platform",
+            "must be linux/amd64 or linux/arm64",
+        )),
+    }
+}
+
+fn canonical_source_root(source_root: &Path) -> Result<PathBuf, BoxBuildPlanError> {
+    if !source_root.is_absolute() {
+        return Err(BoxBuildPlanError::InvalidSourceRoot {
+            reason: "must be absolute",
+        });
+    }
+    let root = source_root
+        .canonicalize()
+        .map_err(|_| BoxBuildPlanError::InvalidSourceRoot {
+            reason: "does not exist or cannot be resolved",
+        })?;
+    if !root.is_dir() {
+        return Err(BoxBuildPlanError::InvalidSourceRoot {
+            reason: "must be a directory",
+        });
+    }
+    Ok(root)
+}
+
+fn resolve_plan_path(
+    source_root: &Path,
+    relative: &str,
+    field: &'static str,
+    kind: PathKind,
+) -> Result<PathBuf, BoxBuildPlanError> {
+    let unresolved = if relative == "." {
+        source_root.to_path_buf()
+    } else {
+        source_root.join(relative)
+    };
+    let resolved = unresolved
+        .canonicalize()
+        .map_err(|_| BoxBuildPlanError::UnsafePath {
+            field,
+            reason: "does not exist or cannot be resolved",
+        })?;
+    if !resolved.starts_with(source_root) {
+        return Err(BoxBuildPlanError::UnsafePath {
+            field,
+            reason: "escapes the admitted source root",
+        });
+    }
+    let expected_kind = match kind {
+        PathKind::Dir => resolved.is_dir(),
+        PathKind::File => resolved.is_file(),
+    };
+    if !expected_kind {
+        return Err(BoxBuildPlanError::UnsafePath {
+            field,
+            reason: match kind {
+                PathKind::Dir => "must resolve to a directory",
+                PathKind::File => "must resolve to a regular file",
+            },
+        });
+    }
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/runtime/src/oci/build/plan/tests.rs
+++ b/src/runtime/src/oci/build/plan/tests.rs
@@ -1,0 +1,235 @@
+use super::*;
+use a3s_acl::SchemaDiagnosticCode;
+use a3s_box_core::platform::Platform;
+
+const PLAN: &str = r#"
+build "oci" {
+  target = "release"
+  schema = "a3s.box.build-plan.v1"
+  platform = "linux/amd64"
+  network = "none"
+  file = "Dockerfile"
+  context = "."
+  cache = "content-addressed"
+}
+"#;
+
+#[test]
+fn canonical_acl_and_digest_are_stable() {
+    let reordered = r#"
+      # Input order and comments do not define build identity.
+      build "oci" {
+        cache = "content-addressed"
+        context = "."
+        file = "Dockerfile"
+        network = "none"
+        platform = "linux/amd64"
+        schema = "a3s.box.build-plan.v1"
+        target = "release"
+      }
+    "#;
+    let expected = concat!(
+        "build \"oci\" {\n",
+        "  cache = \"content-addressed\"\n",
+        "  context = \".\"\n",
+        "  file = \"Dockerfile\"\n",
+        "  network = \"none\"\n",
+        "  platform = \"linux/amd64\"\n",
+        "  schema = \"a3s.box.build-plan.v1\"\n",
+        "  target = \"release\"\n",
+        "}\n",
+    );
+
+    let first = BoxBuildPlan::parse_acl(PLAN).expect("valid build plan");
+    let second = BoxBuildPlan::parse_acl(reordered).expect("valid reordered build plan");
+
+    assert_eq!(first, second);
+    assert_eq!(first.canonical_acl().unwrap(), expected);
+    assert_eq!(
+        first.canonical_digest().unwrap(),
+        "sha256:f8f1fbacf18535adbf39217cacf7eec46d415c607ecceefeeae37f0e16b1d816"
+    );
+}
+
+#[test]
+fn parser_applies_a_bounded_document_limit() {
+    let oversized = format!("{PLAN}\n# {}", "x".repeat(16 * 1024));
+
+    assert!(matches!(
+        BoxBuildPlan::parse_acl(&oversized),
+        Err(BoxBuildPlanError::AclParse { .. })
+    ));
+}
+
+#[test]
+fn schema_is_closed_and_identity_values_are_exact() {
+    let unknown = PLAN.replace(
+        "  cache = \"content-addressed\"",
+        "  cache = \"content-addressed\"\n  extra = \"rejected\"",
+    );
+    assert!(matches!(
+        BoxBuildPlan::parse_acl(&unknown),
+        Err(BoxBuildPlanError::Schema {
+            code: SchemaDiagnosticCode::UnknownAttribute,
+            ..
+        })
+    ));
+
+    let wrong_label = PLAN.replace("build \"oci\"", "build \"container\"");
+    assert!(matches!(
+        BoxBuildPlan::parse_acl(&wrong_label),
+        Err(BoxBuildPlanError::InvalidValue { field: "label", .. })
+    ));
+
+    let wrong_schema = PLAN.replace("a3s.box.build-plan.v1", "a3s.box.build-plan.experimental");
+    assert!(matches!(
+        BoxBuildPlan::parse_acl(&wrong_schema),
+        Err(BoxBuildPlanError::InvalidValue {
+            field: "schema",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn cache_and_network_policies_are_closed() {
+    let outbound = BoxBuildPlan::parse_acl(
+        &PLAN
+            .replace("network = \"none\"", "network = \"outbound\"")
+            .replace("content-addressed", "disabled"),
+    )
+    .unwrap();
+    assert_eq!(outbound.network(), BuildNetworkPolicy::Outbound);
+    assert_eq!(outbound.cache(), BuildCachePolicy::Disabled);
+
+    let bad_cache = PLAN.replace("content-addressed", "shared-directory");
+    assert!(matches!(
+        BoxBuildPlan::parse_acl(&bad_cache),
+        Err(BoxBuildPlanError::InvalidValue { field: "cache", .. })
+    ));
+
+    let bad_network = PLAN.replace("network = \"none\"", "network = \"host\"");
+    assert!(matches!(
+        BoxBuildPlan::parse_acl(&bad_network),
+        Err(BoxBuildPlanError::InvalidValue {
+            field: "network",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn repository_paths_and_target_are_bounded_posix_values() {
+    for invalid in [
+        PLAN.replace("context = \".\"", "context = \"../outside\""),
+        PLAN.replace("file = \"Dockerfile\"", "file = \"/Dockerfile\""),
+        PLAN.replace("file = \"Dockerfile\"", "file = \"build//Dockerfile\""),
+        PLAN.replace("file = \"Dockerfile\"", "file = \"build\\\\Dockerfile\""),
+        PLAN.replace("target = \"release\"", "target = \"release/escape\""),
+    ] {
+        assert!(
+            matches!(
+                BoxBuildPlan::parse_acl(&invalid),
+                Err(BoxBuildPlanError::InvalidValue { .. })
+            ),
+            "unsafe plan was admitted:\n{invalid}"
+        );
+    }
+}
+
+#[test]
+fn compiles_exactly_into_the_existing_build_engine() {
+    let source = tempfile::TempDir::new().unwrap();
+    let context = source.path().join("service");
+    let recipe = source.path().join(".a3s");
+    std::fs::create_dir_all(&context).unwrap();
+    std::fs::create_dir_all(&recipe).unwrap();
+    std::fs::write(recipe.join("Containerfile"), "FROM scratch\n").unwrap();
+
+    let plan = BoxBuildPlan::parse_acl(
+        r#"
+build "oci" {
+  schema = "a3s.box.build-plan.v1"
+  context = "service"
+  file = ".a3s/Containerfile"
+  platform = "linux/arm64"
+  target = "release"
+  network = "none"
+  cache = "disabled"
+}
+"#,
+    )
+    .unwrap();
+    let options = BoxBuildOptions {
+        tag: Some("registry.example/a3s/test:build".to_string()),
+        quiet: true,
+    };
+
+    let config = plan.compile(source.path(), options).unwrap();
+
+    assert_eq!(config.context_dir, context.canonicalize().unwrap());
+    assert_eq!(
+        config.dockerfile_path,
+        recipe.join("Containerfile").canonicalize().unwrap()
+    );
+    assert_eq!(
+        config.tag.as_deref(),
+        Some("registry.example/a3s/test:build")
+    );
+    assert!(config.build_args.is_empty());
+    assert!(config.quiet);
+    assert_eq!(config.platforms, vec![Platform::linux_arm64()]);
+    assert_eq!(config.target.as_deref(), Some("release"));
+    assert!(config.no_cache);
+    assert_eq!(config.network, BuildNetworkPolicy::None);
+    assert!(config.metrics.is_none());
+    assert!(config.run_pool.is_none());
+}
+
+#[test]
+fn compilation_requires_an_absolute_existing_source_root() {
+    let plan = BoxBuildPlan::parse_acl(PLAN).unwrap();
+
+    assert!(matches!(
+        plan.compile(
+            std::path::Path::new("relative/source"),
+            BoxBuildOptions::default()
+        ),
+        Err(BoxBuildPlanError::InvalidSourceRoot { .. })
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn compilation_rejects_context_and_file_symlink_escapes() {
+    use std::os::unix::fs::symlink;
+
+    let temporary = tempfile::TempDir::new().unwrap();
+    let source = temporary.path().join("source");
+    let outside = temporary.path().join("outside");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(source.join("Dockerfile"), "FROM scratch\n").unwrap();
+    std::fs::write(outside.join("Containerfile"), "FROM scratch\n").unwrap();
+
+    symlink(&outside, source.join("context-link")).unwrap();
+    let context_plan =
+        BoxBuildPlan::parse_acl(&PLAN.replace("context = \".\"", "context = \"context-link\""))
+            .unwrap();
+    assert!(matches!(
+        context_plan.compile(&source, BoxBuildOptions::default()),
+        Err(BoxBuildPlanError::UnsafePath {
+            field: "context",
+            ..
+        })
+    ));
+
+    symlink(outside.join("Containerfile"), source.join("file-link")).unwrap();
+    let file_plan =
+        BoxBuildPlan::parse_acl(&PLAN.replace("file = \"Dockerfile\"", "file = \"file-link\""))
+            .unwrap();
+    assert!(matches!(
+        file_plan.compile(&source, BoxBuildOptions::default()),
+        Err(BoxBuildPlanError::UnsafePath { field: "file", .. })
+    ));
+}

--- a/src/runtime/src/oci/mod.rs
+++ b/src/runtime/src/oci/mod.rs
@@ -38,7 +38,10 @@ pub mod signing;
 pub mod store;
 
 #[cfg(feature = "build")]
-pub use build::{BuildConfig, BuildResult, BuildRunPoolConfig, Dockerfile, Instruction};
+pub use build::{
+    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildConfig,
+    BuildNetworkPolicy, BuildResult, BuildRunPoolConfig, Dockerfile, Instruction,
+};
 pub use credentials::CredentialStore;
 pub use image::{OciHealthCheck, OciImage, OciImageConfig};
 pub use layers::extract_layer;

--- a/src/sdk/src/client/core.rs
+++ b/src/sdk/src/client/core.rs
@@ -330,6 +330,7 @@ impl A3sBoxClient {
                 platforms: request.platforms,
                 target: request.target,
                 no_cache: request.no_cache,
+                network: BuildNetworkPolicy::Outbound,
                 metrics: None,
                 run_pool: None,
             },

--- a/src/sdk/src/client/mod.rs
+++ b/src/sdk/src/client/mod.rs
@@ -27,9 +27,9 @@ use a3s_box_core::{
 use a3s_box_runtime::oci::BuildResult as RuntimeBuildResult;
 use a3s_box_runtime::{
     is_process_alive, is_process_alive_with_identity, load_resolved_image_config,
-    BuildConfig as RuntimeBuildConfig, ImagePuller, ImageReference, ImageStore, NetworkStore,
-    OciImage, PushResult, RegistryAuth, RegistryProtocol, RegistryPusher, SignaturePolicy,
-    SnapshotStore, VolumeStore,
+    BuildConfig as RuntimeBuildConfig, BuildNetworkPolicy, ImagePuller, ImageReference, ImageStore,
+    NetworkStore, OciImage, PushResult, RegistryAuth, RegistryProtocol, RegistryPusher,
+    SignaturePolicy, SnapshotStore, VolumeStore,
 };
 use serde::{Deserialize, Serialize};
 use sysinfo::{Pid, System};


### PR DESCRIPTION
## Summary

- add the closed `a3s.box.build-plan.v1` A3S ACL contract over Box's existing native OCI build engine
- generate canonical ACL and a stable digest with `a3s-acl` 0.3, and confine canonicalized context/build-file paths to one admitted source root
- compile typed cache and network policies into the existing `BuildConfig` without adding another engine, cache, scheduler, or lifecycle store
- enforce `network = "none"` for native Linux `RUN` with an independent network namespace, reject remote URL `ADD`, bind network policy into RUN cache identity, and reject the warm pool until it has equivalent isolation evidence
- preserve outbound defaults for existing CLI and Rust SDK callers

## Scope

This is the Box-owned BX0.4 contract foundation for A3S-Lab/Cloud#85 and #172. It does not mark BX0.4 complete. Cloud still has to consume this boundary while preserving OCI publication, content-addressed cache evidence, SPDX/SLSA evidence, signing, cancellation, process-death recovery, and cleanup.

## Verification

- `cargo test -p a3s-box-runtime` — 1472 passed, 1 ignored
- `cargo test -p a3s-box-core compose::acl` — 5 passed
- `cargo test -p a3s-box-core --test compose_normalization` — 6 passed
- `cargo test -p a3s-box-sdk` — 58 passed, 2 real-runtime tests ignored
- `cargo test -p a3s-box-cli commands::build::tests` — 19 passed
- `cargo clippy -p a3s-box-runtime -p a3s-box-core -p a3s-box-sdk -p a3s-box-cli --all-targets -- -D warnings`
- `cargo fmt --all --check`
