### PR TITLE
feat(build): add durable recorded build receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,13 @@ runtime state changes instead of being silently stored or weakened.
   caching. Closed A3S ACL build plans add canonical identities, source-root
   path confinement, an enforced network-none Linux `RUN` policy, and
   plan-bound typed OCI descriptors with durable image-layout paths over the
-  same native build engine.
+  same native build engine. The sole recorded-plan boundary persists immutable
+  operation, source, and plan intent before build side effects, then commits a
+  path-independent terminal receipt over the same ImageStore. Restarted callers
+  adopt an output committed before the terminal receipt and revalidate the
+  complete OCI graph, platform, blob inventory, and byte count before replay.
+  The internal operation journal is derived from the ImageStore and is not a
+  second caller-configurable output store or build engine.
 - **Storage** — bind mounts, named volumes, tmpfs, file copy, diff, export,
   commit, filesystem snapshots, copy-on-write restore, and Box-owned read-only
   aliases for caller-provided Artifact trees below private provider roots.

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -373,8 +373,23 @@ Current notes:
   exact OCI manifest descriptor, platform, durable image-store layout path,
   total content bytes, layer count, and blob count. Callers no longer have to
   infer a publishable build result from a temporary workspace or reparse CLI
-  output; cache export/import receipts and multi-platform assembly remain
-  separate release gates.
+  output.
+- Recorded plan execution is the sole public plan-bound execution boundary. It
+  serializes each bounded operation identity across processes, durably records
+  immutable source and canonical plan intent before native build side effects,
+  and commits one path-independent `a3s.box.build-output-receipt.v1` before
+  returning success. Its internal journal is always derived from the existing
+  ImageStore; callers cannot configure another receipt root or output store.
+  The native build and replay paths share one output validator for the root
+  descriptor, platform, complete referenced blob set, blob-inventory digest,
+  exact content bytes, and layer count. A restarted caller refreshes the
+  authoritative cross-process ImageStore index, adopts output committed in the
+  ImageStore-to-terminal-receipt crash gap, and replays without reopening the
+  source tree. Cleanup removes the receipt and operation-specific image
+  reference idempotently. This terminal boundary does not supervise a build
+  that is still running: cache import/export receipts, explicit cancellation,
+  deterministic temporary-workspace and child-process reclamation after caller
+  death, and multi-platform assembly remain separate release gates.
 - Dockerfile `RUN` no longer has any silent skip path on unsupported hosts.
   Linux uses isolated `chroot`; the built-in engine also has an isolated
   warm-pool VM lease path via `--run-pool`, which mounts each mutable build

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -147,9 +147,12 @@ pub use volume::VolumeStore;
 
 #[cfg(feature = "build")]
 pub use oci::{
-    execute_build_plan, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy,
-    BuildConfig, BuildNetworkPolicy, BuildOutputDescriptor, BuildPlanExecutionError, BuildResult,
-    BuildRunPoolConfig, Dockerfile, Instruction, PlannedBuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    execute_recorded_build_plan, inspect_recorded_build_plan, remove_recorded_build_plan,
+    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildConfig,
+    BuildNetworkPolicy, BuildOperationIdentity, BuildOutputDescriptor, BuildOutputReceipt,
+    BuildPlanExecutionError, BuildReceiptError, BuildReceiptOutput, BuildResult,
+    BuildRunPoolConfig, Dockerfile, Instruction, RecordedBuildResult,
+    OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 
 #[cfg(feature = "compose")]

--- a/src/runtime/src/oci/build/engine/mod.rs
+++ b/src/runtime/src/oci/build/engine/mod.rs
@@ -15,6 +15,8 @@ use super::cache::{hash_context_sources, BuildCache};
 use super::dockerfile::{Dockerfile, Instruction, RunBindMount, RunCacheMount};
 use super::dockerignore::DockerIgnore;
 use super::layer::{sha256_bytes, sha256_file, LayerInfo};
+use super::output::inspect_stored_build_output;
+pub use super::output::{BuildOutputDescriptor, BuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
 use crate::oci::image::OciImageConfig;
 use crate::oci::layers::extract_layer;
 use crate::oci::store::ImageStore;
@@ -33,9 +35,6 @@ use handlers::{
 };
 use stages::{global_arg_decls, resolve_stage_rootfs, split_into_stages};
 use utils::{compute_diff_id, expand_args, format_size, resolve_path};
-
-/// OCI media type emitted for the root descriptor of a native build.
-pub const OCI_IMAGE_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
 
 /// Network access available to Dockerfile execution instructions.
 ///
@@ -115,46 +114,6 @@ pub struct BuildRunPoolConfig {
     pub timeout_ns: u64,
     /// Persistent cache directory for `RUN --mount=type=cache`.
     pub run_cache_dir: PathBuf,
-}
-
-/// Result of a successful build.
-#[derive(Debug)]
-pub struct BuildResult {
-    /// Image reference stored in the image store
-    pub reference: String,
-    /// Content digest
-    pub digest: String,
-    /// Total image size in bytes
-    pub size: u64,
-    /// Number of layers
-    pub layer_count: usize,
-    /// Typed root descriptor published by the OCI layout.
-    pub descriptor: BuildOutputDescriptor,
-    /// Exact platform represented by the single-platform output.
-    pub platform: Platform,
-    /// Durable local OCI image-layout directory owned by the image store.
-    pub layout_directory: PathBuf,
-    /// Number of content-addressed blobs in the output layout.
-    pub blob_count: usize,
-}
-
-impl BuildResult {
-    /// Total bytes occupied by the durable OCI layout.
-    pub const fn content_bytes(&self) -> u64 {
-        self.size
-    }
-}
-
-/// Typed root descriptor for a native Box build output.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct BuildOutputDescriptor {
-    /// OCI descriptor media type.
-    pub media_type: String,
-    /// Canonical lowercase SHA-256 content digest.
-    pub digest: String,
-    /// Exact descriptor payload size.
-    pub size: u64,
 }
 
 #[cfg_attr(not(feature = "pool"), allow(dead_code))]
@@ -1764,67 +1723,7 @@ async fn assemble_image(
     // Store in image store
     let digest_str = format!("sha256:{}", manifest_digest);
     let stored = store.put(reference, &digest_str, &output_dir).await?;
-    let layout_directory = stored.path.canonicalize().map_err(|error| {
-        BoxError::BuildError(format!(
-            "Failed to canonicalize stored OCI build output {}: {error}",
-            stored.path.display()
-        ))
-    })?;
-    let blob_count = count_output_blobs(&layout_directory)?;
-    let descriptor_size = u64::try_from(manifest_bytes.len())
-        .map_err(|_| BoxError::BuildError("OCI build descriptor size overflowed".to_string()))?;
-
-    let total_layers = base_layers.len() + state.layers.len();
-
-    Ok(BuildResult {
-        reference: reference.to_string(),
-        digest: digest_str.clone(),
-        size: stored.size_bytes,
-        layer_count: total_layers,
-        descriptor: BuildOutputDescriptor {
-            media_type: OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_string(),
-            digest: digest_str,
-            size: descriptor_size,
-        },
-        platform: target_platform.clone(),
-        layout_directory,
-        blob_count,
-    })
-}
-
-fn count_output_blobs(layout: &Path) -> Result<usize> {
-    let blobs = layout.join("blobs").join("sha256");
-    let entries = std::fs::read_dir(&blobs).map_err(|error| {
-        BoxError::BuildError(format!(
-            "Failed to inspect stored OCI build blobs {}: {error}",
-            blobs.display()
-        ))
-    })?;
-    let mut count = 0_usize;
-    for entry in entries {
-        let entry = entry.map_err(|error| {
-            BoxError::BuildError(format!(
-                "Failed to inspect an OCI build blob in {}: {error}",
-                blobs.display()
-            ))
-        })?;
-        let file_type = entry.file_type().map_err(|error| {
-            BoxError::BuildError(format!(
-                "Failed to inspect OCI build blob {}: {error}",
-                entry.path().display()
-            ))
-        })?;
-        if !file_type.is_file() || file_type.is_symlink() {
-            return Err(BoxError::BuildError(format!(
-                "Stored OCI build blob {} is not a regular file",
-                entry.path().display()
-            )));
-        }
-        count = count.checked_add(1).ok_or_else(|| {
-            BoxError::BuildError("Stored OCI build blob count overflowed".to_string())
-        })?;
-    }
-    Ok(count)
+    inspect_stored_build_output(reference, stored, store.store_dir())
 }
 
 fn copy_layer_blob(layer: &LayerInfo, blob_path: &Path, label: &str) -> Result<()> {

--- a/src/runtime/src/oci/build/execution.rs
+++ b/src/runtime/src/oci/build/execution.rs
@@ -6,12 +6,18 @@ use std::sync::Arc;
 use a3s_box_core::error::BoxError;
 use thiserror::Error;
 
-use super::{build, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildResult};
+use super::receipt::{
+    inspect_stored_output, BuildOperationJournal, PendingBuildOperation, PersistedBuildOperation,
+};
+use super::{
+    build, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildOperationIdentity,
+    BuildOutputReceipt, BuildReceiptError, BuildResult, RecordedBuildResult,
+};
 use crate::oci::ImageStore;
 
 /// Successful native output bound to the canonical admitted build plan.
 #[derive(Debug)]
-pub struct PlannedBuildResult {
+pub(super) struct PlannedBuildResult {
     /// Canonical A3S ACL plan identity.
     pub plan_digest: String,
     /// Durable typed OCI output owned by the Box image store.
@@ -27,6 +33,9 @@ pub enum BuildPlanExecutionError {
     /// The native build engine or durable image store rejected the operation.
     #[error(transparent)]
     Build(#[from] BoxError),
+    /// Durable receipt identity, persistence, or output validation failed.
+    #[error(transparent)]
+    Receipt(#[from] BuildReceiptError),
 }
 
 /// Compile and execute one canonical plan through Box's existing native engine.
@@ -34,7 +43,7 @@ pub enum BuildPlanExecutionError {
 /// The returned layout path points at the durable image-store copy rather than
 /// the temporary build workspace, so a caller can capture or publish the exact
 /// OCI graph after this future returns.
-pub async fn execute_build_plan(
+pub(super) async fn execute_build_plan(
     plan: &BoxBuildPlan,
     source_root: &Path,
     options: BoxBuildOptions,
@@ -46,6 +55,176 @@ pub async fn execute_build_plan(
     Ok(PlannedBuildResult {
         plan_digest,
         output,
+    })
+}
+
+/// Execute or exactly replay one terminal plan-bound native build.
+///
+/// The per-operation lock serializes the complete build and receipt commit
+/// across processes. A successful receipt is written durably before this
+/// future returns. A retry validates the same source and plan identities, then
+/// reconstructs the exact output from the existing ImageStore without touching
+/// the source tree.
+///
+/// This terminal receipt boundary does not supervise or cancel an in-flight
+/// build. Those controls require the separate durable operation supervisor.
+pub async fn execute_recorded_build_plan(
+    identity: &BuildOperationIdentity,
+    plan: &BoxBuildPlan,
+    source_root: &Path,
+    quiet: bool,
+    store: Arc<ImageStore>,
+) -> Result<RecordedBuildResult, BuildPlanExecutionError> {
+    let plan_digest = plan.canonical_digest()?;
+    let journal = BuildOperationJournal::for_image_store(&store, identity.operation_id()).await?;
+    let locked = journal.lock(identity.operation_id()).await?;
+    match locked.read().await? {
+        Some(PersistedBuildOperation::Succeeded(receipt)) => {
+            return recover_recorded_build(identity, &plan_digest, receipt, &store).await;
+        }
+        Some(PersistedBuildOperation::Pending(pending)) => {
+            pending.require_identity(identity, &plan_digest)?;
+            if let Some(output) =
+                inspect_stored_output(identity.operation_id(), identity.output_reference(), &store)
+                    .await?
+            {
+                let receipt =
+                    BuildOutputReceipt::from_result(identity, plan_digest.clone(), &output)?;
+                let receipt = locked.write_succeeded(receipt).await?;
+                return Ok(RecordedBuildResult {
+                    receipt,
+                    output,
+                    replayed: true,
+                });
+            }
+        }
+        None => {
+            if store
+                .get_checked(identity.output_reference())
+                .await?
+                .is_some()
+            {
+                return Err(BuildReceiptError::OutputInvalid {
+                    operation_id: identity.operation_id().to_string(),
+                    message: "operation output exists without a persisted owning intent"
+                        .to_string(),
+                }
+                .into());
+            }
+            let pending = PendingBuildOperation::new(identity, plan_digest.clone())?;
+            locked.write_pending(pending).await?;
+        }
+    }
+
+    let planned = execute_build_plan(
+        plan,
+        source_root,
+        BoxBuildOptions {
+            tag: Some(identity.output_reference().to_string()),
+            quiet,
+        },
+        Arc::clone(&store),
+    )
+    .await?;
+    let receipt = BuildOutputReceipt::from_result(identity, planned.plan_digest, &planned.output)?;
+    let receipt = locked.write_succeeded(receipt).await?;
+    Ok(RecordedBuildResult {
+        receipt,
+        output: planned.output,
+        replayed: false,
+    })
+}
+
+/// Inspect and revalidate one terminal receipt without accessing build source.
+pub async fn inspect_recorded_build_plan(
+    identity: &BuildOperationIdentity,
+    plan: &BoxBuildPlan,
+    store: &ImageStore,
+) -> Result<Option<RecordedBuildResult>, BuildPlanExecutionError> {
+    let plan_digest = plan.canonical_digest()?;
+    let journal = BuildOperationJournal::for_image_store(store, identity.operation_id()).await?;
+    let locked = journal.lock(identity.operation_id()).await?;
+    match locked.read().await? {
+        None => Ok(None),
+        Some(PersistedBuildOperation::Succeeded(receipt)) => {
+            recover_recorded_build(identity, &plan_digest, receipt, store)
+                .await
+                .map(Some)
+        }
+        Some(PersistedBuildOperation::Pending(pending)) => {
+            pending.require_identity(identity, &plan_digest)?;
+            let Some(output) =
+                inspect_stored_output(identity.operation_id(), identity.output_reference(), store)
+                    .await?
+            else {
+                return Ok(None);
+            };
+            let receipt = BuildOutputReceipt::from_result(identity, plan_digest, &output)?;
+            let receipt = locked.write_succeeded(receipt).await?;
+            Ok(Some(RecordedBuildResult {
+                receipt,
+                output,
+                replayed: true,
+            }))
+        }
+    }
+}
+
+/// Remove one terminal receipt and its operation-specific ImageStore reference.
+///
+/// Missing image content is tolerated during cleanup so an already-pruned
+/// output cannot leave a permanent stale receipt. A present reference must
+/// still match the receipt digest before it is removed.
+pub async fn remove_recorded_build_plan(
+    identity: &BuildOperationIdentity,
+    plan: &BoxBuildPlan,
+    store: &ImageStore,
+) -> Result<bool, BuildPlanExecutionError> {
+    let plan_digest = plan.canonical_digest()?;
+    let journal = BuildOperationJournal::for_image_store(store, identity.operation_id()).await?;
+    let locked = journal.lock(identity.operation_id()).await?;
+    let Some(record) = locked.read().await? else {
+        return Ok(false);
+    };
+    let (reference, expected_digest) = match record {
+        PersistedBuildOperation::Pending(pending) => {
+            pending.require_identity(identity, &plan_digest)?;
+            (identity.output_reference().to_string(), None)
+        }
+        PersistedBuildOperation::Succeeded(receipt) => {
+            receipt.require_identity(identity, &plan_digest)?;
+            (
+                receipt.output.reference,
+                Some(receipt.output.descriptor.digest),
+            )
+        }
+    };
+    if let Some(stored) = store.get_checked(&reference).await? {
+        if expected_digest.is_some_and(|digest| stored.digest != digest) {
+            return Err(BuildReceiptError::OutputInvalid {
+                operation_id: identity.operation_id().to_string(),
+                message: "operation reference was rebound to another digest".to_string(),
+            }
+            .into());
+        }
+        store.remove(&reference).await?;
+    }
+    locked.delete().await?;
+    Ok(true)
+}
+
+async fn recover_recorded_build(
+    identity: &BuildOperationIdentity,
+    plan_digest: &str,
+    receipt: BuildOutputReceipt,
+    store: &ImageStore,
+) -> Result<RecordedBuildResult, BuildPlanExecutionError> {
+    receipt.require_identity(identity, plan_digest)?;
+    let output = receipt.resolve(store).await?;
+    Ok(RecordedBuildResult {
+        receipt,
+        output,
+        replayed: true,
     })
 }
 

--- a/src/runtime/src/oci/build/mod.rs
+++ b/src/runtime/src/oci/build/mod.rs
@@ -24,13 +24,20 @@ pub(crate) mod dockerignore;
 pub mod engine;
 mod execution;
 pub mod layer;
+mod output;
 pub mod plan;
+mod receipt;
 
 pub use dockerfile::{Dockerfile, Instruction};
-pub use engine::{
-    build, BuildConfig, BuildNetworkPolicy, BuildOutputDescriptor, BuildResult, BuildRunPoolConfig,
-    OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+pub use engine::{build, BuildConfig, BuildNetworkPolicy, BuildRunPoolConfig};
+pub use execution::{
+    execute_recorded_build_plan, inspect_recorded_build_plan, remove_recorded_build_plan,
+    BuildPlanExecutionError,
 };
-pub use execution::{execute_build_plan, BuildPlanExecutionError, PlannedBuildResult};
 pub use layer::{DirSnapshot, LayerInfo};
+pub use output::{BuildOutputDescriptor, BuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
 pub use plan::{BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy};
+pub use receipt::{
+    BuildOperationIdentity, BuildOutputReceipt, BuildReceiptError, BuildReceiptOutput,
+    RecordedBuildResult,
+};

--- a/src/runtime/src/oci/build/output.rs
+++ b/src/runtime/src/oci/build/output.rs
@@ -1,0 +1,379 @@
+//! Single validation and reconstruction path for native OCI build outputs.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use a3s_box_core::error::{BoxError, Result};
+use a3s_box_core::platform::Platform;
+use a3s_box_core::StoredImage;
+use oci_spec::image::Descriptor;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::oci::image::{
+    canonical_sha256_digest_hex, read_regular_file_bounded, validate_plain_directory,
+    MAX_OCI_INDEX_BYTES, MAX_OCI_LAYOUT_BYTES,
+};
+use crate::oci::OciImage;
+
+/// OCI media type emitted for the root descriptor of a native build.
+pub const OCI_IMAGE_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+
+/// Result of a successful build.
+#[derive(Debug)]
+pub struct BuildResult {
+    /// Image reference stored in the image store.
+    pub reference: String,
+    /// Content digest.
+    pub digest: String,
+    /// Total image size in bytes.
+    pub size: u64,
+    /// Number of layers.
+    pub layer_count: usize,
+    /// Typed root descriptor published by the OCI layout.
+    pub descriptor: BuildOutputDescriptor,
+    /// Exact platform represented by the single-platform output.
+    pub platform: Platform,
+    /// Durable local OCI image-layout directory owned by the image store.
+    pub layout_directory: PathBuf,
+    /// Number of unique content-addressed blobs in the output layout.
+    pub blob_count: usize,
+    /// Canonical digest of the sorted digest-and-size blob inventory.
+    pub blob_inventory_digest: String,
+}
+
+impl BuildResult {
+    /// Total bytes occupied by the durable OCI layout.
+    pub const fn content_bytes(&self) -> u64 {
+        self.size
+    }
+}
+
+/// Typed root descriptor for a native Box build output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BuildOutputDescriptor {
+    /// OCI descriptor media type.
+    pub media_type: String,
+    /// Canonical lowercase SHA-256 content digest.
+    pub digest: String,
+    /// Exact descriptor payload size.
+    pub size: u64,
+}
+
+/// Reconstruct one build result through the same complete validation used
+/// immediately after native output publication and during durable replay.
+pub(super) fn inspect_stored_build_output(
+    reference: &str,
+    stored: StoredImage,
+    store_root: &Path,
+) -> Result<BuildResult> {
+    if stored.reference != reference {
+        return Err(output_error(format!(
+            "ImageStore returned reference {:?} for requested build output {reference:?}",
+            stored.reference
+        )));
+    }
+    canonical_sha256_digest_hex(&stored.digest)?;
+
+    let store_root = store_root.canonicalize().map_err(|error| {
+        output_error(format!(
+            "Failed to canonicalize ImageStore root {}: {error}",
+            store_root.display()
+        ))
+    })?;
+    let layout_directory = stored.path.canonicalize().map_err(|error| {
+        output_error(format!(
+            "Failed to canonicalize stored OCI build output {}: {error}",
+            stored.path.display()
+        ))
+    })?;
+    if !layout_directory.starts_with(&store_root) {
+        return Err(output_error(format!(
+            "Stored OCI build output {} escaped ImageStore {}",
+            layout_directory.display(),
+            store_root.display()
+        )));
+    }
+
+    let image = OciImage::from_path(&layout_directory)
+        .map_err(|error| output_error(format!("OCI graph validation failed: {error}")))?;
+    if image.index_manifest_count() != 1 {
+        return Err(output_error(
+            "Native single-platform build output must contain exactly one root manifest",
+        ));
+    }
+
+    let root = image.manifest_descriptor();
+    let descriptor = BuildOutputDescriptor {
+        media_type: root.media_type().to_string(),
+        digest: root.digest().to_string(),
+        size: root.size(),
+    };
+    if descriptor.media_type != OCI_IMAGE_MANIFEST_MEDIA_TYPE
+        || canonical_sha256_digest_hex(&descriptor.digest).is_err()
+        || descriptor.size == 0
+    {
+        return Err(output_error(
+            "Native build root descriptor is outside the closed output contract",
+        ));
+    }
+    if image.manifest_digest() != descriptor.digest || stored.digest != descriptor.digest {
+        return Err(output_error(
+            "ImageStore, OCI image, and root descriptor digests differ",
+        ));
+    }
+
+    let platform = root
+        .platform()
+        .as_ref()
+        .ok_or_else(|| output_error("Native build root descriptor has no platform"))?;
+    let platform = Platform {
+        os: platform.os().to_string(),
+        architecture: platform.architecture().to_string(),
+        variant: platform.variant().clone(),
+    };
+    if platform.os != "linux" || platform.architecture.trim().is_empty() {
+        return Err(output_error(
+            "Native build output platform is outside the closed Linux contract",
+        ));
+    }
+
+    validate_native_layout_entries(&layout_directory)?;
+    let (blob_count, blob_bytes, blob_inventory_digest) =
+        validate_blob_inventory(&layout_directory, image.content_descriptors())?;
+    let metadata_bytes = metadata_bytes(&layout_directory)?;
+    let content_bytes = metadata_bytes
+        .checked_add(blob_bytes)
+        .ok_or_else(|| output_error("Native build output byte count overflowed"))?;
+    if stored.size_bytes != content_bytes {
+        return Err(output_error(format!(
+            "ImageStore reports {} bytes but the validated OCI output contains {content_bytes}",
+            stored.size_bytes
+        )));
+    }
+
+    Ok(BuildResult {
+        reference: reference.to_string(),
+        digest: descriptor.digest.clone(),
+        size: content_bytes,
+        layer_count: image.layer_paths().len(),
+        descriptor,
+        platform,
+        layout_directory,
+        blob_count,
+        blob_inventory_digest,
+    })
+}
+
+fn validate_native_layout_entries(layout: &Path) -> Result<()> {
+    validate_exact_entries(
+        layout,
+        &[
+            ("blobs", EntryKind::Directory),
+            ("index.json", EntryKind::File),
+            ("oci-layout", EntryKind::File),
+        ],
+        "native OCI layout",
+    )?;
+    validate_exact_entries(
+        &layout.join("blobs"),
+        &[("sha256", EntryKind::Directory)],
+        "native OCI blob root",
+    )
+}
+
+fn validate_blob_inventory(
+    layout: &Path,
+    descriptors: &[Descriptor],
+) -> Result<(usize, u64, String)> {
+    let mut expected = BTreeMap::<String, u64>::new();
+    for descriptor in descriptors {
+        let digest = descriptor.digest().to_string();
+        canonical_sha256_digest_hex(&digest)?;
+        let size = descriptor.size();
+        if size == 0 {
+            return Err(output_error(format!(
+                "Native OCI blob {digest} has an empty descriptor"
+            )));
+        }
+        if let Some(existing) = expected.insert(digest.clone(), size) {
+            if existing != size {
+                return Err(output_error(format!(
+                    "Native OCI blob {digest} has conflicting descriptor sizes"
+                )));
+            }
+        }
+    }
+
+    let blob_root = layout.join("blobs").join("sha256");
+    validate_plain_directory(&blob_root, "native OCI sha256 blobs")?;
+    let mut actual = BTreeSet::new();
+    for entry in std::fs::read_dir(&blob_root).map_err(|error| {
+        output_error(format!(
+            "Failed to inspect native OCI blobs {}: {error}",
+            blob_root.display()
+        ))
+    })? {
+        let entry = entry.map_err(|error| {
+            output_error(format!(
+                "Failed to inspect an entry in {}: {error}",
+                blob_root.display()
+            ))
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            output_error(format!(
+                "Failed to inspect native OCI blob {}: {error}",
+                entry.path().display()
+            ))
+        })?;
+        if !file_type.is_file() || file_type.is_symlink() {
+            return Err(output_error(format!(
+                "Native OCI blob {} is not a regular file",
+                entry.path().display()
+            )));
+        }
+        let name = entry.file_name().into_string().map_err(|_| {
+            output_error(format!(
+                "Native OCI blob name in {} is not UTF-8",
+                blob_root.display()
+            ))
+        })?;
+        let digest = format!("sha256:{name}");
+        canonical_sha256_digest_hex(&digest)?;
+        let expected_size = expected.get(&digest).ok_or_else(|| {
+            output_error(format!(
+                "Native OCI output contains unreferenced blob {digest}"
+            ))
+        })?;
+        let actual_size = entry
+            .metadata()
+            .map_err(|error| {
+                output_error(format!(
+                    "Failed to inspect native OCI blob {}: {error}",
+                    entry.path().display()
+                ))
+            })?
+            .len();
+        if actual_size != *expected_size {
+            return Err(output_error(format!(
+                "Native OCI blob {digest} has {actual_size} bytes, expected {expected_size}"
+            )));
+        }
+        actual.insert(digest);
+    }
+    let expected_names = expected.keys().cloned().collect::<BTreeSet<_>>();
+    if actual != expected_names {
+        let missing = expected_names
+            .difference(&actual)
+            .next()
+            .cloned()
+            .unwrap_or_else(|| "<unknown>".to_string());
+        return Err(output_error(format!(
+            "Native OCI output is missing referenced blob {missing}"
+        )));
+    }
+
+    let mut inventory_hasher = Sha256::new();
+    let mut blob_bytes = 0_u64;
+    for (digest, size) in &expected {
+        inventory_hasher.update(digest.as_bytes());
+        inventory_hasher.update([0]);
+        inventory_hasher.update(size.to_be_bytes());
+        blob_bytes = blob_bytes
+            .checked_add(*size)
+            .ok_or_else(|| output_error("Native OCI blob byte count overflowed"))?;
+    }
+    Ok((
+        expected.len(),
+        blob_bytes,
+        format!("sha256:{:x}", inventory_hasher.finalize()),
+    ))
+}
+
+fn metadata_bytes(layout: &Path) -> Result<u64> {
+    let layout_bytes = read_regular_file_bounded(
+        &layout.join("oci-layout"),
+        MAX_OCI_LAYOUT_BYTES,
+        "oci-layout",
+    )?;
+    let index_bytes = read_regular_file_bounded(
+        &layout.join("index.json"),
+        MAX_OCI_INDEX_BYTES,
+        "index.json",
+    )?;
+    u64::try_from(layout_bytes.len())
+        .ok()
+        .and_then(|left| {
+            u64::try_from(index_bytes.len())
+                .ok()
+                .and_then(|right| left.checked_add(right))
+        })
+        .ok_or_else(|| output_error("Native OCI metadata byte count overflowed"))
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EntryKind {
+    File,
+    Directory,
+}
+
+fn validate_exact_entries(
+    directory: &Path,
+    expected: &[(&str, EntryKind)],
+    label: &str,
+) -> Result<()> {
+    validate_plain_directory(directory, label)?;
+    let mut actual = BTreeMap::new();
+    for entry in std::fs::read_dir(directory).map_err(|error| {
+        output_error(format!(
+            "Failed to inspect {label} {}: {error}",
+            directory.display()
+        ))
+    })? {
+        let entry = entry.map_err(|error| {
+            output_error(format!(
+                "Failed to inspect an entry in {label} {}: {error}",
+                directory.display()
+            ))
+        })?;
+        let name = entry.file_name().into_string().map_err(|_| {
+            output_error(format!(
+                "{label} {} contains a non-UTF-8 entry",
+                directory.display()
+            ))
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            output_error(format!(
+                "Failed to inspect {label} entry {}: {error}",
+                entry.path().display()
+            ))
+        })?;
+        let kind = if file_type.is_file() && !file_type.is_symlink() {
+            EntryKind::File
+        } else if file_type.is_dir() && !file_type.is_symlink() {
+            EntryKind::Directory
+        } else {
+            return Err(output_error(format!(
+                "{label} entry {} is not a plain file or directory",
+                entry.path().display()
+            )));
+        };
+        actual.insert(name, kind);
+    }
+    let expected = expected
+        .iter()
+        .map(|(name, kind)| ((*name).to_string(), *kind))
+        .collect::<BTreeMap<_, _>>();
+    if actual != expected {
+        return Err(output_error(format!(
+            "{label} {} does not contain the exact native output entries",
+            directory.display()
+        )));
+    }
+    Ok(())
+}
+
+fn output_error(message: impl Into<String>) -> BoxError {
+    BoxError::BuildError(message.into())
+}

--- a/src/runtime/src/oci/build/receipt.rs
+++ b/src/runtime/src/oci/build/receipt.rs
@@ -1,0 +1,473 @@
+//! Durable terminal receipts for plan-bound native OCI builds.
+//!
+//! Receipts bind one caller operation and immutable source digest to the exact
+//! native OCI output already owned by [`ImageStore`]. They deliberately do not
+//! copy image content or supervise an in-flight build. A later operation
+//! supervisor can use this terminal boundary for start/inspect/cancel recovery
+//! without adding another build engine or image store.
+
+use a3s_box_core::platform::Platform;
+use a3s_box_core::OperationId;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use super::output::inspect_stored_build_output;
+use super::{BuildOutputDescriptor, BuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
+use crate::oci::image::canonical_sha256_digest_hex;
+use crate::oci::ImageStore;
+
+const MAX_OPERATION_ID_BYTES: usize = 255;
+const MAX_RECEIPT_BYTES: u64 = 64 * 1024;
+const RECEIPT_DIRECTORY: &str = "build-receipts";
+
+mod journal;
+
+pub(super) use journal::BuildOperationJournal;
+
+/// Immutable caller identity for one recoverable build output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildOperationIdentity {
+    operation_id: OperationId,
+    source_digest: String,
+    output_reference: String,
+}
+
+impl BuildOperationIdentity {
+    /// Validate one bounded operation ID and canonical source Artifact digest.
+    pub fn new(
+        operation_id: OperationId,
+        source_digest: impl Into<String>,
+    ) -> Result<Self, BuildReceiptError> {
+        if operation_id.as_str().len() > MAX_OPERATION_ID_BYTES
+            || operation_id
+                .as_str()
+                .bytes()
+                .any(|byte| byte.is_ascii_control())
+        {
+            return Err(BuildReceiptError::InvalidIdentity {
+                field: "operation_id",
+                reason: "must contain at most 255 non-control UTF-8 bytes",
+            });
+        }
+        let source_digest = source_digest.into();
+        if canonical_sha256_digest_hex(&source_digest).is_err() {
+            return Err(BuildReceiptError::InvalidIdentity {
+                field: "source_digest",
+                reason: "must be canonical sha256:<64 lowercase hex>",
+            });
+        }
+        let operation_key = operation_key(&operation_id);
+        Ok(Self {
+            operation_id,
+            source_digest,
+            output_reference: format!("a3s-box/build-operation:{operation_key}"),
+        })
+    }
+
+    /// Caller-owned idempotency identity.
+    pub fn operation_id(&self) -> &OperationId {
+        &self.operation_id
+    }
+
+    /// Immutable source Artifact content identity.
+    pub fn source_digest(&self) -> &str {
+        &self.source_digest
+    }
+
+    /// Box-internal image reference derived from the operation identity.
+    pub fn output_reference(&self) -> &str {
+        &self.output_reference
+    }
+}
+
+/// Intent persisted before native build side effects begin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct PendingBuildOperation {
+    schema: String,
+    operation_id: OperationId,
+    source_digest: String,
+    plan_digest: String,
+    output_reference: String,
+}
+
+impl PendingBuildOperation {
+    const SCHEMA: &'static str = "a3s.box.build-output-intent.v1";
+
+    pub(super) fn new(
+        identity: &BuildOperationIdentity,
+        plan_digest: String,
+    ) -> Result<Self, BuildReceiptError> {
+        let pending = Self {
+            schema: Self::SCHEMA.to_string(),
+            operation_id: identity.operation_id.clone(),
+            source_digest: identity.source_digest.clone(),
+            plan_digest,
+            output_reference: identity.output_reference.clone(),
+        };
+        pending.require_identity(identity, &pending.plan_digest)?;
+        Ok(pending)
+    }
+
+    fn validate(&self) -> Result<(), BuildReceiptError> {
+        if self.schema != Self::SCHEMA
+            || !valid_operation_id(&self.operation_id)
+            || canonical_sha256_digest_hex(&self.source_digest).is_err()
+            || canonical_sha256_digest_hex(&self.plan_digest).is_err()
+            || self.output_reference
+                != format!(
+                    "a3s-box/build-operation:{}",
+                    operation_key(&self.operation_id)
+                )
+        {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id: self.operation_id.to_string(),
+                message: "pending build intent violates its closed identity".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    pub(super) fn require_identity(
+        &self,
+        identity: &BuildOperationIdentity,
+        plan_digest: &str,
+    ) -> Result<(), BuildReceiptError> {
+        self.validate()?;
+        if self.operation_id != identity.operation_id
+            || self.source_digest != identity.source_digest
+            || self.plan_digest != plan_digest
+            || self.output_reference != identity.output_reference
+        {
+            return Err(BuildReceiptError::Conflict {
+                operation_id: identity.operation_id.to_string(),
+                message: "the pending source, plan, or output identity differs".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn matches_receipt(&self, receipt: &BuildOutputReceipt) -> bool {
+        self.operation_id == receipt.operation_id
+            && self.source_digest == receipt.source_digest
+            && self.plan_digest == receipt.plan_digest
+            && self.output_reference == receipt.output.reference
+    }
+}
+
+/// Strict on-disk state for one build operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(super) enum PersistedBuildOperation {
+    Pending(PendingBuildOperation),
+    Succeeded(BuildOutputReceipt),
+}
+
+impl PersistedBuildOperation {
+    fn validate(&self) -> Result<(), BuildReceiptError> {
+        match self {
+            Self::Pending(pending) => pending.validate(),
+            Self::Succeeded(receipt) => receipt.validate(),
+        }
+    }
+
+    fn operation_id(&self) -> &OperationId {
+        match self {
+            Self::Pending(pending) => &pending.operation_id,
+            Self::Succeeded(receipt) => &receipt.operation_id,
+        }
+    }
+}
+
+/// Persisted, path-independent description of one native OCI output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BuildReceiptOutput {
+    /// Operation-specific internal ImageStore reference.
+    pub reference: String,
+    /// Exact root OCI manifest descriptor.
+    pub descriptor: BuildOutputDescriptor,
+    /// Exact single-platform output.
+    pub platform: Platform,
+    /// Bytes occupied by the durable ImageStore layout.
+    pub content_bytes: u64,
+    /// Manifest layer count.
+    pub layer_count: u64,
+    /// Content-addressed blob count.
+    pub blob_count: u64,
+    /// Canonical digest of the sorted digest-and-size blob inventory.
+    pub blob_inventory_digest: String,
+}
+
+/// Durable terminal receipt for a successful native build.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BuildOutputReceipt {
+    /// Exact receipt schema.
+    pub schema: String,
+    /// Caller-owned idempotency identity.
+    pub operation_id: OperationId,
+    /// Immutable source Artifact content identity.
+    pub source_digest: String,
+    /// Canonical A3S ACL build-plan identity.
+    pub plan_digest: String,
+    /// Path-independent native OCI output evidence.
+    pub output: BuildReceiptOutput,
+}
+
+impl BuildOutputReceipt {
+    /// Current closed receipt schema.
+    pub const SCHEMA: &'static str = "a3s.box.build-output-receipt.v1";
+
+    pub(super) fn from_result(
+        identity: &BuildOperationIdentity,
+        plan_digest: String,
+        result: &BuildResult,
+    ) -> Result<Self, BuildReceiptError> {
+        let layer_count =
+            u64::try_from(result.layer_count).map_err(|_| BuildReceiptError::OutputInvalid {
+                operation_id: identity.operation_id.to_string(),
+                message: "layer count exceeds the durable receipt range".to_string(),
+            })?;
+        let blob_count =
+            u64::try_from(result.blob_count).map_err(|_| BuildReceiptError::OutputInvalid {
+                operation_id: identity.operation_id.to_string(),
+                message: "blob count exceeds the durable receipt range".to_string(),
+            })?;
+        let receipt = Self {
+            schema: Self::SCHEMA.to_string(),
+            operation_id: identity.operation_id.clone(),
+            source_digest: identity.source_digest.clone(),
+            plan_digest,
+            output: BuildReceiptOutput {
+                reference: result.reference.clone(),
+                descriptor: result.descriptor.clone(),
+                platform: result.platform.clone(),
+                content_bytes: result.content_bytes(),
+                layer_count,
+                blob_count,
+                blob_inventory_digest: result.blob_inventory_digest.clone(),
+            },
+        };
+        receipt.validate()?;
+        receipt.require_identity(identity, &receipt.plan_digest)?;
+        Ok(receipt)
+    }
+
+    fn validate(&self) -> Result<(), BuildReceiptError> {
+        let operation_id = self.operation_id.to_string();
+        if self.schema != Self::SCHEMA {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id,
+                message: format!("unsupported schema {:?}", self.schema),
+            });
+        }
+        if !valid_operation_id(&self.operation_id) {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id,
+                message: "operation ID is outside the closed receipt bounds".to_string(),
+            });
+        }
+        for (field, digest) in [
+            ("source digest", self.source_digest.as_str()),
+            ("plan digest", self.plan_digest.as_str()),
+            ("output digest", self.output.descriptor.digest.as_str()),
+            (
+                "blob inventory digest",
+                self.output.blob_inventory_digest.as_str(),
+            ),
+        ] {
+            if canonical_sha256_digest_hex(digest).is_err() {
+                return Err(BuildReceiptError::InvalidReceipt {
+                    operation_id,
+                    message: format!("{field} is not canonical SHA-256"),
+                });
+            }
+        }
+        if self.output.reference
+            != format!(
+                "a3s-box/build-operation:{}",
+                operation_key(&self.operation_id)
+            )
+        {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id,
+                message: "output reference is not derived from the operation identity".to_string(),
+            });
+        }
+        if self.output.descriptor.media_type != OCI_IMAGE_MANIFEST_MEDIA_TYPE
+            || self.output.descriptor.size == 0
+            || self.output.content_bytes < self.output.descriptor.size
+            || self.output.blob_count < 2
+        {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id,
+                message: "output descriptor or content counts are invalid".to_string(),
+            });
+        }
+        if self.output.platform.os != "linux" || self.output.platform.architecture.trim().is_empty()
+        {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id,
+                message: "output platform is outside the native build contract".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    pub(super) fn require_identity(
+        &self,
+        identity: &BuildOperationIdentity,
+        plan_digest: &str,
+    ) -> Result<(), BuildReceiptError> {
+        self.validate()?;
+        if self.operation_id != identity.operation_id
+            || self.source_digest != identity.source_digest
+            || self.plan_digest != plan_digest
+            || self.output.reference != identity.output_reference
+        {
+            return Err(BuildReceiptError::Conflict {
+                operation_id: identity.operation_id.to_string(),
+                message: "the persisted source, plan, or output identity differs".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    pub(super) async fn resolve(
+        &self,
+        store: &ImageStore,
+    ) -> Result<BuildResult, BuildReceiptError> {
+        self.validate()?;
+        let actual = inspect_stored_output(&self.operation_id, &self.output.reference, store)
+            .await?
+            .ok_or_else(|| BuildReceiptError::OutputMissing {
+                operation_id: self.operation_id.to_string(),
+                reference: self.output.reference.clone(),
+            })?;
+        if actual.descriptor != self.output.descriptor
+            || actual.platform != self.output.platform
+            || actual.content_bytes() != self.output.content_bytes
+            || u64::try_from(actual.layer_count).ok() != Some(self.output.layer_count)
+            || u64::try_from(actual.blob_count).ok() != Some(self.output.blob_count)
+            || actual.blob_inventory_digest != self.output.blob_inventory_digest
+        {
+            return Err(BuildReceiptError::OutputInvalid {
+                operation_id: self.operation_id.to_string(),
+                message: "revalidated ImageStore output differs from the receipt".to_string(),
+            });
+        }
+        Ok(actual)
+    }
+}
+
+pub(super) async fn inspect_stored_output(
+    operation_id: &OperationId,
+    reference: &str,
+    store: &ImageStore,
+) -> Result<Option<BuildResult>, BuildReceiptError> {
+    let Some(stored) =
+        store
+            .get_checked(reference)
+            .await
+            .map_err(|error| BuildReceiptError::OutputInvalid {
+                operation_id: operation_id.to_string(),
+                message: format!("failed to read the authoritative ImageStore index: {error}"),
+            })?
+    else {
+        return Ok(None);
+    };
+    let reference = reference.to_string();
+    let store_root = store.store_dir().to_path_buf();
+    let output = tokio::task::spawn_blocking(move || {
+        inspect_stored_build_output(&reference, stored, &store_root)
+    })
+    .await
+    .map_err(|error| BuildReceiptError::Task {
+        operation_id: operation_id.to_string(),
+        message: format!("OCI receipt validation task failed: {error}"),
+    })?
+    .map_err(|error| BuildReceiptError::OutputInvalid {
+        operation_id: operation_id.to_string(),
+        message: error.to_string(),
+    })?;
+    Ok(Some(output))
+}
+
+/// A successful recorded execution or exact durable replay.
+#[derive(Debug)]
+pub struct RecordedBuildResult {
+    /// Stable path-independent terminal receipt.
+    pub receipt: BuildOutputReceipt,
+    /// Revalidated store-owned OCI output.
+    pub output: BuildResult,
+    /// Whether this call replayed an existing terminal receipt.
+    pub replayed: bool,
+}
+
+/// Fail-closed receipt identity, persistence, conflict, and output errors.
+#[derive(Debug, Error)]
+pub enum BuildReceiptError {
+    /// Caller identity is outside the closed contract.
+    #[error("Box build receipt identity field {field} {reason}")]
+    InvalidIdentity {
+        field: &'static str,
+        reason: &'static str,
+    },
+    /// Receipt storage could not be used safely.
+    #[error("Box build receipt store is unsafe: {message}")]
+    UnsafeStore { message: String },
+    /// Receipt persistence failed.
+    #[error("Box build receipt store I/O failed: {message}: {source}")]
+    StoreIo {
+        message: String,
+        #[source]
+        source: std::io::Error,
+    },
+    /// Blocking persistence task failed.
+    #[error("Box build receipt task failed for {operation_id}: {message}")]
+    Task {
+        operation_id: String,
+        message: String,
+    },
+    /// Existing receipt bytes or fields violate the closed schema.
+    #[error("Box build receipt is invalid for {operation_id}: {message}")]
+    InvalidReceipt {
+        operation_id: String,
+        message: String,
+    },
+    /// One operation ID was reused for different immutable intent.
+    #[error("Box build receipt conflict for {operation_id}: {message}")]
+    Conflict {
+        operation_id: String,
+        message: String,
+    },
+    /// Receipt exists but its ImageStore reference is absent.
+    #[error("Box build output is missing for {operation_id}: ImageStore reference {reference}")]
+    OutputMissing {
+        operation_id: String,
+        reference: String,
+    },
+    /// Persisted output no longer proves the receipt.
+    #[error("Box build output is invalid for {operation_id}: {message}")]
+    OutputInvalid {
+        operation_id: String,
+        message: String,
+    },
+}
+
+fn operation_key(operation_id: &OperationId) -> String {
+    format!("{:x}", Sha256::digest(operation_id.as_str().as_bytes()))
+}
+
+fn valid_operation_id(operation_id: &OperationId) -> bool {
+    operation_id.as_str().len() <= MAX_OPERATION_ID_BYTES
+        && !operation_id
+            .as_str()
+            .bytes()
+            .any(|byte| byte.is_ascii_control())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/runtime/src/oci/build/receipt/journal.rs
+++ b/src/runtime/src/oci/build/receipt/journal.rs
@@ -1,0 +1,296 @@
+//! Internal cross-process journal for one recorded build operation.
+
+use std::path::{Path, PathBuf};
+
+use a3s_box_core::OperationId;
+
+use super::{
+    operation_key, BuildOutputReceipt, BuildReceiptError, PendingBuildOperation,
+    PersistedBuildOperation, MAX_RECEIPT_BYTES, RECEIPT_DIRECTORY,
+};
+use crate::file_lock::FileLock;
+use crate::oci::image::{read_regular_file_bounded, validate_plain_directory};
+use crate::oci::ImageStore;
+
+/// Store co-located with one ImageStore and keyed by hashed operation IDs.
+#[derive(Debug, Clone)]
+pub struct BuildOperationJournal {
+    root: PathBuf,
+}
+
+impl BuildOperationJournal {
+    /// Open the one receipt directory associated with an ImageStore.
+    pub(in crate::oci::build) async fn for_image_store(
+        store: &ImageStore,
+        operation_id: &OperationId,
+    ) -> Result<Self, BuildReceiptError> {
+        let store_root = store.store_dir().to_path_buf();
+        let operation = operation_id.to_string();
+        tokio::task::spawn_blocking(move || Self::open(&store_root))
+            .await
+            .map_err(|error| BuildReceiptError::Task {
+                operation_id: operation,
+                message: format!("receipt store initialization task failed: {error}"),
+            })?
+    }
+
+    fn open(store_root: &Path) -> Result<Self, BuildReceiptError> {
+        let store_root = store_root
+            .canonicalize()
+            .map_err(|error| BuildReceiptError::StoreIo {
+                message: format!("failed to canonicalize ImageStore {}", store_root.display()),
+                source: error,
+            })?;
+        let root = store_root.join(RECEIPT_DIRECTORY).join("sha256");
+        std::fs::create_dir_all(&root).map_err(|error| BuildReceiptError::StoreIo {
+            message: format!("failed to create receipt directory {}", root.display()),
+            source: error,
+        })?;
+        validate_plain_directory(&root, "build receipt").map_err(|error| {
+            BuildReceiptError::UnsafeStore {
+                message: error.to_string(),
+            }
+        })?;
+        let canonical = root
+            .canonicalize()
+            .map_err(|error| BuildReceiptError::StoreIo {
+                message: format!(
+                    "failed to canonicalize receipt directory {}",
+                    root.display()
+                ),
+                source: error,
+            })?;
+        if !canonical.starts_with(&store_root) {
+            return Err(BuildReceiptError::UnsafeStore {
+                message: format!(
+                    "receipt directory {} escaped ImageStore {}",
+                    canonical.display(),
+                    store_root.display()
+                ),
+            });
+        }
+        Ok(Self { root: canonical })
+    }
+
+    pub(super) fn receipt_path(&self, operation_id: &OperationId) -> PathBuf {
+        self.root
+            .join(format!("{}.json", operation_key(operation_id)))
+    }
+
+    pub(in crate::oci::build) async fn lock(
+        &self,
+        operation_id: &OperationId,
+    ) -> Result<LockedBuildOperation, BuildReceiptError> {
+        let path = self.receipt_path(operation_id);
+        let lock_target = path.clone();
+        let operation = operation_id.to_string();
+        let lock = tokio::task::spawn_blocking(move || FileLock::acquire(&lock_target))
+            .await
+            .map_err(|error| BuildReceiptError::Task {
+                operation_id: operation.clone(),
+                message: format!("receipt lock task failed: {error}"),
+            })?
+            .map_err(|error| BuildReceiptError::StoreIo {
+                message: format!("failed to lock receipt for operation {operation}"),
+                source: error,
+            })?;
+        Ok(LockedBuildOperation {
+            path,
+            operation_id: operation_id.clone(),
+            _lock: lock,
+        })
+    }
+}
+
+pub(in crate::oci::build) struct LockedBuildOperation {
+    path: PathBuf,
+    operation_id: OperationId,
+    _lock: FileLock,
+}
+
+impl LockedBuildOperation {
+    pub(in crate::oci::build) async fn read(
+        &self,
+    ) -> Result<Option<PersistedBuildOperation>, BuildReceiptError> {
+        let path = self.path.clone();
+        let operation_id = self.operation_id.clone();
+        tokio::task::spawn_blocking(move || read_receipt_file(&path, &operation_id))
+            .await
+            .map_err(|error| BuildReceiptError::Task {
+                operation_id: self.operation_id.to_string(),
+                message: format!("receipt read task failed: {error}"),
+            })?
+    }
+
+    pub(in crate::oci::build) async fn write_pending(
+        &self,
+        pending: PendingBuildOperation,
+    ) -> Result<PendingBuildOperation, BuildReceiptError> {
+        let path = self.path.clone();
+        let operation_id = self.operation_id.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Some(existing) = read_receipt_file(&path, &operation_id)? {
+                if existing == PersistedBuildOperation::Pending(pending.clone()) {
+                    return Ok(pending);
+                }
+                return Err(BuildReceiptError::Conflict {
+                    operation_id: operation_id.to_string(),
+                    message: "a different build operation record already exists".to_string(),
+                });
+            }
+            pending.validate()?;
+            if pending.operation_id != operation_id {
+                return Err(BuildReceiptError::Conflict {
+                    operation_id: operation_id.to_string(),
+                    message: "pending intent belongs to another operation".to_string(),
+                });
+            }
+            persist_record(
+                &path,
+                &operation_id,
+                &PersistedBuildOperation::Pending(pending.clone()),
+            )?;
+            Ok(pending)
+        })
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: self.operation_id.to_string(),
+            message: format!("pending receipt write task failed: {error}"),
+        })?
+    }
+
+    pub(in crate::oci::build) async fn write_succeeded(
+        &self,
+        receipt: BuildOutputReceipt,
+    ) -> Result<BuildOutputReceipt, BuildReceiptError> {
+        let path = self.path.clone();
+        let operation_id = self.operation_id.clone();
+        tokio::task::spawn_blocking(move || {
+            match read_receipt_file(&path, &operation_id)? {
+                Some(PersistedBuildOperation::Succeeded(existing)) if existing == receipt => {
+                    return Ok(existing);
+                }
+                Some(PersistedBuildOperation::Pending(pending))
+                    if pending.matches_receipt(&receipt) => {}
+                Some(_) => {
+                    return Err(BuildReceiptError::Conflict {
+                        operation_id: operation_id.to_string(),
+                        message: "a different terminal receipt already exists".to_string(),
+                    })
+                }
+                None => {
+                    return Err(BuildReceiptError::Conflict {
+                        operation_id: operation_id.to_string(),
+                        message: "terminal receipt has no persisted build intent".to_string(),
+                    })
+                }
+            }
+            receipt.validate()?;
+            if receipt.operation_id != operation_id {
+                return Err(BuildReceiptError::Conflict {
+                    operation_id: operation_id.to_string(),
+                    message: "terminal receipt belongs to another operation".to_string(),
+                });
+            }
+            persist_record(
+                &path,
+                &operation_id,
+                &PersistedBuildOperation::Succeeded(receipt.clone()),
+            )?;
+            Ok(receipt)
+        })
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: self.operation_id.to_string(),
+            message: format!("receipt write task failed: {error}"),
+        })?
+    }
+
+    pub(in crate::oci::build) async fn delete(&self) -> Result<(), BuildReceiptError> {
+        let path = self.path.clone();
+        let operation_id = self.operation_id.to_string();
+        tokio::task::spawn_blocking(move || match std::fs::remove_file(&path) {
+            Ok(()) => {
+                if let Some(parent) = path.parent() {
+                    if let Ok(directory) = std::fs::File::open(parent) {
+                        let _ = directory.sync_all();
+                    }
+                }
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(BuildReceiptError::StoreIo {
+                message: format!("failed to remove receipt for operation {operation_id}"),
+                source: error,
+            }),
+        })
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: self.operation_id.to_string(),
+            message: format!("receipt removal task failed: {error}"),
+        })?
+    }
+}
+
+fn read_receipt_file(
+    path: &Path,
+    expected_operation_id: &OperationId,
+) -> Result<Option<PersistedBuildOperation>, BuildReceiptError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id: expected_operation_id.to_string(),
+                message: "receipt path is not a regular file".to_string(),
+            });
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(BuildReceiptError::StoreIo {
+                message: format!("failed to inspect receipt {}", path.display()),
+                source: error,
+            })
+        }
+    }
+    let bytes =
+        read_regular_file_bounded(path, MAX_RECEIPT_BYTES, "build receipt").map_err(|error| {
+            BuildReceiptError::InvalidReceipt {
+                operation_id: expected_operation_id.to_string(),
+                message: error.to_string(),
+            }
+        })?;
+    let receipt: PersistedBuildOperation =
+        serde_json::from_slice(&bytes).map_err(|error| BuildReceiptError::InvalidReceipt {
+            operation_id: expected_operation_id.to_string(),
+            message: format!("JSON or schema validation failed: {error}"),
+        })?;
+    receipt.validate()?;
+    if receipt.operation_id() != expected_operation_id {
+        return Err(BuildReceiptError::InvalidReceipt {
+            operation_id: expected_operation_id.to_string(),
+            message: "hashed receipt path contains another operation identity".to_string(),
+        });
+    }
+    Ok(Some(receipt))
+}
+
+fn persist_record(
+    path: &Path,
+    operation_id: &OperationId,
+    record: &PersistedBuildOperation,
+) -> Result<(), BuildReceiptError> {
+    record.validate()?;
+    let mut bytes =
+        serde_json::to_vec_pretty(record).map_err(|error| BuildReceiptError::InvalidReceipt {
+            operation_id: operation_id.to_string(),
+            message: format!("serialization failed: {error}"),
+        })?;
+    bytes.push(b'\n');
+    let temporary = path.with_extension("json.tmp");
+    a3s_box_core::fs_atomic::write_durable(&temporary, path, &bytes).map_err(|error| {
+        BuildReceiptError::StoreIo {
+            message: format!("failed to persist receipt for operation {operation_id}"),
+            source: error,
+        }
+    })
+}

