### PR TITLE
feat(build): supervise recorded build operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,80 @@ jobs:
             echo 'A removed external build or Docker execution path was reintroduced'
             exit 1
           fi
+      - name: Enforce the sole recorded-build authority
+        run: |
+          removed_patterns=(
+            'BuildSupervisor'"Store"
+            'BuildOperation'"Store"
+            'BuildReceipt'"Store"
+            'BuildWorkspace'"Store"
+            'BuildJob'"Queue"
+            'BuildOperation'"Queue"
+            'Build'"Scheduler"
+            'BuildImage'"Store"
+            'build-operations.'"json"
+            'build-jobs.'"json"
+            'build-queue.'"json"
+          )
+          found=0
+          for pattern in "${removed_patterns[@]}"; do
+            if git grep -n -I -F -e "$pattern" -- \
+              .github docs scripts src README.md justfile \
+              ':(exclude)src/Cargo.lock'; then
+              found=1
+            fi
+          done
+          if ((found != 0)); then
+            echo 'A second recorded-build store, queue, scheduler, or image authority was introduced'
+            exit 1
+          fi
+
+          require_single_authority() {
+            local pattern="$1"
+            local expected_file="$2"
+            local actual_files
+            actual_files="$(git grep -l -F "$pattern" -- \
+              src/runtime/src/oci/build || true)"
+            if [[ "$actual_files" != "$expected_file" ]]; then
+              echo "Recorded-build authority '$pattern' must exist only in $expected_file"
+              exit 1
+            fi
+          }
+
+          require_single_authority \
+            'pub async fn start_recorded_build_plan' \
+            'src/runtime/src/oci/build/execution.rs'
+          require_single_authority \
+            'pub async fn cancel_recorded_build_plan' \
+            'src/runtime/src/oci/build/execution.rs'
+          require_single_authority \
+            'pub struct BuildOperationJournal' \
+            'src/runtime/src/oci/build/receipt/journal.rs'
+          require_single_authority \
+            'fn persist_record(' \
+            'src/runtime/src/oci/build/receipt/journal.rs'
+          require_single_authority \
+            'fn remove_workspace_if_present(' \
+            'src/runtime/src/oci/build/receipt/journal.rs'
+          require_single_authority \
+            'fn spawn_supervised_build(' \
+            'src/runtime/src/oci/build/execution.rs'
+          require_single_authority \
+            'store.put(reference' \
+            'src/runtime/src/oci/build/engine/mod.rs'
+          require_single_authority \
+            'tokio::process::Command' \
+            'src/runtime/src/oci/build/engine/run_process.rs'
+
+          if git grep -n -I -E \
+            '(tokio|std)::sync::(mpsc|broadcast|watch)|\b(VecDeque|BinaryHeap)\b' -- \
+            src/runtime/src/oci/build/execution.rs \
+            src/runtime/src/oci/build/receipt.rs \
+            src/runtime/src/oci/build/receipt/journal.rs \
+            src/runtime/src/oci/build/engine/control.rs; then
+            echo 'The recorded-build supervisor must not own an in-memory queue or scheduler'
+            exit 1
+          fi
 
   clippy:
     name: Clippy

--- a/README.md
+++ b/README.md
@@ -172,15 +172,19 @@ runtime state changes instead of being silently stored or weakened.
   path confinement, an enforced network-none Linux `RUN` policy, and
   plan-bound typed OCI descriptors with durable image-layout paths over the
   same native build engine. The sole recorded-plan boundary persists immutable
-  operation, source, and plan intent before build side effects, then commits a
-  path-independent terminal receipt over the same ImageStore. Restarted callers
-  adopt an output committed before the terminal receipt and revalidate the
-  complete OCI graph, platform, blob inventory, and byte count before replay.
-  The internal operation journal is derived from the ImageStore and is not a
-  second caller-configurable output store or build engine. The CLI exposes
-  only this native engine: Linux `RUN` uses the isolated local path and macOS
-  uses the same engine through `--run-pool`; publication remains the separate
-  `a3s-box push` image operation.
+  operation, source, and plan identity in one ImageStore-derived journal and
+  exposes typed start, nonblocking inspect, cancel, exact replay, and terminal
+  cleanup. A crash-released execution lease distinguishes live work from a
+  dead caller without becoming another state store. Every supervised build uses
+  a hash-derived operation workspace below that journal; cancellation, failure,
+  and caller-death recovery fence the current Linux `RUN` process tree before
+  reclaiming it. Restarted callers adopt an output committed before the
+  terminal receipt and revalidate the complete OCI graph, platform, blob
+  inventory, and byte count before replay. The journal, native engine, and
+  ImageStore remain the only lifecycle, execution, and image authorities. The
+  CLI exposes only this native engine: Linux `RUN` uses the isolated local path
+  and macOS uses the same engine through `--run-pool`; publication remains the
+  separate `a3s-box push` image operation.
 - **Storage** — bind mounts, named volumes, tmpfs, file copy, diff, export,
   commit, filesystem snapshots, copy-on-write restore, and Box-owned read-only
   aliases for caller-provided Artifact trees below private provider roots.

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -374,22 +374,27 @@ Current notes:
   total content bytes, layer count, and blob count. Callers no longer have to
   infer a publishable build result from a temporary workspace or reparse CLI
   output.
-- Recorded plan execution is the sole public plan-bound execution boundary. It
-  serializes each bounded operation identity across processes, durably records
-  immutable source and canonical plan intent before native build side effects,
-  and commits one path-independent `a3s.box.build-output-receipt.v1` before
-  returning success. Its internal journal is always derived from the existing
-  ImageStore; callers cannot configure another receipt root or output store.
-  The native build and replay paths share one output validator for the root
-  descriptor, platform, complete referenced blob set, blob-inventory digest,
-  exact content bytes, and layer count. A restarted caller refreshes the
-  authoritative cross-process ImageStore index, adopts output committed in the
-  ImageStore-to-terminal-receipt crash gap, and replays without reopening the
-  source tree. Cleanup removes the receipt and operation-specific image
-  reference idempotently. This terminal boundary does not supervise a build
-  that is still running: cache import/export receipts, explicit cancellation,
-  deterministic temporary-workspace and child-process reclamation after caller
-  death, and multi-platform assembly remain separate release gates.
+- Recorded plan execution is the sole public plan-bound execution boundary. Its
+  ImageStore-derived receipt journal is now the complete operation state
+  machine for typed start, nonblocking inspect, durable cancellation, failure,
+  success, exact replay, and cleanup. The crash-released execution lease proves
+  task liveness but stores no second copy of state. Every running operation
+  owns one hash-derived workspace below the journal. Linux `RUN` executes
+  asynchronously with kill-on-drop, a parent-death signal, a private PID
+  namespace, and a journaled PID/start-time fence; cancellation and stale-owner
+  recovery stop that process tree before reclaiming the workspace. The legacy
+  pending intent and successful receipt remain compatible states in this same
+  journal rather than a parallel supervisor.
+- The native build, immediate publication, recovery, and replay paths share one
+  output validator for the root descriptor, platform, complete referenced blob
+  set, blob-inventory digest, exact content bytes, and layer count. ImageStore
+  publication is the commit point: a restarted caller refreshes its
+  authoritative cross-process index, adopts output committed in the
+  output-to-terminal-receipt crash gap, and replays without reopening the
+  source tree. Cleanup removes the workspace, receipt, and operation-specific
+  image reference idempotently. Cache import/export receipts and multi-platform
+  assembly remain the Box build release gates; Cloud consumption, publication,
+  and SPDX/SLSA evidence remain integration gates.
 - Dockerfile `RUN` no longer has any silent skip path on unsupported hosts.
   The native engine uses isolated `chroot` on Linux and an isolated
   warm-pool VM lease path via `--run-pool`, which mounts each mutable build

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -388,13 +388,14 @@ Current notes:
 - The native build, immediate publication, recovery, and replay paths share one
   output validator for the root descriptor, platform, complete referenced blob
   set, blob-inventory digest, exact content bytes, and layer count. ImageStore
-  publication is the commit point: a restarted caller refreshes its
-  authoritative cross-process index, adopts output committed in the
-  output-to-terminal-receipt crash gap, and replays without reopening the
-  source tree. Cleanup removes the workspace, receipt, and operation-specific
-  image reference idempotently. Cache import/export receipts and multi-platform
-  assembly remain the Box build release gates; Cloud consumption, publication,
-  and SPDX/SLSA evidence remain integration gates.
+  publication is serialized with cancellation by the existing journal lock and
+  is the commit point: a restarted caller refreshes its authoritative
+  cross-process index, adopts output committed in the output-to-terminal-receipt
+  crash gap, and replays without reopening the source tree. Cleanup removes the
+  workspace, receipt, and operation-specific image reference idempotently.
+  Cache import/export receipts and multi-platform assembly remain the Box build
+  release gates; Cloud consumption, publication, and SPDX/SLSA evidence remain
+  integration gates.
 - Dockerfile `RUN` no longer has any silent skip path on unsupported hosts.
   The native engine uses isolated `chroot` on Linux and an isolated
   warm-pool VM lease path via `--run-pool`, which mounts each mutable build

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -91,8 +91,10 @@ the workload and therefore never become log-redaction inputs.
 build intent. It validates one `build "oci"` block, produces canonical ACL
 bytes and a stable SHA-256 digest through `a3s-acl`, confines both the context
 and build file to one canonical source root, and compiles into the existing
-`BuildConfig`. It does not introduce another build engine, cache, scheduler, or
-lifecycle store. Content-changing build arguments are deliberately absent from
+`BuildConfig`. The recorded-build API adds supervision by extending the same
+native engine, receipt journal, and `ImageStore`; it does not introduce another
+build backend, cache, queue, scheduler, lifecycle store, workspace registry, or
+image authority. Content-changing build arguments are deliberately absent from
 version 1; adding them requires a new closed schema so they cannot alter output
 behind an unchanged plan digest.
 
@@ -117,19 +119,43 @@ equivalent isolated network boundary.
 
 ```rust
 use std::path::Path;
+use std::sync::Arc;
 
-use a3s_box_runtime::{BoxBuildOptions, BoxBuildPlan};
+use a3s_box_core::OperationId;
+use a3s_box_runtime::{
+    execute_recorded_build_plan, BoxBuildPlan, BuildOperationIdentity,
+};
 
 let plan = BoxBuildPlan::parse_acl(plan_acl)?;
-let digest = plan.canonical_digest()?;
-let config = plan.compile(Path::new("/srv/a3s/source"), BoxBuildOptions::default())?;
-let result = a3s_box_runtime::oci::build::build(config, image_store).await?;
+let identity = BuildOperationIdentity::new(
+    OperationId::new("cloud-build-018f")?,
+    source_artifact_digest,
+)?;
+let result = execute_recorded_build_plan(
+    &identity,
+    &plan,
+    Path::new("/srv/a3s/source"),
+    true,
+    Arc::clone(&image_store),
+)
+.await?;
 ```
 
-This contract is the Box-owned `BX0.4` foundation. Cloud integration must still
-preserve publication, content-addressed cache evidence, SPDX/SLSA evidence,
-signing, cancellation, process-death recovery, and cleanup before the gate can
-be called complete.
+`start_recorded_build_plan` starts without blocking;
+`inspect_recorded_build_status` returns running, cancelling, cancelled, failed,
+or a revalidated successful output; and `cancel_recorded_build_plan` durably
+requests cancellation through that same journal. A crash-released execution
+lease is liveness evidence, not a second state store. Linux `RUN` uses one
+asynchronous subprocess boundary with kill-on-drop, a parent-death signal, a
+private PID namespace, and a journaled PID/start-time identity. Recovery fences
+that process tree before removing the hash-derived operation workspace.
+ImageStore publication is the commit point, so recovery adopts and validates an
+output written in the output-to-receipt crash gap instead of publishing it
+again.
+
+This completes the Box-owned `BX0.4` supervision slice. Content-addressed cache
+receipts, multi-platform OCI assembly, Cloud Node Agent consumption,
+publication, and end-to-end SPDX/SLSA signing evidence remain separate gates.
 
 ## Components
 

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -149,9 +149,9 @@ lease is liveness evidence, not a second state store. Linux `RUN` uses one
 asynchronous subprocess boundary with kill-on-drop, a parent-death signal, a
 private PID namespace, and a journaled PID/start-time identity. Recovery fences
 that process tree before removing the hash-derived operation workspace.
-ImageStore publication is the commit point, so recovery adopts and validates an
-output written in the output-to-receipt crash gap instead of publishing it
-again.
+The existing journal lock serializes cancellation with ImageStore publication;
+publication is the commit point, so recovery adopts and validates an output
+written in the output-to-receipt crash gap instead of publishing it again.
 
 This completes the Box-owned `BX0.4` supervision slice. Content-addressed cache
 receipts, multi-platform OCI assembly, Cloud Node Agent consumption,

--- a/src/runtime/src/file_lock.rs
+++ b/src/runtime/src/file_lock.rs
@@ -47,6 +47,34 @@ impl FileLock {
         Ok(Self { _file: file })
     }
 
+    /// Try to acquire an exclusive advisory lock without waiting on Unix.
+    ///
+    /// `Ok(None)` means another process or file descriptor currently owns the
+    /// lock. Every other I/O error remains fail-closed.
+    #[cfg(unix)]
+    pub(crate) fn try_acquire(target: &Path) -> std::io::Result<Option<Self>> {
+        use std::os::unix::io::AsRawFd;
+
+        let lock_path = lock_path(target);
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            return Ok(Some(Self { _file: file }));
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::WouldBlock {
+            return Ok(None);
+        }
+        Err(error)
+    }
+
     /// Acquire the Windows lock by opening the sibling file without sharing.
     ///
     /// `CreateFileW` reports a sharing violation instead of blocking, so retry
@@ -87,10 +115,48 @@ impl FileLock {
         }
     }
 
