### PR TITLE
feat(build): return typed OCI build outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ runtime state changes instead of being silently stored or weakened.
   layers, registry credentials, optional cosign verification, save/load,
   multi-stage builds, selected `RUN --mount` forms, and content-addressed
   caching. Closed A3S ACL build plans add canonical identities, source-root
-  path confinement, and an enforced network-none Linux `RUN` policy over the
+  path confinement, an enforced network-none Linux `RUN` policy, and
+  plan-bound typed OCI descriptors with durable image-layout paths over the
   same native build engine.
 - **Storage** — bind mounts, named volumes, tmpfs, file copy, diff, export,
   commit, filesystem snapshots, copy-on-write restore, and Box-owned read-only

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -369,6 +369,12 @@ Current notes:
   `network = "none"` rejects remote URL `ADD`, changes the native `RUN` cache
   identity, and adds a private network namespace on Linux. It rejects the warm
   RUN pool until that path has equivalent isolation evidence.
+- Plan execution now returns one plan-bound typed native output containing the
+  exact OCI manifest descriptor, platform, durable image-store layout path,
+  total content bytes, layer count, and blob count. Callers no longer have to
+  infer a publishable build result from a temporary workspace or reparse CLI
+  output; cache export/import receipts and multi-platform assembly remain
+  separate release gates.
 - Dockerfile `RUN` no longer has any silent skip path on unsupported hosts.
   Linux uses isolated `chroot`; the built-in engine also has an isolated
   warm-pool VM lease path via `--run-pool`, which mounts each mutable build

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -147,8 +147,9 @@ pub use volume::VolumeStore;
 
 #[cfg(feature = "build")]
 pub use oci::{
-    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildConfig,
-    BuildNetworkPolicy, BuildRunPoolConfig, Dockerfile, Instruction,
+    execute_build_plan, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy,
+    BuildConfig, BuildNetworkPolicy, BuildOutputDescriptor, BuildPlanExecutionError, BuildResult,
+    BuildRunPoolConfig, Dockerfile, Instruction, PlannedBuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 
 #[cfg(feature = "compose")]

--- a/src/runtime/src/oci/build/engine/mod.rs
+++ b/src/runtime/src/oci/build/engine/mod.rs
@@ -34,6 +34,9 @@ use handlers::{
 use stages::{global_arg_decls, resolve_stage_rootfs, split_into_stages};
 use utils::{compute_diff_id, expand_args, format_size, resolve_path};
 
+/// OCI media type emitted for the root descriptor of a native build.
+pub const OCI_IMAGE_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+
 /// Network access available to Dockerfile execution instructions.
 ///
 /// Base-image and external-stage resolution remain trusted host-side OCI
@@ -125,6 +128,33 @@ pub struct BuildResult {
     pub size: u64,
     /// Number of layers
     pub layer_count: usize,
+    /// Typed root descriptor published by the OCI layout.
+    pub descriptor: BuildOutputDescriptor,
+    /// Exact platform represented by the single-platform output.
+    pub platform: Platform,
+    /// Durable local OCI image-layout directory owned by the image store.
+    pub layout_directory: PathBuf,
+    /// Number of content-addressed blobs in the output layout.
+    pub blob_count: usize,
+}
+
+impl BuildResult {
+    /// Total bytes occupied by the durable OCI layout.
+    pub const fn content_bytes(&self) -> u64 {
+        self.size
+    }
+}
+
+/// Typed root descriptor for a native Box build output.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BuildOutputDescriptor {
+    /// OCI descriptor media type.
+    pub media_type: String,
+    /// Canonical lowercase SHA-256 content digest.
+    pub digest: String,
+    /// Exact descriptor payload size.
+    pub size: u64,
 }
 
 #[cfg_attr(not(feature = "pool"), allow(dead_code))]
@@ -1685,7 +1715,7 @@ async fn assemble_image(
     // Build manifest
     let manifest = serde_json::json!({
         "schemaVersion": 2,
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "mediaType": OCI_IMAGE_MANIFEST_MEDIA_TYPE,
         "config": {
             "mediaType": "application/vnd.oci.image.config.v1+json",
             "digest": format!("sha256:{}", config_digest),
@@ -1712,7 +1742,7 @@ async fn assemble_image(
         "schemaVersion": 2,
         "mediaType": "application/vnd.oci.image.index.v1+json",
         "manifests": [{
-            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "mediaType": OCI_IMAGE_MANIFEST_MEDIA_TYPE,
             "digest": format!("sha256:{}", manifest_digest),
             "size": manifest_bytes.len(),
             "platform": platform_obj
@@ -1734,15 +1764,67 @@ async fn assemble_image(
     // Store in image store
     let digest_str = format!("sha256:{}", manifest_digest);
     let stored = store.put(reference, &digest_str, &output_dir).await?;
+    let layout_directory = stored.path.canonicalize().map_err(|error| {
+        BoxError::BuildError(format!(
+            "Failed to canonicalize stored OCI build output {}: {error}",
+            stored.path.display()
+        ))
+    })?;
+    let blob_count = count_output_blobs(&layout_directory)?;
+    let descriptor_size = u64::try_from(manifest_bytes.len())
+        .map_err(|_| BoxError::BuildError("OCI build descriptor size overflowed".to_string()))?;
 
     let total_layers = base_layers.len() + state.layers.len();
 
     Ok(BuildResult {
         reference: reference.to_string(),
-        digest: digest_str,
+        digest: digest_str.clone(),
         size: stored.size_bytes,
         layer_count: total_layers,
+        descriptor: BuildOutputDescriptor {
+            media_type: OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_string(),
+            digest: digest_str,
+            size: descriptor_size,
+        },
+        platform: target_platform.clone(),
+        layout_directory,
+        blob_count,
     })
+}
+
+fn count_output_blobs(layout: &Path) -> Result<usize> {
+    let blobs = layout.join("blobs").join("sha256");
+    let entries = std::fs::read_dir(&blobs).map_err(|error| {
+        BoxError::BuildError(format!(
+            "Failed to inspect stored OCI build blobs {}: {error}",
+            blobs.display()
+        ))
+    })?;
+    let mut count = 0_usize;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            BoxError::BuildError(format!(
+                "Failed to inspect an OCI build blob in {}: {error}",
+                blobs.display()
+            ))
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            BoxError::BuildError(format!(
+                "Failed to inspect OCI build blob {}: {error}",
+                entry.path().display()
+            ))
+        })?;
+        if !file_type.is_file() || file_type.is_symlink() {
+            return Err(BoxError::BuildError(format!(
+                "Stored OCI build blob {} is not a regular file",
+                entry.path().display()
+            )));
+        }
+        count = count.checked_add(1).ok_or_else(|| {
+            BoxError::BuildError("Stored OCI build blob count overflowed".to_string())
+        })?;
+    }
+    Ok(count)
 }
 
 fn copy_layer_blob(layer: &LayerInfo, blob_path: &Path, label: &str) -> Result<()> {

--- a/src/runtime/src/oci/build/execution.rs
+++ b/src/runtime/src/oci/build/execution.rs
@@ -1,0 +1,53 @@
+//! Plan-bound execution over the one native Box OCI build engine.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use a3s_box_core::error::BoxError;
+use thiserror::Error;
+
+use super::{build, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildResult};
+use crate::oci::ImageStore;
+
+/// Successful native output bound to the canonical admitted build plan.
+#[derive(Debug)]
+pub struct PlannedBuildResult {
+    /// Canonical A3S ACL plan identity.
+    pub plan_digest: String,
+    /// Durable typed OCI output owned by the Box image store.
+    pub output: BuildResult,
+}
+
+/// Stable failure boundary for plan admission, compilation, and execution.
+#[derive(Debug, Error)]
+pub enum BuildPlanExecutionError {
+    /// The closed build plan could not be canonicalized or compiled.
+    #[error(transparent)]
+    Plan(#[from] BoxBuildPlanError),
+    /// The native build engine or durable image store rejected the operation.
+    #[error(transparent)]
+    Build(#[from] BoxError),
+}
+
+/// Compile and execute one canonical plan through Box's existing native engine.
+///
+/// The returned layout path points at the durable image-store copy rather than
+/// the temporary build workspace, so a caller can capture or publish the exact
+/// OCI graph after this future returns.
+pub async fn execute_build_plan(
+    plan: &BoxBuildPlan,
+    source_root: &Path,
+    options: BoxBuildOptions,
+    store: Arc<ImageStore>,
+) -> Result<PlannedBuildResult, BuildPlanExecutionError> {
+    let plan_digest = plan.canonical_digest()?;
+    let config = plan.compile(source_root, options)?;
+    let output = build(config, store).await?;
+    Ok(PlannedBuildResult {
+        plan_digest,
+        output,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/runtime/src/oci/build/execution/tests.rs
+++ b/src/runtime/src/oci/build/execution/tests.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::OCI_IMAGE_MANIFEST_MEDIA_TYPE;
+
+#[tokio::test]
+async fn execution_returns_a_plan_bound_typed_oci_output() {
+    let temporary = tempfile::TempDir::new().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::write(
+        source.join("Dockerfile"),
+        "FROM scratch\nCOPY value /value\n",
+    )
+    .unwrap();
+    std::fs::write(source.join("value"), "typed-output\n").unwrap();
+
+    let platform = if cfg!(target_arch = "aarch64") {
+        "linux/arm64"
+    } else {
+        "linux/amd64"
+    };
+    let plan = BoxBuildPlan::parse_acl(&format!(
+        r#"
+build "oci" {{
+  cache = "disabled"
+  context = "."
+  file = "Dockerfile"
+  network = "none"
+  platform = "{platform}"
+  schema = "a3s.box.build-plan.v1"
+}}
+"#
+    ))
+    .unwrap();
+    let expected_plan_digest = plan.canonical_digest().unwrap();
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+
+    let result = execute_build_plan(
+        &plan,
+        &source,
+        BoxBuildOptions {
+            tag: Some("a3s-cloud/build:test".into()),
+            quiet: true,
+        },
+        Arc::clone(&store),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.plan_digest, expected_plan_digest);
+    assert_eq!(result.output.reference, "a3s-cloud/build:test");
+    assert_eq!(result.output.platform, *plan.platform());
+    assert_eq!(
+        result.output.descriptor.media_type,
+        OCI_IMAGE_MANIFEST_MEDIA_TYPE
+    );
+    assert_eq!(result.output.descriptor.digest, result.output.digest);
+    assert!(result.output.descriptor.size > 0);
+    assert_eq!(result.output.layer_count, 1);
+    assert_eq!(result.output.blob_count, 3);
+    assert!(result.output.content_bytes() >= result.output.descriptor.size);
+    assert!(result
+        .output
+        .layout_directory
+        .starts_with(store_root.canonicalize().unwrap()));
+    assert!(result.output.layout_directory.join("oci-layout").is_file());
+    assert!(result.output.layout_directory.join("index.json").is_file());
+    crate::oci::OciImage::from_path(&result.output.layout_directory).unwrap();
+
+    let stored = store.get("a3s-cloud/build:test").await.unwrap();
+    assert_eq!(stored.digest, result.output.descriptor.digest);
+    assert_eq!(
+        stored.path.canonicalize().unwrap(),
+        result.output.layout_directory
+    );
+    assert_eq!(stored.size_bytes, result.output.content_bytes());
+}

--- a/src/runtime/src/oci/build/mod.rs
+++ b/src/runtime/src/oci/build/mod.rs
@@ -22,10 +22,15 @@ pub(crate) mod cache;
 pub mod dockerfile;
 pub(crate) mod dockerignore;
 pub mod engine;
+mod execution;
 pub mod layer;
 pub mod plan;
 
 pub use dockerfile::{Dockerfile, Instruction};
-pub use engine::{build, BuildConfig, BuildNetworkPolicy, BuildResult, BuildRunPoolConfig};
+pub use engine::{
+    build, BuildConfig, BuildNetworkPolicy, BuildOutputDescriptor, BuildResult, BuildRunPoolConfig,
+    OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+};
+pub use execution::{execute_build_plan, BuildPlanExecutionError, PlannedBuildResult};
 pub use layer::{DirSnapshot, LayerInfo};
 pub use plan::{BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy};

--- a/src/runtime/src/oci/mod.rs
+++ b/src/runtime/src/oci/mod.rs
@@ -39,8 +39,9 @@ pub mod store;
 
 #[cfg(feature = "build")]
 pub use build::{
-    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildConfig,
-    BuildNetworkPolicy, BuildResult, BuildRunPoolConfig, Dockerfile, Instruction,
+    execute_build_plan, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy,
+    BuildConfig, BuildNetworkPolicy, BuildOutputDescriptor, BuildPlanExecutionError, BuildResult,
+    BuildRunPoolConfig, Dockerfile, Instruction, PlannedBuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 pub use credentials::CredentialStore;
 pub use image::{OciHealthCheck, OciImage, OciImageConfig};


### PR DESCRIPTION
## Summary

- execute the closed A3S ACL build plan through the existing native engine
- bind the result to the canonical plan digest
- return the exact OCI manifest descriptor, platform, durable image-store layout path, content bytes, layer count, and blob count
- keep CLI/SDK behavior and the single native image store unchanged

## Why

A3S Cloud must capture and validate the exact Box-built OCI graph without parsing CLI output or depending on the temporary native build workspace. This is the typed output foundation for BX0.4 publication and recovery work.

## Verification

- `cargo test -p a3s-box-runtime` — 1,473 passed, 1 ignored
- `cargo test -p a3s-box-sdk` — 58 passed; real-runtime suites ignored as designed
- `cargo test -p a3s-box-cli build` — focused build and scratch smoke coverage passed
- `cargo clippy -p a3s-box-runtime -p a3s-box-sdk -p a3s-box-cli --all-targets -- -D warnings`
- `cargo fmt --all --check`

## Scope

This does not claim BX0.4 complete. Durable cache import/export receipts, multi-platform assembly, cancellation/process-death recovery, and the Cloud Node Agent consumer remain follow-up gates.