### PR TITLE
feat(build): export content-addressed cache receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,9 +134,16 @@ jobs:
             'BuildOperation'"Queue"
             'Build'"Scheduler"
             'BuildImage'"Store"
+            'BuildCache'"Store"
+            'BuildCache'"Service"
+            'BuildCache'"Queue"
+            'BuildCache'"Scheduler"
+            'CacheExport'"Store"
+            'CacheExport'"Publisher"
             'build-operations.'"json"
             'build-jobs.'"json"
             'build-queue.'"json"
+            'build-cache-exports.'"json"
           )
           found=0
           for pattern in "${removed_patterns[@]}"; do
@@ -176,11 +183,26 @@ jobs:
             'fn persist_record(' \
             'src/runtime/src/oci/build/receipt/journal.rs'
           require_single_authority \
-            'fn remove_workspace_if_present(' \
+            'fn remove_operation_directory_if_present(' \
+            'src/runtime/src/oci/build/receipt/journal.rs'
+          require_single_authority \
+            'pub(crate) struct BuildCache {' \
+            'src/runtime/src/oci/build/cache.rs'
+          require_single_authority \
+            'pub(in crate::oci::build) fn stage_export(' \
+            'src/runtime/src/oci/build/cache/export.rs'
+          require_single_authority \
+            'pub(in crate::oci::build) async fn publish_cache_export(' \
+            'src/runtime/src/oci/build/receipt/journal.rs'
+          require_single_authority \
+            'pub(in crate::oci::build) async fn cleanup_cache_export(' \
             'src/runtime/src/oci/build/receipt/journal.rs'
           require_single_authority \
             'fn spawn_supervised_build(' \
             'src/runtime/src/oci/build/execution.rs'
+          require_single_authority \
+            'pub(super) struct JournalBuildObserver {' \
+            'src/runtime/src/oci/build/execution/supervision.rs'
           require_single_authority \
             'store.put(reference' \
             'src/runtime/src/oci/build/engine/mod.rs'
@@ -191,6 +213,7 @@ jobs:
           if git grep -n -I -E \
             '(tokio|std)::sync::(mpsc|broadcast|watch)|\b(VecDeque|BinaryHeap)\b' -- \
             src/runtime/src/oci/build/execution.rs \
+            src/runtime/src/oci/build/execution/supervision.rs \
             src/runtime/src/oci/build/receipt.rs \
             src/runtime/src/oci/build/receipt/journal.rs \
             src/runtime/src/oci/build/engine/control.rs; then

--- a/README.md
+++ b/README.md
@@ -174,17 +174,22 @@ runtime state changes instead of being silently stored or weakened.
   same native build engine. The sole recorded-plan boundary persists immutable
   operation, source, and plan identity in one ImageStore-derived journal and
   exposes typed start, nonblocking inspect, cancel, exact replay, and terminal
-  cleanup. A crash-released execution lease distinguishes live work from a
-  dead caller without becoming another state store. Every supervised build uses
-  a hash-derived operation workspace below that journal; cancellation, failure,
-  and caller-death recovery fence the current Linux `RUN` process tree before
-  reclaiming it. Restarted callers adopt an output committed before the
-  terminal receipt and revalidate the complete OCI graph, platform, blob
-  inventory, and byte count before replay. The journal, native engine, and
-  ImageStore remain the only lifecycle, execution, and image authorities. The
-  CLI exposes only this native engine: Linux `RUN` uses the isolated local path
-  and macOS uses the same engine through `--run-pool`; publication remains the
-  separate `a3s-box push` image operation.
+  cleanup. Content-addressed plans also export one portable Box-native OCI
+  cache artifact from the existing `BuildCache`; the cache key binds source,
+  plan, platform, and cache-schema semantics. The operation record persists
+  the admitted cache policy, and replay validates the exact cache manifest,
+  config, layers, blob inventory, and byte count. A crash-released execution
+  lease distinguishes live work from a dead caller without becoming another
+  state store. Every supervised build uses a hash-derived operation workspace
+  below that journal; cancellation, failure, and caller-death recovery fence
+  the current Linux `RUN` process tree before reclaiming it. The existing
+  journal lock orders cache publication, cancellation, and ImageStore
+  publication, so restarted callers can adopt both artifacts committed before
+  the terminal receipt. The journal, native engine, `BuildCache`, and
+  ImageStore remain the only lifecycle, execution, cache, and image
+  authorities. The CLI exposes only this native engine: Linux `RUN` uses the
+  isolated local path and macOS uses the same engine through `--run-pool`;
+  publication remains the separate `a3s-box push` image operation.
 - **Storage** — bind mounts, named volumes, tmpfs, file copy, diff, export,
   commit, filesystem snapshots, copy-on-write restore, and Box-owned read-only
   aliases for caller-provided Artifact trees below private provider roots.

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -392,10 +392,23 @@ Current notes:
   is the commit point: a restarted caller refreshes its authoritative
   cross-process index, adopts output committed in the output-to-terminal-receipt
   crash gap, and replays without reopening the source tree. Cleanup removes the
-  workspace, receipt, and operation-specific image reference idempotently.
-  Cache import/export receipts and multi-platform assembly remain the Box build
-  release gates; Cloud consumption, publication, and SPDX/SLSA evidence remain
-  integration gates.
+  workspace, receipt, operation-specific cache export, and image reference
+  idempotently.
+- Content-addressed plans now export one portable Box-native OCI cache artifact
+  from the existing `BuildCache`. One trace spans native cache hits and stores;
+  no second cache service, queue, scheduler, publisher, or lifecycle store was
+  added. The operation-derived journal path owns the immutable export snapshot,
+  and the existing journal lock orders its publication before the ImageStore
+  commit. The cache key binds source digest, canonical plan digest, platform,
+  and cache-schema semantics. Recovery adopts the cache and image together
+  across the terminal-receipt crash gap, while replay revalidates the exact OCI
+  entries, manifest, config, layer bytes, descriptor sizes, blob inventory, and
+  content bytes. The v2 operation record durably enforces that new
+  `content-addressed` plans contain cache evidence and `disabled` plans do not;
+  legacy v1 records remain readable without cache evidence.
+- Typed cache import and hydration plus multi-platform assembly remain the Box
+  build release gates; Cloud consumption, publication, and SPDX/SLSA evidence
+  remain integration gates.
 - Dockerfile `RUN` no longer has any silent skip path on unsupported hosts.
   The native engine uses isolated `chroot` on Linux and an isolated
   warm-pool VM lease path via `--run-pool`, which mounts each mutable build

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -150,12 +150,26 @@ asynchronous subprocess boundary with kill-on-drop, a parent-death signal, a
 private PID namespace, and a journaled PID/start-time identity. Recovery fences
 that process tree before removing the hash-derived operation workspace.
 The existing journal lock serializes cancellation with ImageStore publication;
-publication is the commit point, so recovery adopts and validates an output
-written in the output-to-receipt crash gap instead of publishing it again.
+content-addressed plans use that same permit to publish one operation-owned
+Box-native OCI cache artifact before the ImageStore commit. One trace records
+hits and stores from the existing `BuildCache`; there is no export cache,
+publisher, or cache lifecycle store alongside it. Export layers are copied
+into an immutable snapshot so receipt validation and cleanup cannot mutate the
+live cache authority through shared inodes.
 