--- a/src/runtime/src/oci/build/receipt/tests.rs
+++ b/src/runtime/src/oci/build/receipt/tests.rs
@@ -1,0 +1,489 @@
+use std::sync::Arc;
+
+use a3s_box_core::OperationId;
+
+use super::*;
+use crate::oci::build::{
+    execute_recorded_build_plan, inspect_recorded_build_plan, remove_recorded_build_plan,
+    BoxBuildPlan, BuildPlanExecutionError,
+};
+use crate::oci::ImageStore;
+
+fn source_digest(byte: char) -> String {
+    format!("sha256:{}", byte.to_string().repeat(64))
+}
+
+fn platform() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "linux/arm64"
+    } else {
+        "linux/amd64"
+    }
+}
+
+fn plan(cache: &str) -> BoxBuildPlan {
+    BoxBuildPlan::parse_acl(&format!(
+        r#"
+build "oci" {{
+  cache = "{cache}"
+  context = "."
+  file = "Dockerfile"
+  network = "none"
+  platform = "{}"
+  schema = "a3s.box.build-plan.v1"
+}}
+"#,
+        platform()
+    ))
+    .unwrap()
+}
+
+fn write_source(root: &std::path::Path) {
+    std::fs::create_dir_all(root).unwrap();
+    std::fs::write(root.join("Dockerfile"), "FROM scratch\nCOPY value /value\n").unwrap();
+    std::fs::write(root.join("value"), "durable-receipt\n").unwrap();
+}
+
+fn identity(operation: &str, digest_byte: char) -> BuildOperationIdentity {
+    BuildOperationIdentity::new(
+        OperationId::new(operation).unwrap(),
+        source_digest(digest_byte),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn recorded_build_replays_the_exact_output_after_reconstruction() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-run-1", 'a');
+    let build_plan = plan("disabled");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let receipts = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+
+    let first =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+
+    assert!(!first.replayed);
+    assert_eq!(first.receipt.schema, BuildOutputReceipt::SCHEMA);
+    assert_eq!(first.receipt.operation_id, *operation.operation_id());
+    assert_eq!(first.receipt.source_digest, source_digest('a'));
+    assert_eq!(
+        first.receipt.plan_digest,
+        build_plan.canonical_digest().unwrap()
+    );
+    assert!(first
+        .receipt
+        .output
+        .reference
+        .starts_with("a3s-box/build-operation:"));
+    assert_eq!(first.receipt.output.descriptor, first.output.descriptor);
+    assert_eq!(first.receipt.output.platform, first.output.platform);
+    assert_eq!(
+        first.receipt.output.content_bytes,
+        first.output.content_bytes()
+    );
+
+    let receipt_path = receipts.receipt_path(operation.operation_id());
+    let persisted = std::fs::read_to_string(&receipt_path).unwrap();
+    assert!(persisted.contains(BuildOutputReceipt::SCHEMA));
+    assert!(
+        !persisted.contains(store_root.to_string_lossy().as_ref()),
+        "the receipt must re-derive its store-owned layout path"
+    );
+
+    let expected_receipt = first.receipt.clone();
+    let expected_digest = first.output.descriptor.digest.clone();
+    let expected_path = first.output.layout_directory.clone();
+    drop(first);
+    drop(receipts);
+    drop(store);
+    std::fs::remove_dir_all(&source).unwrap();
+
+    let reopened_store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let replay = execute_recorded_build_plan(
+        &operation,
+        &build_plan,
+        &source,
+        true,
+        Arc::clone(&reopened_store),
+    )
+    .await
+    .unwrap();
+
+    assert!(replay.replayed);
+    assert_eq!(replay.output.descriptor.digest, expected_digest);
+    assert_eq!(replay.output.layout_directory, expected_path);
+    assert_eq!(replay.receipt, expected_receipt);
+
+    let inspected = inspect_recorded_build_plan(&operation, &build_plan, &reopened_store)
+        .await
+        .unwrap()
+        .expect("persisted receipt");
+    assert!(inspected.replayed);
+    assert_eq!(inspected.receipt, replay.receipt);
+    assert_eq!(
+        inspected.output.layout_directory,
+        replay.output.layout_directory
+    );
+}
+
+#[tokio::test]
+async fn pending_intent_adopts_output_committed_before_terminal_receipt() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-run-response-gap", 'a');
+    let build_plan = plan("disabled");
+    let plan_digest = build_plan.canonical_digest().unwrap();
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let receipts = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    let built =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+    let expected_descriptor = built.output.descriptor.clone();
+    let pending = PendingBuildOperation::new(&operation, plan_digest).unwrap();
+    let mut pending_bytes = serde_json::to_vec_pretty(&pending).unwrap();
+    pending_bytes.push(b'\n');
+    std::fs::write(
+        receipts.receipt_path(operation.operation_id()),
+        pending_bytes,
+    )
+    .unwrap();
+    std::fs::remove_dir_all(&source).unwrap();
+    drop(receipts);
+    drop(store);
+
+    let reopened_store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let reopened_receipts =
+        BuildOperationJournal::for_image_store(&reopened_store, operation.operation_id())
+            .await
+            .unwrap();
+    let recovered = execute_recorded_build_plan(
+        &operation,
+        &build_plan,
+        &source,
+        true,
+        Arc::clone(&reopened_store),
+    )
+    .await
+    .unwrap();
+
+    assert!(recovered.replayed);
+    assert_eq!(recovered.output.descriptor, expected_descriptor);
+    let committed =
+        std::fs::read_to_string(reopened_receipts.receipt_path(operation.operation_id())).unwrap();
+    assert!(committed.contains(BuildOutputReceipt::SCHEMA));
+    assert!(!committed.contains(PendingBuildOperation::SCHEMA));
+}
+
+#[tokio::test]
+async fn recorded_build_rejects_operation_identity_drift_before_source_access() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-run-2", 'a');
+    let build_plan = plan("disabled");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+        .await
+        .unwrap();
+    std::fs::remove_dir_all(&source).unwrap();
+
+    let changed_source = identity("cloud-build-run-2", 'b');
+    let source_error = execute_recorded_build_plan(
+        &changed_source,
+        &build_plan,
+        &source,
+        true,
+        Arc::clone(&store),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(
+        source_error,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::Conflict { .. })
+    ));
+
+    let plan_error = execute_recorded_build_plan(
+        &operation,
+        &plan("content-addressed"),
+        &source,
+        true,
+        Arc::clone(&store),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(
+        plan_error,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::Conflict { .. })
+    ));
+}
+
+#[tokio::test]
+async fn concurrent_retries_publish_once_and_replay_once() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-run-concurrent", 'a');
+    let build_plan = plan("disabled");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let first =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store));
+    let second =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store));
+    let (first, second) = tokio::join!(first, second);
+    let first = first.unwrap();
+    let second = second.unwrap();
+
+    assert_ne!(first.replayed, second.replayed);
+    assert_eq!(first.receipt, second.receipt);
+    assert_eq!(first.output.descriptor, second.output.descriptor);
+    assert_eq!(store.list().await.len(), 1);
+}
+
+#[tokio::test]
+async fn replay_refreshes_the_single_image_store_authority_across_instances() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-run-cross-instance", 'a');
+    let build_plan = plan("disabled");
+    let builder_store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let stale_replay_store = ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap();
+
+    let built = execute_recorded_build_plan(
+        &operation,
+        &build_plan,
+        &source,
+        true,
+        Arc::clone(&builder_store),
+    )
+    .await
+    .unwrap();
+    std::fs::remove_dir_all(&source).unwrap();
+
+    let replay = inspect_recorded_build_plan(&operation, &build_plan, &stale_replay_store)
+        .await
+        .unwrap()
+        .expect("terminal receipt");
+
+    assert!(replay.replayed);
+    assert_eq!(replay.receipt, built.receipt);
+    assert_eq!(replay.output.descriptor, built.output.descriptor);
+}
+
+#[tokio::test]
+async fn failed_build_keeps_immutable_intent_until_idempotent_cleanup() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::write(
+        source.join("Dockerfile"),
+        "FROM scratch\nCOPY missing /missing\n",
+    )
+    .unwrap();
+
+    let operation = identity("cloud-build-run-failed", 'a');
+    let build_plan = plan("disabled");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let receipts = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    let failure =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap_err();
+    assert!(matches!(failure, BuildPlanExecutionError::Build(_)));
+
+    let persisted =
+        std::fs::read_to_string(receipts.receipt_path(operation.operation_id())).unwrap();
+    assert!(persisted.contains(PendingBuildOperation::SCHEMA));
+    assert!(inspect_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap()
+        .is_none());
+
+    let changed_plan = execute_recorded_build_plan(
+        &operation,
+        &plan("content-addressed"),
+        &source,
+        true,
+        Arc::clone(&store),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(
+        changed_plan,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::Conflict { .. })
+    ));
+
+    assert!(remove_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap());
+    assert!(!receipts.receipt_path(operation.operation_id()).exists());
+}
+
+#[tokio::test]
+async fn recorded_build_fails_closed_for_corrupt_receipt_or_missing_output() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-run-3", 'a');
+    let build_plan = plan("disabled");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let receipts = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    let built =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+
+    let receipt_path = receipts.receipt_path(operation.operation_id());
+    let valid_receipt = std::fs::read(&receipt_path).unwrap();
+    std::fs::write(&receipt_path, br#"{"schema":"unknown"}"#).unwrap();
+    let corrupt = inspect_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        corrupt,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::InvalidReceipt { .. })
+    ));
+
+    std::fs::write(&receipt_path, valid_receipt).unwrap();
+    store.remove(&built.receipt.output.reference).await.unwrap();
+    let missing = inspect_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        missing,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::OutputMissing { .. })
+    ));
+}
+
+#[tokio::test]
+async fn recorded_build_revalidates_the_exact_blob_inventory_and_bytes() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-run-inventory", 'a');
+    let build_plan = plan("disabled");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let built =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+    assert_eq!(
+        built.receipt.output.blob_inventory_digest,
+        built.output.blob_inventory_digest
+    );
+
+    let blob_root = built.output.layout_directory.join("blobs").join("sha256");
+    let unreferenced = blob_root.join("f".repeat(64));
+    std::fs::write(&unreferenced, b"unreferenced").unwrap();
+    let extra = inspect_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        extra,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::OutputInvalid { .. })
+    ));
+    std::fs::remove_file(unreferenced).unwrap();
+
+    let manifest_hex = built
+        .output
+        .descriptor
+        .digest
+        .strip_prefix("sha256:")
+        .unwrap();
+    let manifest_path = blob_root.join(manifest_hex);
+    let mut manifest = std::fs::read(&manifest_path).unwrap();
+    manifest[0] ^= 1;
+    std::fs::write(manifest_path, manifest).unwrap();
+    let changed = inspect_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        changed,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::OutputInvalid { .. })
+    ));
+}
+
+#[tokio::test]
+async fn recorded_build_cleanup_removes_receipt_and_internal_image_idempotently() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-run-4", 'a');
+    let build_plan = plan("disabled");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let receipts = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    let built =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+    let reference = built.receipt.output.reference.clone();
+    assert!(receipts.receipt_path(operation.operation_id()).is_file());
+    assert!(store.get(&reference).await.is_some());
+
+    assert!(remove_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap());
+    assert!(!receipts.receipt_path(operation.operation_id()).exists());
+    assert!(store.get(&reference).await.is_none());
+
+    assert!(!remove_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap());
+}
+
+#[test]
+fn operation_identity_is_bounded_and_requires_a_canonical_source_digest() {
+    let oversized = OperationId::new("x".repeat(256)).unwrap();
+    assert!(matches!(
+        BuildOperationIdentity::new(oversized, source_digest('a')),
+        Err(BuildReceiptError::InvalidIdentity {
+            field: "operation_id",
+            ..
+        })
+    ));
+
+    assert!(matches!(
+        BuildOperationIdentity::new(
+            OperationId::new("cloud-build-run-5").unwrap(),
+            "not-a-digest",
+        ),
+        Err(BuildReceiptError::InvalidIdentity {
+            field: "source_digest",
+            ..
+        })
+    ));
+}