+    /// Try to acquire the Windows lock without retrying a sharing violation.
+    #[cfg(windows)]
+    pub(crate) fn try_acquire(target: &Path) -> std::io::Result<Option<Self>> {
+        use std::os::windows::fs::OpenOptionsExt;
+
+        const ERROR_SHARING_VIOLATION: i32 = 32;
+        const ERROR_LOCK_VIOLATION: i32 = 33;
+
+        let lock_path = lock_path(target);
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .share_mode(0)
+            .open(&lock_path)
+        {
+            Ok(file) => Ok(Some(Self { _file: file })),
+            Err(error)
+                if matches!(
+                    error.raw_os_error(),
+                    Some(ERROR_SHARING_VIOLATION | ERROR_LOCK_VIOLATION)
+                ) =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// Fallback for platforms without a native implementation.
     #[cfg(not(any(unix, windows)))]
     pub(crate) fn acquire(_target: &Path) -> std::io::Result<Self> {
         Ok(Self {})
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    pub(crate) fn try_acquire(_target: &Path) -> std::io::Result<Option<Self>> {
+        Ok(Some(Self {}))
     }
 }
 
@@ -141,5 +207,16 @@ mod tests {
         rx.recv_timeout(Duration::from_secs(2))
             .expect("second lock acquisition should proceed after drop");
         waiter.join().unwrap();
+    }
+
+    #[test]
+    fn try_acquire_reports_live_owner_without_blocking() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("operation.json");
+        let guard = FileLock::acquire(&target).unwrap();
+
+        assert!(FileLock::try_acquire(&target).unwrap().is_none());
+        drop(guard);
+        assert!(FileLock::try_acquire(&target).unwrap().is_some());
     }
 }

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -147,12 +147,13 @@ pub use volume::VolumeStore;
 
 #[cfg(feature = "build")]
 pub use oci::{
-    execute_recorded_build_plan, inspect_recorded_build_plan, remove_recorded_build_plan,
-    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildConfig,
-    BuildNetworkPolicy, BuildOperationIdentity, BuildOutputDescriptor, BuildOutputReceipt,
-    BuildPlanExecutionError, BuildReceiptError, BuildReceiptOutput, BuildResult,
-    BuildRunPoolConfig, Dockerfile, Instruction, RecordedBuildResult,
-    OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    cancel_recorded_build_plan, execute_recorded_build_plan, inspect_recorded_build_plan,
+    inspect_recorded_build_status, remove_recorded_build_plan, start_recorded_build_plan,
+    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildCancellationOutcome,
+    BuildConfig, BuildNetworkPolicy, BuildOperationIdentity, BuildOutputDescriptor,
+    BuildOutputReceipt, BuildPlanExecutionError, BuildReceiptError, BuildReceiptOutput,
+    BuildResult, BuildRunPoolConfig, Dockerfile, Instruction, RecordedBuildResult,
+    RecordedBuildStatus, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 
 #[cfg(feature = "compose")]

--- a/src/runtime/src/oci/build/engine/control.rs
+++ b/src/runtime/src/oci/build/engine/control.rs
@@ -1,0 +1,75 @@
+//! Transient native-engine control derived from the durable operation journal.
+//!
+//! This module deliberately owns no state store, queue, or scheduler. The
+//! observer reads and updates the existing receipt journal; this cloneable
+//! wrapper only lets the native engine reach that single authority.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use a3s_box_core::error::{BoxError, Result};
+use async_trait::async_trait;
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+const CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+#[async_trait]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(in crate::oci::build) trait BuildExecutionObserver: Send + Sync {
+    async fn cancellation_requested(&self) -> Result<bool>;
+
+    async fn run_process_started(&self, pid: u32, start_time: Option<u64>) -> Result<()>;
+
+    async fn run_process_finished(&self, pid: u32, start_time: Option<u64>) -> Result<()>;
+}
+
+/// Native-engine view of the one durable operation journal.
+#[derive(Clone)]
+pub(in crate::oci::build) struct BuildExecutionControl {
+    observer: Arc<dyn BuildExecutionObserver>,
+}
+
+impl BuildExecutionControl {
+    pub(in crate::oci::build) fn new(observer: Arc<dyn BuildExecutionObserver>) -> Self {
+        Self { observer }
+    }
+
+    pub(in crate::oci::build) async fn ensure_active(&self) -> Result<()> {
+        if self.observer.cancellation_requested().await? {
+            return Err(cancelled_error());
+        }
+        Ok(())
+    }
+
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(super) async fn wait_for_cancellation(&self) -> Result<()> {
+        loop {
+            if self.observer.cancellation_requested().await? {
+                return Ok(());
+            }
+            tokio::time::sleep(CANCELLATION_POLL_INTERVAL).await;
+        }
+    }
+
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(super) async fn run_process_started(
+        &self,
+        pid: u32,
+        start_time: Option<u64>,
+    ) -> Result<()> {
+        self.observer.run_process_started(pid, start_time).await
+    }
+
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(super) async fn run_process_finished(
+        &self,
+        pid: u32,
+        start_time: Option<u64>,
+    ) -> Result<()> {
+        self.observer.run_process_finished(pid, start_time).await
+    }
+}
+
+pub(super) fn cancelled_error() -> BoxError {
+    BoxError::BuildError("recorded build operation was cancelled".to_string())
+}

--- a/src/runtime/src/oci/build/engine/control.rs
+++ b/src/runtime/src/oci/build/engine/control.rs
@@ -18,9 +18,31 @@ const CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(25);
 pub(in crate::oci::build) trait BuildExecutionObserver: Send + Sync {
     async fn cancellation_requested(&self) -> Result<bool>;
 
+    async fn acquire_image_commit_permit(&self) -> Result<BuildImageCommitPermit>;
+
     async fn run_process_started(&self, pid: u32, start_time: Option<u64>) -> Result<()>;
 
     async fn run_process_finished(&self, pid: u32, start_time: Option<u64>) -> Result<()>;
+}
+
+trait SendGuard: Send {}
+
+impl<T: Send> SendGuard for T {}
+
+/// RAII permit that serializes ImageStore publication with cancellation.
+///
+/// The concrete guard is supplied by the existing operation journal. This
+/// wrapper owns no lock implementation or state of its own.
+pub(in crate::oci::build) struct BuildImageCommitPermit {
+    _guard: Box<dyn SendGuard>,
+}
+
+impl BuildImageCommitPermit {
+    pub(in crate::oci::build) fn new(guard: impl Send + 'static) -> Self {
+        Self {
+            _guard: Box::new(guard),
+        }
+    }
 }
 
 /// Native-engine view of the one durable operation journal.
@@ -39,6 +61,10 @@ impl BuildExecutionControl {
             return Err(cancelled_error());
         }
         Ok(())
+    }
+
+    pub(super) async fn acquire_image_commit_permit(&self) -> Result<BuildImageCommitPermit> {
+        self.observer.acquire_image_commit_permit().await
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]

--- a/src/runtime/src/oci/build/engine/handlers.rs
+++ b/src/runtime/src/oci/build/engine/handlers.rs
@@ -11,6 +11,7 @@ use super::super::dockerignore::DockerIgnore;
 use super::super::layer::{
     create_layer_with_chown, create_layer_with_deletions, sha256_bytes, LayerInfo,
 };