-This completes the Box-owned `BX0.4` supervision slice. Content-addressed cache
-receipts, multi-platform OCI assembly, Cloud Node Agent consumption,
-publication, and end-to-end SPDX/SLSA signing evidence remain separate gates.
+The cache key length-binds the source digest, canonical plan digest, platform,
+and cache schema profile. The v2 supervised operation record persists the
+admitted cache policy: a new `content-addressed` operation must commit cache
+evidence, while a `disabled` operation must not. Legacy v1 operation and output
+records remain readable without cache evidence. Replay rejects extra,
+missing, symlinked, or changed cache entries and revalidates the manifest,
+config, layers, descriptor sizes, exact blob inventory, and byte count before
+returning the cache receipt.
+
+This completes the Box-owned `BX0.4` supervision and portable cache-export
+receipt slices. Typed cache import and hydration, multi-platform OCI assembly,
+Cloud Node Agent consumption, publication, and end-to-end SPDX/SLSA signing
+evidence remain separate gates.
 
 ## Components
 

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -149,11 +149,12 @@ pub use volume::VolumeStore;
 pub use oci::{
     cancel_recorded_build_plan, execute_recorded_build_plan, inspect_recorded_build_plan,
     inspect_recorded_build_status, remove_recorded_build_plan, start_recorded_build_plan,
-    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildCancellationOutcome,
-    BuildConfig, BuildNetworkPolicy, BuildOperationIdentity, BuildOutputDescriptor,
-    BuildOutputReceipt, BuildPlanExecutionError, BuildReceiptError, BuildReceiptOutput,
-    BuildResult, BuildRunPoolConfig, Dockerfile, Instruction, RecordedBuildResult,
-    RecordedBuildStatus, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildCacheReceipt,
+    BuildCancellationOutcome, BuildConfig, BuildNetworkPolicy, BuildOperationIdentity,
+    BuildOutputDescriptor, BuildOutputReceipt, BuildPlanExecutionError, BuildReceiptError,
+    BuildReceiptOutput, BuildResult, BuildRunPoolConfig, Dockerfile, Instruction,
+    RecordedBuildCache, RecordedBuildResult, RecordedBuildStatus, BUILD_CACHE_ARTIFACT_MEDIA_TYPE,
+    BUILD_CACHE_CONFIG_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 
 #[cfg(feature = "compose")]

--- a/src/runtime/src/oci/build/cache.rs
+++ b/src/runtime/src/oci/build/cache.rs
@@ -22,6 +22,14 @@ use serde::{Deserialize, Serialize};
 
 use super::layer::{sha256_bytes, sha256_file, LayerInfo};
 
+mod export;
+
+pub(super) use export::{inspect_build_cache_export, BuildCacheExportIdentity, BuildCacheTrace};
+pub use export::{
+    BuildCacheReceipt, RecordedBuildCache, BUILD_CACHE_ARTIFACT_MEDIA_TYPE,
+    BUILD_CACHE_CONFIG_MEDIA_TYPE,
+};
+
 /// Per-process counter for unique staging-file names in `store`.
 static STORE_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -47,6 +55,7 @@ struct KeyRecord {
 }
 
 /// A cache hit: a previously produced layer that can be reused.
+#[derive(Debug, Clone)]
 pub(crate) struct CachedLayer {
     /// Path to the cached layer tar.gz blob.
     pub(crate) blob_path: PathBuf,
@@ -79,6 +88,10 @@ impl BuildCache {
         Some(Self { dir })
     }
 
+    fn lock(&self) -> std::io::Result<crate::file_lock::FileLock> {
+        crate::file_lock::FileLock::acquire(&self.dir.join("cache"))
+    }
+
     /// Compute the next chain key from the previous key, the canonical
     /// instruction representation, and an optional input hash.
     ///
@@ -106,6 +119,11 @@ impl BuildCache {
     /// Returns the cached layer only if its key record exists and the
     /// referenced blob is a regular file with the recorded size and digest.
     pub(crate) fn lookup(&self, key: &str) -> Option<CachedLayer> {
+        let _lock = self.lock().ok()?;
+        self.lookup_unlocked(key)
+    }
+
+    fn lookup_unlocked(&self, key: &str) -> Option<CachedLayer> {
         let key_path = self.dir.join("keys").join(key);
         let bytes = std::fs::read(&key_path).ok()?;
         let record: KeyRecord = serde_json::from_slice(&bytes).ok()?;
@@ -129,6 +147,13 @@ impl BuildCache {
     /// absent or invalid, then writes the `keys/<key>` record. Best-effort: I/O
     /// errors are ignored.
     pub(crate) fn store(&self, key: &str, layer: &LayerInfo, diff_id: &str) {
+        let Ok(_lock) = self.lock() else {
+            return;
+        };
+        self.store_unlocked(key, layer, diff_id);
+    }
+
+    fn store_unlocked(&self, key: &str, layer: &LayerInfo, diff_id: &str) {
         if !cached_blob_is_valid(&layer.path, &layer.digest, layer.size) {
             return;
         }
@@ -171,17 +196,27 @@ impl BuildCache {
             size: layer.size,
         };
         if let Ok(bytes) = serde_json::to_vec(&record) {
-            let _ = std::fs::write(self.dir.join("keys").join(key), bytes);
+            let target = self.dir.join("keys").join(key);
+            let temporary = target.with_extension("tmp");
+            let _ = a3s_box_core::fs_atomic::write_durable(&temporary, &target, &bytes);
         }
 
-        self.prune_to(configured_max_bytes());
+        self.prune_to_unlocked(configured_max_bytes());
     }
 
     /// Evict oldest layer blobs (by modification time) until the total blob
     /// size is at or below `cap` bytes. Best-effort; key records that point at
     /// an evicted blob simply miss on the next lookup (and the instruction is
     /// re-run), so eviction can never corrupt a build.
+    #[cfg(test)]
     fn prune_to(&self, cap: u64) {
+        let Ok(_lock) = self.lock() else {
+            return;
+        };
+        self.prune_to_unlocked(cap);
+    }
+
+    fn prune_to_unlocked(&self, cap: u64) {
         let blobs_dir = self.dir.join("blobs");
         let Ok(read_dir) = std::fs::read_dir(&blobs_dir) else {
             return;
@@ -317,215 +352,4 @@ fn collect_files(root: &Path, current: &Path, out: &mut Vec<(PathBuf, PathBuf)>)
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use tempfile::TempDir;
-
-    /// Test constructor: open a cache at an explicit directory.
-    fn open_at(dir: &Path) -> BuildCache {
-        BuildCache::open_in(dir.to_path_buf()).expect("open build cache at temp dir")
-    }
-
-    #[test]
-    fn test_chain_is_deterministic() {
-        let a = BuildCache::chain("prev", "RUN echo hi", None);
-        let b = BuildCache::chain("prev", "RUN echo hi", None);
-        assert_eq!(a, b);
-        assert_eq!(a.len(), 64); // SHA256 hex
-    }
-
-    #[test]
-    fn test_chain_is_order_sensitive() {
-        // Different repr -> different key.
-        let a = BuildCache::chain("prev", "RUN echo a", None);
-        let b = BuildCache::chain("prev", "RUN echo b", None);
-        assert_ne!(a, b);
-
-        // Different prev key -> different key (order of instructions matters).
-        let c = BuildCache::chain("prev1", "RUN echo a", None);
-        let d = BuildCache::chain("prev2", "RUN echo a", None);
-        assert_ne!(c, d);
-    }
-
-    #[test]
-    fn test_chain_input_hash_changes_key() {
-        let none = BuildCache::chain("prev", "COPY . /app", None);
-        let some = BuildCache::chain("prev", "COPY . /app", Some("deadbeef"));
-        assert_ne!(none, some);
-
-        let other = BuildCache::chain("prev", "COPY . /app", Some("cafebabe"));
-        assert_ne!(some, other);
-    }
-
-    #[test]
-    fn test_store_then_lookup_round_trips() {
-        let tmp = TempDir::new().unwrap();
-        let cache_dir = tmp.path().join("buildcache");
-        let cache = open_at(&cache_dir);
-
-        // Create a fake layer blob to be cached.
-        let layer_path = tmp.path().join("layer.tar.gz");
-        let contents = b"fake layer contents";
-        fs::write(&layer_path, contents).unwrap();
-        let layer = LayerInfo {
-            path: layer_path,
-            digest: sha256_bytes(contents),
-            size: contents.len() as u64,
-        };
-
-        let key = BuildCache::chain("", "RUN echo hi", None);
-        assert!(cache.lookup(&key).is_none());
-
-        cache.store(&key, &layer, "diff-id-xyz");
-
-        let hit = cache
-            .lookup(&key)
-            .expect("expected a cache hit after store");
-        assert_eq!(hit.digest, sha256_bytes(contents));
-        assert_eq!(hit.diff_id, "diff-id-xyz");
-        assert_eq!(hit.size, contents.len() as u64);
-        assert!(hit.blob_path.exists());
-        assert_eq!(fs::read(&hit.blob_path).unwrap(), b"fake layer contents");
-    }
-
-    #[test]
-    fn prune_evicts_orphan_key_records() {
-        let tmp = TempDir::new().unwrap();
-        let cache_dir = tmp.path().join("buildcache");
-        let cache = open_at(&cache_dir);
-
-        let layer_path = tmp.path().join("layer.tar.gz");
-        let contents = vec![0u8; 4096];
-        fs::write(&layer_path, &contents).unwrap();
-        let layer = LayerInfo {
-            path: layer_path,
-            digest: sha256_bytes(&contents),
-            size: 4096,
-        };
-        let key = BuildCache::chain("", "RUN make", None);
-        cache.store(&key, &layer, "diff");
-
-        let blob = cache_dir.join("blobs").join(&layer.digest);
-        let key_file = cache_dir.join("keys").join(&key);
-        assert!(blob.exists() && key_file.exists());
-
-        // Force the cache under the blob size: evicts the blob AND prunes its
-        // now-dangling key record (previously the key file leaked forever).
-        cache.prune_to(0);
-        assert!(!blob.exists(), "blob should be evicted");
-        assert!(!key_file.exists(), "orphaned key record should be pruned");
-    }
-
-    #[test]
-    fn test_lookup_misses_when_blob_removed() {
-        let tmp = TempDir::new().unwrap();
-        let cache = open_at(&tmp.path().join("buildcache"));
-
-        let layer_path = tmp.path().join("layer.tar.gz");
-        let contents = b"data";
-        fs::write(&layer_path, contents).unwrap();
-        let layer = LayerInfo {
-            path: layer_path,
-            digest: sha256_bytes(contents),
-            size: contents.len() as u64,
-        };
-        let key = BuildCache::chain("", "RUN x", None);
-        cache.store(&key, &layer, "diff");
-
-        // Remove the blob; the key record remains but lookup must miss.
-        fs::remove_file(tmp.path().join("buildcache/blobs").join(&layer.digest)).unwrap();
-        assert!(cache.lookup(&key).is_none());
-    }
-
-    #[test]
-    fn test_lookup_rejects_and_store_repairs_corrupt_blob() {
-        let tmp = TempDir::new().unwrap();
-        let cache_dir = tmp.path().join("buildcache");
-        let cache = open_at(&cache_dir);
-        let contents = b"verified layer";
-        let layer_path = tmp.path().join("layer.tar.gz");
-        fs::write(&layer_path, contents).unwrap();
-        let layer = LayerInfo {
-            path: layer_path,
-            digest: sha256_bytes(contents),
-            size: contents.len() as u64,
-        };
-        let key = BuildCache::chain("", "COPY value /value", None);
-        cache.store(&key, &layer, "diff");
-
-        let blob = cache_dir.join("blobs").join(&layer.digest);
-        fs::write(&blob, b"corrupted data").unwrap();
-        assert!(cache.lookup(&key).is_none());
-
-        cache.store(&key, &layer, "diff");
-        assert_eq!(fs::read(&blob).unwrap(), contents);
-        assert!(cache.lookup(&key).is_some());
-    }
-
-    #[test]
-    fn test_hash_context_sources_detects_change() {
-        let ctx = TempDir::new().unwrap();
-        fs::write(ctx.path().join("a.txt"), "hello").unwrap();
-        fs::create_dir(ctx.path().join("sub")).unwrap();
-        fs::write(ctx.path().join("sub/b.txt"), "world").unwrap();
-
-        let srcs = vec![".".to_string()];
-        let h1 = hash_context_sources(ctx.path(), &srcs).unwrap();
-        let h2 = hash_context_sources(ctx.path(), &srcs).unwrap();
-        assert_eq!(h1, h2, "stable hash for unchanged content");
-
-        // Change a file -> different hash.
-        fs::write(ctx.path().join("a.txt"), "HELLO").unwrap();
-        let h3 = hash_context_sources(ctx.path(), &srcs).unwrap();
-        assert_ne!(h1, h3, "changed content must change the hash");
-    }
-
-    #[test]
-    fn test_prune_evicts_until_under_cap() {
-        let tmp = TempDir::new().unwrap();
-        let cache = open_at(&tmp.path().join("buildcache"));
-
-        // Store three ~100-byte blobs under distinct keys/digests.
-        for i in 0..3 {
-            let payload = vec![b'x' + i as u8; 100];
-            let src = tmp.path().join(format!("src{i}"));
-            fs::write(&src, &payload).unwrap();
-            let layer = LayerInfo {
-                path: src,
-                digest: sha256_bytes(&payload),
-                size: payload.len() as u64,
-            };
-            cache.store(
-                &BuildCache::chain("", &format!("RUN step {i}"), None),
-                &layer,
-                "d",
-            );
-        }
-
-        let blobs_dir = tmp.path().join("buildcache/blobs");
-        let total = |dir: &Path| -> u64 {
-            fs::read_dir(dir)
-                .unwrap()
-                .flatten()
-                .map(|e| e.metadata().unwrap().len())
-                .sum()
-        };
-        assert_eq!(total(&blobs_dir), 300, "three blobs stored");
-
-        // Cap at 150 bytes: prune must leave the total at or below the cap.
-        cache.prune_to(150);
-        assert!(
-            total(&blobs_dir) <= 150,
-            "prune must bring total under the cap"
-        );
-        assert!(total(&blobs_dir) > 0, "prune must keep what fits");
-    }
-
-    #[test]
-    fn test_hash_context_sources_missing_source_is_none() {
-        let ctx = TempDir::new().unwrap();
-        let srcs = vec!["does-not-exist".to_string()];
-        assert!(hash_context_sources(ctx.path(), &srcs).is_none());
-    }
-}
+mod tests;

--- a/src/runtime/src/oci/build/cache/export.rs
+++ b/src/runtime/src/oci/build/cache/export.rs
@@ -1,0 +1,496 @@
+//! Portable OCI artifact emitted by the native layer-cache authority.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::str::FromStr;
+
+use a3s_box_core::error::{BoxError, Result};
+use a3s_box_core::platform::Platform;
+use oci_spec::image::{
+    Arch, Descriptor, DescriptorBuilder, ImageIndex, ImageIndexBuilder, ImageManifest,
+    ImageManifestBuilder, MediaType, Os, PlatformBuilder, Sha256Digest, SCHEMA_VERSION,
+};
+use serde::{Deserialize, Serialize};
+
+use super::{cached_blob_is_valid, BuildCache, CachedLayer};
+use crate::oci::build::layer::sha256_bytes;
+use crate::oci::build::layout::{
+    metadata_bytes, validate_blob_inventory, validate_exact_entries, EntryKind,
+};
+use crate::oci::build::BuildOutputDescriptor;
+use crate::oci::image::{
+    canonical_sha256_digest_hex, read_regular_file_bounded, read_verified_oci_blob,
+    verify_oci_blob_file, MAX_OCI_CONFIG_BYTES, MAX_OCI_INDEX_BYTES, MAX_OCI_LAYER_BLOB_BYTES,
+    MAX_OCI_MANIFEST_BYTES,
+};
+
+pub const BUILD_CACHE_ARTIFACT_MEDIA_TYPE: &str = "application/vnd.a3s.box.build-cache.v1";
+pub const BUILD_CACHE_CONFIG_MEDIA_TYPE: &str =
+    "application/vnd.a3s.box.build-cache.config.v1+json";
+
+const CACHE_CONFIG_SCHEMA: &str = "a3s.box.build-cache-config.v1";
+const MAX_CACHE_ENTRIES: usize = 16 * 1024;
+
+mod model;
+#[cfg(test)]
+mod tests;
+
+pub(in crate::oci::build) use model::BuildCacheExportIdentity;
+pub use model::{BuildCacheReceipt, RecordedBuildCache};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CacheEntry {
+    key: String,
+    layer: BuildOutputDescriptor,
+    diff_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CacheConfig {
+    schema: String,
+    key: String,
+    source_digest: String,
+    plan_digest: String,
+    platform: Platform,
+    entries: Vec<CacheEntry>,
+}
+
+/// Exact layer keys observed through the one native cache implementation.
+#[derive(Debug, Default)]
+pub(in crate::oci::build) struct BuildCacheTrace {
+    entries: BTreeMap<String, CacheEntry>,
+}
+
+impl BuildCacheTrace {
+    pub(in crate::oci::build) fn record(
+        &mut self,
+        raw_key: &str,
+        layer: &CachedLayer,
+    ) -> Result<()> {
+        let key = prefixed_digest(raw_key, "native cache chain key")?;
+        let entry = CacheEntry {
+            key,
+            layer: BuildOutputDescriptor {
+                media_type: MediaType::ImageLayerGzip.as_ref().to_string(),
+                digest: prefixed_digest(&layer.digest, "native cache layer digest")?,
+                size: layer.size,
+            },
+            diff_id: prefixed_digest(&layer.diff_id, "native cache diff ID")?,
+        };
+        if let Some(existing) = self.entries.insert(raw_key.to_string(), entry.clone()) {
+            if existing != entry {
+                return Err(cache_error(
+                    "one native cache chain key resolved to conflicting content",
+                ));
+            }
+        }
+        if self.entries.len() > MAX_CACHE_ENTRIES {
+            return Err(cache_error("native build cache entry bound was exceeded"));
+        }
+        Ok(())
+    }
+}
+
+impl BuildCache {
+    pub(in crate::oci::build) fn stage_export(
+        &self,
+        trace: &BuildCacheTrace,
+        identity: &BuildCacheExportIdentity,
+        staging: &Path,
+    ) -> Result<RecordedBuildCache> {
+        let _lock = self
+            .lock()
+            .map_err(|error| cache_error(format!("failed to lock native cache: {error}")))?;
+        match std::fs::symlink_metadata(staging) {
+            Ok(_) => {
+                return Err(cache_error(
+                    "native cache export staging path already exists",
+                ))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(cache_error(format!(
+                    "failed to inspect native cache export staging path: {error}"
+                )))
+            }
+        }
+        let blob_root = staging.join("blobs").join("sha256");
+        std::fs::create_dir_all(&blob_root).map_err(|error| {
+            cache_error(format!("failed to create native cache export: {error}"))
+        })?;
+
+        let mut entries = Vec::with_capacity(trace.entries.len());
+        let mut layers = BTreeMap::<String, Descriptor>::new();
+        for (raw_key, expected) in &trace.entries {
+            let actual = self.lookup_unlocked(raw_key).ok_or_else(|| {
+                cache_error(format!(
+                    "native cache entry {} disappeared before export",
+                    expected.key
+                ))
+            })?;
+            let actual_entry = CacheEntry {
+                key: expected.key.clone(),
+                layer: BuildOutputDescriptor {
+                    media_type: MediaType::ImageLayerGzip.as_ref().to_string(),
+                    digest: prefixed_digest(&actual.digest, "native cache layer digest")?,
+                    size: actual.size,
+                },
+                diff_id: prefixed_digest(&actual.diff_id, "native cache diff ID")?,
+            };
+            if &actual_entry != expected {
+                return Err(cache_error(format!(
+                    "native cache entry {} changed before export",
+                    expected.key
+                )));
+            }
+            let target = blob_root.join(&actual.digest);
+            if !target.exists() {
+                // The export is operation-owned evidence, not another view of
+                // the mutable BuildCache authority. A copy prevents replay
+                // validation, publication, or cleanup from mutating the cache
+                // blob through a shared inode.
+                std::fs::copy(&actual.blob_path, &target).map_err(|error| {
+                    cache_error(format!(
+                        "failed to copy native cache layer {}: {error}",
+                        actual_entry.layer.digest
+                    ))
+                })?;
+            }
+            if !cached_blob_is_valid(&target, &actual.digest, actual.size) {
+                return Err(cache_error(format!(
+                    "exported native cache layer {} failed verification",
+                    actual_entry.layer.digest
+                )));
+            }
+            layers
+                .entry(actual_entry.layer.digest.clone())
+                .or_insert(build_descriptor(
+                    MediaType::ImageLayerGzip,
+                    actual.size,
+                    &actual.digest,
+                )?);
+            entries.push(actual_entry);
+        }
+
+        let config = CacheConfig {
+            schema: CACHE_CONFIG_SCHEMA.to_string(),
+            key: identity.key.clone(),
+            source_digest: identity.source_digest.clone(),
+            plan_digest: identity.plan_digest.clone(),
+            platform: identity.platform.clone(),
+            entries,
+        };
+        let config_bytes = serde_json::to_vec(&config)
+            .map_err(|error| cache_error(format!("failed to encode cache config: {error}")))?;
+        let config_descriptor =
+            write_json_blob(&blob_root, BUILD_CACHE_CONFIG_MEDIA_TYPE, &config_bytes)?;
+        let manifest = ImageManifestBuilder::default()
+            .schema_version(SCHEMA_VERSION)
+            .media_type(MediaType::ImageManifest)
+            .artifact_type(MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
+            .config(config_descriptor)
+            .layers(layers.into_values().collect::<Vec<_>>())
+            .build()
+            .map_err(|error| cache_error(format!("failed to build cache manifest: {error}")))?;
+        let manifest_bytes = serde_json::to_vec(&manifest)
+            .map_err(|error| cache_error(format!("failed to encode cache manifest: {error}")))?;
+        let manifest_hex = sha256_bytes(&manifest_bytes);
+        std::fs::write(blob_root.join(&manifest_hex), &manifest_bytes).map_err(|error| {
+            cache_error(format!("failed to write native cache manifest: {error}"))
+        })?;
+
+        let mut platform = PlatformBuilder::default()
+            .architecture(Arch::from(identity.platform.architecture.as_str()))
+            .os(Os::from(identity.platform.os.as_str()));
+        if let Some(variant) = &identity.platform.variant {
+            platform = platform.variant(variant.clone());
+        }
+        let root_descriptor = DescriptorBuilder::default()
+            .media_type(MediaType::ImageManifest)
+            .artifact_type(MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
+            .digest(parse_digest(&manifest_hex)?)
+            .size(manifest_bytes.len() as u64)
+            .platform(
+                platform
+                    .build()
+                    .map_err(|error| cache_error(format!("invalid cache platform: {error}")))?,
+            )
+            .build()
+            .map_err(|error| cache_error(format!("invalid cache root descriptor: {error}")))?;
+        let index = ImageIndexBuilder::default()
+            .schema_version(SCHEMA_VERSION)
+            .media_type(MediaType::ImageIndex)
+            .artifact_type(MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
+            .manifests(vec![root_descriptor])
+            .build()
+            .map_err(|error| cache_error(format!("failed to build cache index: {error}")))?;
+        std::fs::write(
+            staging.join("index.json"),
+            serde_json::to_vec(&index)
+                .map_err(|error| cache_error(format!("failed to encode cache index: {error}")))?,
+        )
+        .map_err(|error| cache_error(format!("failed to write cache index: {error}")))?;
+        std::fs::write(
+            staging.join("oci-layout"),
+            br#"{"imageLayoutVersion":"1.0.0"}"#,
+        )
+        .map_err(|error| cache_error(format!("failed to write cache layout marker: {error}")))?;
+
+        inspect_build_cache_export(staging, identity, None)
+    }
+}
+
+pub(in crate::oci::build) fn inspect_build_cache_export(
+    root: &Path,
+    identity: &BuildCacheExportIdentity,
+    expected: Option<&BuildCacheReceipt>,
+) -> Result<RecordedBuildCache> {
+    validate_exact_entries(
+        root,
+        &[
+            ("blobs", EntryKind::Directory),
+            ("index.json", EntryKind::File),
+            ("oci-layout", EntryKind::File),
+        ],
+        "native cache OCI layout",
+    )?;
+    validate_exact_entries(
+        &root.join("blobs"),
+        &[("sha256", EntryKind::Directory)],
+        "native cache OCI blob root",
+    )?;
+    let index_bytes =
+        read_regular_file_bounded(&root.join("index.json"), MAX_OCI_INDEX_BYTES, "cache index")?;
+    let index: ImageIndex = serde_json::from_slice(&index_bytes)
+        .map_err(|error| cache_error(format!("native cache index is invalid: {error}")))?;
+    require_index(&index, &identity.platform)?;
+    let root_descriptor = index.manifests()[0].clone();
+    let manifest_bytes = read_descriptor(
+        root,
+        &root_descriptor,
+        MAX_OCI_MANIFEST_BYTES,
+        "cache manifest",
+    )?;
+    let manifest: ImageManifest = serde_json::from_slice(&manifest_bytes)
+        .map_err(|error| cache_error(format!("native cache manifest is invalid: {error}")))?;
+    require_manifest(&manifest)?;
+    let config_bytes = read_descriptor(
+        root,
+        manifest.config(),
+        MAX_OCI_CONFIG_BYTES,
+        "cache config",
+    )?;
+    let config: CacheConfig = serde_json::from_slice(&config_bytes)
+        .map_err(|error| cache_error(format!("native cache config is invalid: {error}")))?;
+    validate_config(&config, identity, manifest.layers())?;
+    for layer in manifest.layers() {
+        verify_descriptor_file(root, layer, "cache layer")?;
+    }
+
+    let mut descriptors = Vec::with_capacity(manifest.layers().len() + 2);
+    descriptors.push(root_descriptor.clone());
+    descriptors.push(manifest.config().clone());
+    descriptors.extend(manifest.layers().iter().cloned());
+    let (blob_count, blob_bytes, blob_inventory_digest) =
+        validate_blob_inventory(root, &descriptors, "Native cache OCI artifact")?;
+    let content_bytes = metadata_bytes(root, "Native cache OCI artifact")?
+        .checked_add(blob_bytes)
+        .ok_or_else(|| cache_error("native cache artifact byte count overflowed"))?;
+    let receipt = BuildCacheReceipt {
+        schema: BuildCacheReceipt::SCHEMA.to_string(),
+        key: identity.key.clone(),
+        source_digest: identity.source_digest.clone(),
+        plan_digest: identity.plan_digest.clone(),
+        descriptor: BuildOutputDescriptor {
+            media_type: root_descriptor.media_type().as_ref().to_string(),
+            digest: root_descriptor.digest().to_string(),
+            size: root_descriptor.size(),
+        },
+        platform: identity.platform.clone(),
+        content_bytes,
+        entry_count: config.entries.len() as u64,
+        blob_count: blob_count as u64,
+        blob_inventory_digest,
+    };
+    receipt.validate()?;
+    if expected.is_some_and(|expected| expected != &receipt) {
+        return Err(cache_error(
+            "revalidated native cache artifact differs from its receipt",
+        ));
+    }
+    Ok(RecordedBuildCache {
+        receipt,
+        layout_directory: root.to_path_buf(),
+    })
+}
+
+fn validate_config(
+    config: &CacheConfig,
+    identity: &BuildCacheExportIdentity,
+    layers: &[Descriptor],
+) -> Result<()> {
+    if config.schema != CACHE_CONFIG_SCHEMA
+        || config.key != identity.key
+        || config.source_digest != identity.source_digest
+        || config.plan_digest != identity.plan_digest
+        || config.platform != identity.platform
+        || config.entries.len() > MAX_CACHE_ENTRIES
+    {
+        return Err(cache_error("native cache config identity is invalid"));
+    }
+    let mut previous = None;
+    let mut expected_layers = BTreeMap::new();
+    for entry in &config.entries {
+        if previous.as_ref().is_some_and(|key| key >= &entry.key)
+            || canonical_sha256_digest_hex(&entry.key).is_err()
+            || canonical_sha256_digest_hex(&entry.diff_id).is_err()
+            || canonical_sha256_digest_hex(&entry.layer.digest).is_err()
+            || entry.layer.media_type != MediaType::ImageLayerGzip.as_ref()
+            || entry.layer.size == 0
+        {
+            return Err(cache_error("native cache config entry is invalid"));
+        }
+        previous = Some(entry.key.clone());
+        expected_layers.insert(
+            entry.layer.digest.clone(),
+            (entry.layer.media_type.clone(), entry.layer.size),
+        );
+    }
+    let actual_layers = layers
+        .iter()
+        .map(|layer| {
+            (
+                layer.digest().to_string(),
+                (layer.media_type().as_ref().to_string(), layer.size()),
+            )
+        })
+        .collect::<Vec<_>>();
+    let expected_layers = expected_layers.into_iter().collect::<Vec<_>>();
+    if actual_layers != expected_layers {
+        return Err(cache_error(
+            "native cache manifest layers differ from the cache config",
+        ));
+    }
+    Ok(())
+}
+
+fn require_index(index: &ImageIndex, platform: &Platform) -> Result<()> {
+    if index.schema_version() != SCHEMA_VERSION
+        || index.media_type().as_ref() != Some(&MediaType::ImageIndex)
+        || index.artifact_type().as_ref() != Some(&MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
+        || index.subject().is_some()
+        || index.annotations().is_some()
+        || index.manifests().len() != 1
+    {
+        return Err(cache_error("native cache OCI index shape is invalid"));
+    }
+    let descriptor = &index.manifests()[0];
+    require_descriptor(descriptor, MediaType::ImageManifest, true)?;
+    let Some(actual) = descriptor.platform() else {
+        return Err(cache_error("native cache root descriptor has no platform"));
+    };
+    if actual.os().to_string() != platform.os
+        || actual.architecture().to_string() != platform.architecture
+        || actual.variant() != &platform.variant
+        || descriptor.artifact_type().as_ref()
+            != Some(&MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
+    {
+        return Err(cache_error("native cache root platform is invalid"));
+    }
+    Ok(())
+}
+
+fn require_manifest(manifest: &ImageManifest) -> Result<()> {
+    if manifest.schema_version() != SCHEMA_VERSION
+        || manifest.media_type().as_ref() != Some(&MediaType::ImageManifest)
+        || manifest.artifact_type().as_ref()
+            != Some(&MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
+        || manifest.subject().is_some()
+        || manifest.annotations().is_some()
+        || manifest.config().media_type().as_ref() != BUILD_CACHE_CONFIG_MEDIA_TYPE
+    {
+        return Err(cache_error("native cache OCI manifest shape is invalid"));
+    }
+    require_descriptor(
+        manifest.config(),
+        MediaType::from(BUILD_CACHE_CONFIG_MEDIA_TYPE),
+        false,
+    )?;
+    for layer in manifest.layers() {
+        require_descriptor(layer, MediaType::ImageLayerGzip, false)?;
+    }
+    Ok(())
+}
+
+fn require_descriptor(descriptor: &Descriptor, media_type: MediaType, root: bool) -> Result<()> {
+    if descriptor.media_type() != &media_type
+        || descriptor.size() == 0
+        || canonical_sha256_digest_hex(descriptor.digest().as_ref()).is_err()
+        || descriptor.urls().is_some()
+        || descriptor.annotations().is_some()
+        || descriptor.data().is_some()
+        || (!root && descriptor.platform().is_some())
+        || (!root && descriptor.artifact_type().is_some())
+    {
+        return Err(cache_error("native cache OCI descriptor is invalid"));
+    }
+    Ok(())
+}
+
+fn read_descriptor(
+    root: &Path,
+    descriptor: &Descriptor,
+    limit: u64,
+    label: &str,
+) -> Result<Vec<u8>> {
+    let size = i64::try_from(descriptor.size())
+        .map_err(|_| cache_error(format!("{label} size exceeds the supported range")))?;
+    read_verified_oci_blob(root, descriptor.digest().as_ref(), size, limit, label)
+}
+
+fn verify_descriptor_file(root: &Path, descriptor: &Descriptor, label: &str) -> Result<()> {
+    let size = i64::try_from(descriptor.size())
+        .map_err(|_| cache_error(format!("{label} size exceeds the supported range")))?;
+    verify_oci_blob_file(
+        root,
+        descriptor.digest().as_ref(),
+        size,
+        MAX_OCI_LAYER_BLOB_BYTES,
+        label,
+    )
+    .map(|_| ())
+}
+
+fn write_json_blob(root: &Path, media_type: &str, bytes: &[u8]) -> Result<Descriptor> {
+    let digest = sha256_bytes(bytes);
+    std::fs::write(root.join(&digest), bytes)
+        .map_err(|error| cache_error(format!("failed to write native cache blob: {error}")))?;
+    build_descriptor(MediaType::from(media_type), bytes.len() as u64, &digest)
+}
+
+fn build_descriptor(media_type: MediaType, size: u64, digest: &str) -> Result<Descriptor> {
+    DescriptorBuilder::default()
+        .media_type(media_type)
+        .digest(parse_digest(digest)?)
+        .size(size)
+        .build()
+        .map_err(|error| cache_error(format!("invalid native cache descriptor: {error}")))
+}
+
+fn parse_digest(hex: &str) -> Result<Sha256Digest> {
+    Sha256Digest::from_str(hex)
+        .map_err(|error| cache_error(format!("invalid native cache digest: {error}")))
+}
+
+fn prefixed_digest(hex: &str, label: &str) -> Result<String> {
+    let digest = format!("sha256:{hex}");
+    canonical_sha256_digest_hex(&digest)
+        .map_err(|_| cache_error(format!("{label} is not canonical SHA-256")))?;
+    Ok(digest)
+}
+
+fn cache_error(message: impl Into<String>) -> BoxError {
+    BoxError::BuildError(message.into())
+}

--- a/src/runtime/src/oci/build/cache/export/model.rs
+++ b/src/runtime/src/oci/build/cache/export/model.rs
@@ -1,0 +1,116 @@
+//! Durable identity and receipt types for one native cache export.
+
+use std::path::PathBuf;
+
+use a3s_box_core::error::Result;
+use a3s_box_core::platform::Platform;
+use oci_spec::image::MediaType;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::{cache_error, CACHE_CONFIG_SCHEMA, MAX_CACHE_ENTRIES};
+use crate::oci::build::BuildOutputDescriptor;
+use crate::oci::image::canonical_sha256_digest_hex;
+
+const CACHE_KEY_PROFILE: &str = "a3s.box.build-cache-key.v1";
+
+/// Path-independent evidence for one portable native cache artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BuildCacheReceipt {
+    pub schema: String,
+    pub key: String,
+    pub source_digest: String,
+    pub plan_digest: String,
+    pub descriptor: BuildOutputDescriptor,
+    pub platform: Platform,
+    pub content_bytes: u64,
+    pub entry_count: u64,
+    pub blob_count: u64,
+    pub blob_inventory_digest: String,
+}
+
+impl BuildCacheReceipt {
+    pub const SCHEMA: &'static str = "a3s.box.build-cache-receipt.v1";
+
+    pub(in crate::oci::build) fn validate(&self) -> Result<()> {
+        if self.schema != Self::SCHEMA
+            || canonical_sha256_digest_hex(&self.key).is_err()
+            || canonical_sha256_digest_hex(&self.source_digest).is_err()
+            || canonical_sha256_digest_hex(&self.plan_digest).is_err()
+            || canonical_sha256_digest_hex(&self.descriptor.digest).is_err()
+            || canonical_sha256_digest_hex(&self.blob_inventory_digest).is_err()
+            || self.descriptor.media_type != MediaType::ImageManifest.as_ref()
+            || self.descriptor.size == 0
+            || self.content_bytes < self.descriptor.size
+            || self.entry_count > MAX_CACHE_ENTRIES as u64
+            || self.blob_count < 2
+            || self.platform.os != "linux"
+            || self.platform.architecture.trim().is_empty()
+            || self.key != cache_key(&self.source_digest, &self.plan_digest, &self.platform)?
+        {
+            return Err(cache_error(
+                "native build cache receipt violates its closed identity",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Revalidated portable cache artifact owned by a recorded operation.
+#[derive(Debug)]
+pub struct RecordedBuildCache {
+    pub receipt: BuildCacheReceipt,
+    pub layout_directory: PathBuf,
+}
+
+/// Immutable identity compiled into the cache artifact itself.
+#[derive(Debug, Clone)]
+pub(in crate::oci::build) struct BuildCacheExportIdentity {
+    pub(super) source_digest: String,
+    pub(super) plan_digest: String,
+    pub(super) platform: Platform,
+    pub(super) key: String,
+}
+
+impl BuildCacheExportIdentity {
+    pub(in crate::oci::build) fn new(
+        source_digest: impl Into<String>,
+        plan_digest: impl Into<String>,
+        platform: Platform,
+    ) -> Result<Self> {
+        let source_digest = source_digest.into();
+        let plan_digest = plan_digest.into();
+        canonical_sha256_digest_hex(&source_digest)?;
+        canonical_sha256_digest_hex(&plan_digest)?;
+        if platform.os != "linux" || platform.architecture.trim().is_empty() {
+            return Err(cache_error("native build cache platform is invalid"));
+        }
+        let key = cache_key(&source_digest, &plan_digest, &platform)?;
+        Ok(Self {
+            source_digest,
+            plan_digest,
+            platform,
+            key,
+        })
+    }
+}
+
+fn cache_key(source_digest: &str, plan_digest: &str, platform: &Platform) -> Result<String> {
+    let mut digest = Sha256::new();
+    for value in [
+        CACHE_KEY_PROFILE,
+        CACHE_CONFIG_SCHEMA,
+        source_digest,
+        plan_digest,
+        platform.os.as_str(),
+        platform.architecture.as_str(),
+        platform.variant.as_deref().unwrap_or(""),
+    ] {
+        let length = u64::try_from(value.len())
+            .map_err(|_| cache_error("native cache key field exceeds its bound"))?;
+        digest.update(length.to_be_bytes());
+        digest.update(value.as_bytes());
+    }
+    Ok(format!("sha256:{:x}", digest.finalize()))
+}

--- a/src/runtime/src/oci/build/cache/export/tests.rs
+++ b/src/runtime/src/oci/build/cache/export/tests.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+fn payload_descriptor(platform: bool, artifact_type: bool) -> Descriptor {
+    let mut builder = DescriptorBuilder::default()
+        .media_type(MediaType::ImageLayerGzip)
+        .digest(parse_digest(&"a".repeat(64)).unwrap())
+        .size(1_u64);
+    if platform {
+        builder = builder.platform(
+            PlatformBuilder::default()
+                .architecture(Arch::from("amd64"))
+                .os(Os::from("linux"))
+                .build()
+                .unwrap(),
+        );
+    }
+    if artifact_type {
+        builder = builder.artifact_type(MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE));
+    }
+    builder.build().unwrap()
+}
+
+#[test]
+fn cache_payload_descriptors_reject_root_only_identity_fields() {
+    assert!(require_descriptor(
+        &payload_descriptor(false, false),
+        MediaType::ImageLayerGzip,
+        false,
+    )
+    .is_ok());
+    assert!(require_descriptor(
+        &payload_descriptor(true, false),
+        MediaType::ImageLayerGzip,
+        false,
+    )
+    .is_err());
+    assert!(require_descriptor(
+        &payload_descriptor(false, true),
+        MediaType::ImageLayerGzip,
+        false,
+    )
+    .is_err());
+}
+
+#[test]
+fn cache_manifest_layers_are_unique_and_canonical() {
+    let platform = Platform::linux_amd64();
+    let identity = BuildCacheExportIdentity::new(
+        format!("sha256:{}", "1".repeat(64)),
+        format!("sha256:{}", "2".repeat(64)),
+        platform.clone(),
+    )
+    .unwrap();
+    let layer = build_descriptor(MediaType::ImageLayerGzip, 1, &"3".repeat(64)).unwrap();
+    let entry = CacheEntry {
+        key: format!("sha256:{}", "4".repeat(64)),
+        layer: BuildOutputDescriptor {
+            media_type: layer.media_type().as_ref().to_string(),
+            digest: layer.digest().to_string(),
+            size: layer.size(),
+        },
+        diff_id: format!("sha256:{}", "5".repeat(64)),
+    };
+    let config = CacheConfig {
+        schema: CACHE_CONFIG_SCHEMA.to_string(),
+        key: identity.key.clone(),
+        source_digest: identity.source_digest.clone(),
+        plan_digest: identity.plan_digest.clone(),
+        platform,
+        entries: vec![entry],
+    };
+
+    assert!(validate_config(&config, &identity, std::slice::from_ref(&layer)).is_ok());
+    assert!(validate_config(&config, &identity, &[layer.clone(), layer]).is_err());
+}

--- a/src/runtime/src/oci/build/cache/tests.rs
+++ b/src/runtime/src/oci/build/cache/tests.rs
@@ -1,0 +1,204 @@
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use super::*;
+
+/// Test constructor: open a cache at an explicit directory.
+fn open_at(dir: &Path) -> BuildCache {
+    BuildCache::open_in(dir.to_path_buf()).expect("open build cache at temp dir")
+}
+
+#[test]
+fn test_chain_is_deterministic() {
+    let a = BuildCache::chain("prev", "RUN echo hi", None);
+    let b = BuildCache::chain("prev", "RUN echo hi", None);
+    assert_eq!(a, b);
+    assert_eq!(a.len(), 64);
+}
+
+#[test]
+fn test_chain_is_order_sensitive() {
+    let a = BuildCache::chain("prev", "RUN echo a", None);
+    let b = BuildCache::chain("prev", "RUN echo b", None);
+    assert_ne!(a, b);
+
+    let c = BuildCache::chain("prev1", "RUN echo a", None);
+    let d = BuildCache::chain("prev2", "RUN echo a", None);
+    assert_ne!(c, d);
+}
+
+#[test]
+fn test_chain_input_hash_changes_key() {
+    let none = BuildCache::chain("prev", "COPY . /app", None);
+    let some = BuildCache::chain("prev", "COPY . /app", Some("deadbeef"));
+    assert_ne!(none, some);
+
+    let other = BuildCache::chain("prev", "COPY . /app", Some("cafebabe"));
+    assert_ne!(some, other);
+}
+
+#[test]
+fn test_store_then_lookup_round_trips() {
+    let tmp = TempDir::new().unwrap();
+    let cache_dir = tmp.path().join("buildcache");
+    let cache = open_at(&cache_dir);
+
+    let layer_path = tmp.path().join("layer.tar.gz");
+    let contents = b"fake layer contents";
+    fs::write(&layer_path, contents).unwrap();
+    let layer = LayerInfo {
+        path: layer_path,
+        digest: sha256_bytes(contents),
+        size: contents.len() as u64,
+    };
+
+    let key = BuildCache::chain("", "RUN echo hi", None);
+    assert!(cache.lookup(&key).is_none());
+
+    cache.store(&key, &layer, "diff-id-xyz");
+
+    let hit = cache
+        .lookup(&key)
+        .expect("expected a cache hit after store");
+    assert_eq!(hit.digest, sha256_bytes(contents));
+    assert_eq!(hit.diff_id, "diff-id-xyz");
+    assert_eq!(hit.size, contents.len() as u64);
+    assert!(hit.blob_path.exists());
+    assert_eq!(fs::read(&hit.blob_path).unwrap(), b"fake layer contents");
+}
+
+#[test]
+fn prune_evicts_orphan_key_records() {
+    let tmp = TempDir::new().unwrap();
+    let cache_dir = tmp.path().join("buildcache");
+    let cache = open_at(&cache_dir);
+
+    let layer_path = tmp.path().join("layer.tar.gz");
+    let contents = vec![0u8; 4096];
+    fs::write(&layer_path, &contents).unwrap();
+    let layer = LayerInfo {
+        path: layer_path,
+        digest: sha256_bytes(&contents),
+        size: 4096,
+    };
+    let key = BuildCache::chain("", "RUN make", None);
+    cache.store(&key, &layer, "diff");
+
+    let blob = cache_dir.join("blobs").join(&layer.digest);
+    let key_file = cache_dir.join("keys").join(&key);
+    assert!(blob.exists() && key_file.exists());
+
+    cache.prune_to(0);
+    assert!(!blob.exists(), "blob should be evicted");
+    assert!(!key_file.exists(), "orphaned key record should be pruned");
+}
+
+#[test]
+fn test_lookup_misses_when_blob_removed() {
+    let tmp = TempDir::new().unwrap();
+    let cache = open_at(&tmp.path().join("buildcache"));
+
+    let layer_path = tmp.path().join("layer.tar.gz");
+    let contents = b"data";
+    fs::write(&layer_path, contents).unwrap();
+    let layer = LayerInfo {
+        path: layer_path,
+        digest: sha256_bytes(contents),
+        size: contents.len() as u64,
+    };
+    let key = BuildCache::chain("", "RUN x", None);
+    cache.store(&key, &layer, "diff");
+
+    fs::remove_file(tmp.path().join("buildcache/blobs").join(&layer.digest)).unwrap();
+    assert!(cache.lookup(&key).is_none());
+}
+
+#[test]
+fn test_lookup_rejects_and_store_repairs_corrupt_blob() {
+    let tmp = TempDir::new().unwrap();
+    let cache_dir = tmp.path().join("buildcache");
+    let cache = open_at(&cache_dir);
+    let contents = b"verified layer";
+    let layer_path = tmp.path().join("layer.tar.gz");
+    fs::write(&layer_path, contents).unwrap();
+    let layer = LayerInfo {
+        path: layer_path,
+        digest: sha256_bytes(contents),
+        size: contents.len() as u64,
+    };
+    let key = BuildCache::chain("", "COPY value /value", None);
+    cache.store(&key, &layer, "diff");
+
+    let blob = cache_dir.join("blobs").join(&layer.digest);
+    fs::write(&blob, b"corrupted data").unwrap();
+    assert!(cache.lookup(&key).is_none());
+
+    cache.store(&key, &layer, "diff");
+    assert_eq!(fs::read(&blob).unwrap(), contents);
+    assert!(cache.lookup(&key).is_some());
+}
+
+#[test]
+fn test_hash_context_sources_detects_change() {
+    let ctx = TempDir::new().unwrap();
+    fs::write(ctx.path().join("a.txt"), "hello").unwrap();
+    fs::create_dir(ctx.path().join("sub")).unwrap();
+    fs::write(ctx.path().join("sub/b.txt"), "world").unwrap();
+
+    let srcs = vec![".".to_string()];
+    let h1 = hash_context_sources(ctx.path(), &srcs).unwrap();
+    let h2 = hash_context_sources(ctx.path(), &srcs).unwrap();
+    assert_eq!(h1, h2, "stable hash for unchanged content");
+
+    fs::write(ctx.path().join("a.txt"), "HELLO").unwrap();
+    let h3 = hash_context_sources(ctx.path(), &srcs).unwrap();
+    assert_ne!(h1, h3, "changed content must change the hash");
+}
+
+#[test]
+fn test_prune_evicts_until_under_cap() {
+    let tmp = TempDir::new().unwrap();
+    let cache = open_at(&tmp.path().join("buildcache"));
+
+    for i in 0..3 {
+        let payload = vec![b'x' + i as u8; 100];
+        let src = tmp.path().join(format!("src{i}"));
+        fs::write(&src, &payload).unwrap();
+        let layer = LayerInfo {
+            path: src,
+            digest: sha256_bytes(&payload),
+            size: payload.len() as u64,
+        };
+        cache.store(
+            &BuildCache::chain("", &format!("RUN step {i}"), None),
+            &layer,
+            "d",
+        );
+    }
+
+    let blobs_dir = tmp.path().join("buildcache/blobs");
+    let total = |dir: &Path| -> u64 {
+        fs::read_dir(dir)
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.metadata().unwrap().len())
+            .sum()
+    };
+    assert_eq!(total(&blobs_dir), 300, "three blobs stored");
+
+    cache.prune_to(150);
+    assert!(
+        total(&blobs_dir) <= 150,
+        "prune must bring total under the cap"
+    );
+    assert!(total(&blobs_dir) > 0, "prune must keep what fits");
+}
+
+#[test]
+fn test_hash_context_sources_missing_source_is_none() {
+    let ctx = TempDir::new().unwrap();
+    let srcs = vec!["does-not-exist".to_string()];
+    assert!(hash_context_sources(ctx.path(), &srcs).is_none());
+}

--- a/src/runtime/src/oci/build/engine/control.rs
+++ b/src/runtime/src/oci/build/engine/control.rs
@@ -10,6 +10,8 @@ use std::time::Duration;
 use a3s_box_core::error::{BoxError, Result};
 use async_trait::async_trait;
 
+use crate::oci::build::cache::RecordedBuildCache;
+
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
@@ -19,6 +21,15 @@ pub(in crate::oci::build) trait BuildExecutionObserver: Send + Sync {
     async fn cancellation_requested(&self) -> Result<bool>;
 
     async fn acquire_image_commit_permit(&self) -> Result<BuildImageCommitPermit>;
+
+    async fn publish_cache_export(
+        &self,
+        _staged: RecordedBuildCache,
+    ) -> Result<RecordedBuildCache> {
+        Err(BoxError::BuildError(
+            "recorded build cache export has no journal publisher".to_string(),
+        ))
+    }
 
     async fn run_process_started(&self, pid: u32, start_time: Option<u64>) -> Result<()>;
 
@@ -65,6 +76,13 @@ impl BuildExecutionControl {
 
     pub(super) async fn acquire_image_commit_permit(&self) -> Result<BuildImageCommitPermit> {
         self.observer.acquire_image_commit_permit().await
+    }
+
+    pub(super) async fn publish_cache_export(
+        &self,
+        staged: RecordedBuildCache,
+    ) -> Result<RecordedBuildCache> {
+        self.observer.publish_cache_export(staged).await
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]

--- a/src/runtime/src/oci/build/engine/mod.rs
+++ b/src/runtime/src/oci/build/engine/mod.rs
@@ -11,7 +11,10 @@ use std::sync::Arc;
 use a3s_box_core::error::{BoxError, Result};
 use a3s_box_core::platform::Platform;
 
-use super::cache::{hash_context_sources, BuildCache};
+use super::cache::{
+    hash_context_sources, BuildCache, BuildCacheExportIdentity, BuildCacheTrace, CachedLayer,
+    RecordedBuildCache,
+};
 use super::dockerfile::{Dockerfile, Instruction, RunBindMount, RunCacheMount};
 use super::dockerignore::DockerIgnore;
 use super::layer::{sha256_bytes, sha256_file, LayerInfo};
@@ -40,6 +43,11 @@ use stages::{global_arg_decls, resolve_stage_rootfs, split_into_stages};
 use utils::{compute_diff_id, expand_args, format_size, resolve_path};
 
 pub(super) use control::{BuildExecutionControl, BuildExecutionObserver, BuildImageCommitPermit};
+
+pub(super) struct SupervisedBuildResult {
+    pub(super) output: BuildResult,
+    pub(super) cache: Option<RecordedBuildCache>,
+}
 
 /// Network access available to Dockerfile execution instructions.
 ///
@@ -488,7 +496,9 @@ pub async fn build(config: BuildConfig, store: Arc<ImageStore>) -> Result<BuildR
 
     let build_dir = tempfile::TempDir::new()
         .map_err(|e| BoxError::BuildError(format!("Failed to create build directory: {}", e)))?;
-    build_in_workspace(config, store, build_dir.path(), None).await
+    build_in_workspace(config, store, build_dir.path(), None, None)
+        .await
+        .map(|result| result.output)
 }
 
 /// Execute the same native engine in one journal-owned workspace.
@@ -497,10 +507,11 @@ pub(super) async fn build_supervised(
     store: Arc<ImageStore>,
     workspace: &Path,
     control: BuildExecutionControl,
-) -> Result<BuildResult> {
+    cache_identity: Option<BuildCacheExportIdentity>,
+) -> Result<SupervisedBuildResult> {
     validate_build_config(&config)?;
     control.ensure_active().await?;
-    build_in_workspace(config, store, workspace, Some(control)).await
+    build_in_workspace(config, store, workspace, Some(control), cache_identity).await
 }
 
 async fn build_in_workspace(
@@ -508,7 +519,8 @@ async fn build_in_workspace(
     store: Arc<ImageStore>,
     build_dir: &Path,
     control: Option<BuildExecutionControl>,
-) -> Result<BuildResult> {
+    cache_identity: Option<BuildCacheExportIdentity>,
+) -> Result<SupervisedBuildResult> {
     // Parse Dockerfile
     let dockerfile = Dockerfile::from_file(&config.dockerfile_path)?;
 
@@ -556,6 +568,15 @@ async fn build_in_workspace(
 
     let total_instructions = dockerfile.instructions.len();
     let mut global_step = 0;
+    // One cache implementation and one trace span every stage. The trace owns
+    // no blobs or persistence; it only selects exact entries for the terminal
+    // portable artifact.
+    let cache = if config.no_cache {
+        None
+    } else {
+        BuildCache::open()
+    };
+    let mut cache_trace = cache_identity.as_ref().map(|_| BuildCacheTrace::default());
 
     for (stage_idx, stage) in stages.iter().enumerate() {
         if let Some(control) = &control {
@@ -583,12 +604,6 @@ async fn build_in_workspace(
         }
         let mut base_layers: Vec<LayerInfo> = Vec::new();
         let mut base_diff_ids: Vec<String> = Vec::new();
-        // Layer-level build cache (best-effort; None disables caching).
-        let cache = if config.no_cache {
-            None
-        } else {
-            BuildCache::open()
-        };
         // Running chain key over all instructions in this stage. Reset at FROM.
         let mut chain_key = String::new();
         // Once a cache miss forces re-execution, all later layers must be rebuilt.
@@ -770,7 +785,7 @@ async fn build_in_workspace(
                     } else {
                         format!("COPY {} {}", src.join(" "), dst)
                     };
-                    if try_reuse_cached_layer(
+                    if let Some(cached) = try_reuse_cached_layer(
                         CachedLayerReuse {
                             cache_valid,
                             cache: cache.as_ref(),
@@ -781,9 +796,10 @@ async fn build_in_workspace(
                             created_by: &created_by,
                         },
                         &mut state,
-                    )?
-                    .is_some()
-                    {
+                    )? {
+                        if let Some(trace) = &mut cache_trace {
+                            trace.record(&chain_key, &cached)?;
+                        }
                         if !config.quiet {
                             println!(
                                 "Step {}/{}: {} (CACHED)",
@@ -836,9 +852,13 @@ async fn build_in_workspace(
                             None,
                         )?;
                         let diff_id = compute_diff_id(&layer_info.path)?;
-                        if let Some(c) = &cache {
-                            c.store(&chain_key, &layer_info, &diff_id);
-                        }
+                        store_cache_entry(
+                            cache.as_ref(),
+                            cache_trace.as_mut(),
+                            &chain_key,
+                            &layer_info,
+                            &diff_id,
+                        )?;
                         state.diff_ids.push(diff_id);
                         state.layers.push(layer_info);
                         state.history.push(HistoryEntry {
@@ -872,9 +892,13 @@ async fn build_in_workspace(
                             Some(&dockerignore),
                         )?;
                         let diff_id = compute_diff_id(&layer_info.path)?;
-                        if let Some(c) = &cache {
-                            c.store(&chain_key, &layer_info, &diff_id);
-                        }
+                        store_cache_entry(
+                            cache.as_ref(),
+                            cache_trace.as_mut(),
+                            &chain_key,
+                            &layer_info,
+                            &diff_id,
+                        )?;
                         state.diff_ids.push(diff_id);
                         state.layers.push(layer_info);
                         state.history.push(HistoryEntry {
@@ -886,7 +910,7 @@ async fn build_in_workspace(
 
                 Instruction::Add { src, dst, chown } => {
                     let created_by = format!("ADD {} {}", src.join(" "), dst);
-                    if try_reuse_cached_layer(
+                    if let Some(cached) = try_reuse_cached_layer(
                         CachedLayerReuse {
                             cache_valid,
                             cache: cache.as_ref(),
@@ -897,9 +921,10 @@ async fn build_in_workspace(
                             created_by: &created_by,
                         },
                         &mut state,
-                    )?
-                    .is_some()
-                    {
+                    )? {
+                        if let Some(trace) = &mut cache_trace {
+                            trace.record(&chain_key, &cached)?;
+                        }
                         if !config.quiet {
                             println!(
                                 "Step {}/{}: {} (CACHED)",
@@ -931,9 +956,13 @@ async fn build_in_workspace(
                         Some(&dockerignore),
                     )?;
                     let diff_id = compute_diff_id(&layer_info.path)?;
-                    if let Some(c) = &cache {
-                        c.store(&chain_key, &layer_info, &diff_id);
-                    }
+                    store_cache_entry(
+                        cache.as_ref(),
+                        cache_trace.as_mut(),
+                        &chain_key,
+                        &layer_info,
+                        &diff_id,
+                    )?;
                     state.diff_ids.push(diff_id);
                     state.layers.push(layer_info);
                     state.history.push(HistoryEntry {
@@ -949,7 +978,7 @@ async fn build_in_workspace(
                     tmpfs_mounts,
                 } => {
                     let created_by = instruction_to_string(instruction);
-                    if try_reuse_cached_layer(
+                    if let Some(cached) = try_reuse_cached_layer(
                         CachedLayerReuse {
                             cache_valid,
                             cache: cache.as_ref(),
@@ -960,9 +989,10 @@ async fn build_in_workspace(
                             created_by: &created_by,
                         },
                         &mut state,
-                    )?
-                    .is_some()
-                    {
+                    )? {
+                        if let Some(trace) = &mut cache_trace {
+                            trace.record(&chain_key, &cached)?;
+                        }
                         if !config.quiet {
                             println!(
                                 "Step {}/{}: {} (CACHED)",
@@ -1028,9 +1058,13 @@ async fn build_in_workspace(
                     };
                     if let Some(layer_info) = layer_opt {
                         let diff_id = compute_diff_id(&layer_info.path)?;
-                        if let Some(c) = &cache {
-                            c.store(&chain_key, &layer_info, &diff_id);
-                        }
+                        store_cache_entry(
+                            cache.as_ref(),
+                            cache_trace.as_mut(),
+                            &chain_key,
+                            &layer_info,
+                            &diff_id,
+                        )?;
                         state.diff_ids.push(diff_id);
                         state.layers.push(layer_info);
                         state.history.push(HistoryEntry {
@@ -1299,6 +1333,22 @@ async fn build_in_workspace(
     if let Some(control) = &control {
         control.ensure_active().await?;
     }
+    let staged_cache = match cache_identity.as_ref() {
+        Some(identity) => {
+            let cache = cache.as_ref().ok_or_else(|| {
+                BoxError::BuildError(
+                    "content-addressed build cache could not be opened for export".to_string(),
+                )
+            })?;
+            let trace = cache_trace.as_ref().ok_or_else(|| {
+                BoxError::BuildError(
+                    "content-addressed build cache export lost its native trace".to_string(),
+                )
+            })?;
+            Some(cache.stage_export(trace, identity, &build_dir.join("_cache_export"))?)
+        }
+        None => None,
+    };
     let result = assemble_image(
         &reference,
         &final_state,
@@ -1308,6 +1358,7 @@ async fn build_in_workspace(
         &store,
         &target_platform,
         control.as_ref(),
+        staged_cache,
     )
     .await?;
 
@@ -1315,8 +1366,8 @@ async fn build_in_workspace(
         println!(
             "Successfully built {} ({} layers, {}, {})",
             reference,
-            result.layer_count,
-            format_size(result.size),
+            result.output.layer_count,
+            format_size(result.output.size),
             target_platform,
         );
     }
@@ -1332,12 +1383,40 @@ async fn build_in_workspace(
 // Helper functions
 // =============================================================================
 
+fn store_cache_entry(
+    cache: Option<&BuildCache>,
+    trace: Option<&mut BuildCacheTrace>,
+    chain_key: &str,
+    layer: &LayerInfo,
+    diff_id: &str,
+) -> Result<()> {
+    let Some(cache) = cache else {
+        if trace.is_some() {
+            return Err(BoxError::BuildError(
+                "content-addressed build cache could not be opened".to_string(),
+            ));
+        }
+        return Ok(());
+    };
+    cache.store(chain_key, layer, diff_id);
+    if let Some(trace) = trace {
+        let cached = cache.lookup(chain_key).ok_or_else(|| {
+            BoxError::BuildError(format!(
+                "content-addressed build cache did not retain chain key sha256:{chain_key}"
+            ))
+        })?;
+        trace.record(chain_key, &cached)?;
+    }
+    Ok(())
+}
+
 /// Attempt to reuse a cached layer for a layer-producing instruction.
 ///
 /// On a cache hit (and only when `cache_valid` is still true and a cache is
 /// open), this applies the cached layer's diff to `rootfs_dir` so later
 /// instructions build on the correct rootfs, then records the layer, diff_id,
-/// and a non-empty history entry in `state`. Returns `Some(())` on a hit (the
+/// and a non-empty history entry in `state`. Returns the verified cache entry
+/// on a hit (the
 /// caller should `continue`), or `None` to fall through to normal execution.
 struct CachedLayerReuse<'a> {
     cache_valid: bool,
@@ -1352,7 +1431,7 @@ struct CachedLayerReuse<'a> {
 fn try_reuse_cached_layer(
     request: CachedLayerReuse<'_>,
     state: &mut BuildState,
-) -> Result<Option<()>> {
+) -> Result<Option<CachedLayer>> {
     if !request.cache_valid {
         return Ok(None);
     }
@@ -1382,15 +1461,15 @@ fn try_reuse_cached_layer(
 
     state.layers.push(LayerInfo {
         path: local_layer,
-        digest: cached.digest,
+        digest: cached.digest.clone(),
         size: local_size,
     });
-    state.diff_ids.push(cached.diff_id);
+    state.diff_ids.push(cached.diff_id.clone());
     state.history.push(HistoryEntry {
         created_by: request.created_by.to_string(),
         empty_layer: false,
     });
-    Ok(Some(()))
+    Ok(Some(cached))
 }
 
 /// Handle FROM: pull base image and extract layers into rootfs.
@@ -1566,7 +1645,8 @@ async fn assemble_image(
     store: &Arc<ImageStore>,
     target_platform: &Platform,
     control: Option<&BuildExecutionControl>,
-) -> Result<BuildResult> {
+    staged_cache: Option<RecordedBuildCache>,
+) -> Result<SupervisedBuildResult> {
     // Create output directory
     let output_dir = layers_dir.join("_output");
     let blobs_dir = output_dir.join("blobs").join("sha256");
@@ -1762,8 +1842,20 @@ async fn assemble_image(
         Some(control) => Some(control.acquire_image_commit_permit().await?),
         None => None,
     };
+    let cache = match staged_cache {
+        Some(staged) => {
+            let control = control.ok_or_else(|| {
+                BoxError::BuildError(
+                    "native cache export requires the recorded-build journal".to_string(),
+                )
+            })?;
+            Some(control.publish_cache_export(staged).await?)
+        }
+        None => None,
+    };
     let stored = store.put(reference, &digest_str, &output_dir).await?;
-    inspect_stored_build_output(reference, stored, store.store_dir())
+    let output = inspect_stored_build_output(reference, stored, store.store_dir())?;
+    Ok(SupervisedBuildResult { output, cache })
 }
 
 fn copy_layer_blob(layer: &LayerInfo, blob_path: &Path, label: &str) -> Result<()> {

--- a/src/runtime/src/oci/build/execution.rs
+++ b/src/runtime/src/oci/build/execution.rs
@@ -4,27 +4,27 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use a3s_box_core::error::{BoxError, Result as BoxResult};
-use async_trait::async_trait;
+use a3s_box_core::error::BoxError;
 use thiserror::Error;
 
-use super::engine::{
-    build_supervised, BuildExecutionControl, BuildExecutionObserver, BuildImageCommitPermit,
-};
+use super::cache::{inspect_build_cache_export, BuildCacheExportIdentity, RecordedBuildCache};
+use super::engine::{build_supervised, BuildExecutionControl};
 use super::receipt::{
-    inspect_stored_output, BuildExecutionLease, BuildOperationJournal, BuildProcessIdentity,
-    LockedBuildOperation, PersistedBuildOperation, PersistedBuildPhase, SupervisedBuildOperation,
+    inspect_stored_output, BuildExecutionLease, BuildOperationJournal, LockedBuildOperation,
+    PersistedBuildOperation, PersistedBuildPhase, SupervisedBuildOperation,
 };
 use super::{
-    build, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCancellationOutcome,
-    BuildOperationIdentity, BuildOutputReceipt, BuildReceiptError, BuildResult,
-    RecordedBuildResult, RecordedBuildStatus,
+    build, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy,
+    BuildCancellationOutcome, BuildOperationIdentity, BuildOutputReceipt, BuildReceiptError,
+    BuildResult, RecordedBuildResult, RecordedBuildStatus,
 };
 use crate::oci::ImageStore;
 
+mod supervision;
+
+use supervision::{fence_run_process, JournalBuildObserver};
+
 const EXECUTION_POLL_INTERVAL: Duration = Duration::from_millis(25);
-#[cfg(target_os = "linux")]
-const RUN_PROCESS_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Successful native output bound to the canonical admitted build plan.
 #[derive(Debug)]
@@ -33,6 +33,8 @@ pub(super) struct PlannedBuildResult {
     pub plan_digest: String,
     /// Durable typed OCI output owned by the Box image store.
     pub output: BuildResult,
+    /// Portable native cache artifact committed with the image output.
+    pub cache: Option<RecordedBuildCache>,
 }
 
 /// Stable failure boundary for plan admission, compilation, and execution.
@@ -79,10 +81,12 @@ pub(super) async fn execute_build_plan(
     Ok(PlannedBuildResult {
         plan_digest,
         output,
+        cache: None,
     })
 }
 
 async fn execute_supervised_build_plan(
+    identity: &BuildOperationIdentity,
     plan: &BoxBuildPlan,
     source_root: &Path,
     options: BoxBuildOptions,
@@ -92,10 +96,20 @@ async fn execute_supervised_build_plan(
 ) -> Result<PlannedBuildResult, BuildPlanExecutionError> {
     let plan_digest = plan.canonical_digest()?;
     let config = plan.compile(source_root, options)?;
-    let output = build_supervised(config, store, workspace, control).await?;
+    let cache_identity = (plan.cache() == BuildCachePolicy::ContentAddressed)
+        .then(|| {
+            BuildCacheExportIdentity::new(
+                identity.source_digest(),
+                plan_digest.clone(),
+                plan.platform().clone(),
+            )
+        })
+        .transpose()?;
+    let result = build_supervised(config, store, workspace, control, cache_identity).await?;
     Ok(PlannedBuildResult {
         plan_digest,
-        output,
+        output: result.output,
+        cache: result.cache,
     })
 }
 
@@ -179,21 +193,27 @@ pub async fn inspect_recorded_build_status(
     store: &ImageStore,
 ) -> Result<Option<RecordedBuildStatus>, BuildPlanExecutionError> {
     let plan_digest = plan.canonical_digest()?;
+    let cache_policy = plan.cache();
     let journal = BuildOperationJournal::for_image_store(store, identity.operation_id()).await?;
     let locked = journal.lock(identity.operation_id()).await?;
     let Some(record) = locked.read().await? else {
         return Ok(None);
     };
     match record {
-        PersistedBuildOperation::Succeeded(receipt) => {
-            recover_recorded_build(identity, &plan_digest, receipt, store)
-                .await
-                .map(Box::new)
-                .map(RecordedBuildStatus::Succeeded)
-                .map(Some)
-        }
+        PersistedBuildOperation::Succeeded(receipt) => recover_recorded_build(
+            identity,
+            &plan_digest,
+            cache_policy,
+            *receipt,
+            store,
+            &journal,
+        )
+        .await
+        .map(Box::new)
+        .map(RecordedBuildStatus::Succeeded)
+        .map(Some),
         PersistedBuildOperation::Supervised(operation) => {
-            operation.require_identity(identity, &plan_digest)?;
+            operation.require_identity(identity, &plan_digest, cache_policy)?;
             match operation.phase {
                 PersistedBuildPhase::Cancelled | PersistedBuildPhase::Failed => {
                     Ok(Some(status_from_terminal_operation(&operation)?))
@@ -220,7 +240,8 @@ pub async fn inspect_recorded_build_status(
         PersistedBuildOperation::Pending(pending) => {
             pending.require_identity(identity, &plan_digest)?;
             if let Some(result) =
-                adopt_committed_output(identity, &plan_digest, store, &journal, &locked).await?
+                adopt_committed_output(identity, &plan_digest, None, store, &journal, &locked)
+                    .await?
             {
                 return Ok(Some(RecordedBuildStatus::Succeeded(Box::new(result))));
             }
@@ -228,8 +249,15 @@ pub async fn inspect_recorded_build_status(
                 return Ok(Some(RecordedBuildStatus::Running));
             };
             journal.cleanup_workspace(identity.operation_id()).await?;
-            let mut operation =
-                SupervisedBuildOperation::from_pending(&pending, identity, &plan_digest)?;
+            journal
+                .cleanup_cache_export(identity.operation_id())
+                .await?;
+            let mut operation = SupervisedBuildOperation::from_pending(
+                &pending,
+                identity,
+                &plan_digest,
+                cache_policy,
+            )?;
             operation.finish(
                 PersistedBuildPhase::Failed,
                 "legacy build intent has no live execution owner or committed output".to_string(),
@@ -270,6 +298,7 @@ pub async fn cancel_recorded_build_plan(
     store: &ImageStore,
 ) -> Result<BuildCancellationOutcome, BuildPlanExecutionError> {
     let plan_digest = plan.canonical_digest()?;
+    let cache_policy = plan.cache();
     let journal = BuildOperationJournal::for_image_store(store, identity.operation_id()).await?;
     let locked = journal.lock(identity.operation_id()).await?;
     let Some(record) = locked.read().await? else {
@@ -277,12 +306,12 @@ pub async fn cancel_recorded_build_plan(
     };
     match record {
         PersistedBuildOperation::Succeeded(receipt) => {
-            receipt.require_identity(identity, &plan_digest)?;
+            receipt.require_identity(identity, &plan_digest, cache_policy)?;
             Ok(BuildCancellationOutcome::AlreadyTerminal)
         }
         PersistedBuildOperation::Pending(pending) => {
             pending.require_identity(identity, &plan_digest)?;
-            if adopt_committed_output(identity, &plan_digest, store, &journal, &locked)
+            if adopt_committed_output(identity, &plan_digest, None, store, &journal, &locked)
                 .await?
                 .is_some()
             {
@@ -297,8 +326,15 @@ pub async fn cancel_recorded_build_plan(
                 .into());
             };
             journal.cleanup_workspace(identity.operation_id()).await?;
-            let mut operation =
-                SupervisedBuildOperation::from_pending(&pending, identity, &plan_digest)?;
+            journal
+                .cleanup_cache_export(identity.operation_id())
+                .await?;
+            let mut operation = SupervisedBuildOperation::from_pending(
+                &pending,
+                identity,
+                &plan_digest,
+                cache_policy,
+            )?;
             operation.request_cancellation();
             operation.finish(
                 PersistedBuildPhase::Cancelled,
@@ -308,7 +344,7 @@ pub async fn cancel_recorded_build_plan(
             Ok(BuildCancellationOutcome::Requested)
         }
         PersistedBuildOperation::Supervised(mut operation) => {
-            operation.require_identity(identity, &plan_digest)?;
+            operation.require_identity(identity, &plan_digest, cache_policy)?;
             match operation.phase {
                 PersistedBuildPhase::Cancelled => {
                     return Ok(BuildCancellationOutcome::AlreadyCancelled);
@@ -318,9 +354,16 @@ pub async fn cancel_recorded_build_plan(
                 }
                 PersistedBuildPhase::Running | PersistedBuildPhase::Cancelling => {}
             }
-            if adopt_committed_output(identity, &plan_digest, store, &journal, &locked)
-                .await?
-                .is_some()
+            if adopt_committed_output(
+                identity,
+                &plan_digest,
+                operation.cache_policy(),
+                store,
+                &journal,
+                &locked,
+            )
+            .await?
+            .is_some()
             {
                 return Ok(BuildCancellationOutcome::AlreadyTerminal);
             }
@@ -331,6 +374,9 @@ pub async fn cancel_recorded_build_plan(
             if let Some(lease) = journal.try_execution_lease(identity.operation_id()).await? {
                 fence_run_process(run_process, identity.operation_id()).await?;
                 journal.cleanup_workspace(identity.operation_id()).await?;
+                journal
+                    .cleanup_cache_export(identity.operation_id())
+                    .await?;
                 operation.finish(
                     PersistedBuildPhase::Cancelled,
                     "cancelled while recovering an abandoned native execution".to_string(),
@@ -365,6 +411,7 @@ pub async fn remove_recorded_build_plan(
     store: &ImageStore,
 ) -> Result<bool, BuildPlanExecutionError> {
     let plan_digest = plan.canonical_digest()?;
+    let cache_policy = plan.cache();
     let journal = BuildOperationJournal::for_image_store(store, identity.operation_id()).await?;
     let locked = journal.lock(identity.operation_id()).await?;
     let Some(record) = locked.read().await? else {
@@ -376,14 +423,15 @@ pub async fn remove_recorded_build_plan(
             (identity.output_reference().to_string(), None)
         }
         PersistedBuildOperation::Succeeded(receipt) => {
-            receipt.require_identity(identity, &plan_digest)?;
+            let receipt = *receipt;
+            receipt.require_identity(identity, &plan_digest, cache_policy)?;
             (
                 receipt.output.reference,
                 Some(receipt.output.descriptor.digest),
             )
         }
         PersistedBuildOperation::Supervised(operation) => {
-            operation.require_identity(identity, &plan_digest)?;
+            operation.require_identity(identity, &plan_digest, cache_policy)?;
             if matches!(
                 operation.phase,
                 PersistedBuildPhase::Running | PersistedBuildPhase::Cancelling
@@ -408,6 +456,9 @@ pub async fn remove_recorded_build_plan(
         store.remove(&reference).await?;
     }
     journal.cleanup_workspace(identity.operation_id()).await?;
+    journal
+        .cleanup_cache_export(identity.operation_id())
+        .await?;
     locked.delete().await?;
     Ok(true)
 }
@@ -425,20 +476,29 @@ async fn start_recorded_build_plan_internal(
     store: Arc<ImageStore>,
 ) -> Result<StartOutcome, BuildPlanExecutionError> {
     let plan_digest = plan.canonical_digest()?;
+    let cache_policy = plan.cache();
     let journal = BuildOperationJournal::for_image_store(&store, identity.operation_id()).await?;
     let locked = journal.lock(identity.operation_id()).await?;
     let record = locked.read().await?;
 
     match record {
         Some(PersistedBuildOperation::Succeeded(receipt)) => {
-            let result = recover_recorded_build(identity, &plan_digest, receipt, &store).await?;
+            let result = recover_recorded_build(
+                identity,
+                &plan_digest,
+                cache_policy,
+                *receipt,
+                &store,
+                &journal,
+            )
+            .await?;
             return Ok(StartOutcome {
                 status: RecordedBuildStatus::Succeeded(Box::new(result)),
                 started_here: false,
             });
         }
         Some(PersistedBuildOperation::Supervised(operation)) => {
-            operation.require_identity(identity, &plan_digest)?;
+            operation.require_identity(identity, &plan_digest, cache_policy)?;
             if matches!(
                 operation.phase,
                 PersistedBuildPhase::Cancelled | PersistedBuildPhase::Failed
@@ -472,7 +532,8 @@ async fn start_recorded_build_plan_internal(
         Some(PersistedBuildOperation::Pending(pending)) => {
             pending.require_identity(identity, &plan_digest)?;
             if let Some(result) =
-                adopt_committed_output(identity, &plan_digest, &store, &journal, &locked).await?
+                adopt_committed_output(identity, &plan_digest, None, &store, &journal, &locked)
+                    .await?
             {
                 return Ok(StartOutcome {
                     status: RecordedBuildStatus::Succeeded(Box::new(result)),
@@ -487,8 +548,12 @@ async fn start_recorded_build_plan_internal(
                     message: "pending intent has an unknown live execution owner".to_string(),
                 })?;
             let workspace = journal.prepare_workspace(identity.operation_id()).await?;
-            let operation =
-                SupervisedBuildOperation::from_pending(&pending, identity, &plan_digest)?;
+            let operation = SupervisedBuildOperation::from_pending(
+                &pending,
+                identity,
+                &plan_digest,
+                cache_policy,
+            )?;
             locked.write_supervised(operation).await?;
             drop(locked);
             spawn_supervised_build(SupervisedBuildTask {
@@ -529,7 +594,7 @@ async fn start_recorded_build_plan_internal(
             message: "execution lease exists without a persisted operation record".to_string(),
         })?;
     let workspace = journal.prepare_workspace(identity.operation_id()).await?;
-    let operation = SupervisedBuildOperation::new(identity, plan_digest.clone())?;
+    let operation = SupervisedBuildOperation::new(identity, plan_digest.clone(), cache_policy)?;
     locked.write_supervised(operation).await?;
     drop(locked);
     spawn_supervised_build(SupervisedBuildTask {
@@ -590,9 +655,11 @@ async fn run_supervised_build(task: SupervisedBuildTask) -> Result<(), BuildPlan
         journal: journal.clone(),
         identity: identity.clone(),
         plan_digest: plan_digest.clone(),
+        cache_policy: plan.cache(),
     });
     let control = BuildExecutionControl::new(observer);
     let result = execute_supervised_build_plan(
+        &identity,
         &plan,
         &source_root,
         BoxBuildOptions {
@@ -607,20 +674,34 @@ async fn run_supervised_build(task: SupervisedBuildTask) -> Result<(), BuildPlan
 
     if let Ok(planned) = result {
         journal.cleanup_workspace(identity.operation_id()).await?;
-        let receipt =
-            BuildOutputReceipt::from_result(&identity, planned.plan_digest, &planned.output)?;
+        let receipt = BuildOutputReceipt::from_result(
+            &identity,
+            planned.plan_digest,
+            &planned.output,
+            plan.cache(),
+            planned.cache.as_ref(),
+        )?;
         let locked = journal.lock(identity.operation_id()).await?;
         locked.write_succeeded(receipt).await?;
         return Ok(());
     }
 
     let error = result.unwrap_err();
-    finish_failed_execution(&identity, &plan_digest, &store, &journal, error.to_string()).await
+    finish_failed_execution(
+        &identity,
+        &plan_digest,
+        plan.cache(),
+        &store,
+        &journal,
+        error.to_string(),
+    )
+    .await
 }
 
 async fn finish_failed_execution(
     identity: &BuildOperationIdentity,
     plan_digest: &str,
+    cache_policy: BuildCachePolicy,
     store: &ImageStore,
     journal: &BuildOperationJournal,
     message: String,
@@ -636,8 +717,20 @@ async fn finish_failed_execution(
     if matches!(record, PersistedBuildOperation::Succeeded(_)) {
         return Ok(());
     }
-    if let Some(result) =
-        adopt_committed_output(identity, plan_digest, store, journal, &locked).await?
+    let persisted_cache_policy = match &record {
+        PersistedBuildOperation::Supervised(operation) => operation.cache_policy(),
+        PersistedBuildOperation::Pending(_) => None,
+        PersistedBuildOperation::Succeeded(_) => unreachable!(),
+    };
+    if let Some(result) = adopt_committed_output(
+        identity,
+        plan_digest,
+        persisted_cache_policy,
+        store,
+        journal,
+        &locked,
+    )
+    .await?
     {
         drop(result);
         return Ok(());
@@ -645,13 +738,16 @@ async fn finish_failed_execution(
     let mut operation = match record {
         PersistedBuildOperation::Supervised(operation) => operation,
         PersistedBuildOperation::Pending(pending) => {
-            SupervisedBuildOperation::from_pending(&pending, identity, plan_digest)?
+            SupervisedBuildOperation::from_pending(&pending, identity, plan_digest, cache_policy)?
         }
         PersistedBuildOperation::Succeeded(_) => unreachable!(),
     };
-    operation.require_identity(identity, plan_digest)?;
+    operation.require_identity(identity, plan_digest, cache_policy)?;
     fence_run_process(operation.run_process, identity.operation_id()).await?;
     journal.cleanup_workspace(identity.operation_id()).await?;
+    journal
+        .cleanup_cache_export(identity.operation_id())
+        .await?;
     let phase = if operation.phase == PersistedBuildPhase::Cancelling {
         PersistedBuildPhase::Cancelled
     } else {
@@ -671,13 +767,23 @@ async fn recover_stale_operation(
     locked: &LockedBuildOperation,
     _lease: BuildExecutionLease,
 ) -> Result<RecordedBuildStatus, BuildPlanExecutionError> {
-    if let Some(result) =
-        adopt_committed_output(identity, plan_digest, store, journal, locked).await?
+    if let Some(result) = adopt_committed_output(
+        identity,
+        plan_digest,
+        operation.cache_policy(),
+        store,
+        journal,
+        locked,
+    )
+    .await?
     {
         return Ok(RecordedBuildStatus::Succeeded(Box::new(result)));
     }
     fence_run_process(operation.run_process, identity.operation_id()).await?;
     journal.cleanup_workspace(identity.operation_id()).await?;
+    journal
+        .cleanup_cache_export(identity.operation_id())
+        .await?;
     let (phase, message) = if operation.phase == PersistedBuildPhase::Cancelling {
         (
             PersistedBuildPhase::Cancelled,
@@ -697,6 +803,7 @@ async fn recover_stale_operation(
 async fn adopt_committed_output(
     identity: &BuildOperationIdentity,
     plan_digest: &str,
+    cache_policy: Option<BuildCachePolicy>,
     store: &ImageStore,
     journal: &BuildOperationJournal,
     locked: &LockedBuildOperation,
@@ -707,13 +814,94 @@ async fn adopt_committed_output(
         return Ok(None);
     };
     journal.cleanup_workspace(identity.operation_id()).await?;
-    let receipt = BuildOutputReceipt::from_result(identity, plan_digest.to_string(), &output)?;
+    let cache =
+        inspect_committed_cache(identity, plan_digest, cache_policy, &output, journal).await?;
+    let receipt = match cache_policy {
+        Some(cache_policy) => BuildOutputReceipt::from_result(
+            identity,
+            plan_digest.to_string(),
+            &output,
+            cache_policy,
+            cache.as_ref(),
+        )?,
+        None => BuildOutputReceipt::from_legacy_result(identity, plan_digest.to_string(), &output)?,
+    };
     let receipt = locked.write_succeeded(receipt).await?;
     Ok(Some(RecordedBuildResult {
         receipt,
         output,
+        cache,
         replayed: true,
     }))
+}
+
+async fn inspect_committed_cache(
+    identity: &BuildOperationIdentity,
+    plan_digest: &str,
+    cache_policy: Option<BuildCachePolicy>,
+    output: &BuildResult,
+    journal: &BuildOperationJournal,
+) -> Result<Option<RecordedBuildCache>, BuildPlanExecutionError> {
+    let path = journal.cache_export_path(identity.operation_id());
+    let cache_exists = match tokio::fs::symlink_metadata(&path).await {
+        Ok(_) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => {
+            return Err(BuildReceiptError::StoreIo {
+                message: format!(
+                    "failed to inspect cache export for operation {}",
+                    identity.operation_id()
+                ),
+                source: error,
+            }
+            .into())
+        }
+    };
+    match (cache_policy, cache_exists) {
+        (None, true) => {
+            journal
+                .cleanup_cache_export(identity.operation_id())
+                .await?;
+            return Ok(None);
+        }
+        (None | Some(BuildCachePolicy::Disabled), false) => return Ok(None),
+        (Some(BuildCachePolicy::Disabled), true) => {
+            return Err(BuildReceiptError::CacheInvalid {
+                operation_id: identity.operation_id().to_string(),
+                message: "cache export exists for a cache-disabled operation".to_string(),
+            }
+            .into())
+        }
+        (Some(BuildCachePolicy::ContentAddressed), false) => {
+            return Err(BuildReceiptError::CacheInvalid {
+                operation_id: identity.operation_id().to_string(),
+                message: "content-addressed operation committed an image without its cache export"
+                    .to_string(),
+            }
+            .into())
+        }
+        (Some(BuildCachePolicy::ContentAddressed), true) => {}
+    }
+    let cache_identity = BuildCacheExportIdentity::new(
+        identity.source_digest(),
+        plan_digest,
+        output.platform.clone(),
+    )?;
+    let operation = identity.operation_id().to_string();
+    tokio::task::spawn_blocking(move || inspect_build_cache_export(&path, &cache_identity, None))
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: operation.clone(),
+            message: format!("cache export validation task failed: {error}"),
+        })?
+        .map(Some)
+        .map_err(|error| {
+            BuildReceiptError::CacheInvalid {
+                operation_id: operation,
+                message: error.to_string(),
+            }
+            .into()
+        })
 }
 
 fn status_from_live_operation(operation: &SupervisedBuildOperation) -> RecordedBuildStatus {
@@ -750,196 +938,21 @@ fn status_from_terminal_operation(
 async fn recover_recorded_build(
     identity: &BuildOperationIdentity,
     plan_digest: &str,
+    cache_policy: BuildCachePolicy,
     receipt: BuildOutputReceipt,
     store: &ImageStore,
+    journal: &BuildOperationJournal,
 ) -> Result<RecordedBuildResult, BuildPlanExecutionError> {
-    receipt.require_identity(identity, plan_digest)?;
+    receipt.require_identity(identity, plan_digest, cache_policy)?;
     let output = receipt.resolve(store).await?;
+    let cache = receipt
+        .resolve_cache(&journal.cache_export_path(identity.operation_id()))
+        .await?;
     Ok(RecordedBuildResult {
         receipt,
         output,
+        cache,
         replayed: true,
-    })
-}
-
-struct JournalBuildObserver {
-    journal: BuildOperationJournal,
-    identity: BuildOperationIdentity,
-    plan_digest: String,
-}
-
-#[async_trait]
-impl BuildExecutionObserver for JournalBuildObserver {
-    async fn cancellation_requested(&self) -> BoxResult<bool> {
-        let locked = self
-            .journal
-            .lock(self.identity.operation_id())
-            .await
-            .map_err(observer_error)?;
-        let record = locked.read().await.map_err(observer_error)?;
-        match record {
-            Some(PersistedBuildOperation::Supervised(operation)) => {
-                operation
-                    .require_identity(&self.identity, &self.plan_digest)
-                    .map_err(observer_error)?;
-                Ok(operation.phase != PersistedBuildPhase::Running)
-            }
-            Some(PersistedBuildOperation::Succeeded(_)) => Ok(true),
-            Some(PersistedBuildOperation::Pending(_)) | None => Err(BoxError::BuildError(
-                "supervised build lost its authoritative operation state".to_string(),
-            )),
-        }
-    }
-
-    async fn acquire_image_commit_permit(&self) -> BoxResult<BuildImageCommitPermit> {
-        let locked = self
-            .journal
-            .lock(self.identity.operation_id())
-            .await
-            .map_err(observer_error)?;
-        let Some(PersistedBuildOperation::Supervised(operation)) =
-            locked.read().await.map_err(observer_error)?
-        else {
-            return Err(BoxError::BuildError(
-                "supervised build lost its authoritative operation state before image commit"
-                    .to_string(),
-            ));
-        };
-        operation
-            .require_identity(&self.identity, &self.plan_digest)
-            .map_err(observer_error)?;
-        if operation.phase != PersistedBuildPhase::Running {
-            return Err(BoxError::BuildError(
-                "recorded build operation was cancelled before image commit".to_string(),
-            ));
-        }
-        Ok(BuildImageCommitPermit::new(locked))
-    }
-
-    async fn run_process_started(&self, pid: u32, start_time: Option<u64>) -> BoxResult<()> {
-        let locked = self
-            .journal
-            .lock(self.identity.operation_id())
-            .await
-            .map_err(observer_error)?;
-        let Some(PersistedBuildOperation::Supervised(mut operation)) =
-            locked.read().await.map_err(observer_error)?
-        else {
-            return Err(BoxError::BuildError(
-                "supervised RUN has no active operation record".to_string(),
-            ));
-        };
-        operation
-            .require_identity(&self.identity, &self.plan_digest)
-            .map_err(observer_error)?;
-        operation
-            .set_run_process(Some(BuildProcessIdentity { pid, start_time }))
-            .map_err(observer_error)?;
-        let cancelling = operation.phase == PersistedBuildPhase::Cancelling;
-        locked
-            .write_supervised(operation)
-            .await
-            .map_err(observer_error)?;
-        if cancelling {
-            return Err(BoxError::BuildError(
-                "recorded build cancellation raced Dockerfile RUN startup".to_string(),
-            ));
-        }
-        Ok(())
-    }
-
-    async fn run_process_finished(&self, pid: u32, start_time: Option<u64>) -> BoxResult<()> {
-        let locked = self
-            .journal
-            .lock(self.identity.operation_id())
-            .await
-            .map_err(observer_error)?;
-        let Some(PersistedBuildOperation::Supervised(mut operation)) =
-            locked.read().await.map_err(observer_error)?
-        else {
-            return Ok(());
-        };
-        operation
-            .require_identity(&self.identity, &self.plan_digest)
-            .map_err(observer_error)?;
-        if operation.run_process == Some(BuildProcessIdentity { pid, start_time }) {
-            operation.set_run_process(None).map_err(observer_error)?;
-            locked
-                .write_supervised(operation)
-                .await
-                .map_err(observer_error)?;
-        }
-        Ok(())
-    }
-}
-
-fn observer_error(error: BuildReceiptError) -> BoxError {
-    BoxError::BuildError(format!(
-        "build operation journal rejected native execution: {error}"
-    ))
-}
-
-async fn fence_run_process(
-    process: Option<BuildProcessIdentity>,
-    operation_id: &a3s_box_core::OperationId,
-) -> Result<(), BuildReceiptError> {
-    let Some(process) = process else {
-        return Ok(());
-    };
-    let operation = operation_id.to_string();
-    tokio::task::spawn_blocking(move || fence_run_process_blocking(process, &operation))
-        .await
-        .map_err(|error| BuildReceiptError::Task {
-            operation_id: operation_id.to_string(),
-            message: format!("RUN process fencing task failed: {error}"),
-        })?
-}
-
-#[cfg(target_os = "linux")]
-fn fence_run_process_blocking(
-    process: BuildProcessIdentity,
-    operation_id: &str,
-) -> Result<(), BuildReceiptError> {
-    if !crate::process::is_process_alive_with_identity(process.pid, process.start_time) {
-        return Ok(());
-    }
-    let pid = i32::try_from(process.pid).map_err(|_| BuildReceiptError::InvalidReceipt {
-        operation_id: operation_id.to_string(),
-        message: "RUN process PID exceeds the host signal range".to_string(),
-    })?;
-    if unsafe { libc::kill(pid, libc::SIGKILL) } != 0 {
-        let source = std::io::Error::last_os_error();
-        if source.raw_os_error() != Some(libc::ESRCH) {
-            return Err(BuildReceiptError::StoreIo {
-                message: format!("failed to kill RUN process for operation {operation_id}"),
-                source,
-            });
-        }
-    }
-    let deadline = std::time::Instant::now() + RUN_PROCESS_STOP_TIMEOUT;
-    while crate::process::is_process_running_with_identity(process.pid, process.start_time) {
-        if std::time::Instant::now() >= deadline {
-            return Err(BuildReceiptError::Task {
-                operation_id: operation_id.to_string(),
-                message: format!(
-                    "RUN process {} did not stop within {:?}",
-                    process.pid, RUN_PROCESS_STOP_TIMEOUT
-                ),
-            });
-        }
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn fence_run_process_blocking(
-    _process: BuildProcessIdentity,
-    operation_id: &str,
-) -> Result<(), BuildReceiptError> {
-    Err(BuildReceiptError::Task {
-        operation_id: operation_id.to_string(),
-        message: "a recorded Linux RUN process cannot be fenced on this host".to_string(),
     })
 }
 

--- a/src/runtime/src/oci/build/execution/supervision.rs
+++ b/src/runtime/src/oci/build/execution/supervision.rs
@@ -1,0 +1,210 @@
+//! Adapter from native-engine control to the sole durable operation journal.
+
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
+use a3s_box_core::error::{BoxError, Result as BoxResult};
+use a3s_box_core::OperationId;
+use async_trait::async_trait;
+
+use crate::oci::build::cache::RecordedBuildCache;
+use crate::oci::build::engine::{BuildExecutionObserver, BuildImageCommitPermit};
+use crate::oci::build::receipt::{
+    BuildOperationJournal, BuildProcessIdentity, PersistedBuildOperation, PersistedBuildPhase,
+};
+use crate::oci::build::{BuildCachePolicy, BuildOperationIdentity, BuildReceiptError};
+
+#[cfg(target_os = "linux")]
+const RUN_PROCESS_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(super) struct JournalBuildObserver {
+    pub(super) journal: BuildOperationJournal,
+    pub(super) identity: BuildOperationIdentity,
+    pub(super) plan_digest: String,
+    pub(super) cache_policy: BuildCachePolicy,
+}
+
+#[async_trait]
+impl BuildExecutionObserver for JournalBuildObserver {
+    async fn cancellation_requested(&self) -> BoxResult<bool> {
+        let locked = self
+            .journal
+            .lock(self.identity.operation_id())
+            .await
+            .map_err(observer_error)?;
+        let record = locked.read().await.map_err(observer_error)?;
+        match record {
+            Some(PersistedBuildOperation::Supervised(operation)) => {
+                operation
+                    .require_identity(&self.identity, &self.plan_digest, self.cache_policy)
+                    .map_err(observer_error)?;
+                Ok(operation.phase != PersistedBuildPhase::Running)
+            }
+            Some(PersistedBuildOperation::Succeeded(_)) => Ok(true),
+            Some(PersistedBuildOperation::Pending(_)) | None => Err(BoxError::BuildError(
+                "supervised build lost its authoritative operation state".to_string(),
+            )),
+        }
+    }
+
+    async fn acquire_image_commit_permit(&self) -> BoxResult<BuildImageCommitPermit> {
+        let locked = self
+            .journal
+            .lock(self.identity.operation_id())
+            .await
+            .map_err(observer_error)?;
+        let Some(PersistedBuildOperation::Supervised(operation)) =
+            locked.read().await.map_err(observer_error)?
+        else {
+            return Err(BoxError::BuildError(
+                "supervised build lost its authoritative operation state before image commit"
+                    .to_string(),
+            ));
+        };
+        operation
+            .require_identity(&self.identity, &self.plan_digest, self.cache_policy)
+            .map_err(observer_error)?;
+        if operation.phase != PersistedBuildPhase::Running {
+            return Err(BoxError::BuildError(
+                "recorded build operation was cancelled before image commit".to_string(),
+            ));
+        }
+        Ok(BuildImageCommitPermit::new(locked))
+    }
+
+    async fn publish_cache_export(
+        &self,
+        staged: RecordedBuildCache,
+    ) -> BoxResult<RecordedBuildCache> {
+        self.journal
+            .publish_cache_export(self.identity.operation_id(), staged)
+            .await
+            .map_err(observer_error)
+    }
+
+    async fn run_process_started(&self, pid: u32, start_time: Option<u64>) -> BoxResult<()> {
+        let locked = self
+            .journal
+            .lock(self.identity.operation_id())
+            .await
+            .map_err(observer_error)?;
+        let Some(PersistedBuildOperation::Supervised(mut operation)) =
+            locked.read().await.map_err(observer_error)?
+        else {
+            return Err(BoxError::BuildError(
+                "supervised RUN has no active operation record".to_string(),
+            ));
+        };
+        operation
+            .require_identity(&self.identity, &self.plan_digest, self.cache_policy)
+            .map_err(observer_error)?;
+        operation
+            .set_run_process(Some(BuildProcessIdentity { pid, start_time }))
+            .map_err(observer_error)?;
+        let cancelling = operation.phase == PersistedBuildPhase::Cancelling;
+        locked
+            .write_supervised(operation)
+            .await
+            .map_err(observer_error)?;
+        if cancelling {
+            return Err(BoxError::BuildError(
+                "recorded build cancellation raced Dockerfile RUN startup".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn run_process_finished(&self, pid: u32, start_time: Option<u64>) -> BoxResult<()> {
+        let locked = self
+            .journal
+            .lock(self.identity.operation_id())
+            .await
+            .map_err(observer_error)?;
+        let Some(PersistedBuildOperation::Supervised(mut operation)) =
+            locked.read().await.map_err(observer_error)?
+        else {
+            return Ok(());
+        };
+        operation
+            .require_identity(&self.identity, &self.plan_digest, self.cache_policy)
+            .map_err(observer_error)?;
+        if operation.run_process == Some(BuildProcessIdentity { pid, start_time }) {
+            operation.set_run_process(None).map_err(observer_error)?;
+            locked
+                .write_supervised(operation)
+                .await
+                .map_err(observer_error)?;
+        }
+        Ok(())
+    }
+}
+
+fn observer_error(error: BuildReceiptError) -> BoxError {
+    BoxError::BuildError(format!(
+        "build operation journal rejected native execution: {error}"
+    ))
+}
+
+pub(super) async fn fence_run_process(
+    process: Option<BuildProcessIdentity>,
+    operation_id: &OperationId,
+) -> Result<(), BuildReceiptError> {
+    let Some(process) = process else {
+        return Ok(());
+    };
+    let operation = operation_id.to_string();
+    tokio::task::spawn_blocking(move || fence_run_process_blocking(process, &operation))
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: operation_id.to_string(),
+            message: format!("RUN process fencing task failed: {error}"),
+        })?
+}
+
+#[cfg(target_os = "linux")]
+fn fence_run_process_blocking(
+    process: BuildProcessIdentity,
+    operation_id: &str,
+) -> Result<(), BuildReceiptError> {
+    if !crate::process::is_process_alive_with_identity(process.pid, process.start_time) {
+        return Ok(());
+    }
+    let pid = i32::try_from(process.pid).map_err(|_| BuildReceiptError::InvalidReceipt {
+        operation_id: operation_id.to_string(),
+        message: "RUN process PID exceeds the host signal range".to_string(),
+    })?;
+    if unsafe { libc::kill(pid, libc::SIGKILL) } != 0 {
+        let source = std::io::Error::last_os_error();
+        if source.raw_os_error() != Some(libc::ESRCH) {
+            return Err(BuildReceiptError::StoreIo {
+                message: format!("failed to kill RUN process for operation {operation_id}"),
+                source,
+            });
+        }
+    }
+    let deadline = std::time::Instant::now() + RUN_PROCESS_STOP_TIMEOUT;
+    while crate::process::is_process_running_with_identity(process.pid, process.start_time) {
+        if std::time::Instant::now() >= deadline {
+            return Err(BuildReceiptError::Task {
+                operation_id: operation_id.to_string(),
+                message: format!(
+                    "RUN process {} did not stop within {:?}",
+                    process.pid, RUN_PROCESS_STOP_TIMEOUT
+                ),
+            });
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn fence_run_process_blocking(
+    _process: BuildProcessIdentity,
+    operation_id: &str,
+) -> Result<(), BuildReceiptError> {
+    Err(BuildReceiptError::Task {
+        operation_id: operation_id.to_string(),
+        message: "a recorded Linux RUN process cannot be fenced on this host".to_string(),
+    })
+}

--- a/src/runtime/src/oci/build/execution/tests.rs
+++ b/src/runtime/src/oci/build/execution/tests.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use a3s_box_core::OperationId;
 
 use super::*;
+use crate::oci::build::engine::BuildExecutionObserver;
 use crate::OCI_IMAGE_MANIFEST_MEDIA_TYPE;
 
 #[tokio::test]
@@ -114,7 +115,9 @@ build "oci" {{
         .unwrap();
     let locked = journal.lock(identity.operation_id()).await.unwrap();
     locked
-        .write_supervised(SupervisedBuildOperation::new(&identity, plan_digest.clone()).unwrap())
+        .write_supervised(
+            SupervisedBuildOperation::new(&identity, plan_digest.clone(), plan.cache()).unwrap(),
+        )
         .await
         .unwrap();
     drop(locked);
@@ -123,6 +126,7 @@ build "oci" {{
         journal,
         identity: identity.clone(),
         plan_digest,
+        cache_policy: plan.cache(),
     };
     let permit = observer.acquire_image_commit_permit().await.unwrap();
     let cancellation_identity = identity.clone();

--- a/src/runtime/src/oci/build/layout.rs
+++ b/src/runtime/src/oci/build/layout.rs
@@ -1,0 +1,207 @@
+//! Shared validation for complete, content-addressed OCI build layouts.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use a3s_box_core::error::{BoxError, Result};
+use oci_spec::image::Descriptor;
+use sha2::{Digest, Sha256};
+
+use crate::oci::image::{
+    canonical_sha256_digest_hex, read_regular_file_bounded, validate_plain_directory,
+    MAX_OCI_INDEX_BYTES, MAX_OCI_LAYOUT_BYTES,
+};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum EntryKind {
+    File,
+    Directory,
+}
+
+pub(super) fn validate_exact_entries(
+    directory: &Path,
+    expected: &[(&str, EntryKind)],
+    label: &str,
+) -> Result<()> {
+    validate_plain_directory(directory, label)?;
+    let mut actual = BTreeMap::new();
+    for entry in std::fs::read_dir(directory).map_err(|error| {
+        layout_error(format!(
+            "Failed to inspect {label} {}: {error}",
+            directory.display()
+        ))
+    })? {
+        let entry = entry.map_err(|error| {
+            layout_error(format!(
+                "Failed to inspect an entry in {label} {}: {error}",
+                directory.display()
+            ))
+        })?;
+        let name = entry.file_name().into_string().map_err(|_| {
+            layout_error(format!(
+                "{label} {} contains a non-UTF-8 entry",
+                directory.display()
+            ))
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            layout_error(format!(
+                "Failed to inspect {label} entry {}: {error}",
+                entry.path().display()
+            ))
+        })?;
+        let kind = if file_type.is_file() && !file_type.is_symlink() {
+            EntryKind::File
+        } else if file_type.is_dir() && !file_type.is_symlink() {
+            EntryKind::Directory
+        } else {
+            return Err(layout_error(format!(
+                "{label} entry {} is not a plain file or directory",
+                entry.path().display()
+            )));
+        };
+        actual.insert(name, kind);
+    }
+    let expected = expected
+        .iter()
+        .map(|(name, kind)| ((*name).to_string(), *kind))
+        .collect::<BTreeMap<_, _>>();
+    if actual != expected {
+        return Err(layout_error(format!(
+            "{label} {} does not contain the exact expected entries",
+            directory.display()
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_blob_inventory(
+    layout: &Path,
+    descriptors: &[Descriptor],
+    label: &str,
+) -> Result<(usize, u64, String)> {
+    let mut expected = BTreeMap::<String, u64>::new();
+    for descriptor in descriptors {
+        let digest = descriptor.digest().to_string();
+        canonical_sha256_digest_hex(&digest)?;
+        let size = descriptor.size();
+        if size == 0 {
+            return Err(layout_error(format!(
+                "{label} blob {digest} has an empty descriptor"
+            )));
+        }
+        if let Some(existing) = expected.insert(digest.clone(), size) {
+            if existing != size {
+                return Err(layout_error(format!(
+                    "{label} blob {digest} has conflicting descriptor sizes"
+                )));
+            }
+        }
+    }
+
+    let blob_root = layout.join("blobs").join("sha256");
+    validate_plain_directory(&blob_root, &format!("{label} sha256 blobs"))?;
+    let mut actual = BTreeSet::new();
+    for entry in std::fs::read_dir(&blob_root).map_err(|error| {
+        layout_error(format!(
+            "Failed to inspect {label} blobs {}: {error}",
+            blob_root.display()
+        ))
+    })? {
+        let entry = entry.map_err(|error| {
+            layout_error(format!(
+                "Failed to inspect an entry in {}: {error}",
+                blob_root.display()
+            ))
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            layout_error(format!(
+                "Failed to inspect {label} blob {}: {error}",
+                entry.path().display()
+            ))
+        })?;
+        if !file_type.is_file() || file_type.is_symlink() {
+            return Err(layout_error(format!(
+                "{label} blob {} is not a regular file",
+                entry.path().display()
+            )));
+        }
+        let name = entry.file_name().into_string().map_err(|_| {
+            layout_error(format!(
+                "{label} blob name in {} is not UTF-8",
+                blob_root.display()
+            ))
+        })?;
+        let digest = format!("sha256:{name}");
+        canonical_sha256_digest_hex(&digest)?;
+        let expected_size = expected
+            .get(&digest)
+            .ok_or_else(|| layout_error(format!("{label} contains unreferenced blob {digest}")))?;
+        let actual_size = entry
+            .metadata()
+            .map_err(|error| {
+                layout_error(format!(
+                    "Failed to inspect {label} blob {}: {error}",
+                    entry.path().display()
+                ))
+            })?
+            .len();
+        if actual_size != *expected_size {
+            return Err(layout_error(format!(
+                "{label} blob {digest} has {actual_size} bytes, expected {expected_size}"
+            )));
+        }
+        actual.insert(digest);
+    }
+    let expected_names = expected.keys().cloned().collect::<BTreeSet<_>>();
+    if actual != expected_names {
+        let missing = expected_names
+            .difference(&actual)
+            .next()
+            .cloned()
+            .unwrap_or_else(|| "<unknown>".to_string());
+        return Err(layout_error(format!(
+            "{label} is missing referenced blob {missing}"
+        )));
+    }
+
+    let mut inventory_hasher = Sha256::new();
+    let mut blob_bytes = 0_u64;
+    for (digest, size) in &expected {
+        inventory_hasher.update(digest.as_bytes());
+        inventory_hasher.update([0]);
+        inventory_hasher.update(size.to_be_bytes());
+        blob_bytes = blob_bytes
+            .checked_add(*size)
+            .ok_or_else(|| layout_error(format!("{label} blob byte count overflowed")))?;
+    }
+    Ok((
+        expected.len(),
+        blob_bytes,
+        format!("sha256:{:x}", inventory_hasher.finalize()),
+    ))
+}
+
+pub(super) fn metadata_bytes(layout: &Path, label: &str) -> Result<u64> {
+    let layout_bytes = read_regular_file_bounded(
+        &layout.join("oci-layout"),
+        MAX_OCI_LAYOUT_BYTES,
+        "oci-layout",
+    )?;
+    let index_bytes = read_regular_file_bounded(
+        &layout.join("index.json"),
+        MAX_OCI_INDEX_BYTES,
+        "index.json",
+    )?;
+    u64::try_from(layout_bytes.len())
+        .ok()
+        .and_then(|left| {
+            u64::try_from(index_bytes.len())
+                .ok()
+                .and_then(|right| left.checked_add(right))
+        })
+        .ok_or_else(|| layout_error(format!("{label} metadata byte count overflowed")))
+}
+
+fn layout_error(message: impl Into<String>) -> BoxError {
+    BoxError::BuildError(message.into())
+}

--- a/src/runtime/src/oci/build/mod.rs
+++ b/src/runtime/src/oci/build/mod.rs
@@ -24,10 +24,15 @@ pub(crate) mod dockerignore;
 pub mod engine;
 mod execution;
 pub mod layer;
+mod layout;
 mod output;
 pub mod plan;
 mod receipt;
 
+pub use cache::{
+    BuildCacheReceipt, RecordedBuildCache, BUILD_CACHE_ARTIFACT_MEDIA_TYPE,
+    BUILD_CACHE_CONFIG_MEDIA_TYPE,
+};
 pub use dockerfile::{Dockerfile, Instruction};
 pub use engine::{build, BuildConfig, BuildNetworkPolicy, BuildRunPoolConfig};
 pub use execution::{

--- a/src/runtime/src/oci/build/output.rs
+++ b/src/runtime/src/oci/build/output.rs
@@ -1,19 +1,14 @@
 //! Single validation and reconstruction path for native OCI build outputs.
 
-use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use a3s_box_core::error::{BoxError, Result};
 use a3s_box_core::platform::Platform;
 use a3s_box_core::StoredImage;
-use oci_spec::image::Descriptor;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
-use crate::oci::image::{
-    canonical_sha256_digest_hex, read_regular_file_bounded, validate_plain_directory,
-    MAX_OCI_INDEX_BYTES, MAX_OCI_LAYOUT_BYTES,
-};
+use super::layout::{metadata_bytes, validate_blob_inventory, validate_exact_entries, EntryKind};
+use crate::oci::image::canonical_sha256_digest_hex;
 use crate::oci::OciImage;
 
 /// OCI media type emitted for the root descriptor of a native build.
@@ -140,9 +135,12 @@ pub(super) fn inspect_stored_build_output(
     }
 
     validate_native_layout_entries(&layout_directory)?;
-    let (blob_count, blob_bytes, blob_inventory_digest) =
-        validate_blob_inventory(&layout_directory, image.content_descriptors())?;
-    let metadata_bytes = metadata_bytes(&layout_directory)?;
+    let (blob_count, blob_bytes, blob_inventory_digest) = validate_blob_inventory(
+        &layout_directory,
+        image.content_descriptors(),
+        "Native OCI output",
+    )?;
+    let metadata_bytes = metadata_bytes(&layout_directory, "Native OCI output")?;
     let content_bytes = metadata_bytes
         .checked_add(blob_bytes)
         .ok_or_else(|| output_error("Native build output byte count overflowed"))?;
@@ -181,197 +179,6 @@ fn validate_native_layout_entries(layout: &Path) -> Result<()> {
         &[("sha256", EntryKind::Directory)],
         "native OCI blob root",
     )
-}
-
-fn validate_blob_inventory(
-    layout: &Path,
-    descriptors: &[Descriptor],
-) -> Result<(usize, u64, String)> {
-    let mut expected = BTreeMap::<String, u64>::new();
-    for descriptor in descriptors {
-        let digest = descriptor.digest().to_string();
-        canonical_sha256_digest_hex(&digest)?;
-        let size = descriptor.size();
-        if size == 0 {
-            return Err(output_error(format!(
-                "Native OCI blob {digest} has an empty descriptor"
-            )));
-        }
-        if let Some(existing) = expected.insert(digest.clone(), size) {
-            if existing != size {
-                return Err(output_error(format!(
-                    "Native OCI blob {digest} has conflicting descriptor sizes"
-                )));
-            }
-        }
-    }
-
-    let blob_root = layout.join("blobs").join("sha256");
-    validate_plain_directory(&blob_root, "native OCI sha256 blobs")?;
-    let mut actual = BTreeSet::new();
-    for entry in std::fs::read_dir(&blob_root).map_err(|error| {
-        output_error(format!(
-            "Failed to inspect native OCI blobs {}: {error}",
-            blob_root.display()
-        ))
-    })? {
-        let entry = entry.map_err(|error| {
-            output_error(format!(
-                "Failed to inspect an entry in {}: {error}",
-                blob_root.display()
-            ))
-        })?;
-        let file_type = entry.file_type().map_err(|error| {
-            output_error(format!(
-                "Failed to inspect native OCI blob {}: {error}",
-                entry.path().display()
-            ))
-        })?;
-        if !file_type.is_file() || file_type.is_symlink() {
-            return Err(output_error(format!(
-                "Native OCI blob {} is not a regular file",
-                entry.path().display()
-            )));
-        }
-        let name = entry.file_name().into_string().map_err(|_| {
-            output_error(format!(
-                "Native OCI blob name in {} is not UTF-8",
-                blob_root.display()
-            ))
-        })?;
-        let digest = format!("sha256:{name}");
-        canonical_sha256_digest_hex(&digest)?;
-        let expected_size = expected.get(&digest).ok_or_else(|| {
-            output_error(format!(
-                "Native OCI output contains unreferenced blob {digest}"
-            ))
-        })?;
-        let actual_size = entry
-            .metadata()
-            .map_err(|error| {
-                output_error(format!(
-                    "Failed to inspect native OCI blob {}: {error}",
-                    entry.path().display()
-                ))
-            })?
-            .len();
-        if actual_size != *expected_size {
-            return Err(output_error(format!(
-                "Native OCI blob {digest} has {actual_size} bytes, expected {expected_size}"
-            )));
-        }
-        actual.insert(digest);
-    }
-    let expected_names = expected.keys().cloned().collect::<BTreeSet<_>>();
-    if actual != expected_names {
-        let missing = expected_names
-            .difference(&actual)
-            .next()
-            .cloned()
-            .unwrap_or_else(|| "<unknown>".to_string());
-        return Err(output_error(format!(
-            "Native OCI output is missing referenced blob {missing}"
-        )));
-    }
-
-    let mut inventory_hasher = Sha256::new();
-    let mut blob_bytes = 0_u64;
-    for (digest, size) in &expected {
-        inventory_hasher.update(digest.as_bytes());
-        inventory_hasher.update([0]);
-        inventory_hasher.update(size.to_be_bytes());
-        blob_bytes = blob_bytes
-            .checked_add(*size)
-            .ok_or_else(|| output_error("Native OCI blob byte count overflowed"))?;
-    }
-    Ok((
-        expected.len(),
-        blob_bytes,
-        format!("sha256:{:x}", inventory_hasher.finalize()),
-    ))
-}
-
-fn metadata_bytes(layout: &Path) -> Result<u64> {
-    let layout_bytes = read_regular_file_bounded(
-        &layout.join("oci-layout"),
-        MAX_OCI_LAYOUT_BYTES,
-        "oci-layout",
-    )?;
-    let index_bytes = read_regular_file_bounded(
-        &layout.join("index.json"),
-        MAX_OCI_INDEX_BYTES,
-        "index.json",
-    )?;
-    u64::try_from(layout_bytes.len())
-        .ok()
-        .and_then(|left| {
-            u64::try_from(index_bytes.len())
-                .ok()
-                .and_then(|right| left.checked_add(right))
-        })
-        .ok_or_else(|| output_error("Native OCI metadata byte count overflowed"))
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum EntryKind {
-    File,
-    Directory,
-}
-
-fn validate_exact_entries(
-    directory: &Path,
-    expected: &[(&str, EntryKind)],
-    label: &str,
-) -> Result<()> {
-    validate_plain_directory(directory, label)?;
-    let mut actual = BTreeMap::new();
-    for entry in std::fs::read_dir(directory).map_err(|error| {
-        output_error(format!(
-            "Failed to inspect {label} {}: {error}",
-            directory.display()
-        ))
-    })? {
-        let entry = entry.map_err(|error| {
-            output_error(format!(
-                "Failed to inspect an entry in {label} {}: {error}",
-                directory.display()
-            ))
-        })?;
-        let name = entry.file_name().into_string().map_err(|_| {
-            output_error(format!(
-                "{label} {} contains a non-UTF-8 entry",
-                directory.display()
-            ))
-        })?;
-        let file_type = entry.file_type().map_err(|error| {
-            output_error(format!(
-                "Failed to inspect {label} entry {}: {error}",
-                entry.path().display()
-            ))
-        })?;
-        let kind = if file_type.is_file() && !file_type.is_symlink() {
-            EntryKind::File
-        } else if file_type.is_dir() && !file_type.is_symlink() {
-            EntryKind::Directory
-        } else {
-            return Err(output_error(format!(
-                "{label} entry {} is not a plain file or directory",
-                entry.path().display()
-            )));
-        };
-        actual.insert(name, kind);
-    }
-    let expected = expected
-        .iter()
-        .map(|(name, kind)| ((*name).to_string(), *kind))
-        .collect::<BTreeMap<_, _>>();
-    if actual != expected {
-        return Err(output_error(format!(
-            "{label} {} does not contain the exact native output entries",
-            directory.display()
-        )));
-    }
-    Ok(())
 }
 
 fn output_error(message: impl Into<String>) -> BoxError {

--- a/src/runtime/src/oci/build/plan.rs
+++ b/src/runtime/src/oci/build/plan.rs
@@ -13,6 +13,7 @@ use a3s_acl::{
     ParseLimits, Schema, SchemaDiagnosticCode, Value, ValueSchema,
 };
 use a3s_box_core::platform::Platform;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::engine::{BuildConfig, BuildNetworkPolicy};
@@ -29,7 +30,8 @@ const BUILD_PLAN_LIMITS: ParseLimits = ParseLimits {
 };
 
 /// Cache behavior admitted by the Box build-plan contract.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum BuildCachePolicy {
     /// Reuse only content-addressed native build-engine cache entries.
     ContentAddressed,

--- a/src/runtime/src/oci/build/receipt.rs
+++ b/src/runtime/src/oci/build/receipt.rs
@@ -14,8 +14,11 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+use super::cache::{
+    inspect_build_cache_export, BuildCacheExportIdentity, BuildCacheReceipt, RecordedBuildCache,
+};
 use super::output::inspect_stored_build_output;
-use super::{BuildOutputDescriptor, BuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
+use super::{BuildCachePolicy, BuildOutputDescriptor, BuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
 use crate::oci::image::canonical_sha256_digest_hex;
 use crate::oci::ImageStore;
 
@@ -161,6 +164,8 @@ impl PendingBuildOperation {
             && self.source_digest == receipt.source_digest
             && self.plan_digest == receipt.plan_digest
             && self.output_reference == receipt.output.reference
+            && receipt.schema == BuildOutputReceipt::LEGACY_SCHEMA
+            && receipt.cache.is_none()
     }
 }
 
@@ -212,6 +217,8 @@ pub(super) struct SupervisedBuildOperation {
     source_digest: String,
     plan_digest: String,
     output_reference: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cache_policy: Option<BuildCachePolicy>,
     pub(super) phase: PersistedBuildPhase,
     owner: BuildProcessIdentity,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -223,11 +230,13 @@ pub(super) struct SupervisedBuildOperation {
 }
 
 impl SupervisedBuildOperation {
-    pub(super) const SCHEMA: &'static str = "a3s.box.build-operation.v1";
+    pub(super) const SCHEMA: &'static str = "a3s.box.build-operation.v2";
+    const LEGACY_SCHEMA: &'static str = "a3s.box.build-operation.v1";
 
     pub(super) fn new(
         identity: &BuildOperationIdentity,
         plan_digest: String,
+        cache_policy: BuildCachePolicy,
     ) -> Result<Self, BuildReceiptError> {
         let now = Utc::now();
         let operation = Self {
@@ -236,6 +245,7 @@ impl SupervisedBuildOperation {
             source_digest: identity.source_digest.clone(),
             plan_digest,
             output_reference: identity.output_reference.clone(),
+            cache_policy: Some(cache_policy),
             phase: PersistedBuildPhase::Running,
             owner: BuildProcessIdentity::current(),
             run_process: None,
@@ -244,7 +254,7 @@ impl SupervisedBuildOperation {
             updated_at: now,
         };
         operation.validate()?;
-        operation.require_identity(identity, &operation.plan_digest)?;
+        operation.require_identity(identity, &operation.plan_digest, cache_policy)?;
         Ok(operation)
     }
 
@@ -252,13 +262,16 @@ impl SupervisedBuildOperation {
         pending: &PendingBuildOperation,
         identity: &BuildOperationIdentity,
         plan_digest: &str,
+        cache_policy: BuildCachePolicy,
     ) -> Result<Self, BuildReceiptError> {
         pending.require_identity(identity, plan_digest)?;
-        Self::new(identity, plan_digest.to_string())
+        Self::new(identity, plan_digest.to_string(), cache_policy)
     }
 
     fn validate(&self) -> Result<(), BuildReceiptError> {
-        if self.schema != Self::SCHEMA
+        let schema_is_valid = (self.schema == Self::SCHEMA && self.cache_policy.is_some())
+            || (self.schema == Self::LEGACY_SCHEMA && self.cache_policy.is_none());
+        if !schema_is_valid
             || !valid_operation_id(&self.operation_id)
             || canonical_sha256_digest_hex(&self.source_digest).is_err()
             || canonical_sha256_digest_hex(&self.plan_digest).is_err()
@@ -300,12 +313,16 @@ impl SupervisedBuildOperation {
         &self,
         identity: &BuildOperationIdentity,
         plan_digest: &str,
+        cache_policy: BuildCachePolicy,
     ) -> Result<(), BuildReceiptError> {
         self.validate()?;
         if self.operation_id != identity.operation_id
             || self.source_digest != identity.source_digest
             || self.plan_digest != plan_digest
             || self.output_reference != identity.output_reference
+            || self
+                .cache_policy
+                .is_some_and(|persisted| persisted != cache_policy)
         {
             return Err(BuildReceiptError::Conflict {
                 operation_id: identity.operation_id.to_string(),
@@ -313,6 +330,10 @@ impl SupervisedBuildOperation {
             });
         }
         Ok(())
+    }
+
+    pub(super) const fn cache_policy(&self) -> Option<BuildCachePolicy> {
+        self.cache_policy
     }
 
     pub(super) fn request_cancellation(&mut self) -> bool {
@@ -367,6 +388,15 @@ impl SupervisedBuildOperation {
             && self.source_digest == receipt.source_digest
             && self.plan_digest == receipt.plan_digest
             && self.output_reference == receipt.output.reference
+            && match self.cache_policy {
+                Some(policy) => {
+                    receipt.schema == BuildOutputReceipt::SCHEMA
+                        && receipt.matches_cache_policy(policy)
+                }
+                None => {
+                    receipt.schema == BuildOutputReceipt::LEGACY_SCHEMA && receipt.cache.is_none()
+                }
+            }
     }
 }
 
@@ -376,7 +406,7 @@ impl SupervisedBuildOperation {
 pub(super) enum PersistedBuildOperation {
     Supervised(SupervisedBuildOperation),
     Pending(PendingBuildOperation),
-    Succeeded(BuildOutputReceipt),
+    Succeeded(Box<BuildOutputReceipt>),
 }
 
 impl PersistedBuildOperation {
@@ -431,16 +461,22 @@ pub struct BuildOutputReceipt {
     pub plan_digest: String,
     /// Path-independent native OCI output evidence.
     pub output: BuildReceiptOutput,
+    /// Portable native cache evidence, present for new content-addressed plans.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache: Option<BuildCacheReceipt>,
 }
 
 impl BuildOutputReceipt {
     /// Current closed receipt schema.
-    pub const SCHEMA: &'static str = "a3s.box.build-output-receipt.v1";
+    pub const SCHEMA: &'static str = "a3s.box.build-output-receipt.v2";
+    const LEGACY_SCHEMA: &'static str = "a3s.box.build-output-receipt.v1";
 
     pub(super) fn from_result(
         identity: &BuildOperationIdentity,
         plan_digest: String,
         result: &BuildResult,
+        cache_policy: BuildCachePolicy,
+        cache: Option<&RecordedBuildCache>,
     ) -> Result<Self, BuildReceiptError> {
         let layer_count =
             u64::try_from(result.layer_count).map_err(|_| BuildReceiptError::OutputInvalid {
@@ -466,18 +502,42 @@ impl BuildOutputReceipt {
                 blob_count,
                 blob_inventory_digest: result.blob_inventory_digest.clone(),
             },
+            cache: cache.map(|cache| cache.receipt.clone()),
         };
         receipt.validate()?;
-        receipt.require_identity(identity, &receipt.plan_digest)?;
+        receipt.require_identity(identity, &receipt.plan_digest, cache_policy)?;
+        Ok(receipt)
+    }
+
+    pub(super) fn from_legacy_result(
+        identity: &BuildOperationIdentity,
+        plan_digest: String,
+        result: &BuildResult,
+    ) -> Result<Self, BuildReceiptError> {
+        let mut receipt = Self::from_result(
+            identity,
+            plan_digest,
+            result,
+            BuildCachePolicy::Disabled,
+            None,
+        )?;
+        receipt.schema = Self::LEGACY_SCHEMA.to_string();
+        receipt.validate()?;
         Ok(receipt)
     }
 
     fn validate(&self) -> Result<(), BuildReceiptError> {
         let operation_id = self.operation_id.to_string();
-        if self.schema != Self::SCHEMA {
+        if self.schema != Self::SCHEMA && self.schema != Self::LEGACY_SCHEMA {
             return Err(BuildReceiptError::InvalidReceipt {
                 operation_id,
                 message: format!("unsupported schema {:?}", self.schema),
+            });
+        }
+        if self.schema == Self::LEGACY_SCHEMA && self.cache.is_some() {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id,
+                message: "legacy output receipt cannot contain cache evidence".to_string(),
             });
         }
         if !valid_operation_id(&self.operation_id) {
@@ -530,6 +590,23 @@ impl BuildOutputReceipt {
                 message: "output platform is outside the native build contract".to_string(),
             });
         }
+        if let Some(cache) = &self.cache {
+            cache
+                .validate()
+                .map_err(|error| BuildReceiptError::CacheInvalid {
+                    operation_id: self.operation_id.to_string(),
+                    message: error.to_string(),
+                })?;
+            if cache.source_digest != self.source_digest
+                || cache.plan_digest != self.plan_digest
+                || cache.platform != self.output.platform
+            {
+                return Err(BuildReceiptError::InvalidReceipt {
+                    operation_id: self.operation_id.to_string(),
+                    message: "cache and image receipts have different immutable intent".to_string(),
+                });
+            }
+        }
         Ok(())
     }
 
@@ -537,6 +614,7 @@ impl BuildOutputReceipt {
         &self,
         identity: &BuildOperationIdentity,
         plan_digest: &str,
+        cache_policy: BuildCachePolicy,
     ) -> Result<(), BuildReceiptError> {
         self.validate()?;
         if self.operation_id != identity.operation_id
@@ -549,7 +627,20 @@ impl BuildOutputReceipt {
                 message: "the persisted source, plan, or output identity differs".to_string(),
             });
         }
+        if self.schema == Self::SCHEMA && !self.matches_cache_policy(cache_policy) {
+            return Err(BuildReceiptError::InvalidReceipt {
+                operation_id: identity.operation_id.to_string(),
+                message: "cache evidence differs from the admitted build-plan policy".to_string(),
+            });
+        }
         Ok(())
+    }
+
+    fn matches_cache_policy(&self, cache_policy: BuildCachePolicy) -> bool {
+        match cache_policy {
+            BuildCachePolicy::ContentAddressed => self.cache.is_some(),
+            BuildCachePolicy::Disabled => self.cache.is_none(),
+        }
     }
 
     pub(super) async fn resolve(
@@ -576,6 +667,39 @@ impl BuildOutputReceipt {
             });
         }
         Ok(actual)
+    }
+
+    pub(super) async fn resolve_cache(
+        &self,
+        layout_directory: &std::path::Path,
+    ) -> Result<Option<RecordedBuildCache>, BuildReceiptError> {
+        let Some(expected) = self.cache.clone() else {
+            return Ok(None);
+        };
+        let identity = BuildCacheExportIdentity::new(
+            self.source_digest.clone(),
+            self.plan_digest.clone(),
+            expected.platform.clone(),
+        )
+        .map_err(|error| BuildReceiptError::CacheInvalid {
+            operation_id: self.operation_id.to_string(),
+            message: error.to_string(),
+        })?;
+        let root = layout_directory.to_path_buf();
+        let operation = self.operation_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            inspect_build_cache_export(&root, &identity, Some(&expected))
+        })
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: self.operation_id.to_string(),
+            message: format!("cache receipt validation task failed: {error}"),
+        })?
+        .map(Some)
+        .map_err(|error| BuildReceiptError::CacheInvalid {
+            operation_id: operation,
+            message: error.to_string(),
+        })
     }
 }
 
@@ -619,6 +743,8 @@ pub struct RecordedBuildResult {
     pub receipt: BuildOutputReceipt,
     /// Revalidated store-owned OCI output.
     pub output: BuildResult,
+    /// Revalidated operation-owned portable cache artifact.
+    pub cache: Option<RecordedBuildCache>,
     /// Whether this call replayed an existing terminal receipt.
     pub replayed: bool,
 }
@@ -699,6 +825,12 @@ pub enum BuildReceiptError {
     /// Persisted output no longer proves the receipt.
     #[error("Box build output is invalid for {operation_id}: {message}")]
     OutputInvalid {
+        operation_id: String,
+        message: String,
+    },
+    /// Persisted cache evidence or its operation-owned OCI artifact is invalid.
+    #[error("Box build cache is invalid for {operation_id}: {message}")]
+    CacheInvalid {
         operation_id: String,
         message: String,
     },

--- a/src/runtime/src/oci/build/receipt/journal.rs
+++ b/src/runtime/src/oci/build/receipt/journal.rs
@@ -9,6 +9,7 @@ use super::{
     PersistedBuildPhase, SupervisedBuildOperation, MAX_RECEIPT_BYTES, RECEIPT_DIRECTORY,
 };
 use crate::file_lock::FileLock;
+use crate::oci::build::cache::RecordedBuildCache;
 use crate::oci::image::{read_regular_file_bounded, validate_plain_directory};
 use crate::oci::ImageStore;
 
@@ -82,6 +83,11 @@ impl BuildOperationJournal {
             .join(format!("{}.workspace", operation_key(operation_id)))
     }
 
+    pub(in crate::oci::build) fn cache_export_path(&self, operation_id: &OperationId) -> PathBuf {
+        self.root
+            .join(format!("{}.cache", operation_key(operation_id)))
+    }
+
     fn execution_lock_target(&self, operation_id: &OperationId) -> PathBuf {
         self.root
             .join(format!("{}.execution", operation_key(operation_id)))
@@ -142,14 +148,21 @@ impl BuildOperationJournal {
     ) -> Result<PathBuf, BuildReceiptError> {
         let root = self.root.clone();
         let workspace = self.workspace_path(operation_id);
+        let cache_export = self.cache_export_path(operation_id);
         let operation = operation_id.to_string();
         tokio::task::spawn_blocking(move || {
-            remove_workspace_if_present(&root, &workspace, &operation)?;
+            remove_operation_directory_if_present(&root, &workspace, "workspace", &operation)?;
+            remove_operation_directory_if_present(
+                &root,
+                &cache_export,
+                "cache export",
+                &operation,
+            )?;
             std::fs::create_dir(&workspace).map_err(|source| BuildReceiptError::StoreIo {
                 message: format!("failed to create workspace for operation {operation}"),
                 source,
             })?;
-            validate_workspace(&root, &workspace, &operation)
+            validate_operation_directory(&root, &workspace, "workspace", &operation)
         })
         .await
         .map_err(|error| BuildReceiptError::Task {
@@ -166,12 +179,95 @@ impl BuildOperationJournal {
         let workspace = self.workspace_path(operation_id);
         let operation = operation_id.to_string();
         tokio::task::spawn_blocking(move || {
-            remove_workspace_if_present(&root, &workspace, &operation)
+            remove_operation_directory_if_present(&root, &workspace, "workspace", &operation)
         })
         .await
         .map_err(|error| BuildReceiptError::Task {
             operation_id: operation_id.to_string(),
             message: format!("workspace cleanup task failed: {error}"),
+        })?
+    }
+
+    pub(in crate::oci::build) async fn publish_cache_export(
+        &self,
+        operation_id: &OperationId,
+        staged: RecordedBuildCache,
+    ) -> Result<RecordedBuildCache, BuildReceiptError> {
+        let root = self.root.clone();
+        let workspace = self.workspace_path(operation_id);
+        let target = self.cache_export_path(operation_id);
+        let operation = operation_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let workspace =
+                validate_operation_directory(&root, &workspace, "workspace", &operation)?;
+            let staging = staged.layout_directory.canonicalize().map_err(|source| {
+                BuildReceiptError::StoreIo {
+                    message: format!(
+                        "failed to canonicalize cache export staging for operation {operation}"
+                    ),
+                    source,
+                }
+            })?;
+            if staging.parent() != Some(workspace.as_path()) {
+                return Err(BuildReceiptError::UnsafeStore {
+                    message: format!(
+                        "cache export staging {} escaped operation workspace {}",
+                        staging.display(),
+                        workspace.display()
+                    ),
+                });
+            }
+            match std::fs::symlink_metadata(&target) {
+                Ok(_) => {
+                    return Err(BuildReceiptError::Conflict {
+                        operation_id: operation,
+                        message: "a cache export already exists before publication".to_string(),
+                    })
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(source) => {
+                    return Err(BuildReceiptError::StoreIo {
+                        message: format!(
+                            "failed to inspect cache export target for operation {operation}"
+                        ),
+                        source,
+                    })
+                }
+            }
+            std::fs::rename(&staging, &target).map_err(|source| BuildReceiptError::StoreIo {
+                message: format!("failed to publish cache export for operation {operation}"),
+                source,
+            })?;
+            let target = validate_operation_directory(&root, &target, "cache export", &operation)?;
+            if let Ok(directory) = std::fs::File::open(&root) {
+                let _ = directory.sync_all();
+            }
+            Ok(RecordedBuildCache {
+                receipt: staged.receipt,
+                layout_directory: target,
+            })
+        })
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: operation_id.to_string(),
+            message: format!("cache export publication task failed: {error}"),
+        })?
+    }
+
+    pub(in crate::oci::build) async fn cleanup_cache_export(
+        &self,
+        operation_id: &OperationId,
+    ) -> Result<(), BuildReceiptError> {
+        let root = self.root.clone();
+        let cache_export = self.cache_export_path(operation_id);
+        let operation = operation_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            remove_operation_directory_if_present(&root, &cache_export, "cache export", &operation)
+        })
+        .await
+        .map_err(|error| BuildReceiptError::Task {
+            operation_id: operation_id.to_string(),
+            message: format!("cache export cleanup task failed: {error}"),
         })?
     }
 }
@@ -209,8 +305,10 @@ impl LockedBuildOperation {
         let operation_id = self.operation_id.clone();
         tokio::task::spawn_blocking(move || {
             match read_receipt_file(&path, &operation_id)? {
-                Some(PersistedBuildOperation::Succeeded(existing)) if existing == receipt => {
-                    return Ok(existing);
+                Some(PersistedBuildOperation::Succeeded(existing))
+                    if existing.as_ref() == &receipt =>
+                {
+                    return Ok(*existing);
                 }
                 Some(PersistedBuildOperation::Pending(pending))
                     if pending.matches_receipt(&receipt) => {}
@@ -243,7 +341,7 @@ impl LockedBuildOperation {
             persist_record(
                 &path,
                 &operation_id,
-                &PersistedBuildOperation::Succeeded(receipt.clone()),
+                &PersistedBuildOperation::Succeeded(Box::new(receipt.clone())),
             )?;
             Ok(receipt)
         })
@@ -336,6 +434,8 @@ fn valid_supervised_transition(
         || existing.source_digest != next.source_digest
         || existing.plan_digest != next.plan_digest
         || existing.output_reference != next.output_reference
+        || existing.schema != next.schema
+        || existing.cache_policy != next.cache_policy
         || existing.started_at != next.started_at
         || existing.owner != next.owner
     {
@@ -421,26 +521,27 @@ fn persist_record(
     })
 }
 
-fn validate_workspace(
+fn validate_operation_directory(
     root: &Path,
-    workspace: &Path,
+    directory: &Path,
+    label: &str,
     operation_id: &str,
 ) -> Result<PathBuf, BuildReceiptError> {
-    validate_plain_directory(workspace, "build operation workspace").map_err(|error| {
+    validate_plain_directory(directory, &format!("build operation {label}")).map_err(|error| {
         BuildReceiptError::UnsafeStore {
             message: error.to_string(),
         }
     })?;
-    let canonical = workspace
+    let canonical = directory
         .canonicalize()
         .map_err(|source| BuildReceiptError::StoreIo {
-            message: format!("failed to canonicalize workspace for operation {operation_id}"),
+            message: format!("failed to canonicalize {label} for operation {operation_id}"),
             source,
         })?;
     if canonical.parent() != Some(root) {
         return Err(BuildReceiptError::UnsafeStore {
             message: format!(
-                "workspace {} escaped receipt journal {}",
+                "{label} {} escaped receipt journal {}",
                 canonical.display(),
                 root.display()
             ),
@@ -449,23 +550,24 @@ fn validate_workspace(
     Ok(canonical)
 }
 
-fn remove_workspace_if_present(
+fn remove_operation_directory_if_present(
     root: &Path,
-    workspace: &Path,
+    directory: &Path,
+    label: &str,
     operation_id: &str,
 ) -> Result<(), BuildReceiptError> {
-    match std::fs::symlink_metadata(workspace) {
+    match std::fs::symlink_metadata(directory) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
             Err(BuildReceiptError::UnsafeStore {
                 message: format!(
-                    "workspace path for operation {operation_id} is not a plain directory"
+                    "{label} path for operation {operation_id} is not a plain directory"
                 ),
             })
         }
         Ok(_) => {
-            validate_workspace(root, workspace, operation_id)?;
-            std::fs::remove_dir_all(workspace).map_err(|source| BuildReceiptError::StoreIo {
-                message: format!("failed to remove workspace for operation {operation_id}"),
+            validate_operation_directory(root, directory, label, operation_id)?;
+            std::fs::remove_dir_all(directory).map_err(|source| BuildReceiptError::StoreIo {
+                message: format!("failed to remove {label} for operation {operation_id}"),
                 source,
             })?;
             if let Ok(directory) = std::fs::File::open(root) {
@@ -475,7 +577,7 @@ fn remove_workspace_if_present(
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(source) => Err(BuildReceiptError::StoreIo {
-            message: format!("failed to inspect workspace for operation {operation_id}"),
+            message: format!("failed to inspect {label} for operation {operation_id}"),
             source,
         }),
     }

--- a/src/runtime/src/oci/build/receipt/tests.rs
+++ b/src/runtime/src/oci/build/receipt/tests.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
 use a3s_box_core::OperationId;
+use serde::Serialize;
 
 use super::*;
 use crate::oci::build::{
     execute_recorded_build_plan, inspect_recorded_build_plan, inspect_recorded_build_status,
-    remove_recorded_build_plan, BoxBuildPlan, BuildPlanExecutionError,
+    remove_recorded_build_plan, BoxBuildPlan, BuildCacheReceipt, BuildPlanExecutionError,
 };
 use crate::oci::ImageStore;
 
@@ -52,6 +53,32 @@ fn identity(operation: &str, digest_byte: char) -> BuildOperationIdentity {
     .unwrap()
 }
 
+fn overwrite_record(path: &std::path::Path, record: &impl Serialize) {
+    let mut bytes = serde_json::to_vec_pretty(record).unwrap();
+    bytes.push(b'\n');
+    std::fs::write(path, bytes).unwrap();
+}
+
+async fn assert_cache_blob_tampering_is_rejected(
+    blob: &std::path::Path,
+    operation: &BuildOperationIdentity,
+    plan: &BoxBuildPlan,
+    store: &ImageStore,
+) {
+    let original = std::fs::read(blob).unwrap();
+    let mut corrupt = original.clone();
+    corrupt[0] ^= 1;
+    std::fs::write(blob, corrupt).unwrap();
+    let error = inspect_recorded_build_plan(operation, plan, store)
+        .await
+        .unwrap_err();
+    std::fs::write(blob, original).unwrap();
+    assert!(matches!(
+        error,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::CacheInvalid { .. })
+    ));
+}
+
 #[tokio::test]
 async fn recorded_build_replays_the_exact_output_after_reconstruction() {
     let temporary = tempfile::tempdir().unwrap();
@@ -72,6 +99,8 @@ async fn recorded_build_replays_the_exact_output_after_reconstruction() {
             .unwrap();
 
     assert!(!first.replayed);
+    assert!(first.cache.is_none());
+    assert!(first.receipt.cache.is_none());
     assert_eq!(first.receipt.schema, BuildOutputReceipt::SCHEMA);
     assert_eq!(first.receipt.operation_id, *operation.operation_id());
     assert_eq!(first.receipt.source_digest, source_digest('a'));
@@ -136,6 +165,153 @@ async fn recorded_build_replays_the_exact_output_after_reconstruction() {
 }
 
 #[tokio::test]
+async fn content_addressed_build_exports_and_replays_one_native_cache_receipt() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-cache-export", 'a');
+    let build_plan = plan("content-addressed");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+
+    let built =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+    let cache = built
+        .cache
+        .as_ref()
+        .expect("content-addressed plans export one native cache artifact");
+    assert_eq!(built.receipt.cache.as_ref(), Some(&cache.receipt));
+    assert_eq!(cache.receipt.schema, BuildCacheReceipt::SCHEMA);
+    assert_eq!(cache.receipt.source_digest, operation.source_digest());
+    assert_eq!(
+        cache.receipt.plan_digest,
+        build_plan.canonical_digest().unwrap()
+    );
+    assert_eq!(cache.receipt.platform, *build_plan.platform());
+    assert_eq!(cache.receipt.entry_count, 1);
+    assert!(cache.receipt.blob_count >= 3);
+    assert!(cache.receipt.content_bytes > cache.receipt.descriptor.size);
+    assert_eq!(
+        cache.layout_directory,
+        journal.cache_export_path(operation.operation_id())
+    );
+    assert!(cache.layout_directory.join("oci-layout").is_file());
+    assert!(cache.layout_directory.join("index.json").is_file());
+
+    let receipt_path = journal.receipt_path(operation.operation_id());
+    let persisted = std::fs::read_to_string(&receipt_path).unwrap();
+    assert!(persisted.contains(BuildCacheReceipt::SCHEMA));
+    assert!(
+        !persisted.contains(cache.layout_directory.to_string_lossy().as_ref()),
+        "the receipt must re-derive its operation-owned cache path"
+    );
+
+    let expected_receipt = cache.receipt.clone();
+    let expected_path = cache.layout_directory.clone();
+    drop(built);
+    drop(journal);
+    drop(store);
+    std::fs::remove_dir_all(&source).unwrap();
+
+    let reopened = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let replay = execute_recorded_build_plan(
+        &operation,
+        &build_plan,
+        &source,
+        true,
+        Arc::clone(&reopened),
+    )
+    .await
+    .unwrap();
+    let replayed_cache = replay.cache.expect("cache receipt survives reconstruction");
+    assert!(replay.replayed);
+    assert_eq!(replayed_cache.receipt, expected_receipt);
+    assert_eq!(replayed_cache.layout_directory, expected_path);
+}
+
+#[tokio::test]
+async fn content_addressed_cache_tampering_fails_closed_on_replay() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-cache-tamper", 'a');
+    let build_plan = plan("content-addressed");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let built =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+    let cache_root = built.cache.unwrap().layout_directory;
+    std::fs::write(
+        cache_root.join("blobs/sha256").join("f".repeat(64)),
+        b"unreferenced",
+    )
+    .unwrap();
+
+    let error = inspect_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::CacheInvalid { .. })
+    ));
+}
+
+#[tokio::test]
+async fn content_addressed_cache_revalidates_manifest_config_and_layer_bytes() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-cache-blob-tamper", 'a');
+    let build_plan = plan("content-addressed");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let built =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+    let cache = built.cache.as_ref().unwrap();
+    let blob_root = cache.layout_directory.join("blobs/sha256");
+    let manifest_path = blob_root.join(
+        cache
+            .receipt
+            .descriptor
+            .digest
+            .strip_prefix("sha256:")
+            .unwrap(),
+    );
+    let manifest_bytes = std::fs::read(&manifest_path).unwrap();
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes).unwrap();
+    let config_path = blob_root.join(
+        manifest["config"]["digest"]
+            .as_str()
+            .unwrap()
+            .strip_prefix("sha256:")
+            .unwrap(),
+    );
+    let layer_path = blob_root.join(
+        manifest["layers"][0]["digest"]
+            .as_str()
+            .unwrap()
+            .strip_prefix("sha256:")
+            .unwrap(),
+    );
+
+    assert_cache_blob_tampering_is_rejected(&manifest_path, &operation, &build_plan, &store).await;
+    assert_cache_blob_tampering_is_rejected(&config_path, &operation, &build_plan, &store).await;
+    assert_cache_blob_tampering_is_rejected(&layer_path, &operation, &build_plan, &store).await;
+}
+
+#[tokio::test]
 async fn pending_intent_adopts_output_committed_before_terminal_receipt() {
     let temporary = tempfile::tempdir().unwrap();
     let source = temporary.path().join("source");
@@ -155,13 +331,7 @@ async fn pending_intent_adopts_output_committed_before_terminal_receipt() {
             .unwrap();
     let expected_descriptor = built.output.descriptor.clone();
     let pending = PendingBuildOperation::new(&operation, plan_digest).unwrap();
-    let mut pending_bytes = serde_json::to_vec_pretty(&pending).unwrap();
-    pending_bytes.push(b'\n');
-    std::fs::write(
-        receipts.receipt_path(operation.operation_id()),
-        pending_bytes,
-    )
-    .unwrap();
+    overwrite_record(&receipts.receipt_path(operation.operation_id()), &pending);
     std::fs::remove_dir_all(&source).unwrap();
     drop(receipts);
     drop(store);
@@ -185,7 +355,7 @@ async fn pending_intent_adopts_output_committed_before_terminal_receipt() {
     assert_eq!(recovered.output.descriptor, expected_descriptor);
     let committed =
         std::fs::read_to_string(reopened_receipts.receipt_path(operation.operation_id())).unwrap();
-    assert!(committed.contains(BuildOutputReceipt::SCHEMA));
+    assert!(committed.contains(BuildOutputReceipt::LEGACY_SCHEMA));
     assert!(!committed.contains(PendingBuildOperation::SCHEMA));
 }
 
@@ -197,7 +367,7 @@ async fn supervised_recovery_adopts_the_image_store_commit_gap() {
     write_source(&source);
 
     let operation = identity("cloud-build-supervised-output-gap", 'a');
-    let build_plan = plan("disabled");
+    let build_plan = plan("content-addressed");
     let plan_digest = build_plan.canonical_digest().unwrap();
     let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
     let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
@@ -208,15 +378,13 @@ async fn supervised_recovery_adopts_the_image_store_commit_gap() {
             .await
             .unwrap();
     let expected_descriptor = built.output.descriptor.clone();
-    let workspace = journal
-        .prepare_workspace(operation.operation_id())
-        .await
-        .unwrap();
+    let cache_receipt = built.cache.as_ref().unwrap().receipt.clone();
+    let workspace = journal.workspace_path(operation.operation_id());
+    std::fs::create_dir(&workspace).unwrap();
     std::fs::write(workspace.join("uncommitted"), "partial").unwrap();
-    let active = SupervisedBuildOperation::new(&operation, plan_digest).unwrap();
-    let mut active_bytes = serde_json::to_vec_pretty(&active).unwrap();
-    active_bytes.push(b'\n');
-    std::fs::write(journal.receipt_path(operation.operation_id()), active_bytes).unwrap();
+    let active =
+        SupervisedBuildOperation::new(&operation, plan_digest, build_plan.cache()).unwrap();
+    overwrite_record(&journal.receipt_path(operation.operation_id()), &active);
     std::fs::remove_dir_all(&source).unwrap();
     drop(store);
 
@@ -229,6 +397,7 @@ async fn supervised_recovery_adopts_the_image_store_commit_gap() {
         panic!("committed ImageStore output must win the receipt gap");
     };
     assert_eq!(recovered.output.descriptor, expected_descriptor);
+    assert_eq!(recovered.cache.as_ref().unwrap().receipt, cache_receipt);
     assert!(!journal.workspace_path(operation.operation_id()).exists());
     let committed =
         std::fs::read_to_string(journal.receipt_path(operation.operation_id())).unwrap();
@@ -237,11 +406,105 @@ async fn supervised_recovery_adopts_the_image_store_commit_gap() {
 }
 
 #[tokio::test]
+async fn current_content_addressed_operation_rejects_a_missing_cache_commit() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-cache-missing-gap", 'a');
+    let build_plan = plan("content-addressed");
+    let plan_digest = build_plan.canonical_digest().unwrap();
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    let built =
+        execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+            .await
+            .unwrap();
+    std::fs::remove_dir_all(built.cache.unwrap().layout_directory).unwrap();
+    let active =
+        SupervisedBuildOperation::new(&operation, plan_digest, build_plan.cache()).unwrap();
+    overwrite_record(&journal.receipt_path(operation.operation_id()), &active);
+
+    let error = inspect_recorded_build_status(&operation, &build_plan, &store)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::CacheInvalid { .. })
+    ));
+}
+
+#[tokio::test]
+async fn current_cache_disabled_operation_rejects_an_unexpected_cache_commit() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-disabled-cache-gap", 'a');
+    let build_plan = plan("disabled");
+    let plan_digest = build_plan.canonical_digest().unwrap();
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+        .await
+        .unwrap();
+    std::fs::create_dir(journal.cache_export_path(operation.operation_id())).unwrap();
+    let active =
+        SupervisedBuildOperation::new(&operation, plan_digest, build_plan.cache()).unwrap();
+    overwrite_record(&journal.receipt_path(operation.operation_id()), &active);
+
+    let error = inspect_recorded_build_status(&operation, &build_plan, &store)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::CacheInvalid { .. })
+    ));
+}
+
+#[tokio::test]
+async fn current_content_addressed_receipt_requires_cache_evidence() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source = temporary.path().join("source");
+    let store_root = temporary.path().join("images");
+    write_source(&source);
+
+    let operation = identity("cloud-build-cache-policy-receipt", 'a');
+    let build_plan = plan("content-addressed");
+    let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
+    execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store))
+        .await
+        .unwrap();
+    let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    let receipt_path = journal.receipt_path(operation.operation_id());
+    let mut receipt: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&receipt_path).unwrap()).unwrap();
+    receipt.as_object_mut().unwrap().remove("cache");
+    std::fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt).unwrap()).unwrap();
+
+    let error = inspect_recorded_build_plan(&operation, &build_plan, &store)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        BuildPlanExecutionError::Receipt(BuildReceiptError::InvalidReceipt { .. })
+    ));
+}
+
+#[tokio::test]
 async fn live_operation_inspection_is_nonblocking_and_cancellation_is_one_state_transition() {
     let temporary = tempfile::tempdir().unwrap();
     let store_root = temporary.path().join("images");
     let operation = identity("cloud-build-live-supervision", 'a');
-    let build_plan = plan("disabled");
+    let build_plan = plan("content-addressed");
     let plan_digest = build_plan.canonical_digest().unwrap();
     let store = ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap();
     let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
@@ -259,7 +522,10 @@ async fn live_operation_inspection_is_nonblocking_and_cancellation_is_one_state_
         .unwrap();
     std::fs::write(workspace.join("partial"), "uncommitted").unwrap();
     locked
-        .write_supervised(SupervisedBuildOperation::new(&operation, plan_digest.clone()).unwrap())
+        .write_supervised(
+            SupervisedBuildOperation::new(&operation, plan_digest.clone(), build_plan.cache())
+                .unwrap(),
+        )
         .await
         .unwrap();
     drop(locked);
@@ -319,8 +585,12 @@ async fn abandoned_operation_reclaims_workspace_and_becomes_failed() {
     let locked = journal.lock(operation.operation_id()).await.unwrap();
     locked
         .write_supervised(
-            SupervisedBuildOperation::new(&operation, build_plan.canonical_digest().unwrap())
-                .unwrap(),
+            SupervisedBuildOperation::new(
+                &operation,
+                build_plan.canonical_digest().unwrap(),
+                build_plan.cache(),
+            )
+            .unwrap(),
         )
         .await
         .unwrap();
@@ -348,6 +618,36 @@ async fn operation_workspace_rejects_a_symlink_without_touching_its_target() {
         .await
         .unwrap();
     std::os::unix::fs::symlink(&outside, journal.workspace_path(operation.operation_id())).unwrap();
+
+    let error = journal
+        .prepare_workspace(operation.operation_id())
+        .await
+        .unwrap_err();
+    assert!(matches!(error, BuildReceiptError::UnsafeStore { .. }));
+    assert_eq!(
+        std::fs::read_to_string(outside.join("keep")).unwrap(),
+        "keep"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn operation_cache_export_rejects_a_symlink_without_touching_its_target() {
+    let temporary = tempfile::tempdir().unwrap();
+    let store_root = temporary.path().join("images");
+    let outside = temporary.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("keep"), "keep").unwrap();
+    let operation = identity("cloud-build-cache-symlink", 'a');
+    let store = ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap();
+    let journal = BuildOperationJournal::for_image_store(&store, operation.operation_id())
+        .await
+        .unwrap();
+    std::os::unix::fs::symlink(
+        &outside,
+        journal.cache_export_path(operation.operation_id()),
+    )
+    .unwrap();
 
     let error = journal
         .prepare_workspace(operation.operation_id())
@@ -413,7 +713,7 @@ async fn concurrent_retries_publish_once_and_replay_once() {
     write_source(&source);
 
     let operation = identity("cloud-build-run-concurrent", 'a');
-    let build_plan = plan("disabled");
+    let build_plan = plan("content-addressed");
     let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
     let first =
         execute_recorded_build_plan(&operation, &build_plan, &source, true, Arc::clone(&store));
@@ -426,6 +726,14 @@ async fn concurrent_retries_publish_once_and_replay_once() {
     assert_ne!(first.replayed, second.replayed);
     assert_eq!(first.receipt, second.receipt);
     assert_eq!(first.output.descriptor, second.output.descriptor);
+    assert_eq!(
+        first.cache.as_ref().map(|cache| &cache.receipt),
+        second.cache.as_ref().map(|cache| &cache.receipt)
+    );
+    assert_eq!(
+        first.cache.as_ref().map(|cache| &cache.layout_directory),
+        second.cache.as_ref().map(|cache| &cache.layout_directory)
+    );
     assert_eq!(store.list().await.len(), 1);
 }
 
@@ -620,7 +928,7 @@ async fn recorded_build_cleanup_removes_receipt_and_internal_image_idempotently(
     write_source(&source);
 
     let operation = identity("cloud-build-run-4", 'a');
-    let build_plan = plan("disabled");
+    let build_plan = plan("content-addressed");
     let store = Arc::new(ImageStore::new(&store_root, 64 * 1024 * 1024).unwrap());
     let receipts = BuildOperationJournal::for_image_store(&store, operation.operation_id())
         .await
@@ -630,14 +938,17 @@ async fn recorded_build_cleanup_removes_receipt_and_internal_image_idempotently(
             .await
             .unwrap();
     let reference = built.receipt.output.reference.clone();
+    let cache_path = built.cache.unwrap().layout_directory;
     assert!(receipts.receipt_path(operation.operation_id()).is_file());
     assert!(store.get(&reference).await.is_some());
+    assert!(cache_path.is_dir());
 
     assert!(remove_recorded_build_plan(&operation, &build_plan, &store)
         .await
         .unwrap());
     assert!(!receipts.receipt_path(operation.operation_id()).exists());
     assert!(store.get(&reference).await.is_none());
+    assert!(!cache_path.exists());
 
     assert!(!remove_recorded_build_plan(&operation, &build_plan, &store)
         .await

--- a/src/runtime/src/oci/image.rs
+++ b/src/runtime/src/oci/image.rs
@@ -222,7 +222,7 @@ pub(crate) fn read_verified_oci_blob(
     Ok(bytes)
 }
 
-fn verify_oci_blob_file(
+pub(crate) fn verify_oci_blob_file(
     root_dir: &Path,
     digest: &str,
     size: i64,

--- a/src/runtime/src/oci/mod.rs
+++ b/src/runtime/src/oci/mod.rs
@@ -41,11 +41,12 @@ pub mod store;
 pub use build::{
     cancel_recorded_build_plan, execute_recorded_build_plan, inspect_recorded_build_plan,
     inspect_recorded_build_status, remove_recorded_build_plan, start_recorded_build_plan,
-    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildCancellationOutcome,
-    BuildConfig, BuildNetworkPolicy, BuildOperationIdentity, BuildOutputDescriptor,
-    BuildOutputReceipt, BuildPlanExecutionError, BuildReceiptError, BuildReceiptOutput,
-    BuildResult, BuildRunPoolConfig, Dockerfile, Instruction, RecordedBuildResult,
-    RecordedBuildStatus, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildCacheReceipt,
+    BuildCancellationOutcome, BuildConfig, BuildNetworkPolicy, BuildOperationIdentity,
+    BuildOutputDescriptor, BuildOutputReceipt, BuildPlanExecutionError, BuildReceiptError,
+    BuildReceiptOutput, BuildResult, BuildRunPoolConfig, Dockerfile, Instruction,
+    RecordedBuildCache, RecordedBuildResult, RecordedBuildStatus, BUILD_CACHE_ARTIFACT_MEDIA_TYPE,
+    BUILD_CACHE_CONFIG_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 pub use credentials::CredentialStore;
 pub use image::{OciHealthCheck, OciImage, OciImageConfig};


### PR DESCRIPTION
## Summary

- export one portable Box-native OCI cache artifact from the existing BuildCache
- publish cache and ImageStore output under the existing operation-journal commit lock
- persist and enforce the admitted cache policy in the v2 supervised operation record
- revalidate exact cache entries, descriptors, manifest, config, layers, bytes, and blob inventory on recovery and replay
- retain legacy v1 operation and output receipt compatibility without adding another store
- add CI architecture gates that reject a second cache store, service, queue, scheduler, or publisher

## Single-authority design

- BuildCache remains the sole native cache implementation
- the native engine remains the sole executor
- BuildOperationJournal remains the sole lifecycle, publication, and cleanup authority
- ImageStore remains the sole image authority

## Validation

- cargo fmt --all -- --check
- cargo test -p a3s-box-runtime: 1498 passed, 1 ignored
- cargo clippy -p a3s-box-runtime --all-targets -- -D warnings
- A3S_DEPS_STUB=1 cargo clippy --workspace --all-targets -- -D warnings
- focused cache and receipt suites: 33 passed

Advances #172.