--- a/src/runtime/src/oci/image.rs
+++ b/src/runtime/src/oci/image.rs
@@ -322,8 +322,14 @@ pub struct OciImage {
     /// Root directory of the OCI image layout
     root_dir: PathBuf,
 
-    /// Manifest digest (e.g. "sha256:abc123...")
-    manifest_digest: String,
+    /// Exact root manifest descriptor selected from the OCI index.
+    manifest_descriptor: Descriptor,
+
+    /// Number of root descriptors in the OCI index.
+    index_manifest_count: usize,
+
+    /// Complete descriptor set whose bytes were verified while loading.
+    content_descriptors: Vec<Descriptor>,
 
     /// Image configuration
     config: OciImageConfig,
@@ -401,11 +407,11 @@ impl OciImage {
         let manifest_descriptor = index
             .manifests()
             .first()
+            .cloned()
             .ok_or_else(|| BoxError::OciImageError("No manifests in index.json".to_string()))?;
-        let manifest_digest = manifest_descriptor.digest().to_string();
 
         // Load manifest
-        let manifest = Self::load_manifest(&root_dir, manifest_descriptor)?;
+        let manifest = Self::load_manifest(&root_dir, &manifest_descriptor)?;
 
         // Load config
         let config = Self::load_config(&root_dir, manifest.config())?;
@@ -427,9 +433,16 @@ impl OciImage {
             })
             .collect::<Result<Vec<_>>>()?;
 
+        let mut content_descriptors = Vec::with_capacity(manifest.layers().len() + 2);
+        content_descriptors.push(manifest_descriptor.clone());
+        content_descriptors.push(manifest.config().clone());
+        content_descriptors.extend(manifest.layers().iter().cloned());
+
         Ok(Self {
             root_dir,
-            manifest_digest,
+            manifest_descriptor,
+            index_manifest_count: index.manifests().len(),
+            content_descriptors,
             config,
             layer_paths,
         })
@@ -452,7 +465,22 @@ impl OciImage {
 
     /// Get the manifest digest (e.g. `"sha256:abc123..."`).
     pub fn manifest_digest(&self) -> &str {
-        &self.manifest_digest
+        self.manifest_descriptor.digest().as_ref()
+    }
+
+    /// Exact root manifest descriptor selected from the OCI index.
+    pub(crate) fn manifest_descriptor(&self) -> &Descriptor {
+        &self.manifest_descriptor
+    }
+
+    /// Number of root descriptors declared by the OCI index.
+    pub(crate) const fn index_manifest_count(&self) -> usize {
+        self.index_manifest_count
+    }
+
+    /// Complete descriptor set whose bytes were verified while loading.
+    pub(crate) fn content_descriptors(&self) -> &[Descriptor] {
+        &self.content_descriptors
     }
 
     /// Get the entrypoint command.

--- a/src/runtime/src/oci/mod.rs
+++ b/src/runtime/src/oci/mod.rs
@@ -39,9 +39,12 @@ pub mod store;
 
 #[cfg(feature = "build")]
 pub use build::{
-    execute_build_plan, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy,
-    BuildConfig, BuildNetworkPolicy, BuildOutputDescriptor, BuildPlanExecutionError, BuildResult,
-    BuildRunPoolConfig, Dockerfile, Instruction, PlannedBuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    execute_recorded_build_plan, inspect_recorded_build_plan, remove_recorded_build_plan,
+    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildConfig,
+    BuildNetworkPolicy, BuildOperationIdentity, BuildOutputDescriptor, BuildOutputReceipt,
+    BuildPlanExecutionError, BuildReceiptError, BuildReceiptOutput, BuildResult,
+    BuildRunPoolConfig, Dockerfile, Instruction, RecordedBuildResult,
+    OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 pub use credentials::CredentialStore;
 pub use image::{OciHealthCheck, OciImage, OciImageConfig};

--- a/src/runtime/src/oci/store.rs
+++ b/src/runtime/src/oci/store.rs
@@ -67,36 +67,57 @@ impl ImageStore {
 
     /// Get a stored image by reference.
     pub async fn get(&self, reference: &str) -> Option<StoredImage> {
-        let mut index = self.index.write().await;
-        if let Some(image) = index.get_mut(reference) {
-            image.last_used = Utc::now();
-            let updated = image.clone();
-            drop(index);
-            // Best-effort save of updated last_used; log on failure so staleness is visible.
-            if let Err(e) = self.save_index_inner().await {
-                tracing::warn!(error = %e, "Failed to persist image store index (last_used may be stale)");
+        match self.get_checked(reference).await {
+            Ok(image) => image,
+            Err(error) => {
+                tracing::warn!(
+                    reference,
+                    %error,
+                    "Failed to read the authoritative image store index"
+                );
+                None
             }
-            Some(updated)
-        } else {
-            None
         }
+    }
+
+    /// Get a stored image through the authoritative cross-process index.
+    pub(crate) async fn get_checked(&self, reference: &str) -> Result<Option<StoredImage>> {
+        let reference = reference.to_string();
+        self.with_index_lock(move |index| {
+            let Some(image) = index.get_mut(&reference) else {
+                return Ok(None);
+            };
+            image.last_used = Utc::now();
+            Ok(Some(image.clone()))
+        })
+        .await
     }
 
     /// Get a stored image by digest.
     pub async fn get_by_digest(&self, digest: &str) -> Option<StoredImage> {
-        let mut index = self.index.write().await;
-        let found = index.values_mut().find(|img| img.digest == digest);
-        if let Some(image) = found {
-            image.last_used = Utc::now();
-            let updated = image.clone();
-            drop(index);
-            if let Err(e) = self.save_index_inner().await {
-                tracing::warn!(error = %e, "Failed to persist image store index (last_used may be stale)");
+        match self.get_by_digest_checked(digest).await {
+            Ok(image) => image,
+            Err(error) => {
+                tracing::warn!(
+                    digest,
+                    %error,
+                    "Failed to read the authoritative image store index"
+                );
+                None
             }
-            Some(updated)
-        } else {
-            None
         }
+    }
+
+    async fn get_by_digest_checked(&self, digest: &str) -> Result<Option<StoredImage>> {
+        let digest = digest.to_string();
+        self.with_index_lock(move |index| {
+            let Some(image) = index.values_mut().find(|image| image.digest == digest) else {
+                return Ok(None);
+            };
+            image.last_used = Utc::now();
+            Ok(Some(image.clone()))
+        })
+        .await
     }
 
     /// Resolve an image reference to a stored image.
@@ -506,31 +527,27 @@ impl ImageStore {
         };
         drop(index);
 
-        let data = serde_json::to_string_pretty(&store_index)?;
+        let data = serde_json::to_vec_pretty(&store_index)?;
         let index_path = self.store_dir.join("index.json");
-        // Write atomically (tmp + rename) so a concurrent reader (e.g. another
-        // process running `create`/`run`) never observes a truncated/empty
-        // index.json mid-write — which previously surfaced as
-        // "Failed to parse image store index: EOF".
         let tmp_path = self.store_dir.join("index.json.tmp");
-        tokio::fs::write(&tmp_path, data).await.map_err(|e| {
+        let display_path = index_path.clone();
+        tokio::task::spawn_blocking(move || {
+            a3s_box_core::fs_atomic::write_durable(&tmp_path, &index_path, &data)
+        })
+        .await
+        .map_err(|error| {
             BoxError::OciImageError(format!(
-                "Failed to write image store index {}: {}. {}",
-                tmp_path.display(),
-                e,
+                "Image store index persistence task failed for {}: {error}",
+                display_path.display()
+            ))
+        })?
+        .map_err(|error| {
+            BoxError::OciImageError(format!(
+                "Failed to durably commit image store index {}: {error}. {}",
+                display_path.display(),
                 state_dir_hint()
             ))
         })?;
-        tokio::fs::rename(&tmp_path, &index_path)
-            .await
-            .map_err(|e| {
-                BoxError::OciImageError(format!(
-                    "Failed to commit image store index {}: {}. {}",
-                    index_path.display(),
-                    e,
-                    state_dir_hint()
-                ))
-            })?;
 
         Ok(())
     }
@@ -1283,6 +1300,37 @@ mod tests {
         let refs: HashSet<String> = s3.list().await.into_iter().map(|i| i.reference).collect();
         assert!(refs.contains("img:a"), "img:a lost: {refs:?}");
         assert!(refs.contains("img:b"), "img:b lost: {refs:?}");
+    }
+
+    #[tokio::test]
+    async fn cross_instance_get_refreshes_the_authoritative_index() {
+        let tmp = TempDir::new().unwrap();
+        let store_dir = tmp.path().join("store");
+        let source_dir = tmp.path().join("source");
+        create_test_oci_layout(&source_dir);
+
+        let writer = ImageStore::new(&store_dir, u64::MAX).unwrap();
+        let reader = ImageStore::new(&store_dir, u64::MAX).unwrap();
+        writer
+            .put(
+                "img:fresh",
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                &source_dir,
+            )
+            .await
+            .unwrap();
+
+        let observed = reader
+            .get("img:fresh")
+            .await
+            .expect("reader created before put must refresh the shared index");
+        assert_eq!(
+            observed.digest,
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+
+        let reopened = ImageStore::new(&store_dir, u64::MAX).unwrap();
+        assert!(reopened.get("img:fresh").await.is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- make recorded plan execution the sole public plan-bound build boundary
- persist immutable operation/source/plan intent before native build side effects
- commit and replay a path-independent terminal OCI output receipt through the existing ImageStore
- recover the ImageStore commit/receipt crash gap and reject identity drift or output corruption
- centralize native output validation for the exact OCI graph, platform, inventory, bytes, blobs, and layers
- refresh and durably update the existing cross-process ImageStore index

No second build engine, image store, queue, scheduler, or caller-configurable receipt store is introduced.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p a3s-box-runtime --all-targets -- -D warnings
- cargo test -p a3s-box-runtime --all-features (1484 passed, 1 ignored)
- prior SDK suite: 58 passed
- prior CLI build suite and scratch smoke: 51 passed

Part of #172.