+use super::control::BuildExecutionControl;
 use super::stages::resolve_stage_rootfs;
 use super::utils::{
     assert_within, copy_dir_filtered, expand_args, extract_tar_to_dst, is_tar_archive,
@@ -402,7 +403,7 @@ pub(super) fn handle_copy(
 /// must route isolated execution through the native engine's warm-pool path.
 /// Returns Some(LayerInfo) if a layer was created, None if skipped.
 #[allow(clippy::too_many_arguments)]
-pub(super) fn handle_run(
+pub(super) async fn handle_run(
     command: &RunCommand,
     cache_mounts: &[RunCacheMount],
     bind_mounts: &[RunBindMount],
@@ -418,7 +419,11 @@ pub(super) fn handle_run(
     layer_index: usize,
     quiet: bool,
     ignore: Option<&DockerIgnore>,
+    control: Option<&BuildExecutionControl>,
 ) -> Result<Option<LayerInfo>> {
+    #[cfg(not(target_os = "linux"))]
+    let _ = control;
+
     #[cfg(target_os = "macos")]
     {
         if network == super::BuildNetworkPolicy::None {
@@ -478,7 +483,9 @@ pub(super) fn handle_run(
         let run_mounts =
             run_mounts.with_cache_mounts(rootfs_dir, cache_mounts, completed_stages)?;
 
-        let output = execute_linux_run_command(rootfs_dir, command, workdir, env, shell, network)?;
+        let output =
+            execute_linux_run_command(rootfs_dir, command, workdir, env, shell, network, control)
+                .await?;
 
         if !output.status.success() {
             return Err(run_command_failed_error(
@@ -535,6 +542,7 @@ pub(super) fn handle_run(
             quiet,
             ignore,
             network,
+            control,
         );
         Err(BoxError::BuildError(format!(
             "Dockerfile RUN is not supported on this platform yet because isolated Linux build execution is not implemented: {}",
@@ -892,23 +900,26 @@ fn run_env_entries(env: &[(String, String)]) -> Vec<String> {
 }
 
 #[cfg(target_os = "linux")]
-fn execute_linux_run_command(
+async fn execute_linux_run_command(
     rootfs_dir: &Path,
     command: &RunCommand,
     workdir: &str,
     env: &[(String, String)],
     shell: &[String],
     network: super::BuildNetworkPolicy,
+    control: Option<&BuildExecutionControl>,
 ) -> Result<std::process::Output> {
     let unshare = find_linux_run_unshare()?;
-    let mut cmd =
+    let cmd =
         isolated_linux_run_command(&unshare, rootfs_dir, command, workdir, env, shell, network);
-    cmd.output().map_err(|error| {
-        BoxError::BuildError(format!(
-            "Failed to execute Dockerfile RUN in an isolated PID namespace with {}: {error}",
-            unshare.display()
-        ))
-    })
+    super::run_process::command_output(cmd, control)
+        .await
+        .map_err(|error| {
+            BoxError::BuildError(format!(
+                "Failed to execute Dockerfile RUN in an isolated PID namespace with {}: {error}",
+                unshare.display()
+            ))
+        })
 }
 
 #[cfg(target_os = "linux")]
@@ -984,8 +995,30 @@ fn isolated_linux_run_command(
         }
     }
     configure_run_command_env(&mut cmd, env);
+    configure_run_parent_death_fence(&mut cmd);
     cmd
 }
+
+#[cfg(target_os = "linux")]
+fn configure_run_parent_death_fence(command: &mut std::process::Command) {
+    use std::os::unix::process::CommandExt;
+
+    let expected_parent = std::process::id();
+    unsafe {
+        command.pre_exec(move || {
+            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::getppid() as u32 != expected_parent {
+                libc::_exit(127);
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(all(test, not(target_os = "linux")))]
+fn configure_run_parent_death_fence(_command: &mut std::process::Command) {}
 
 #[cfg(any(target_os = "linux", test))]
 fn configure_run_command_env(cmd: &mut std::process::Command, env: &[(String, String)]) {
@@ -3108,8 +3141,8 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
-    #[test]
-    fn test_linux_run_waits_for_detached_descendants_to_be_killed() {
+    #[tokio::test]
+    async fn test_linux_run_waits_for_detached_descendants_to_be_killed() {
         if unsafe { libc::geteuid() } != 0 {
             return;
         }
@@ -3123,7 +3156,9 @@ mod tests {
             &[],
             &[],
             BuildNetworkPolicy::Outbound,
+            None,
         )
+        .await
         .expect("util-linux unshare must be installed for Linux RUN");
         if !probe.status.success() {
             let stderr = String::from_utf8_lossy(&probe.stderr);
@@ -3144,7 +3179,9 @@ mod tests {
             &[],
             &[],
             BuildNetworkPolicy::Outbound,
+            None,
         )
+        .await
         .unwrap();
         assert!(
             output.status.success(),
@@ -4508,8 +4545,8 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
-    #[test]
-    fn test_handle_run_rejects_macos_without_unsafe_opt_in() {
+    #[tokio::test]
+    async fn test_handle_run_rejects_macos_without_unsafe_opt_in() {
         std::env::remove_var(super::UNSAFE_HOST_RUN_ENV);
 
         let tmp = tempfile::TempDir::new().unwrap();
@@ -4535,7 +4572,9 @@ mod tests {
             0,
             true,
             None,
-        );
+            None,
+        )
+        .await;
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Dockerfile RUN is not supported on macOS yet"));
         assert!(err.contains("--run-pool"));

--- a/src/runtime/src/oci/build/engine/mod.rs
+++ b/src/runtime/src/oci/build/engine/mod.rs
@@ -22,7 +22,10 @@ use crate::oci::layers::extract_layer;
 use crate::oci::store::ImageStore;
 use crate::oci::{ImagePuller, RegistryAuth};
 
+mod control;
 mod handlers;
+#[cfg(target_os = "linux")]
+mod run_process;
 mod stages;
 mod utils;
 
@@ -35,6 +38,8 @@ use handlers::{
 };
 use stages::{global_arg_decls, resolve_stage_rootfs, split_into_stages};
 use utils::{compute_diff_id, expand_args, format_size, resolve_path};
+
+pub(super) use control::{BuildExecutionControl, BuildExecutionObserver};
 
 /// Network access available to Dockerfile execution instructions.
 ///
@@ -481,6 +486,29 @@ impl BuildState {
 pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildResult> {
     validate_build_config(&config)?;
 
+    let build_dir = tempfile::TempDir::new()
+        .map_err(|e| BoxError::BuildError(format!("Failed to create build directory: {}", e)))?;
+    build_in_workspace(config, store, build_dir.path(), None).await
+}
+
+/// Execute the same native engine in one journal-owned workspace.
+pub(super) async fn build_supervised(
+    config: BuildConfig,
+    store: Arc<ImageStore>,
+    workspace: &Path,
+    control: BuildExecutionControl,
+) -> Result<BuildResult> {
+    validate_build_config(&config)?;
+    control.ensure_active().await?;
+    build_in_workspace(config, store, workspace, Some(control)).await
+}
+
+async fn build_in_workspace(
+    config: BuildConfig,
+    store: Arc<ImageStore>,
+    build_dir: &Path,
+    control: Option<BuildExecutionControl>,
+) -> Result<BuildResult> {
     // Parse Dockerfile
     let dockerfile = Dockerfile::from_file(&config.dockerfile_path)?;
 
@@ -522,10 +550,6 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
     // and RUN mount `from=<image>` sources so repeated references pull once.
     let mut external_from_rootfs: HashMap<String, PathBuf> = HashMap::new();
 
-    // Create temp directory for build workspace
-    let build_dir = tempfile::TempDir::new()
-        .map_err(|e| BoxError::BuildError(format!("Failed to create build directory: {}", e)))?;
-
     let mut final_state = BuildState::new(config.build_args.clone());
     let mut final_base_layers: Vec<LayerInfo> = Vec::new();
     let mut final_base_diff_ids: Vec<String> = Vec::new();
@@ -534,10 +558,13 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
     let mut global_step = 0;
 
     for (stage_idx, stage) in stages.iter().enumerate() {
+        if let Some(control) = &control {
+            control.ensure_active().await?;
+        }
         let is_final_stage = stage_idx == output_stage_idx;
 
-        let rootfs_dir = build_dir.path().join(format!("rootfs_{}", stage_idx));
-        let layers_dir = build_dir.path().join(format!("layers_{}", stage_idx));
+        let rootfs_dir = build_dir.join(format!("rootfs_{}", stage_idx));
+        let layers_dir = build_dir.join(format!("layers_{}", stage_idx));
         std::fs::create_dir_all(&rootfs_dir).map_err(|e| {
             BoxError::BuildError(format!("Failed to create rootfs directory: {}", e))
         })?;
@@ -568,6 +595,9 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
         let mut cache_valid = true;
 
         for instruction in &stage.instructions {
+            if let Some(control) = &control {
+                control.ensure_active().await?;
+            }
             global_step += 1;
             let step = global_step;
             validate_instruction_network(instruction, config.network)?;
@@ -582,7 +612,7 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
                     bind_mounts,
                     cache_mounts,
                     &store,
-                    build_dir.path(),
+                    build_dir,
                     &mut external_from_rootfs,
                 )
                 .await?
@@ -786,7 +816,7 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
                                         from_ref,
                                         "COPY --from",
                                         &store,
-                                        build_dir.path(),
+                                        build_dir,
                                         &mut external_from_rootfs,
                                     )
                                     .await?
@@ -992,7 +1022,9 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
                             state.layers.len() + base_layers.len(),
                             config.quiet,
                             Some(&dockerignore),
-                        )?
+                            control.as_ref(),
+                        )
+                        .await?
                     };
                     if let Some(layer_info) = layer_opt {
                         let diff_id = compute_diff_id(&layer_info.path)?;
@@ -1255,9 +1287,7 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
         .clone()
         .unwrap_or_else(|| "a3s-build:latest".to_string());
 
-    let final_layers_dir = build_dir
-        .path()
-        .join(format!("layers_{}", output_stage_idx));
+    let final_layers_dir = build_dir.join(format!("layers_{}", output_stage_idx));
 
     // Determine target platform (use first platform or host default)
     let target_platform = config
@@ -1266,6 +1296,9 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
         .cloned()
         .unwrap_or_else(default_target_platform);
 
+    if let Some(control) = &control {
+        control.ensure_active().await?;
+    }
     let result = assemble_image(
         &reference,
         &final_state,

--- a/src/runtime/src/oci/build/engine/mod.rs
+++ b/src/runtime/src/oci/build/engine/mod.rs
@@ -39,7 +39,7 @@ use handlers::{
 use stages::{global_arg_decls, resolve_stage_rootfs, split_into_stages};
 use utils::{compute_diff_id, expand_args, format_size, resolve_path};
 
-pub(super) use control::{BuildExecutionControl, BuildExecutionObserver};
+pub(super) use control::{BuildExecutionControl, BuildExecutionObserver, BuildImageCommitPermit};
 
 /// Network access available to Dockerfile execution instructions.
 ///
@@ -1307,6 +1307,7 @@ async fn build_in_workspace(
         &final_layers_dir,
         &store,
         &target_platform,
+        control.as_ref(),
     )
     .await?;
 
@@ -1555,6 +1556,7 @@ fn scratch_config() -> OciImageConfig {
 }
 
 /// Assemble the final OCI image layout and store it.
+#[allow(clippy::too_many_arguments)]
 async fn assemble_image(
     reference: &str,
     state: &BuildState,
@@ -1563,6 +1565,7 @@ async fn assemble_image(
     layers_dir: &Path,
     store: &Arc<ImageStore>,
     target_platform: &Platform,
+    control: Option<&BuildExecutionControl>,
 ) -> Result<BuildResult> {
     // Create output directory
     let output_dir = layers_dir.join("_output");
@@ -1755,6 +1758,10 @@ async fn assemble_image(
 
     // Store in image store
     let digest_str = format!("sha256:{}", manifest_digest);
+    let _commit_permit = match control {
+        Some(control) => Some(control.acquire_image_commit_permit().await?),
+        None => None,
+    };
     let stored = store.put(reference, &digest_str, &output_dir).await?;
     inspect_stored_build_output(reference, stored, store.store_dir())
 }

--- a/src/runtime/src/oci/build/engine/run_process.rs
+++ b/src/runtime/src/oci/build/engine/run_process.rs
@@ -1,0 +1,199 @@
+//! Cancellable subprocess boundary for native Dockerfile `RUN`.
+
+use std::process::{Output, Stdio};
+
+use a3s_box_core::error::{BoxError, Result};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use super::control::BuildExecutionControl;
+
+pub(super) async fn command_output(
+    command: std::process::Command,
+    control: Option<&BuildExecutionControl>,
+) -> Result<Output> {
+    let mut command = tokio::process::Command::from(command);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = command.spawn().map_err(|error| {
+        BoxError::BuildError(format!(
+            "Failed to spawn isolated Dockerfile RUN process: {error}"
+        ))
+    })?;
+    let pid = child.id().ok_or_else(|| {
+        BoxError::BuildError("isolated Dockerfile RUN process has no host PID".to_string())
+    })?;
+    let start_time = crate::process::pid_start_time(pid);
+    #[cfg(target_os = "linux")]
+    if start_time.is_none() {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        return Err(BoxError::BuildError(format!(
+            "Failed to capture stable identity for Dockerfile RUN process {pid}"
+        )));
+    }
+
+    let stdout = child.stdout.take().ok_or_else(|| {
+        BoxError::BuildError("Dockerfile RUN stdout pipe was not created".to_string())
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        BoxError::BuildError("Dockerfile RUN stderr pipe was not created".to_string())
+    })?;
+    let stdout_task = tokio::spawn(read_pipe(stdout));
+    let stderr_task = tokio::spawn(read_pipe(stderr));
+
+    if let Some(control) = control {
+        if let Err(error) = control.run_process_started(pid, start_time).await {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            let _ = collect_pipe(stdout_task, "stdout").await;
+            let _ = collect_pipe(stderr_task, "stderr").await;
+            return Err(error);
+        }
+    }
+
+    let mut cancellation_error = None;
+    let status = if let Some(control) = control {
+        tokio::select! {
+            status = child.wait() => status,
+            cancellation = control.wait_for_cancellation() => {
+                if let Err(error) = cancellation {
+                    cancellation_error = Some(error);
+                }
+                let _ = child.start_kill();
+                child.wait().await
+            }
+        }
+    } else {
+        child.wait().await
+    };
+
+    let finish_result = if let Some(control) = control {
+        control.run_process_finished(pid, start_time).await
+    } else {
+        Ok(())
+    };
+    let stdout = collect_pipe(stdout_task, "stdout").await?;
+    let stderr = collect_pipe(stderr_task, "stderr").await?;
+    let status = status.map_err(|error| {
+        BoxError::BuildError(format!(
+            "Failed to wait for isolated Dockerfile RUN process {pid}: {error}"
+        ))
+    })?;
+    finish_result?;
+    if let Some(error) = cancellation_error {
+        return Err(error);
+    }
+    if let Some(control) = control {
+        control.ensure_active().await?;
+    }
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+async fn read_pipe(mut pipe: impl AsyncRead + Unpin) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    pipe.read_to_end(&mut bytes).await?;
+    Ok(bytes)
+}
+
+async fn collect_pipe(
+    task: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
+    stream: &str,
+) -> Result<Vec<u8>> {
+    task.await
+        .map_err(|error| {
+            BoxError::BuildError(format!("Dockerfile RUN {stream} task failed: {error}"))
+        })?
+        .map_err(|error| {
+            BoxError::BuildError(format!("Failed to read Dockerfile RUN {stream}: {error}"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use tokio::sync::Semaphore;
+
+    use super::*;
+    use crate::oci::build::engine::BuildExecutionObserver;
+
+    struct TestObserver {
+        cancelled: AtomicBool,
+        started: Semaphore,
+        finished: AtomicBool,
+        process: Mutex<Option<(u32, Option<u64>)>>,
+    }
+
+    impl TestObserver {
+        fn new() -> Self {
+            Self {
+                cancelled: AtomicBool::new(false),
+                started: Semaphore::new(0),
+                finished: AtomicBool::new(false),
+                process: Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl BuildExecutionObserver for TestObserver {
+        async fn cancellation_requested(&self) -> Result<bool> {
+            Ok(self.cancelled.load(Ordering::SeqCst))
+        }
+
+        async fn run_process_started(&self, pid: u32, start_time: Option<u64>) -> Result<()> {
+            *self.process.lock().unwrap() = Some((pid, start_time));
+            self.started.add_permits(1);
+            Ok(())
+        }
+
+        async fn run_process_finished(&self, _pid: u32, _start_time: Option<u64>) -> Result<()> {
+            self.finished.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_kills_and_reaps_the_recorded_run_process() {
+        let observer = Arc::new(TestObserver::new());
+        let control = BuildExecutionControl::new(observer.clone());
+        let mut command = std::process::Command::new("/bin/sh");
+        command.args(["-c", "exec /bin/sleep 30"]);
+
+        let execution = tokio::spawn(async move { command_output(command, Some(&control)).await });
+        observer
+            .started
+            .acquire()
+            .await
+            .expect("test observer remains open")
+            .forget();
+        let process = observer
+            .process
+            .lock()
+            .unwrap()
+            .as_ref()
+            .copied()
+            .expect("RUN identity was recorded");
+        observer.cancelled.store(true, Ordering::SeqCst);
+
+        let error = tokio::time::timeout(std::time::Duration::from_secs(2), execution)
+            .await
+            .expect("cancelled RUN must stop promptly")
+            .expect("RUN task must not panic")
+            .unwrap_err();
+        assert!(error.to_string().contains("cancelled"), "{error}");
+        assert!(observer.finished.load(Ordering::SeqCst));
+        assert!(!crate::process::is_process_running_with_identity(
+            process.0, process.1
+        ));
+    }
+}

--- a/src/runtime/src/oci/build/engine/run_process.rs
+++ b/src/runtime/src/oci/build/engine/run_process.rs
@@ -124,7 +124,7 @@ mod tests {
     use tokio::sync::Semaphore;
 
     use super::*;
-    use crate::oci::build::engine::BuildExecutionObserver;
+    use crate::oci::build::engine::{BuildExecutionObserver, BuildImageCommitPermit};
 
     struct TestObserver {
         cancelled: AtomicBool,
@@ -148,6 +148,10 @@ mod tests {
     impl BuildExecutionObserver for TestObserver {
         async fn cancellation_requested(&self) -> Result<bool> {
             Ok(self.cancelled.load(Ordering::SeqCst))
+        }
+
+        async fn acquire_image_commit_permit(&self) -> Result<BuildImageCommitPermit> {
+            Ok(BuildImageCommitPermit::new(()))
         }
 
         async fn run_process_started(&self, pid: u32, start_time: Option<u64>) -> Result<()> {

--- a/src/runtime/src/oci/build/execution.rs
+++ b/src/runtime/src/oci/build/execution.rs
@@ -1,19 +1,27 @@
 //! Plan-bound execution over the one native Box OCI build engine.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
-use a3s_box_core::error::BoxError;
+use a3s_box_core::error::{BoxError, Result as BoxResult};
+use async_trait::async_trait;
 use thiserror::Error;
 
+use super::engine::{build_supervised, BuildExecutionControl, BuildExecutionObserver};
 use super::receipt::{
-    inspect_stored_output, BuildOperationJournal, PendingBuildOperation, PersistedBuildOperation,
+    inspect_stored_output, BuildExecutionLease, BuildOperationJournal, BuildProcessIdentity,
+    LockedBuildOperation, PersistedBuildOperation, PersistedBuildPhase, SupervisedBuildOperation,
 };
 use super::{
-    build, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildOperationIdentity,
-    BuildOutputReceipt, BuildReceiptError, BuildResult, RecordedBuildResult,
+    build, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCancellationOutcome,
+    BuildOperationIdentity, BuildOutputReceipt, BuildReceiptError, BuildResult,
+    RecordedBuildResult, RecordedBuildStatus,
 };
 use crate::oci::ImageStore;
+
+const EXECUTION_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const RUN_PROCESS_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Successful native output bound to the canonical admitted build plan.
 #[derive(Debug)]
@@ -36,6 +44,18 @@ pub enum BuildPlanExecutionError {
     /// Durable receipt identity, persistence, or output validation failed.
     #[error(transparent)]
     Receipt(#[from] BuildReceiptError),
+    /// A durable cancellation completed.
+    #[error("Box build operation {operation_id} was cancelled: {message}")]
+    Cancelled {
+        operation_id: String,
+        message: String,
+    },
+    /// A durable supervised execution failed.
+    #[error("Box build operation {operation_id} failed: {message}")]
+    Failed {
+        operation_id: String,
+        message: String,
+    },
 }
 
 /// Compile and execute one canonical plan through Box's existing native engine.
@@ -43,6 +63,7 @@ pub enum BuildPlanExecutionError {
 /// The returned layout path points at the durable image-store copy rather than
 /// the temporary build workspace, so a caller can capture or publish the exact
 /// OCI graph after this future returns.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(super) async fn execute_build_plan(
     plan: &BoxBuildPlan,
     source_root: &Path,
@@ -58,16 +79,45 @@ pub(super) async fn execute_build_plan(
     })
 }
 
-/// Execute or exactly replay one terminal plan-bound native build.
+async fn execute_supervised_build_plan(
+    plan: &BoxBuildPlan,
+    source_root: &Path,
+    options: BoxBuildOptions,
+    store: Arc<ImageStore>,
+    workspace: &Path,
+    control: BuildExecutionControl,
+) -> Result<PlannedBuildResult, BuildPlanExecutionError> {
+    let plan_digest = plan.canonical_digest()?;
+    let config = plan.compile(source_root, options)?;
+    let output = build_supervised(config, store, workspace, control).await?;
+    Ok(PlannedBuildResult {
+        plan_digest,
+        output,
+    })
+}
+
+/// Start or exactly replay one supervised plan-bound native build.
 ///
-/// The per-operation lock serializes the complete build and receipt commit
-/// across processes. A successful receipt is written durably before this
-/// future returns. A retry validates the same source and plan identities, then
-/// reconstructs the exact output from the existing ImageStore without touching
-/// the source tree.
+/// Starting is non-blocking. The returned status comes from the existing
+/// receipt journal; callers use [`inspect_recorded_build_status`] and
+/// [`cancel_recorded_build_plan`] against that same authority.
+pub async fn start_recorded_build_plan(
+    identity: &BuildOperationIdentity,
+    plan: &BoxBuildPlan,
+    source_root: &Path,
+    quiet: bool,
+    store: Arc<ImageStore>,
+) -> Result<RecordedBuildStatus, BuildPlanExecutionError> {
+    start_recorded_build_plan_internal(identity, plan, source_root, quiet, store)
+        .await
+        .map(|start| start.status)
+}
+
+/// Execute or exactly replay one supervised plan-bound native build.
 ///
-/// This terminal receipt boundary does not supervise or cancel an in-flight
-/// build. Those controls require the separate durable operation supervisor.
+/// This compatibility API starts through the same durable state machine and
+/// waits for typed inspection to reach a terminal state. It owns no second
+/// execution path, lock, receipt, or cleanup policy.
 pub async fn execute_recorded_build_plan(
     identity: &BuildOperationIdentity,
     plan: &BoxBuildPlan,
@@ -75,106 +125,237 @@ pub async fn execute_recorded_build_plan(
     quiet: bool,
     store: Arc<ImageStore>,
 ) -> Result<RecordedBuildResult, BuildPlanExecutionError> {
-    let plan_digest = plan.canonical_digest()?;
-    let journal = BuildOperationJournal::for_image_store(&store, identity.operation_id()).await?;
-    let locked = journal.lock(identity.operation_id()).await?;
-    match locked.read().await? {
-        Some(PersistedBuildOperation::Succeeded(receipt)) => {
-            return recover_recorded_build(identity, &plan_digest, receipt, &store).await;
-        }
-        Some(PersistedBuildOperation::Pending(pending)) => {
-            pending.require_identity(identity, &plan_digest)?;
-            if let Some(output) =
-                inspect_stored_output(identity.operation_id(), identity.output_reference(), &store)
-                    .await?
-            {
-                let receipt =
-                    BuildOutputReceipt::from_result(identity, plan_digest.clone(), &output)?;
-                let receipt = locked.write_succeeded(receipt).await?;
-                return Ok(RecordedBuildResult {
-                    receipt,
-                    output,
-                    replayed: true,
+    let start =
+        start_recorded_build_plan_internal(identity, plan, source_root, quiet, Arc::clone(&store))
+            .await?;
+    let started_here = start.started_here;
+    let mut status = Some(start.status);
+    loop {
+        let current = match status.take() {
+            Some(status) => status,
+            None => inspect_recorded_build_status(identity, plan, &store)
+                .await?
+                .ok_or_else(|| BuildReceiptError::Conflict {
+                    operation_id: identity.operation_id().to_string(),
+                    message: "supervised operation disappeared while execution was waiting"
+                        .to_string(),
+                })?,
+        };
+        match current {
+            RecordedBuildStatus::Running | RecordedBuildStatus::Cancelling => {
+                tokio::time::sleep(EXECUTION_POLL_INTERVAL).await;
+            }
+            RecordedBuildStatus::Cancelled { message } => {
+                return Err(BuildPlanExecutionError::Cancelled {
+                    operation_id: identity.operation_id().to_string(),
+                    message,
                 });
             }
-        }
-        None => {
-            if store
-                .get_checked(identity.output_reference())
-                .await?
-                .is_some()
-            {
-                return Err(BuildReceiptError::OutputInvalid {
+            RecordedBuildStatus::Failed { message } => {
+                return Err(BuildPlanExecutionError::Failed {
                     operation_id: identity.operation_id().to_string(),
-                    message: "operation output exists without a persisted owning intent"
-                        .to_string(),
-                }
-                .into());
+                    message,
+                });
             }
-            let pending = PendingBuildOperation::new(identity, plan_digest.clone())?;
-            locked.write_pending(pending).await?;
+            RecordedBuildStatus::Succeeded(mut result) => {
+                result.replayed = !started_here;
+                return Ok(*result);
+            }
         }
     }
-
-    let planned = execute_build_plan(
-        plan,
-        source_root,
-        BoxBuildOptions {
-            tag: Some(identity.output_reference().to_string()),
-            quiet,
-        },
-        Arc::clone(&store),
-    )
-    .await?;
-    let receipt = BuildOutputReceipt::from_result(identity, planned.plan_digest, &planned.output)?;
-    let receipt = locked.write_succeeded(receipt).await?;
-    Ok(RecordedBuildResult {
-        receipt,
-        output: planned.output,
-        replayed: false,
-    })
 }
 
-/// Inspect and revalidate one terminal receipt without accessing build source.
+/// Inspect and reconcile the one durable build-operation state machine.
+///
+/// Inspection never waits for a live build. A nonblocking execution lease
+/// distinguishes a live owner from a crashed one; stale work is fenced and its
+/// operation-owned workspace is reclaimed before a terminal status is written.
+pub async fn inspect_recorded_build_status(
+    identity: &BuildOperationIdentity,
+    plan: &BoxBuildPlan,
+    store: &ImageStore,
+) -> Result<Option<RecordedBuildStatus>, BuildPlanExecutionError> {
+    let plan_digest = plan.canonical_digest()?;
+    let journal = BuildOperationJournal::for_image_store(store, identity.operation_id()).await?;
+    let locked = journal.lock(identity.operation_id()).await?;
+    let Some(record) = locked.read().await? else {
+        return Ok(None);
+    };
+    match record {
+        PersistedBuildOperation::Succeeded(receipt) => {
+            recover_recorded_build(identity, &plan_digest, receipt, store)
+                .await
+                .map(Box::new)
+                .map(RecordedBuildStatus::Succeeded)
+                .map(Some)
+        }
+        PersistedBuildOperation::Supervised(operation) => {
+            operation.require_identity(identity, &plan_digest)?;
+            match operation.phase {
+                PersistedBuildPhase::Cancelled | PersistedBuildPhase::Failed => {
+                    Ok(Some(status_from_terminal_operation(&operation)?))
+                }
+                PersistedBuildPhase::Running | PersistedBuildPhase::Cancelling => {
+                    let Some(lease) = journal.try_execution_lease(identity.operation_id()).await?
+                    else {
+                        return Ok(Some(status_from_live_operation(&operation)));
+                    };
+                    recover_stale_operation(
+                        identity,
+                        &plan_digest,
+                        operation,
+                        store,
+                        &journal,
+                        &locked,
+                        lease,
+                    )
+                    .await
+                    .map(Some)
+                }
+            }
+        }
+        PersistedBuildOperation::Pending(pending) => {
+            pending.require_identity(identity, &plan_digest)?;
+            if let Some(result) =
+                adopt_committed_output(identity, &plan_digest, store, &journal, &locked).await?
+            {
+                return Ok(Some(RecordedBuildStatus::Succeeded(Box::new(result))));
+            }
+            let Some(_lease) = journal.try_execution_lease(identity.operation_id()).await? else {
+                return Ok(Some(RecordedBuildStatus::Running));
+            };
+            journal.cleanup_workspace(identity.operation_id()).await?;
+            let mut operation =
+                SupervisedBuildOperation::from_pending(&pending, identity, &plan_digest)?;
+            operation.finish(
+                PersistedBuildPhase::Failed,
+                "legacy build intent has no live execution owner or committed output".to_string(),
+            );
+            let operation = locked.write_supervised(operation).await?;
+            Ok(Some(status_from_terminal_operation(&operation)?))
+        }
+    }
+}
+
+/// Inspect only a successful terminal result for compatibility.
+///
+/// New code should use [`inspect_recorded_build_status`] to distinguish live,
+/// cancelling, cancelled, failed, and successful states.
 pub async fn inspect_recorded_build_plan(
     identity: &BuildOperationIdentity,
     plan: &BoxBuildPlan,
     store: &ImageStore,
 ) -> Result<Option<RecordedBuildResult>, BuildPlanExecutionError> {
+    Ok(
+        match inspect_recorded_build_status(identity, plan, store).await? {
+            Some(RecordedBuildStatus::Succeeded(result)) => Some(*result),
+            Some(
+                RecordedBuildStatus::Running
+                | RecordedBuildStatus::Cancelling
+                | RecordedBuildStatus::Cancelled { .. }
+                | RecordedBuildStatus::Failed { .. },
+            )
+            | None => None,
+        },
+    )
+}
+
+/// Durably request cancellation through the existing receipt journal.
+pub async fn cancel_recorded_build_plan(
+    identity: &BuildOperationIdentity,
+    plan: &BoxBuildPlan,
+    store: &ImageStore,
+) -> Result<BuildCancellationOutcome, BuildPlanExecutionError> {
     let plan_digest = plan.canonical_digest()?;
     let journal = BuildOperationJournal::for_image_store(store, identity.operation_id()).await?;
     let locked = journal.lock(identity.operation_id()).await?;
-    match locked.read().await? {
-        None => Ok(None),
-        Some(PersistedBuildOperation::Succeeded(receipt)) => {
-            recover_recorded_build(identity, &plan_digest, receipt, store)
-                .await
-                .map(Some)
+    let Some(record) = locked.read().await? else {
+        return Ok(BuildCancellationOutcome::NotFound);
+    };
+    match record {
+        PersistedBuildOperation::Succeeded(receipt) => {
+            receipt.require_identity(identity, &plan_digest)?;
+            Ok(BuildCancellationOutcome::AlreadyTerminal)
         }
-        Some(PersistedBuildOperation::Pending(pending)) => {
+        PersistedBuildOperation::Pending(pending) => {
             pending.require_identity(identity, &plan_digest)?;
-            let Some(output) =
-                inspect_stored_output(identity.operation_id(), identity.output_reference(), store)
-                    .await?
-            else {
-                return Ok(None);
+            if adopt_committed_output(identity, &plan_digest, store, &journal, &locked)
+                .await?
+                .is_some()
+            {
+                return Ok(BuildCancellationOutcome::AlreadyTerminal);
+            }
+            let Some(_lease) = journal.try_execution_lease(identity.operation_id()).await? else {
+                return Err(BuildReceiptError::Conflict {
+                    operation_id: identity.operation_id().to_string(),
+                    message: "legacy pending operation has an unknown live execution owner"
+                        .to_string(),
+                }
+                .into());
             };
-            let receipt = BuildOutputReceipt::from_result(identity, plan_digest, &output)?;
-            let receipt = locked.write_succeeded(receipt).await?;
-            Ok(Some(RecordedBuildResult {
-                receipt,
-                output,
-                replayed: true,
-            }))
+            journal.cleanup_workspace(identity.operation_id()).await?;
+            let mut operation =
+                SupervisedBuildOperation::from_pending(&pending, identity, &plan_digest)?;
+            operation.request_cancellation();
+            operation.finish(
+                PersistedBuildPhase::Cancelled,
+                "cancelled before native execution started".to_string(),
+            );
+            locked.write_supervised(operation).await?;
+            Ok(BuildCancellationOutcome::Requested)
+        }
+        PersistedBuildOperation::Supervised(mut operation) => {
+            operation.require_identity(identity, &plan_digest)?;
+            match operation.phase {
+                PersistedBuildPhase::Cancelled => {
+                    return Ok(BuildCancellationOutcome::AlreadyCancelled);
+                }
+                PersistedBuildPhase::Failed => {
+                    return Ok(BuildCancellationOutcome::AlreadyTerminal);
+                }
+                PersistedBuildPhase::Running | PersistedBuildPhase::Cancelling => {}
+            }
+            if adopt_committed_output(identity, &plan_digest, store, &journal, &locked)
+                .await?
+                .is_some()
+            {
+                return Ok(BuildCancellationOutcome::AlreadyTerminal);
+            }
+
+            let newly_requested = operation.request_cancellation();
+            let run_process = operation.run_process;
+            operation = locked.write_supervised(operation).await?;
+            if let Some(lease) = journal.try_execution_lease(identity.operation_id()).await? {
+                fence_run_process(run_process, identity.operation_id()).await?;
+                journal.cleanup_workspace(identity.operation_id()).await?;
+                operation.finish(
+                    PersistedBuildPhase::Cancelled,
+                    "cancelled while recovering an abandoned native execution".to_string(),
+                );
+                locked.write_supervised(operation).await?;
+                drop(lease);
+                return Ok(if newly_requested {
+                    BuildCancellationOutcome::Requested
+                } else {
+                    BuildCancellationOutcome::AlreadyRequested
+                });
+            }
+            drop(locked);
+            fence_run_process(run_process, identity.operation_id()).await?;
+            Ok(if newly_requested {
+                BuildCancellationOutcome::Requested
+            } else {
+                BuildCancellationOutcome::AlreadyRequested
+            })
         }
     }
 }
 
-/// Remove one terminal receipt and its operation-specific ImageStore reference.
+/// Remove one terminal record and its operation-specific ImageStore reference.
 ///
-/// Missing image content is tolerated during cleanup so an already-pruned
-/// output cannot leave a permanent stale receipt. A present reference must
-/// still match the receipt digest before it is removed.
+/// Live or cancelling work must reach a terminal state first. The same journal
+/// cleanup removes the operation workspace; there is no parallel garbage
+/// collector or supervisor-owned image store.
 pub async fn remove_recorded_build_plan(
     identity: &BuildOperationIdentity,
     plan: &BoxBuildPlan,
@@ -198,6 +379,20 @@ pub async fn remove_recorded_build_plan(
                 Some(receipt.output.descriptor.digest),
             )
         }
+        PersistedBuildOperation::Supervised(operation) => {
+            operation.require_identity(identity, &plan_digest)?;
+            if matches!(
+                operation.phase,
+                PersistedBuildPhase::Running | PersistedBuildPhase::Cancelling
+            ) {
+                return Err(BuildReceiptError::Conflict {
+                    operation_id: identity.operation_id().to_string(),
+                    message: "cancel and reconcile the live build before removal".to_string(),
+                }
+                .into());
+            }
+            (identity.output_reference().to_string(), None)
+        }
     };
     if let Some(stored) = store.get_checked(&reference).await? {
         if expected_digest.is_some_and(|digest| stored.digest != digest) {
@@ -209,8 +404,344 @@ pub async fn remove_recorded_build_plan(
         }
         store.remove(&reference).await?;
     }
+    journal.cleanup_workspace(identity.operation_id()).await?;
     locked.delete().await?;
     Ok(true)
+}
+
+struct StartOutcome {
+    status: RecordedBuildStatus,
+    started_here: bool,
+}
+
+async fn start_recorded_build_plan_internal(
+    identity: &BuildOperationIdentity,
+    plan: &BoxBuildPlan,
+    source_root: &Path,
+    quiet: bool,
+    store: Arc<ImageStore>,
+) -> Result<StartOutcome, BuildPlanExecutionError> {
+    let plan_digest = plan.canonical_digest()?;
+    let journal = BuildOperationJournal::for_image_store(&store, identity.operation_id()).await?;
+    let locked = journal.lock(identity.operation_id()).await?;
+    let record = locked.read().await?;
+
+    match record {
+        Some(PersistedBuildOperation::Succeeded(receipt)) => {
+            let result = recover_recorded_build(identity, &plan_digest, receipt, &store).await?;
+            return Ok(StartOutcome {
+                status: RecordedBuildStatus::Succeeded(Box::new(result)),
+                started_here: false,
+            });
+        }
+        Some(PersistedBuildOperation::Supervised(operation)) => {
+            operation.require_identity(identity, &plan_digest)?;
+            if matches!(
+                operation.phase,
+                PersistedBuildPhase::Cancelled | PersistedBuildPhase::Failed
+            ) {
+                return Ok(StartOutcome {
+                    status: status_from_terminal_operation(&operation)?,
+                    started_here: false,
+                });
+            }
+            let Some(lease) = journal.try_execution_lease(identity.operation_id()).await? else {
+                return Ok(StartOutcome {
+                    status: status_from_live_operation(&operation),
+                    started_here: false,
+                });
+            };
+            let status = recover_stale_operation(
+                identity,
+                &plan_digest,
+                operation,
+                &store,
+                &journal,
+                &locked,
+                lease,
+            )
+            .await?;
+            return Ok(StartOutcome {
+                status,
+                started_here: false,
+            });
+        }
+        Some(PersistedBuildOperation::Pending(pending)) => {
+            pending.require_identity(identity, &plan_digest)?;
+            if let Some(result) =
+                adopt_committed_output(identity, &plan_digest, &store, &journal, &locked).await?
+            {
+                return Ok(StartOutcome {
+                    status: RecordedBuildStatus::Succeeded(Box::new(result)),
+                    started_here: false,
+                });
+            }
+            let lease = journal
+                .try_execution_lease(identity.operation_id())
+                .await?
+                .ok_or_else(|| BuildReceiptError::Conflict {
+                    operation_id: identity.operation_id().to_string(),
+                    message: "pending intent has an unknown live execution owner".to_string(),
+                })?;
+            let workspace = journal.prepare_workspace(identity.operation_id()).await?;
+            let operation =
+                SupervisedBuildOperation::from_pending(&pending, identity, &plan_digest)?;
+            locked.write_supervised(operation).await?;
+            drop(locked);
+            spawn_supervised_build(SupervisedBuildTask {
+                identity: identity.clone(),
+                plan: plan.clone(),
+                plan_digest,
+                source_root: source_root.to_path_buf(),
+                quiet,
+                store,
+                journal,
+                workspace,
+                lease,
+            });
+            return Ok(StartOutcome {
+                status: RecordedBuildStatus::Running,
+                started_here: true,
+            });
+        }
+        None => {}
+    }
+
+    if store
+        .get_checked(identity.output_reference())
+        .await?
+        .is_some()
+    {
+        return Err(BuildReceiptError::OutputInvalid {
+            operation_id: identity.operation_id().to_string(),
+            message: "operation output exists without a persisted owning intent".to_string(),
+        }
+        .into());
+    }
+    let lease = journal
+        .try_execution_lease(identity.operation_id())
+        .await?
+        .ok_or_else(|| BuildReceiptError::Conflict {
+            operation_id: identity.operation_id().to_string(),
+            message: "execution lease exists without a persisted operation record".to_string(),
+        })?;
+    let workspace = journal.prepare_workspace(identity.operation_id()).await?;
+    let operation = SupervisedBuildOperation::new(identity, plan_digest.clone())?;
+    locked.write_supervised(operation).await?;
+    drop(locked);
+    spawn_supervised_build(SupervisedBuildTask {
+        identity: identity.clone(),
+        plan: plan.clone(),
+        plan_digest,
+        source_root: source_root.to_path_buf(),
+        quiet,
+        store,
+        journal,
+        workspace,
+        lease,
+    });
+    Ok(StartOutcome {
+        status: RecordedBuildStatus::Running,
+        started_here: true,
+    })
+}
+
+struct SupervisedBuildTask {
+    identity: BuildOperationIdentity,
+    plan: BoxBuildPlan,
+    plan_digest: String,
+    source_root: PathBuf,
+    quiet: bool,
+    store: Arc<ImageStore>,
+    journal: BuildOperationJournal,
+    workspace: PathBuf,
+    lease: BuildExecutionLease,
+}
+
+fn spawn_supervised_build(task: SupervisedBuildTask) {
+    tokio::spawn(async move {
+        let operation_id = task.identity.operation_id().to_string();
+        if let Err(error) = run_supervised_build(task).await {
+            tracing::error!(
+                operation_id,
+                %error,
+                "Supervised native build ended before committing a terminal journal state"
+            );
+        }
+    });
+}
+
+async fn run_supervised_build(task: SupervisedBuildTask) -> Result<(), BuildPlanExecutionError> {
+    let SupervisedBuildTask {
+        identity,
+        plan,
+        plan_digest,
+        source_root,
+        quiet,
+        store,
+        journal,
+        workspace,
+        lease: _lease,
+    } = task;
+    let observer = Arc::new(JournalBuildObserver {
+        journal: journal.clone(),
+        identity: identity.clone(),
+        plan_digest: plan_digest.clone(),
+    });
+    let control = BuildExecutionControl::new(observer);
+    let result = execute_supervised_build_plan(
+        &plan,
+        &source_root,
+        BoxBuildOptions {
+            tag: Some(identity.output_reference().to_string()),
+            quiet,
+        },
+        Arc::clone(&store),
+        &workspace,
+        control,
+    )
+    .await;
+
+    if let Ok(planned) = result {
+        journal.cleanup_workspace(identity.operation_id()).await?;
+        let receipt =
+            BuildOutputReceipt::from_result(&identity, planned.plan_digest, &planned.output)?;
+        let locked = journal.lock(identity.operation_id()).await?;
+        locked.write_succeeded(receipt).await?;
+        return Ok(());
+    }
+
+    let error = result.unwrap_err();
+    finish_failed_execution(&identity, &plan_digest, &store, &journal, error.to_string()).await
+}
+
+async fn finish_failed_execution(
+    identity: &BuildOperationIdentity,
+    plan_digest: &str,
+    store: &ImageStore,
+    journal: &BuildOperationJournal,
+    message: String,
+) -> Result<(), BuildPlanExecutionError> {
+    let locked = journal.lock(identity.operation_id()).await?;
+    let Some(record) = locked.read().await? else {
+        return Err(BuildReceiptError::Conflict {
+            operation_id: identity.operation_id().to_string(),
+            message: "operation record disappeared before failure reconciliation".to_string(),
+        }
+        .into());
+    };
+    if matches!(record, PersistedBuildOperation::Succeeded(_)) {
+        return Ok(());
+    }
+    if let Some(result) =
+        adopt_committed_output(identity, plan_digest, store, journal, &locked).await?
+    {
+        drop(result);
+        return Ok(());
+    }
+    let mut operation = match record {
+        PersistedBuildOperation::Supervised(operation) => operation,
+        PersistedBuildOperation::Pending(pending) => {
+            SupervisedBuildOperation::from_pending(&pending, identity, plan_digest)?
+        }
+        PersistedBuildOperation::Succeeded(_) => unreachable!(),
+    };
+    operation.require_identity(identity, plan_digest)?;
+    fence_run_process(operation.run_process, identity.operation_id()).await?;
+    journal.cleanup_workspace(identity.operation_id()).await?;
+    let phase = if operation.phase == PersistedBuildPhase::Cancelling {
+        PersistedBuildPhase::Cancelled
+    } else {
+        PersistedBuildPhase::Failed
+    };
+    operation.finish(phase, message);
+    locked.write_supervised(operation).await?;
+    Ok(())
+}
+
+async fn recover_stale_operation(
+    identity: &BuildOperationIdentity,
+    plan_digest: &str,
+    mut operation: SupervisedBuildOperation,
+    store: &ImageStore,
+    journal: &BuildOperationJournal,
+    locked: &LockedBuildOperation,
+    _lease: BuildExecutionLease,
+) -> Result<RecordedBuildStatus, BuildPlanExecutionError> {
+    if let Some(result) =
+        adopt_committed_output(identity, plan_digest, store, journal, locked).await?
+    {
+        return Ok(RecordedBuildStatus::Succeeded(Box::new(result)));
+    }
+    fence_run_process(operation.run_process, identity.operation_id()).await?;
+    journal.cleanup_workspace(identity.operation_id()).await?;
+    let (phase, message) = if operation.phase == PersistedBuildPhase::Cancelling {
+        (
+            PersistedBuildPhase::Cancelled,
+            "cancelled after the native execution owner exited".to_string(),
+        )
+    } else {
+        (
+            PersistedBuildPhase::Failed,
+            "native execution owner exited before committing an output".to_string(),
+        )
+    };
+    operation.finish(phase, message);
+    let operation = locked.write_supervised(operation).await?;
+    status_from_terminal_operation(&operation)
+}
+
+async fn adopt_committed_output(
+    identity: &BuildOperationIdentity,
+    plan_digest: &str,
+    store: &ImageStore,
+    journal: &BuildOperationJournal,
+    locked: &LockedBuildOperation,
+) -> Result<Option<RecordedBuildResult>, BuildPlanExecutionError> {
+    let Some(output) =
+        inspect_stored_output(identity.operation_id(), identity.output_reference(), store).await?
+    else {
+        return Ok(None);
+    };
+    journal.cleanup_workspace(identity.operation_id()).await?;
+    let receipt = BuildOutputReceipt::from_result(identity, plan_digest.to_string(), &output)?;
+    let receipt = locked.write_succeeded(receipt).await?;
+    Ok(Some(RecordedBuildResult {
+        receipt,
+        output,
+        replayed: true,
+    }))
+}
+
+fn status_from_live_operation(operation: &SupervisedBuildOperation) -> RecordedBuildStatus {
+    if operation.phase == PersistedBuildPhase::Cancelling {
+        RecordedBuildStatus::Cancelling
+    } else {
+        RecordedBuildStatus::Running
+    }
+}
+
+fn status_from_terminal_operation(
+    operation: &SupervisedBuildOperation,
+) -> Result<RecordedBuildStatus, BuildPlanExecutionError> {
+    let message = operation
+        .terminal_message()
+        .ok_or_else(|| BuildReceiptError::InvalidReceipt {
+            operation_id: operation.operation_id().to_string(),
+            message: "terminal operation has no message".to_string(),
+        })?
+        .to_string();
+    match operation.phase {
+        PersistedBuildPhase::Cancelled => Ok(RecordedBuildStatus::Cancelled { message }),
+        PersistedBuildPhase::Failed => Ok(RecordedBuildStatus::Failed { message }),
+        PersistedBuildPhase::Running | PersistedBuildPhase::Cancelling => {
+            Err(BuildReceiptError::InvalidReceipt {
+                operation_id: operation.operation_id().to_string(),
+                message: "live operation was decoded through the terminal boundary".to_string(),
+            }
+            .into())
+        }
+    }
 }
 
 async fn recover_recorded_build(
@@ -225,6 +756,200 @@ async fn recover_recorded_build(
         receipt,
         output,
         replayed: true,
+    })
+}
+
+struct JournalBuildObserver {
+    journal: BuildOperationJournal,
+    identity: BuildOperationIdentity,
+    plan_digest: String,
+}
+
+#[async_trait]
+impl BuildExecutionObserver for JournalBuildObserver {
+    async fn cancellation_requested(&self) -> BoxResult<bool> {
+        let locked = self
+            .journal
+            .lock(self.identity.operation_id())
+            .await
+            .map_err(observer_error)?;
+        let record = locked.read().await.map_err(observer_error)?;
+        match record {
+            Some(PersistedBuildOperation::Supervised(operation)) => {
+                operation
+                    .require_identity(&self.identity, &self.plan_digest)
+                    .map_err(observer_error)?;
+                Ok(operation.phase != PersistedBuildPhase::Running)
+            }
+            Some(PersistedBuildOperation::Succeeded(_)) => Ok(true),
+            Some(PersistedBuildOperation::Pending(_)) | None => Err(BoxError::BuildError(
+                "supervised build lost its authoritative operation state".to_string(),
+            )),
+        }
+    }
+
+    async fn run_process_started(&self, pid: u32, start_time: Option<u64>) -> BoxResult<()> {
+        let locked = self
+            .journal
+            .lock(self.identity.operation_id())
+            .await
+            .map_err(observer_error)?;
+        let Some(PersistedBuildOperation::Supervised(mut operation)) =
+            locked.read().await.map_err(observer_error)?
+        else {
+            return Err(BoxError::BuildError(
+                "supervised RUN has no active operation record".to_string(),
+            ));
+        };
+        operation
+            .require_identity(&self.identity, &self.plan_digest)
+            .map_err(observer_error)?;
+        operation
+            .set_run_process(Some(BuildProcessIdentity { pid, start_time }))
+            .map_err(observer_error)?;
+        let cancelling = operation.phase == PersistedBuildPhase::Cancelling;
+        locked
+            .write_supervised(operation)
+            .await
+            .map_err(observer_error)?;
+        if cancelling {
+            return Err(BoxError::BuildError(
+                "recorded build cancellation raced Dockerfile RUN startup".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn run_process_finished(&self, pid: u32, start_time: Option<u64>) -> BoxResult<()> {
+        let locked = self
+            .journal
+            .lock(self.identity.operation_id())
+            .await
+            .map_err(observer_error)?;
+        let Some(PersistedBuildOperation::Supervised(mut operation)) =
+            locked.read().await.map_err(observer_error)?
+        else {
+            return Ok(());
+        };
+        operation
+            .require_identity(&self.identity, &self.plan_digest)
+            .map_err(observer_error)?;
+        if operation.run_process == Some(BuildProcessIdentity { pid, start_time }) {
+            operation.set_run_process(None).map_err(observer_error)?;
+            locked
+                .write_supervised(operation)
+                .await
+                .map_err(observer_error)?;
+        }
+        Ok(())
+    }
+}
+
+fn observer_error(error: BuildReceiptError) -> BoxError {
+    BoxError::BuildError(format!(
+        "build operation journal rejected native execution: {error}"
+    ))
+}
+
+async fn fence_run_process(
+    process: Option<BuildProcessIdentity>,
+    operation_id: &a3s_box_core::OperationId,
+) -> Result<(), BuildReceiptError> {
+    let Some(process) = process else {
+        return Ok(());
+    };
+    let operation = operation_id.to_string();
+    tokio::task::spawn_blocking(move || fence_run_process_blocking(process, &operation))
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: operation_id.to_string(),
+            message: format!("RUN process fencing task failed: {error}"),
+        })?
+}
+
+#[cfg(unix)]
+fn fence_run_process_blocking(
+    process: BuildProcessIdentity,
+    operation_id: &str,
+) -> Result<(), BuildReceiptError> {
+    if !crate::process::is_process_alive_with_identity(process.pid, process.start_time) {
+        return Ok(());
+    }
+    let pid = i32::try_from(process.pid).map_err(|_| BuildReceiptError::InvalidReceipt {
+        operation_id: operation_id.to_string(),
+        message: "RUN process PID exceeds the host signal range".to_string(),
+    })?;
+    if unsafe { libc::kill(pid, libc::SIGKILL) } != 0 {
+        let source = std::io::Error::last_os_error();
+        if source.raw_os_error() != Some(libc::ESRCH) {
+            return Err(BuildReceiptError::StoreIo {
+                message: format!("failed to kill RUN process for operation {operation_id}"),
+                source,
+            });
+        }
+    }
+    let deadline = std::time::Instant::now() + RUN_PROCESS_STOP_TIMEOUT;
+    while crate::process::is_process_running_with_identity(process.pid, process.start_time) {
+        if std::time::Instant::now() >= deadline {
+            return Err(BuildReceiptError::Task {
+                operation_id: operation_id.to_string(),
+                message: format!(
+                    "RUN process {} did not stop within {:?}",
+                    process.pid, RUN_PROCESS_STOP_TIMEOUT
+                ),
+            });
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn fence_run_process_blocking(
+    process: BuildProcessIdentity,
+    operation_id: &str,
+) -> Result<(), BuildReceiptError> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, TerminateProcess, PROCESS_QUERY_INFORMATION, PROCESS_TERMINATE,
+    };
+
+    if !crate::process::is_process_alive_with_identity(process.pid, process.start_time) {
+        return Ok(());
+    }
+    unsafe {
+        let handle = OpenProcess(
+            PROCESS_QUERY_INFORMATION | PROCESS_TERMINATE,
+            0,
+            process.pid,
+        );
+        if handle == 0 {
+            return Err(BuildReceiptError::StoreIo {
+                message: format!("failed to open RUN process for operation {operation_id}"),
+                source: std::io::Error::last_os_error(),
+            });
+        }
+        let terminated = TerminateProcess(handle, 1);
+        let error = std::io::Error::last_os_error();
+        CloseHandle(handle);
+        if terminated == 0 {
+            return Err(BuildReceiptError::StoreIo {
+                message: format!("failed to terminate RUN process for operation {operation_id}"),
+                source: error,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn fence_run_process_blocking(
+    _process: BuildProcessIdentity,
+    operation_id: &str,
+) -> Result<(), BuildReceiptError> {
+    Err(BuildReceiptError::Task {
+        operation_id: operation_id.to_string(),
+        message: "this platform cannot fence a recorded RUN process".to_string(),
     })
 }
 

--- a/src/runtime/src/oci/build/execution.rs
+++ b/src/runtime/src/oci/build/execution.rs
@@ -23,6 +23,7 @@ use super::{
 use crate::oci::ImageStore;
 
 const EXECUTION_POLL_INTERVAL: Duration = Duration::from_millis(25);
+#[cfg(target_os = "linux")]
 const RUN_PROCESS_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Successful native output bound to the canonical admitted build plan.
@@ -894,7 +895,7 @@ async fn fence_run_process(
         })?
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn fence_run_process_blocking(
     process: BuildProcessIdentity,
     operation_id: &str,
@@ -931,52 +932,14 @@ fn fence_run_process_blocking(
     Ok(())
 }
 
-#[cfg(windows)]
-fn fence_run_process_blocking(
-    process: BuildProcessIdentity,
-    operation_id: &str,
-) -> Result<(), BuildReceiptError> {
-    use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::System::Threading::{
-        OpenProcess, TerminateProcess, PROCESS_QUERY_INFORMATION, PROCESS_TERMINATE,
-    };
-
-    if !crate::process::is_process_alive_with_identity(process.pid, process.start_time) {
-        return Ok(());
-    }
-    unsafe {
-        let handle = OpenProcess(
-            PROCESS_QUERY_INFORMATION | PROCESS_TERMINATE,
-            0,
-            process.pid,
-        );
-        if handle == 0 {
-            return Err(BuildReceiptError::StoreIo {
-                message: format!("failed to open RUN process for operation {operation_id}"),
-                source: std::io::Error::last_os_error(),
-            });
-        }
-        let terminated = TerminateProcess(handle, 1);
-        let error = std::io::Error::last_os_error();
-        CloseHandle(handle);
-        if terminated == 0 {
-            return Err(BuildReceiptError::StoreIo {
-                message: format!("failed to terminate RUN process for operation {operation_id}"),
-                source: error,
-            });
-        }
-    }
-    Ok(())
-}
-
-#[cfg(not(any(unix, windows)))]
+#[cfg(not(target_os = "linux"))]
 fn fence_run_process_blocking(
     _process: BuildProcessIdentity,
     operation_id: &str,
 ) -> Result<(), BuildReceiptError> {
     Err(BuildReceiptError::Task {
         operation_id: operation_id.to_string(),
-        message: "this platform cannot fence a recorded RUN process".to_string(),
+        message: "a recorded Linux RUN process cannot be fenced on this host".to_string(),
     })
 }
 

--- a/src/runtime/src/oci/build/execution.rs
+++ b/src/runtime/src/oci/build/execution.rs
@@ -8,7 +8,9 @@ use a3s_box_core::error::{BoxError, Result as BoxResult};
 use async_trait::async_trait;
 use thiserror::Error;
 
-use super::engine::{build_supervised, BuildExecutionControl, BuildExecutionObserver};
+use super::engine::{
+    build_supervised, BuildExecutionControl, BuildExecutionObserver, BuildImageCommitPermit,
+};
 use super::receipt::{
     inspect_stored_output, BuildExecutionLease, BuildOperationJournal, BuildProcessIdentity,
     LockedBuildOperation, PersistedBuildOperation, PersistedBuildPhase, SupervisedBuildOperation,
@@ -786,6 +788,31 @@ impl BuildExecutionObserver for JournalBuildObserver {
                 "supervised build lost its authoritative operation state".to_string(),
             )),
         }
+    }
+
+    async fn acquire_image_commit_permit(&self) -> BoxResult<BuildImageCommitPermit> {
+        let locked = self
+            .journal
+            .lock(self.identity.operation_id())
+            .await
+            .map_err(observer_error)?;
+        let Some(PersistedBuildOperation::Supervised(operation)) =
+            locked.read().await.map_err(observer_error)?
+        else {
+            return Err(BoxError::BuildError(
+                "supervised build lost its authoritative operation state before image commit"
+                    .to_string(),
+            ));
+        };
+        operation
+            .require_identity(&self.identity, &self.plan_digest)
+            .map_err(observer_error)?;
+        if operation.phase != PersistedBuildPhase::Running {
+            return Err(BoxError::BuildError(
+                "recorded build operation was cancelled before image commit".to_string(),
+            ));
+        }
+        Ok(BuildImageCommitPermit::new(locked))
     }
 
     async fn run_process_started(&self, pid: u32, start_time: Option<u64>) -> BoxResult<()> {

--- a/src/runtime/src/oci/build/execution/tests.rs
+++ b/src/runtime/src/oci/build/execution/tests.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use a3s_box_core::OperationId;
+
 use super::*;
 use crate::OCI_IMAGE_MANIFEST_MEDIA_TYPE;
 
@@ -76,4 +78,79 @@ build "oci" {{
         result.output.layout_directory
     );
     assert_eq!(stored.size_bytes, result.output.content_bytes());
+}
+
+#[tokio::test]
+async fn image_commit_permit_serializes_cancellation_on_the_operation_journal() {
+    let temporary = tempfile::TempDir::new().unwrap();
+    let store_root = temporary.path().join("images");
+    let identity = BuildOperationIdentity::new(
+        OperationId::new("cloud-build-commit-permit").unwrap(),
+        format!("sha256:{}", "a".repeat(64)),
+    )
+    .unwrap();
+    let plan = BoxBuildPlan::parse_acl(&format!(
+        r#"
+build "oci" {{
+  cache = "disabled"
+  context = "."
+  file = "Dockerfile"
+  network = "none"
+  platform = "linux/{}"
+  schema = "a3s.box.build-plan.v1"
+}}
+"#,
+        if cfg!(target_arch = "aarch64") {
+            "arm64"
+        } else {
+            "amd64"
+        }
+    ))
+    .unwrap();
+    let plan_digest = plan.canonical_digest().unwrap();
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let journal = BuildOperationJournal::for_image_store(&store, identity.operation_id())
+        .await
+        .unwrap();
+    let locked = journal.lock(identity.operation_id()).await.unwrap();
+    locked
+        .write_supervised(SupervisedBuildOperation::new(&identity, plan_digest.clone()).unwrap())
+        .await
+        .unwrap();
+    drop(locked);
+
+    let observer = JournalBuildObserver {
+        journal,
+        identity: identity.clone(),
+        plan_digest,
+    };
+    let permit = observer.acquire_image_commit_permit().await.unwrap();
+    let cancellation_identity = identity.clone();
+    let cancellation_plan = plan.clone();
+    let cancellation_store = Arc::clone(&store);
+    let mut cancellation = tokio::spawn(async move {
+        cancel_recorded_build_plan(
+            &cancellation_identity,
+            &cancellation_plan,
+            &cancellation_store,
+        )
+        .await
+    });
+
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(100), &mut cancellation)
+            .await
+            .is_err(),
+        "cancellation must wait for the ImageStore commit permit"
+    );
+    drop(permit);
+
+    assert_eq!(
+        tokio::time::timeout(std::time::Duration::from_secs(2), cancellation)
+            .await
+            .expect("cancellation must resume after commit permit release")
+            .expect("cancellation task must not panic")
+            .unwrap(),
+        BuildCancellationOutcome::Requested
+    );
 }

--- a/src/runtime/src/oci/build/mod.rs
+++ b/src/runtime/src/oci/build/mod.rs
@@ -31,13 +31,14 @@ mod receipt;
 pub use dockerfile::{Dockerfile, Instruction};
 pub use engine::{build, BuildConfig, BuildNetworkPolicy, BuildRunPoolConfig};
 pub use execution::{
-    execute_recorded_build_plan, inspect_recorded_build_plan, remove_recorded_build_plan,
+    cancel_recorded_build_plan, execute_recorded_build_plan, inspect_recorded_build_plan,
+    inspect_recorded_build_status, remove_recorded_build_plan, start_recorded_build_plan,
     BuildPlanExecutionError,
 };
 pub use layer::{DirSnapshot, LayerInfo};
 pub use output::{BuildOutputDescriptor, BuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
 pub use plan::{BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy};
 pub use receipt::{
-    BuildOperationIdentity, BuildOutputReceipt, BuildReceiptError, BuildReceiptOutput,
-    RecordedBuildResult,
+    BuildCancellationOutcome, BuildOperationIdentity, BuildOutputReceipt, BuildReceiptError,
+    BuildReceiptOutput, RecordedBuildResult, RecordedBuildStatus,
 };

--- a/src/runtime/src/oci/build/receipt.rs
+++ b/src/runtime/src/oci/build/receipt.rs
@@ -1,13 +1,15 @@
-//! Durable terminal receipts for plan-bound native OCI builds.
+//! Durable lifecycle records and terminal receipts for native OCI builds.
 //!
-//! Receipts bind one caller operation and immutable source digest to the exact
-//! native OCI output already owned by [`ImageStore`]. They deliberately do not
-//! copy image content or supervise an in-flight build. A later operation
-//! supervisor can use this terminal boundary for start/inspect/cancel recovery
-//! without adding another build engine or image store.
+//! The receipt journal is the sole build-operation state machine. It binds one
+//! caller operation and immutable source digest to the native engine, its
+//! operation-owned workspace, and the exact output already owned by
+//! [`ImageStore`]. The legacy pending intent and successful receipt schemas are
+//! retained as compatible states in this same journal rather than introducing
+//! a second supervisor store.
 
 use a3s_box_core::platform::Platform;
 use a3s_box_core::OperationId;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -19,11 +21,12 @@ use crate::oci::ImageStore;
 
 const MAX_OPERATION_ID_BYTES: usize = 255;
 const MAX_RECEIPT_BYTES: u64 = 64 * 1024;
+const MAX_TERMINAL_MESSAGE_BYTES: usize = 4 * 1024;
 const RECEIPT_DIRECTORY: &str = "build-receipts";
 
 mod journal;
 
-pub(super) use journal::BuildOperationJournal;
+pub(super) use journal::{BuildExecutionLease, BuildOperationJournal, LockedBuildOperation};
 
 /// Immutable caller identity for one recoverable build output.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,7 +84,11 @@ impl BuildOperationIdentity {
     }
 }
 
-/// Intent persisted before native build side effects begin.
+/// Legacy pre-supervision intent accepted as a state in the same journal.
+///
+/// New starts write [`SupervisedBuildOperation`] directly. This schema remains
+/// readable so an upgrade can adopt a committed output or migrate an abandoned
+/// intent without a second compatibility store.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(super) struct PendingBuildOperation {
@@ -95,6 +102,7 @@ pub(super) struct PendingBuildOperation {
 impl PendingBuildOperation {
     const SCHEMA: &'static str = "a3s.box.build-output-intent.v1";
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn new(
         identity: &BuildOperationIdentity,
         plan_digest: String,
@@ -156,10 +164,217 @@ impl PendingBuildOperation {
     }
 }
 
+/// Stable host-process identity persisted in the one operation journal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct BuildProcessIdentity {
+    pub(super) pid: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) start_time: Option<u64>,
+}
+
+impl BuildProcessIdentity {
+    pub(super) fn current() -> Self {
+        let pid = std::process::id();
+        Self {
+            pid,
+            start_time: crate::process::pid_start_time(pid),
+        }
+    }
+
+    fn validate(self, operation_id: &OperationId) -> Result<(), BuildReceiptError> {
+        if self.pid == 0 {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id: operation_id.to_string(),
+                message: "persisted build process has PID zero".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Non-success phases represented by the authoritative operation record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum PersistedBuildPhase {
+    Running,
+    Cancelling,
+    Cancelled,
+    Failed,
+}
+
+/// Supervised lifecycle state stored in the existing receipt journal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct SupervisedBuildOperation {
+    schema: String,
+    operation_id: OperationId,
+    source_digest: String,
+    plan_digest: String,
+    output_reference: String,
+    pub(super) phase: PersistedBuildPhase,
+    owner: BuildProcessIdentity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) run_process: Option<BuildProcessIdentity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    started_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl SupervisedBuildOperation {
+    pub(super) const SCHEMA: &'static str = "a3s.box.build-operation.v1";
+
+    pub(super) fn new(
+        identity: &BuildOperationIdentity,
+        plan_digest: String,
+    ) -> Result<Self, BuildReceiptError> {
+        let now = Utc::now();
+        let operation = Self {
+            schema: Self::SCHEMA.to_string(),
+            operation_id: identity.operation_id.clone(),
+            source_digest: identity.source_digest.clone(),
+            plan_digest,
+            output_reference: identity.output_reference.clone(),
+            phase: PersistedBuildPhase::Running,
+            owner: BuildProcessIdentity::current(),
+            run_process: None,
+            message: None,
+            started_at: now,
+            updated_at: now,
+        };
+        operation.validate()?;
+        operation.require_identity(identity, &operation.plan_digest)?;
+        Ok(operation)
+    }
+
+    pub(super) fn from_pending(
+        pending: &PendingBuildOperation,
+        identity: &BuildOperationIdentity,
+        plan_digest: &str,
+    ) -> Result<Self, BuildReceiptError> {
+        pending.require_identity(identity, plan_digest)?;
+        Self::new(identity, plan_digest.to_string())
+    }
+
+    fn validate(&self) -> Result<(), BuildReceiptError> {
+        if self.schema != Self::SCHEMA
+            || !valid_operation_id(&self.operation_id)
+            || canonical_sha256_digest_hex(&self.source_digest).is_err()
+            || canonical_sha256_digest_hex(&self.plan_digest).is_err()
+            || self.output_reference
+                != format!(
+                    "a3s-box/build-operation:{}",
+                    operation_key(&self.operation_id)
+                )
+            || self.updated_at < self.started_at
+        {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id: self.operation_id.to_string(),
+                message: "supervised build operation violates its closed identity".to_string(),
+            });
+        }
+        self.owner.validate(&self.operation_id)?;
+        if let Some(process) = self.run_process {
+            process.validate(&self.operation_id)?;
+        }
+        let terminal = matches!(
+            self.phase,
+            PersistedBuildPhase::Cancelled | PersistedBuildPhase::Failed
+        );
+        if terminal != self.message.is_some()
+            || self.message.as_ref().is_some_and(|message| {
+                message.is_empty() || message.len() > MAX_TERMINAL_MESSAGE_BYTES
+            })
+            || (terminal && self.run_process.is_some())
+        {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id: self.operation_id.to_string(),
+                message: "supervised build phase fields are inconsistent".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    pub(super) fn require_identity(
+        &self,
+        identity: &BuildOperationIdentity,
+        plan_digest: &str,
+    ) -> Result<(), BuildReceiptError> {
+        self.validate()?;
+        if self.operation_id != identity.operation_id
+            || self.source_digest != identity.source_digest
+            || self.plan_digest != plan_digest
+            || self.output_reference != identity.output_reference
+        {
+            return Err(BuildReceiptError::Conflict {
+                operation_id: identity.operation_id.to_string(),
+                message: "the supervised source, plan, or output identity differs".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    pub(super) fn request_cancellation(&mut self) -> bool {
+        if self.phase != PersistedBuildPhase::Running {
+            return false;
+        }
+        self.phase = PersistedBuildPhase::Cancelling;
+        self.updated_at = Utc::now();
+        true
+    }
+
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(super) fn set_run_process(
+        &mut self,
+        process: Option<BuildProcessIdentity>,
+    ) -> Result<(), BuildReceiptError> {
+        if matches!(
+            self.phase,
+            PersistedBuildPhase::Cancelled | PersistedBuildPhase::Failed
+        ) {
+            return Err(BuildReceiptError::Conflict {
+                operation_id: self.operation_id.to_string(),
+                message: "a terminal build cannot own a RUN process".to_string(),
+            });
+        }
+        self.run_process = process;
+        self.updated_at = Utc::now();
+        self.validate()
+    }
+
+    pub(super) fn finish(&mut self, phase: PersistedBuildPhase, message: String) {
+        debug_assert!(matches!(
+            phase,
+            PersistedBuildPhase::Cancelled | PersistedBuildPhase::Failed
+        ));
+        self.phase = phase;
+        self.run_process = None;
+        self.message = Some(bounded_terminal_message(message));
+        self.updated_at = Utc::now();
+    }
+
+    pub(super) fn terminal_message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+
+    pub(super) fn operation_id(&self) -> &OperationId {
+        &self.operation_id
+    }
+
+    fn matches_receipt(&self, receipt: &BuildOutputReceipt) -> bool {
+        self.operation_id == receipt.operation_id
+            && self.source_digest == receipt.source_digest
+            && self.plan_digest == receipt.plan_digest
+            && self.output_reference == receipt.output.reference
+    }
+}
+
 /// Strict on-disk state for one build operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub(super) enum PersistedBuildOperation {
+    Supervised(SupervisedBuildOperation),
     Pending(PendingBuildOperation),
     Succeeded(BuildOutputReceipt),
 }
@@ -167,6 +382,7 @@ pub(super) enum PersistedBuildOperation {
 impl PersistedBuildOperation {
     fn validate(&self) -> Result<(), BuildReceiptError> {
         match self {
+            Self::Supervised(operation) => operation.validate(),
             Self::Pending(pending) => pending.validate(),
             Self::Succeeded(receipt) => receipt.validate(),
         }
@@ -174,6 +390,7 @@ impl PersistedBuildOperation {
 
     fn operation_id(&self) -> &OperationId {
         match self {
+            Self::Supervised(operation) => &operation.operation_id,
             Self::Pending(pending) => &pending.operation_id,
             Self::Succeeded(receipt) => &receipt.operation_id,
         }
@@ -406,6 +623,36 @@ pub struct RecordedBuildResult {
     pub replayed: bool,
 }
 
+/// Typed observation of the one durable build-operation state machine.
+#[derive(Debug)]
+pub enum RecordedBuildStatus {
+    /// The native engine owns the operation execution lease.
+    Running,
+    /// Cancellation is durable and the native engine is fencing current work.
+    Cancelling,
+    /// Cancellation completed and the operation-owned workspace was reclaimed.
+    Cancelled { message: String },
+    /// Execution failed and the operation-owned workspace was reclaimed.
+    Failed { message: String },
+    /// The exact ImageStore output and successful receipt were revalidated.
+    Succeeded(Box<RecordedBuildResult>),
+}
+
+/// Idempotent outcome from requesting cancellation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildCancellationOutcome {
+    /// No operation record exists.
+    NotFound,
+    /// The live build accepted a new durable cancellation request.
+    Requested,
+    /// A cancellation request was already durable and remains in progress.
+    AlreadyRequested,
+    /// The operation was already durably cancelled.
+    AlreadyCancelled,
+    /// The operation had already reached success or failure.
+    AlreadyTerminal,
+}
+
 /// Fail-closed receipt identity, persistence, conflict, and output errors.
 #[derive(Debug, Error)]
 pub enum BuildReceiptError {
@@ -467,6 +714,21 @@ fn valid_operation_id(operation_id: &OperationId) -> bool {
             .as_str()
             .bytes()
             .any(|byte| byte.is_ascii_control())
+}
+
+fn bounded_terminal_message(mut message: String) -> String {
+    if message.is_empty() {
+        return "build operation ended without an error message".to_string();
+    }
+    if message.len() <= MAX_TERMINAL_MESSAGE_BYTES {
+        return message;
+    }
+    let mut boundary = MAX_TERMINAL_MESSAGE_BYTES;
+    while !message.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    message.truncate(boundary);
+    message
 }
 
 #[cfg(test)]

--- a/src/runtime/src/oci/build/receipt/journal.rs
+++ b/src/runtime/src/oci/build/receipt/journal.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use a3s_box_core::OperationId;
 
 use super::{
-    operation_key, BuildOutputReceipt, BuildReceiptError, PendingBuildOperation,
-    PersistedBuildOperation, MAX_RECEIPT_BYTES, RECEIPT_DIRECTORY,
+    operation_key, BuildOutputReceipt, BuildReceiptError, PersistedBuildOperation,
+    PersistedBuildPhase, SupervisedBuildOperation, MAX_RECEIPT_BYTES, RECEIPT_DIRECTORY,
 };
 use crate::file_lock::FileLock;
 use crate::oci::image::{read_regular_file_bounded, validate_plain_directory};
@@ -77,6 +77,16 @@ impl BuildOperationJournal {
             .join(format!("{}.json", operation_key(operation_id)))
     }
 
+    pub(super) fn workspace_path(&self, operation_id: &OperationId) -> PathBuf {
+        self.root
+            .join(format!("{}.workspace", operation_key(operation_id)))
+    }
+
+    fn execution_lock_target(&self, operation_id: &OperationId) -> PathBuf {
+        self.root
+            .join(format!("{}.execution", operation_key(operation_id)))
+    }
+
     pub(in crate::oci::build) async fn lock(
         &self,
         operation_id: &OperationId,
@@ -100,6 +110,75 @@ impl BuildOperationJournal {
             _lock: lock,
         })
     }
+
+    /// Try to own execution without blocking state inspection or cancellation.
+    ///
+    /// This uses the same journal and shared [`FileLock`] primitive as receipt
+    /// mutation. The crash-released lease is liveness evidence only; the JSON
+    /// record remains the sole operation state.
+    pub(in crate::oci::build) async fn try_execution_lease(
+        &self,
+        operation_id: &OperationId,
+    ) -> Result<Option<BuildExecutionLease>, BuildReceiptError> {
+        let target = self.execution_lock_target(operation_id);
+        let lock_target = target.clone();
+        let operation = operation_id.to_string();
+        let lock = tokio::task::spawn_blocking(move || FileLock::try_acquire(&lock_target))
+            .await
+            .map_err(|error| BuildReceiptError::Task {
+                operation_id: operation.clone(),
+                message: format!("execution lease task failed: {error}"),
+            })?
+            .map_err(|error| BuildReceiptError::StoreIo {
+                message: format!("failed to inspect execution lease for operation {operation}"),
+                source: error,
+            })?;
+        Ok(lock.map(|lock| BuildExecutionLease { _lock: lock }))
+    }
+
+    pub(in crate::oci::build) async fn prepare_workspace(
+        &self,
+        operation_id: &OperationId,
+    ) -> Result<PathBuf, BuildReceiptError> {
+        let root = self.root.clone();
+        let workspace = self.workspace_path(operation_id);
+        let operation = operation_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            remove_workspace_if_present(&root, &workspace, &operation)?;
+            std::fs::create_dir(&workspace).map_err(|source| BuildReceiptError::StoreIo {
+                message: format!("failed to create workspace for operation {operation}"),
+                source,
+            })?;
+            validate_workspace(&root, &workspace, &operation)
+        })
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: operation_id.to_string(),
+            message: format!("workspace preparation task failed: {error}"),
+        })?
+    }
+
+    pub(in crate::oci::build) async fn cleanup_workspace(
+        &self,
+        operation_id: &OperationId,
+    ) -> Result<(), BuildReceiptError> {
+        let root = self.root.clone();
+        let workspace = self.workspace_path(operation_id);
+        let operation = operation_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            remove_workspace_if_present(&root, &workspace, &operation)
+        })
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: operation_id.to_string(),
+            message: format!("workspace cleanup task failed: {error}"),
+        })?
+    }
+}
+
+/// Crash-released proof that exactly one native engine owns an operation.
+pub(in crate::oci::build) struct BuildExecutionLease {
+    _lock: FileLock,
 }
 
 pub(in crate::oci::build) struct LockedBuildOperation {
@@ -122,43 +201,6 @@ impl LockedBuildOperation {
             })?
     }
 
-    pub(in crate::oci::build) async fn write_pending(
-        &self,
-        pending: PendingBuildOperation,
-    ) -> Result<PendingBuildOperation, BuildReceiptError> {
-        let path = self.path.clone();
-        let operation_id = self.operation_id.clone();
-        tokio::task::spawn_blocking(move || {
-            if let Some(existing) = read_receipt_file(&path, &operation_id)? {
-                if existing == PersistedBuildOperation::Pending(pending.clone()) {
-                    return Ok(pending);
-                }
-                return Err(BuildReceiptError::Conflict {
-                    operation_id: operation_id.to_string(),
-                    message: "a different build operation record already exists".to_string(),
-                });
-            }
-            pending.validate()?;
-            if pending.operation_id != operation_id {
-                return Err(BuildReceiptError::Conflict {
-                    operation_id: operation_id.to_string(),
-                    message: "pending intent belongs to another operation".to_string(),
-                });
-            }
-            persist_record(
-                &path,
-                &operation_id,
-                &PersistedBuildOperation::Pending(pending.clone()),
-            )?;
-            Ok(pending)
-        })
-        .await
-        .map_err(|error| BuildReceiptError::Task {
-            operation_id: self.operation_id.to_string(),
-            message: format!("pending receipt write task failed: {error}"),
-        })?
-    }
-
     pub(in crate::oci::build) async fn write_succeeded(
         &self,
         receipt: BuildOutputReceipt,
@@ -172,6 +214,12 @@ impl LockedBuildOperation {
                 }
                 Some(PersistedBuildOperation::Pending(pending))
                     if pending.matches_receipt(&receipt) => {}
+                Some(PersistedBuildOperation::Supervised(operation))
+                    if operation.matches_receipt(&receipt)
+                        && matches!(
+                            operation.phase,
+                            PersistedBuildPhase::Running | PersistedBuildPhase::Cancelling
+                        ) => {}
                 Some(_) => {
                     return Err(BuildReceiptError::Conflict {
                         operation_id: operation_id.to_string(),
@@ -206,6 +254,54 @@ impl LockedBuildOperation {
         })?
     }
 
+    pub(in crate::oci::build) async fn write_supervised(
+        &self,
+        operation: SupervisedBuildOperation,
+    ) -> Result<SupervisedBuildOperation, BuildReceiptError> {
+        let path = self.path.clone();
+        let operation_id = self.operation_id.clone();
+        tokio::task::spawn_blocking(move || {
+            operation.validate()?;
+            if operation.operation_id != operation_id {
+                return Err(BuildReceiptError::Conflict {
+                    operation_id: operation_id.to_string(),
+                    message: "supervised record belongs to another operation".to_string(),
+                });
+            }
+            match read_receipt_file(&path, &operation_id)? {
+                None if operation.phase == PersistedBuildPhase::Running => {}
+                Some(PersistedBuildOperation::Pending(pending))
+                    if pending.operation_id == operation.operation_id
+                        && pending.source_digest == operation.source_digest
+                        && pending.plan_digest == operation.plan_digest
+                        && pending.output_reference == operation.output_reference
+                        && operation.phase == PersistedBuildPhase::Running => {}
+                Some(PersistedBuildOperation::Supervised(existing))
+                    if valid_supervised_transition(&existing, &operation) => {}
+                Some(PersistedBuildOperation::Supervised(existing)) if existing == operation => {
+                    return Ok(existing);
+                }
+                Some(_) | None => {
+                    return Err(BuildReceiptError::Conflict {
+                        operation_id: operation_id.to_string(),
+                        message: "invalid supervised build state transition".to_string(),
+                    })
+                }
+            }
+            persist_record(
+                &path,
+                &operation_id,
+                &PersistedBuildOperation::Supervised(operation.clone()),
+            )?;
+            Ok(operation)
+        })
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: self.operation_id.to_string(),
+            message: format!("supervised receipt write task failed: {error}"),
+        })?
+    }
+
     pub(in crate::oci::build) async fn delete(&self) -> Result<(), BuildReceiptError> {
         let path = self.path.clone();
         let operation_id = self.operation_id.to_string();
@@ -230,6 +326,36 @@ impl LockedBuildOperation {
             message: format!("receipt removal task failed: {error}"),
         })?
     }
+}
+
+fn valid_supervised_transition(
+    existing: &SupervisedBuildOperation,
+    next: &SupervisedBuildOperation,
+) -> bool {
+    if existing.operation_id != next.operation_id
+        || existing.source_digest != next.source_digest
+        || existing.plan_digest != next.plan_digest
+        || existing.output_reference != next.output_reference
+        || existing.started_at != next.started_at
+        || existing.owner != next.owner
+    {
+        return false;
+    }
+    matches!(
+        (existing.phase, next.phase),
+        (
+            PersistedBuildPhase::Running,
+            PersistedBuildPhase::Running
+                | PersistedBuildPhase::Cancelling
+                | PersistedBuildPhase::Cancelled
+                | PersistedBuildPhase::Failed
+        ) | (
+            PersistedBuildPhase::Cancelling,
+            PersistedBuildPhase::Cancelling
+                | PersistedBuildPhase::Cancelled
+                | PersistedBuildPhase::Failed
+        )
+    )
 }
 
 fn read_receipt_file(
@@ -293,4 +419,64 @@ fn persist_record(
             source: error,
         }
     })
+}
+
+fn validate_workspace(
+    root: &Path,
+    workspace: &Path,
+    operation_id: &str,
+) -> Result<PathBuf, BuildReceiptError> {
+    validate_plain_directory(workspace, "build operation workspace").map_err(|error| {
+        BuildReceiptError::UnsafeStore {
+            message: error.to_string(),
+        }
+    })?;
+    let canonical = workspace
+        .canonicalize()
+        .map_err(|source| BuildReceiptError::StoreIo {
+            message: format!("failed to canonicalize workspace for operation {operation_id}"),
+            source,
+        })?;
+    if canonical.parent() != Some(root) {
+        return Err(BuildReceiptError::UnsafeStore {
+            message: format!(
+                "workspace {} escaped receipt journal {}",
+                canonical.display(),
+                root.display()
+            ),
+        });
+    }
+    Ok(canonical)
+}
+
+fn remove_workspace_if_present(
+    root: &Path,
+    workspace: &Path,
+    operation_id: &str,
+) -> Result<(), BuildReceiptError> {
+    match std::fs::symlink_metadata(workspace) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            Err(BuildReceiptError::UnsafeStore {
+                message: format!(
+                    "workspace path for operation {operation_id} is not a plain directory"
+                ),
+            })
+        }
+        Ok(_) => {
+            validate_workspace(root, workspace, operation_id)?;
+            std::fs::remove_dir_all(workspace).map_err(|source| BuildReceiptError::StoreIo {
+                message: format!("failed to remove workspace for operation {operation_id}"),
+                source,
+            })?;
+            if let Ok(directory) = std::fs::File::open(root) {
+                let _ = directory.sync_all();
+            }
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(BuildReceiptError::StoreIo {
+            message: format!("failed to inspect workspace for operation {operation_id}"),
+            source,
+        }),
+    }
 }

--- a/src/runtime/src/oci/build/receipt/tests.rs
+++ b/src/runtime/src/oci/build/receipt/tests.rs
@@ -4,8 +4,8 @@ use a3s_box_core::OperationId;
 
 use super::*;
 use crate::oci::build::{
-    execute_recorded_build_plan, inspect_recorded_build_plan, remove_recorded_build_plan,
-    BoxBuildPlan, BuildPlanExecutionError,
+    execute_recorded_build_plan, inspect_recorded_build_plan, inspect_recorded_build_status,
+    remove_recorded_build_plan, BoxBuildPlan, BuildPlanExecutionError,
 };
 use crate::oci::ImageStore;
 
@@ -190,6 +190,177 @@ async fn pending_intent_adopts_output_committed_before_terminal_receipt() {
 }
 
 #[tokio::test]
+async fn supervised_recovery_adopts_the_image_store_commit_gap() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-supervised-output-gap", 'a');
+    let build_plan = plan("disabled");
+    let plan_digest = build_plan.canonical_digest().unwrap();
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    let built =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+    let expected_descriptor = built.output.descriptor.clone();
+    let workspace = journal
+        .prepare_workspace(operation.operation_id())
+        .await
+        .unwrap();
+    std::fs::write(workspace.join("uncommitted"), "partial").unwrap();
+    let active = SupervisedBuildOperation::new(&operation, plan_digest).unwrap();
+    let mut active_bytes = serde_json::to_vec_pretty(&active).unwrap();
+    active_bytes.push(b'\n');
+    std::fs::write(journal.receipt_path(operation.operation_id()), active_bytes).unwrap();
+    std::fs::remove_dir_all(&source).unwrap();
+    drop(store);
+
+    let reopened = ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap();
+    let recovered = inspect_recorded_build_status(&operation, &build_plan, &reopened)
+        .await
+        .unwrap()
+        .expect("committed output is terminal");
+    let RecordedBuildStatus::Succeeded(recovered) = recovered else {
+        panic!("committed ImageStore output must win the receipt gap");
+    };
+    assert_eq!(recovered.output.descriptor, expected_descriptor);
+    assert!(!journal.workspace_path(operation.operation_id()).exists());
+    let committed =
+        std::fs::read_to_string(journal.receipt_path(operation.operation_id())).unwrap();
+    assert!(committed.contains(BuildOutputReceipt::SCHEMA));
+    assert!(!committed.contains(SupervisedBuildOperation::SCHEMA));
+}
+
+#[tokio::test]
+async fn live_operation_inspection_is_nonblocking_and_cancellation_is_one_state_transition() {
+    let temporary = tempfile::tempdir().unwrap();
+    let store_root = temporary.path().join("images");
+    let operation = identity("cloud-build-live-supervision", 'a');
+    let build_plan = plan("disabled");
+    let plan_digest = build_plan.canonical_digest().unwrap();
+    let store = ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap();
+    let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    let locked = journal.lock(operation.operation_id()).await.unwrap();
+    let lease = journal
+        .try_execution_lease(operation.operation_id())
+        .await
+        .unwrap()
+        .expect("test owns the execution lease");
+    let workspace = journal
+        .prepare_workspace(operation.operation_id())
+        .await
+        .unwrap();
+    std::fs::write(workspace.join("partial"), "uncommitted").unwrap();
+    locked
+        .write_supervised(SupervisedBuildOperation::new(&operation, plan_digest.clone()).unwrap())
+        .await
+        .unwrap();
+    drop(locked);
+
+    let inspected = tokio::time::timeout(
+        std::time::Duration::from_millis(250),
+        inspect_recorded_build_status(&operation, &build_plan, &store),
+    )
+    .await
+    .expect("inspection must not wait for the live execution lease")
+    .unwrap();
+    assert!(matches!(inspected, Some(RecordedBuildStatus::Running)));
+
+    assert_eq!(
+        crate::oci::build::cancel_recorded_build_plan(&operation, &build_plan, &store)
+            .await
+            .unwrap(),
+        BuildCancellationOutcome::Requested
+    );
+    assert!(matches!(
+        inspect_recorded_build_status(&operation, &build_plan, &store)
+            .await
+            .unwrap(),
+        Some(RecordedBuildStatus::Cancelling)
+    ));
+
+    drop(lease);
+    assert!(matches!(
+        inspect_recorded_build_status(&operation, &build_plan, &store)
+            .await
+            .unwrap(),
+        Some(RecordedBuildStatus::Cancelled { .. })
+    ));
+    assert!(!journal.workspace_path(operation.operation_id()).exists());
+    let persisted =
+        std::fs::read_to_string(journal.receipt_path(operation.operation_id())).unwrap();
+    assert!(persisted.contains(SupervisedBuildOperation::SCHEMA));
+    assert!(!persisted.contains(PendingBuildOperation::SCHEMA));
+}
+
+#[tokio::test]
+async fn abandoned_operation_reclaims_workspace_and_becomes_failed() {
+    let temporary = tempfile::tempdir().unwrap();
+    let store_root = temporary.path().join("images");
+    let operation = identity("cloud-build-abandoned-supervision", 'a');
+    let build_plan = plan("disabled");
+    let store = ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap();
+    let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    let workspace = journal
+        .prepare_workspace(operation.operation_id())
+        .await
+        .unwrap();
+    std::fs::create_dir_all(workspace.join("rootfs_0")).unwrap();
+    std::fs::write(workspace.join("rootfs_0/partial"), "partial").unwrap();
+    let locked = journal.lock(operation.operation_id()).await.unwrap();
+    locked
+        .write_supervised(
+            SupervisedBuildOperation::new(&operation, build_plan.canonical_digest().unwrap())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    drop(locked);
+
+    let status = inspect_recorded_build_status(&operation, &build_plan, &store)
+        .await
+        .unwrap();
+    assert!(matches!(status, Some(RecordedBuildStatus::Failed { .. })));
+    assert!(!journal.workspace_path(operation.operation_id()).exists());
+    assert!(store.get(operation.output_reference()).await.is_none());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn operation_workspace_rejects_a_symlink_without_touching_its_target() {
+    let temporary = tempfile::tempdir().unwrap();
+    let store_root = temporary.path().join("images");
+    let outside = temporary.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("keep"), "keep").unwrap();
+    let operation = identity("cloud-build-workspace-symlink", 'a');
+    let store = ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap();
+    let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    std::os::unix::fs::symlink(&outside, journal.workspace_path(operation.operation_id())).unwrap();
+
+    let error = journal
+        .prepare_workspace(operation.operation_id())
+        .await
+        .unwrap_err();
+    assert!(matches!(error, BuildReceiptError::UnsafeStore { .. }));
+    assert_eq!(
+        std::fs::read_to_string(outside.join("keep")).unwrap(),
+        "keep"
+    );
+}
+
+#[tokio::test]
 async fn recorded_build_rejects_operation_identity_drift_before_source_access() {
     let temporary = tempfile::tempdir().unwrap();
     let source = temporary.path().join("source");
@@ -292,7 +463,7 @@ async fn replay_refreshes_the_single_image_store_authority_across_instances() {
 }
 
 #[tokio::test]
-async fn failed_build_keeps_immutable_intent_until_idempotent_cleanup() {
+async fn failed_build_persists_one_terminal_state_until_idempotent_cleanup() {
     let temporary = tempfile::tempdir().unwrap();
     let source = temporary.path().join("source");
     let store_root = temporary.path().join("images");
@@ -313,11 +484,19 @@ async fn failed_build_keeps_immutable_intent_until_idempotent_cleanup() {
         execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
             .await
             .unwrap_err();
-    assert!(matches!(failure, BuildPlanExecutionError::Build(_)));
+    assert!(matches!(failure, BuildPlanExecutionError::Failed { .. }));
 
     let persisted =
         std::fs::read_to_string(receipts.receipt_path(operation.operation_id())).unwrap();
-    assert!(persisted.contains(PendingBuildOperation::SCHEMA));
+    assert!(persisted.contains(SupervisedBuildOperation::SCHEMA));
+    assert!(persisted.contains("\"phase\": \"failed\""));
+    assert!(!receipts.workspace_path(operation.operation_id()).exists());
+    assert!(matches!(
+        inspect_recorded_build_status(&operation, &build_plan, &store)
+            .await
+            .unwrap(),
+        Some(RecordedBuildStatus::Failed { .. })
+    ));
     assert!(inspect_recorded_build_plan(&operation, &build_plan, &store)
         .await
         .unwrap()

--- a/src/runtime/src/oci/mod.rs
+++ b/src/runtime/src/oci/mod.rs
@@ -39,12 +39,13 @@ pub mod store;
 
 #[cfg(feature = "build")]
 pub use build::{
-    execute_recorded_build_plan, inspect_recorded_build_plan, remove_recorded_build_plan,
-    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildConfig,
-    BuildNetworkPolicy, BuildOperationIdentity, BuildOutputDescriptor, BuildOutputReceipt,
-    BuildPlanExecutionError, BuildReceiptError, BuildReceiptOutput, BuildResult,
-    BuildRunPoolConfig, Dockerfile, Instruction, RecordedBuildResult,
-    OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    cancel_recorded_build_plan, execute_recorded_build_plan, inspect_recorded_build_plan,
+    inspect_recorded_build_status, remove_recorded_build_plan, start_recorded_build_plan,
+    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildCancellationOutcome,
+    BuildConfig, BuildNetworkPolicy, BuildOperationIdentity, BuildOutputDescriptor,
+    BuildOutputReceipt, BuildPlanExecutionError, BuildReceiptError, BuildReceiptOutput,
+    BuildResult, BuildRunPoolConfig, Dockerfile, Instruction, RecordedBuildResult,
+    RecordedBuildStatus, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 pub use credentials::CredentialStore;
 pub use image::{OciHealthCheck, OciImage, OciImageConfig};


### PR DESCRIPTION
## Summary

- extend the existing BuildOperationJournal into the sole recorded-build state machine for typed start, nonblocking inspection, cancellation, failure, success, replay, and cleanup
- keep the existing native build engine as the sole executor and ImageStore as the sole image authority
- add one crash-released execution lease as liveness evidence without persisting a second state copy
- serialize cancellation and ImageStore publication with the existing journal lock so the commit order is linear and recoverable
- run Linux Dockerfile RUN through one asynchronous supervised subprocess boundary with kill-on-drop, parent-death fencing, PID/start-time journaling, cancellation, and reap
- recover abandoned operation workspaces and adopt ImageStore outputs committed before the terminal receipt
- add CI architecture gates that reject a second build store, queue, scheduler, persistence boundary, workspace cleanup authority, image commit boundary, or RUN subprocess boundary

## Single-authority design

- lifecycle state: BuildOperationJournal only
- execution: native Box build engine only
- image ownership: ImageStore only
- cancellation and image commit ordering: existing journal lock only
- task liveness: FileLock execution lease only; it contains no domain state
- workspace cleanup: receipt/journal.rs only
- orchestration: no Box queue or scheduler; Cloud must continue to use its existing Fleet queue

The compatibility execute_recorded_build_plan API waits on the same typed state machine and does not own another execution or receipt path. Legacy pending and success receipts remain states in that same journal.

## Validation

- cargo test -p a3s-box-runtime: 1490 passed, 1 ignored; doc tests 1 passed, 2 ignored
- cargo test -p a3s-box-runtime receipt: 14 passed
- image commit permit cancellation race test: passed
- cargo clippy -p a3s-box-runtime --all-targets -- -D warnings
- A3S_DEPS_STUB=1 cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p a3s-box-cli build: 39 unit tests and the scratch build smoke passed
- cargo check -p a3s-box-sdk --all-targets
- cargo fmt --all -- --check
- git diff --check
- the new single-authority CI script passed locally against the staged tree

## Scope

This advances BX0.4 in #172. Content-addressed cache receipts, multi-platform OCI assembly, Cloud Node Agent consumption, publication, and SPDX/SLSA evidence remain later gates and must extend these existing authorities rather than introduce parallel mechanisms.