### PR TITLE
feat(build): hydrate portable cache receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,10 @@ jobs:
             'BuildCache'"Scheduler"
             'CacheExport'"Store"
             'CacheExport'"Publisher"
+            'CacheImport'"Store"
+            'CacheImport'"Service"
+            'CacheHydration'"Store"
+            'CacheHydration'"Queue"
             'build-operations.'"json"
             'build-jobs.'"json"
             'build-queue.'"json"
@@ -189,8 +193,17 @@ jobs:
             'pub(crate) struct BuildCache {' \
             'src/runtime/src/oci/build/cache.rs'
           require_single_authority \
+            'fn publish_entry_unlocked(' \
+            'src/runtime/src/oci/build/cache.rs'
+          require_single_authority \
             'pub(in crate::oci::build) fn stage_export(' \
             'src/runtime/src/oci/build/cache/export.rs'
+          require_single_authority \
+            'fn validate_build_cache_artifact(' \
+            'src/runtime/src/oci/build/cache/export/validation.rs'
+          require_single_authority \
+            'pub async fn hydrate_recorded_build_cache' \
+            'src/runtime/src/oci/build/cache/import.rs'
           require_single_authority \
             'pub(in crate::oci::build) async fn publish_cache_export(' \
             'src/runtime/src/oci/build/receipt/journal.rs'
@@ -214,6 +227,7 @@ jobs:
             '(tokio|std)::sync::(mpsc|broadcast|watch)|\b(VecDeque|BinaryHeap)\b' -- \
             src/runtime/src/oci/build/execution.rs \
             src/runtime/src/oci/build/execution/supervision.rs \
+            src/runtime/src/oci/build/cache/import.rs \
             src/runtime/src/oci/build/receipt.rs \
             src/runtime/src/oci/build/receipt/journal.rs \
             src/runtime/src/oci/build/engine/control.rs; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- **Portable native build-cache hydration.** The typed
+  `hydrate_recorded_build_cache` boundary revalidates a Box-native OCI cache
+  artifact and imports it through the existing `BuildCache` lock and blob/key
+  writer. Repeated imports are idempotent, valid local key conflicts fail
+  before mutation, layer bytes are copied, and cache-cap pruning preserves the
+  complete imported layer set without adding another cache store, importer
+  service, queue, or validator.
 - **Caller-authorized Runtime Secret materialization.** The shared
   `BoxRuntimeDriver` can compose one `BoxSecretMaterializer` and advertise
   environment, file, and registry-credential `SecretReferences`. Environment

--- a/README.md
+++ b/README.md
@@ -178,18 +178,24 @@ runtime state changes instead of being silently stored or weakened.
   cache artifact from the existing `BuildCache`; the cache key binds source,
   plan, platform, and cache-schema semantics. The operation record persists
   the admitted cache policy, and replay validates the exact cache manifest,
-  config, layers, blob inventory, and byte count. A crash-released execution
-  lease distinguishes live work from a dead caller without becoming another
-  state store. Every supervised build uses a hash-derived operation workspace
-  below that journal; cancellation, failure, and caller-death recovery fence
-  the current Linux `RUN` process tree before reclaiming it. The existing
-  journal lock orders cache publication, cancellation, and ImageStore
-  publication, so restarted callers can adopt both artifacts committed before
-  the terminal receipt. The journal, native engine, `BuildCache`, and
-  ImageStore remain the only lifecycle, execution, cache, and image
-  authorities. The CLI exposes only this native engine: Linux `RUN` uses the
-  isolated local path and macOS uses the same engine through `--run-pool`;
-  publication remains the separate `a3s-box push` image operation.
+  config, layers, blob inventory, and byte count.
+  `hydrate_recorded_build_cache` revalidates that same typed artifact and
+  imports it through the existing cache lock and blob/key publication
+  boundary. Hydration is idempotent, rejects a valid local key conflict before
+  publishing imported keys, copies rather than links layer data, and preserves
+  the imported layer set while enforcing the configured cache cap. A
+  crash-released execution lease distinguishes live work from a dead caller
+  without becoming another state store. Every supervised build uses a
+  hash-derived operation workspace below that journal; cancellation, failure,
+  and caller-death recovery fence the current Linux `RUN` process tree before
+  reclaiming it. The existing journal lock orders cache publication,
+  cancellation, and ImageStore publication, so restarted callers can adopt
+  both artifacts committed before the terminal receipt. The journal, native
+  engine, `BuildCache`, and ImageStore remain the only lifecycle, execution,
+  cache, and image authorities. The CLI exposes only this native engine: Linux
+  `RUN` uses the isolated local path and macOS uses the same engine through
+  `--run-pool`; publication remains the separate `a3s-box push` image
+  operation.
 - **Storage** — bind mounts, named volumes, tmpfs, file copy, diff, export,
   commit, filesystem snapshots, copy-on-write restore, and Box-owned read-only
   aliases for caller-provided Artifact trees below private provider roots.

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -406,9 +406,16 @@ Current notes:
   content bytes. The v2 operation record durably enforces that new
   `content-addressed` plans contain cache evidence and `disabled` plans do not;
   legacy v1 records remain readable without cache evidence.
-- Typed cache import and hydration plus multi-platform assembly remain the Box
-  build release gates; Cloud consumption, publication, and SPDX/SLSA evidence
-  remain integration gates.
+- Typed cache hydration now accepts the existing `RecordedBuildCache`, reuses
+  the exact OCI artifact validator, and writes only through the existing
+  `BuildCache` lock and blob/key publication boundary. It preflights valid
+  local key conflicts before mutation, is idempotent, copies layer bytes,
+  retains the complete imported set while applying the configured cache cap,
+  and returns the revalidated receipt. CI rejects a second cache importer,
+  service, store, queue, validator, or write boundary.
+- Multi-platform OCI assembly remains the Box build release gate; Cloud
+  consumption through Fleet, publication, and SPDX/SLSA evidence remain
+  integration gates.
 - Dockerfile `RUN` no longer has any silent skip path on unsupported hosts.
   The native engine uses isolated `chroot` on Linux and an isolated
   warm-pool VM lease path via `--run-pool`, which mounts each mutable build

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -166,10 +166,18 @@ missing, symlinked, or changed cache entries and revalidates the manifest,
 config, layers, descriptor sizes, exact blob inventory, and byte count before
 returning the cache receipt.
 
-This completes the Box-owned `BX0.4` supervision and portable cache-export
-receipt slices. Typed cache import and hydration, multi-platform OCI assembly,
-Cloud Node Agent consumption, publication, and end-to-end SPDX/SLSA signing
-evidence remain separate gates.
+`hydrate_recorded_build_cache` accepts that existing `RecordedBuildCache`
+type, repeats the same complete artifact validation, and publishes entries
+through the sole `BuildCache` lock and blob/key write boundary. A valid local
+key with different content fails the entire preflight before an imported key
+is written; repeated imports are idempotent. Imported layers are copied, the
+complete imported set is retained while unrelated old blobs are pruned, and a
+successful return carries the exact revalidated receipt.
+
+This completes the Box-owned `BX0.4` supervision, portable cache-export
+receipt, and typed cache-hydration slices. Multi-platform OCI assembly, Cloud
+Node Agent consumption, publication, and end-to-end SPDX/SLSA signing evidence
+remain separate gates.
 
 ## Components
 

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -147,14 +147,14 @@ pub use volume::VolumeStore;
 
 #[cfg(feature = "build")]
 pub use oci::{
-    cancel_recorded_build_plan, execute_recorded_build_plan, inspect_recorded_build_plan,
-    inspect_recorded_build_status, remove_recorded_build_plan, start_recorded_build_plan,
-    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildCacheReceipt,
-    BuildCancellationOutcome, BuildConfig, BuildNetworkPolicy, BuildOperationIdentity,
-    BuildOutputDescriptor, BuildOutputReceipt, BuildPlanExecutionError, BuildReceiptError,
-    BuildReceiptOutput, BuildResult, BuildRunPoolConfig, Dockerfile, Instruction,
-    RecordedBuildCache, RecordedBuildResult, RecordedBuildStatus, BUILD_CACHE_ARTIFACT_MEDIA_TYPE,
-    BUILD_CACHE_CONFIG_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    cancel_recorded_build_plan, execute_recorded_build_plan, hydrate_recorded_build_cache,
+    inspect_recorded_build_plan, inspect_recorded_build_status, remove_recorded_build_plan,
+    start_recorded_build_plan, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy,
+    BuildCacheReceipt, BuildCancellationOutcome, BuildConfig, BuildNetworkPolicy,
+    BuildOperationIdentity, BuildOutputDescriptor, BuildOutputReceipt, BuildPlanExecutionError,
+    BuildReceiptError, BuildReceiptOutput, BuildResult, BuildRunPoolConfig, Dockerfile,
+    Instruction, RecordedBuildCache, RecordedBuildResult, RecordedBuildStatus,
+    BUILD_CACHE_ARTIFACT_MEDIA_TYPE, BUILD_CACHE_CONFIG_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 
 #[cfg(feature = "compose")]

--- a/src/runtime/src/oci/build/cache.rs
+++ b/src/runtime/src/oci/build/cache.rs
@@ -14,6 +14,7 @@
 //! All cache I/O is best-effort: any failure leaves the build uncached but does
 //! NOT fail the build.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -23,12 +24,14 @@ use serde::{Deserialize, Serialize};
 use super::layer::{sha256_bytes, sha256_file, LayerInfo};
 
 mod export;
+mod import;
 
-pub(super) use export::{inspect_build_cache_export, BuildCacheExportIdentity, BuildCacheTrace};
+pub(super) use export::{inspect_build_cache_artifact, BuildCacheExportIdentity, BuildCacheTrace};
 pub use export::{
     BuildCacheReceipt, RecordedBuildCache, BUILD_CACHE_ARTIFACT_MEDIA_TYPE,
     BUILD_CACHE_CONFIG_MEDIA_TYPE,
 };
+pub use import::hydrate_recorded_build_cache;
 
 /// Per-process counter for unique staging-file names in `store`.
 static STORE_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -154,8 +157,16 @@ impl BuildCache {
     }
 
     fn store_unlocked(&self, key: &str, layer: &LayerInfo, diff_id: &str) {
+        if self.publish_entry_unlocked(key, layer, diff_id) {
+            self.prune_to_unlocked(configured_max_bytes());
+        }
+    }
+
+    /// Publish one entry through the native cache's sole blob/key write
+    /// boundary. The caller must hold the cache lock.
+    fn publish_entry_unlocked(&self, key: &str, layer: &LayerInfo, diff_id: &str) -> bool {
         if !cached_blob_is_valid(&layer.path, &layer.digest, layer.size) {
-            return;
+            return false;
         }
         let blob_path = self.dir.join("blobs").join(&layer.digest);
         if !cached_blob_is_valid(&blob_path, &layer.digest, layer.size) {
@@ -171,22 +182,22 @@ impl BuildCache {
             ));
             if std::fs::copy(&layer.path, &staging).is_err() {
                 let _ = std::fs::remove_file(&staging);
-                return;
+                return false;
             }
             if !cached_blob_is_valid(&staging, &layer.digest, layer.size) {
                 let _ = std::fs::remove_file(&staging);
-                return;
+                return false;
             }
             // Windows cannot rename over an existing file. Removing a corrupt
             // destination first is safe because readers independently validate
             // cache blobs and rebuild on a miss or race.
             if blob_path.exists() && std::fs::remove_file(&blob_path).is_err() {
                 let _ = std::fs::remove_file(&staging);
-                return;
+                return false;
             }
             if std::fs::rename(&staging, &blob_path).is_err() {
                 let _ = std::fs::remove_file(&staging);
-                return;
+                return false;
             }
         }
 
@@ -198,10 +209,11 @@ impl BuildCache {
         if let Ok(bytes) = serde_json::to_vec(&record) {
             let target = self.dir.join("keys").join(key);
             let temporary = target.with_extension("tmp");
-            let _ = a3s_box_core::fs_atomic::write_durable(&temporary, &target, &bytes);
+            if a3s_box_core::fs_atomic::write_durable(&temporary, &target, &bytes).is_ok() {
+                return true;
+            }
         }
-
-        self.prune_to_unlocked(configured_max_bytes());
+        false
     }
 
     /// Evict oldest layer blobs (by modification time) until the total blob
@@ -217,12 +229,21 @@ impl BuildCache {
     }
 
     fn prune_to_unlocked(&self, cap: u64) {
+        let _ = self.prune_to_unlocked_preserving(cap, &BTreeSet::new());
+    }
+
+    /// Prune through the native cache authority while retaining the exact
+    /// layer digests required by an in-progress hydration.
+    ///
+    /// Returns whether the configured cap could be reached. The caller must
+    /// hold the cache lock.
+    fn prune_to_unlocked_preserving(&self, cap: u64, preserved: &BTreeSet<String>) -> bool {
         let blobs_dir = self.dir.join("blobs");
         let Ok(read_dir) = std::fs::read_dir(&blobs_dir) else {
-            return;
+            return false;
         };
 
-        let mut blobs: Vec<(std::time::SystemTime, u64, PathBuf)> = Vec::new();
+        let mut blobs: Vec<(std::time::SystemTime, u64, PathBuf, bool)> = Vec::new();
         let mut total: u64 = 0;
         for entry in read_dir.flatten() {
             let Ok(meta) = entry.metadata() else { continue };
@@ -230,19 +251,27 @@ impl BuildCache {
                 continue;
             }
             let len = meta.len();
-            total += len;
+            total = total.saturating_add(len);
             let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
-            blobs.push((mtime, len, entry.path()));
+            let path = entry.path();
+            let keep = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| preserved.contains(name));
+            blobs.push((mtime, len, path, keep));
         }
 
         if total <= cap {
-            return;
+            return true;
         }
 
-        blobs.sort_by_key(|(mtime, _, _)| *mtime); // oldest first
-        for (_, len, path) in blobs {
+        blobs.sort_by_key(|(mtime, _, _, _)| *mtime); // oldest first
+        for (_, len, path, keep) in blobs {
             if total <= cap {
                 break;
+            }
+            if keep {
+                continue;
             }
             if std::fs::remove_file(&path).is_ok() {
                 total = total.saturating_sub(len);
@@ -252,6 +281,7 @@ impl BuildCache {
         // Blobs were just evicted — drop key records that now point at nothing,
         // so the keys/ dir doesn't accumulate dangling pointers without bound.
         self.prune_orphan_keys();
+        total <= cap
     }
 
     /// Remove key records whose referenced blob no longer exists. Each key is a

--- a/src/runtime/src/oci/build/cache/export.rs
+++ b/src/runtime/src/oci/build/cache/export.rs
@@ -7,22 +7,15 @@ use std::str::FromStr;
 use a3s_box_core::error::{BoxError, Result};
 use a3s_box_core::platform::Platform;
 use oci_spec::image::{
-    Arch, Descriptor, DescriptorBuilder, ImageIndex, ImageIndexBuilder, ImageManifest,
-    ImageManifestBuilder, MediaType, Os, PlatformBuilder, Sha256Digest, SCHEMA_VERSION,
+    Arch, Descriptor, DescriptorBuilder, ImageIndexBuilder, ImageManifestBuilder, MediaType, Os,
+    PlatformBuilder, Sha256Digest, SCHEMA_VERSION,
 };
 use serde::{Deserialize, Serialize};
 
 use super::{cached_blob_is_valid, BuildCache, CachedLayer};
 use crate::oci::build::layer::sha256_bytes;
-use crate::oci::build::layout::{
-    metadata_bytes, validate_blob_inventory, validate_exact_entries, EntryKind,
-};
 use crate::oci::build::BuildOutputDescriptor;
-use crate::oci::image::{
-    canonical_sha256_digest_hex, read_regular_file_bounded, read_verified_oci_blob,
-    verify_oci_blob_file, MAX_OCI_CONFIG_BYTES, MAX_OCI_INDEX_BYTES, MAX_OCI_LAYER_BLOB_BYTES,
-    MAX_OCI_MANIFEST_BYTES,
-};
+use crate::oci::image::canonical_sha256_digest_hex;
 
 pub const BUILD_CACHE_ARTIFACT_MEDIA_TYPE: &str = "application/vnd.a3s.box.build-cache.v1";
 pub const BUILD_CACHE_CONFIG_MEDIA_TYPE: &str =
@@ -34,9 +27,12 @@ const MAX_CACHE_ENTRIES: usize = 16 * 1024;
 mod model;
 #[cfg(test)]
 mod tests;
+mod validation;
 
 pub(in crate::oci::build) use model::BuildCacheExportIdentity;
 pub use model::{BuildCacheReceipt, RecordedBuildCache};
+pub(in crate::oci::build) use validation::inspect_build_cache_artifact;
+pub(super) use validation::{validate_build_cache_artifact, ValidatedCacheEntry};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -238,229 +234,8 @@ impl BuildCache {
         )
         .map_err(|error| cache_error(format!("failed to write cache layout marker: {error}")))?;
 
-        inspect_build_cache_export(staging, identity, None)
+        inspect_build_cache_artifact(staging, identity, None)
     }
-}
-
-pub(in crate::oci::build) fn inspect_build_cache_export(
-    root: &Path,
-    identity: &BuildCacheExportIdentity,
-    expected: Option<&BuildCacheReceipt>,
-) -> Result<RecordedBuildCache> {
-    validate_exact_entries(
-        root,
-        &[
-            ("blobs", EntryKind::Directory),
-            ("index.json", EntryKind::File),
-            ("oci-layout", EntryKind::File),
-        ],
-        "native cache OCI layout",
-    )?;
-    validate_exact_entries(
-        &root.join("blobs"),
-        &[("sha256", EntryKind::Directory)],
-        "native cache OCI blob root",
-    )?;
-    let index_bytes =
-        read_regular_file_bounded(&root.join("index.json"), MAX_OCI_INDEX_BYTES, "cache index")?;
-    let index: ImageIndex = serde_json::from_slice(&index_bytes)
-        .map_err(|error| cache_error(format!("native cache index is invalid: {error}")))?;
-    require_index(&index, &identity.platform)?;
-    let root_descriptor = index.manifests()[0].clone();
-    let manifest_bytes = read_descriptor(
-        root,
-        &root_descriptor,
-        MAX_OCI_MANIFEST_BYTES,
-        "cache manifest",
-    )?;
-    let manifest: ImageManifest = serde_json::from_slice(&manifest_bytes)
-        .map_err(|error| cache_error(format!("native cache manifest is invalid: {error}")))?;
-    require_manifest(&manifest)?;
-    let config_bytes = read_descriptor(
-        root,
-        manifest.config(),
-        MAX_OCI_CONFIG_BYTES,
-        "cache config",
-    )?;
-    let config: CacheConfig = serde_json::from_slice(&config_bytes)
-        .map_err(|error| cache_error(format!("native cache config is invalid: {error}")))?;
-    validate_config(&config, identity, manifest.layers())?;
-    for layer in manifest.layers() {
-        verify_descriptor_file(root, layer, "cache layer")?;
-    }
-
-    let mut descriptors = Vec::with_capacity(manifest.layers().len() + 2);
-    descriptors.push(root_descriptor.clone());
-    descriptors.push(manifest.config().clone());
-    descriptors.extend(manifest.layers().iter().cloned());
-    let (blob_count, blob_bytes, blob_inventory_digest) =
-        validate_blob_inventory(root, &descriptors, "Native cache OCI artifact")?;
-    let content_bytes = metadata_bytes(root, "Native cache OCI artifact")?
-        .checked_add(blob_bytes)
-        .ok_or_else(|| cache_error("native cache artifact byte count overflowed"))?;
-    let receipt = BuildCacheReceipt {
-        schema: BuildCacheReceipt::SCHEMA.to_string(),
-        key: identity.key.clone(),
-        source_digest: identity.source_digest.clone(),
-        plan_digest: identity.plan_digest.clone(),
-        descriptor: BuildOutputDescriptor {
-            media_type: root_descriptor.media_type().as_ref().to_string(),
-            digest: root_descriptor.digest().to_string(),
-            size: root_descriptor.size(),
-        },
-        platform: identity.platform.clone(),
-        content_bytes,
-        entry_count: config.entries.len() as u64,
-        blob_count: blob_count as u64,
-        blob_inventory_digest,
-    };
-    receipt.validate()?;
-    if expected.is_some_and(|expected| expected != &receipt) {
-        return Err(cache_error(
-            "revalidated native cache artifact differs from its receipt",
-        ));
-    }
-    Ok(RecordedBuildCache {
-        receipt,
-        layout_directory: root.to_path_buf(),
-    })
-}
-
-fn validate_config(
-    config: &CacheConfig,
-    identity: &BuildCacheExportIdentity,
-    layers: &[Descriptor],
-) -> Result<()> {
-    if config.schema != CACHE_CONFIG_SCHEMA
-        || config.key != identity.key
-        || config.source_digest != identity.source_digest
-        || config.plan_digest != identity.plan_digest
-        || config.platform != identity.platform
-        || config.entries.len() > MAX_CACHE_ENTRIES
-    {
-        return Err(cache_error("native cache config identity is invalid"));
-    }
-    let mut previous = None;
-    let mut expected_layers = BTreeMap::new();
-    for entry in &config.entries {
-        if previous.as_ref().is_some_and(|key| key >= &entry.key)
-            || canonical_sha256_digest_hex(&entry.key).is_err()
-            || canonical_sha256_digest_hex(&entry.diff_id).is_err()
-            || canonical_sha256_digest_hex(&entry.layer.digest).is_err()
-            || entry.layer.media_type != MediaType::ImageLayerGzip.as_ref()
-            || entry.layer.size == 0
-        {
-            return Err(cache_error("native cache config entry is invalid"));
-        }
-        previous = Some(entry.key.clone());
-        expected_layers.insert(
-            entry.layer.digest.clone(),
-            (entry.layer.media_type.clone(), entry.layer.size),
-        );
-    }
-    let actual_layers = layers
-        .iter()
-        .map(|layer| {
-            (
-                layer.digest().to_string(),
-                (layer.media_type().as_ref().to_string(), layer.size()),
-            )
-        })
-        .collect::<Vec<_>>();
-    let expected_layers = expected_layers.into_iter().collect::<Vec<_>>();
-    if actual_layers != expected_layers {
-        return Err(cache_error(
-            "native cache manifest layers differ from the cache config",
-        ));
-    }
-    Ok(())
-}
-
-fn require_index(index: &ImageIndex, platform: &Platform) -> Result<()> {
-    if index.schema_version() != SCHEMA_VERSION
-        || index.media_type().as_ref() != Some(&MediaType::ImageIndex)
-        || index.artifact_type().as_ref() != Some(&MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
-        || index.subject().is_some()
-        || index.annotations().is_some()
-        || index.manifests().len() != 1
-    {
-        return Err(cache_error("native cache OCI index shape is invalid"));
-    }
-    let descriptor = &index.manifests()[0];
-    require_descriptor(descriptor, MediaType::ImageManifest, true)?;
-    let Some(actual) = descriptor.platform() else {
-        return Err(cache_error("native cache root descriptor has no platform"));
-    };
-    if actual.os().to_string() != platform.os
-        || actual.architecture().to_string() != platform.architecture
-        || actual.variant() != &platform.variant
-        || descriptor.artifact_type().as_ref()
-            != Some(&MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
-    {
-        return Err(cache_error("native cache root platform is invalid"));
-    }
-    Ok(())
-}
-
-fn require_manifest(manifest: &ImageManifest) -> Result<()> {
-    if manifest.schema_version() != SCHEMA_VERSION
-        || manifest.media_type().as_ref() != Some(&MediaType::ImageManifest)
-        || manifest.artifact_type().as_ref()
-            != Some(&MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
-        || manifest.subject().is_some()
-        || manifest.annotations().is_some()
-        || manifest.config().media_type().as_ref() != BUILD_CACHE_CONFIG_MEDIA_TYPE
-    {
-        return Err(cache_error("native cache OCI manifest shape is invalid"));
-    }
-    require_descriptor(
-        manifest.config(),
-        MediaType::from(BUILD_CACHE_CONFIG_MEDIA_TYPE),
-        false,
-    )?;
-    for layer in manifest.layers() {
-        require_descriptor(layer, MediaType::ImageLayerGzip, false)?;
-    }
-    Ok(())
-}
-
-fn require_descriptor(descriptor: &Descriptor, media_type: MediaType, root: bool) -> Result<()> {
-    if descriptor.media_type() != &media_type
-        || descriptor.size() == 0
-        || canonical_sha256_digest_hex(descriptor.digest().as_ref()).is_err()
-        || descriptor.urls().is_some()
-        || descriptor.annotations().is_some()
-        || descriptor.data().is_some()
-        || (!root && descriptor.platform().is_some())
-        || (!root && descriptor.artifact_type().is_some())
-    {
-        return Err(cache_error("native cache OCI descriptor is invalid"));
-    }
-    Ok(())
-}
-
-fn read_descriptor(
-    root: &Path,
-    descriptor: &Descriptor,
-    limit: u64,
-    label: &str,
-) -> Result<Vec<u8>> {
-    let size = i64::try_from(descriptor.size())
-        .map_err(|_| cache_error(format!("{label} size exceeds the supported range")))?;
-    read_verified_oci_blob(root, descriptor.digest().as_ref(), size, limit, label)
-}
-
-fn verify_descriptor_file(root: &Path, descriptor: &Descriptor, label: &str) -> Result<()> {
-    let size = i64::try_from(descriptor.size())
-        .map_err(|_| cache_error(format!("{label} size exceeds the supported range")))?;
-    verify_oci_blob_file(
-        root,
-        descriptor.digest().as_ref(),
-        size,
-        MAX_OCI_LAYER_BLOB_BYTES,
-        label,
-    )
-    .map(|_| ())
 }
 
 fn write_json_blob(root: &Path, media_type: &str, bytes: &[u8]) -> Result<Descriptor> {

--- a/src/runtime/src/oci/build/cache/export/tests.rs
+++ b/src/runtime/src/oci/build/cache/export/tests.rs
@@ -1,3 +1,4 @@
+use super::validation::{require_descriptor, validate_config};
 use super::*;
 
 fn payload_descriptor(platform: bool, artifact_type: bool) -> Descriptor {
@@ -71,5 +72,15 @@ fn cache_manifest_layers_are_unique_and_canonical() {
     };
 
     assert!(validate_config(&config, &identity, std::slice::from_ref(&layer)).is_ok());
-    assert!(validate_config(&config, &identity, &[layer.clone(), layer]).is_err());
+    assert!(validate_config(&config, &identity, &[layer.clone(), layer.clone()]).is_err());
+
+    let mut shared_layer = config.clone();
+    let mut second = shared_layer.entries[0].clone();
+    second.key = format!("sha256:{}", "6".repeat(64));
+    shared_layer.entries.push(second.clone());
+    assert!(validate_config(&shared_layer, &identity, std::slice::from_ref(&layer)).is_ok());
+
+    second.diff_id = format!("sha256:{}", "7".repeat(64));
+    shared_layer.entries[1] = second;
+    assert!(validate_config(&shared_layer, &identity, std::slice::from_ref(&layer)).is_err());
 }

--- a/src/runtime/src/oci/build/cache/export/validation.rs
+++ b/src/runtime/src/oci/build/cache/export/validation.rs
@@ -1,0 +1,301 @@
+//! Sole parser and validator for portable native cache artifacts.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use a3s_box_core::error::Result;
+use a3s_box_core::platform::Platform;
+use oci_spec::image::{Descriptor, ImageIndex, ImageManifest, MediaType, SCHEMA_VERSION};
+
+use super::{
+    cache_error, BuildCacheExportIdentity, BuildCacheReceipt, CacheConfig, RecordedBuildCache,
+    BUILD_CACHE_ARTIFACT_MEDIA_TYPE, BUILD_CACHE_CONFIG_MEDIA_TYPE, CACHE_CONFIG_SCHEMA,
+    MAX_CACHE_ENTRIES,
+};
+use crate::oci::build::layout::{
+    metadata_bytes, validate_blob_inventory, validate_exact_entries, EntryKind,
+};
+use crate::oci::build::BuildOutputDescriptor;
+use crate::oci::image::{
+    canonical_sha256_digest_hex, read_regular_file_bounded, read_verified_oci_blob,
+    verify_oci_blob_file, MAX_OCI_CONFIG_BYTES, MAX_OCI_INDEX_BYTES, MAX_OCI_LAYER_BLOB_BYTES,
+    MAX_OCI_MANIFEST_BYTES,
+};
+
+/// One cache entry returned only after the complete artifact is revalidated.
+#[derive(Debug)]
+pub(in crate::oci::build::cache) struct ValidatedCacheEntry {
+    pub(in crate::oci::build::cache) key: String,
+    pub(in crate::oci::build::cache) blob_path: std::path::PathBuf,
+    pub(in crate::oci::build::cache) digest: String,
+    pub(in crate::oci::build::cache) diff_id: String,
+    pub(in crate::oci::build::cache) size: u64,
+}
+
+/// The sole parsed form shared by receipt replay and cache hydration.
+#[derive(Debug)]
+pub(in crate::oci::build::cache) struct ValidatedBuildCacheArtifact {
+    pub(in crate::oci::build::cache) recorded: RecordedBuildCache,
+    pub(in crate::oci::build::cache) entries: Vec<ValidatedCacheEntry>,
+}
+
+pub(in crate::oci::build) fn inspect_build_cache_artifact(
+    root: &Path,
+    identity: &BuildCacheExportIdentity,
+    expected: Option<&BuildCacheReceipt>,
+) -> Result<RecordedBuildCache> {
+    validate_build_cache_artifact(root, identity, expected).map(|artifact| artifact.recorded)
+}
+
+pub(in crate::oci::build::cache) fn validate_build_cache_artifact(
+    root: &Path,
+    identity: &BuildCacheExportIdentity,
+    expected: Option<&BuildCacheReceipt>,
+) -> Result<ValidatedBuildCacheArtifact> {
+    validate_exact_entries(
+        root,
+        &[
+            ("blobs", EntryKind::Directory),
+            ("index.json", EntryKind::File),
+            ("oci-layout", EntryKind::File),
+        ],
+        "native cache OCI layout",
+    )?;
+    validate_exact_entries(
+        &root.join("blobs"),
+        &[("sha256", EntryKind::Directory)],
+        "native cache OCI blob root",
+    )?;
+    let index_bytes =
+        read_regular_file_bounded(&root.join("index.json"), MAX_OCI_INDEX_BYTES, "cache index")?;
+    let index: ImageIndex = serde_json::from_slice(&index_bytes)
+        .map_err(|error| cache_error(format!("native cache index is invalid: {error}")))?;
+    require_index(&index, &identity.platform)?;
+    let root_descriptor = index.manifests()[0].clone();
+    let manifest_bytes = read_descriptor(
+        root,
+        &root_descriptor,
+        MAX_OCI_MANIFEST_BYTES,
+        "cache manifest",
+    )?;
+    let manifest: ImageManifest = serde_json::from_slice(&manifest_bytes)
+        .map_err(|error| cache_error(format!("native cache manifest is invalid: {error}")))?;
+    require_manifest(&manifest)?;
+    let config_bytes = read_descriptor(
+        root,
+        manifest.config(),
+        MAX_OCI_CONFIG_BYTES,
+        "cache config",
+    )?;
+    let config: CacheConfig = serde_json::from_slice(&config_bytes)
+        .map_err(|error| cache_error(format!("native cache config is invalid: {error}")))?;
+    validate_config(&config, identity, manifest.layers())?;
+    for layer in manifest.layers() {
+        verify_descriptor_file(root, layer, "cache layer")?;
+    }
+
+    let mut descriptors = Vec::with_capacity(manifest.layers().len() + 2);
+    descriptors.push(root_descriptor.clone());
+    descriptors.push(manifest.config().clone());
+    descriptors.extend(manifest.layers().iter().cloned());
+    let (blob_count, blob_bytes, blob_inventory_digest) =
+        validate_blob_inventory(root, &descriptors, "Native cache OCI artifact")?;
+    let content_bytes = metadata_bytes(root, "Native cache OCI artifact")?
+        .checked_add(blob_bytes)
+        .ok_or_else(|| cache_error("native cache artifact byte count overflowed"))?;
+    let receipt = BuildCacheReceipt {
+        schema: BuildCacheReceipt::SCHEMA.to_string(),
+        key: identity.key.clone(),
+        source_digest: identity.source_digest.clone(),
+        plan_digest: identity.plan_digest.clone(),
+        descriptor: BuildOutputDescriptor {
+            media_type: root_descriptor.media_type().as_ref().to_string(),
+            digest: root_descriptor.digest().to_string(),
+            size: root_descriptor.size(),
+        },
+        platform: identity.platform.clone(),
+        content_bytes,
+        entry_count: config.entries.len() as u64,
+        blob_count: blob_count as u64,
+        blob_inventory_digest,
+    };
+    receipt.validate()?;
+    if expected.is_some_and(|expected| expected != &receipt) {
+        return Err(cache_error(
+            "revalidated native cache artifact differs from its receipt",
+        ));
+    }
+    let entries = config
+        .entries
+        .into_iter()
+        .map(|entry| {
+            let key = canonical_sha256_digest_hex(&entry.key).map(str::to_string)?;
+            let digest = canonical_sha256_digest_hex(&entry.layer.digest).map(str::to_string)?;
+            let diff_id = canonical_sha256_digest_hex(&entry.diff_id).map(str::to_string)?;
+            Ok(ValidatedCacheEntry {
+                key,
+                blob_path: root.join("blobs").join("sha256").join(&digest),
+                digest,
+                diff_id,
+                size: entry.layer.size,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(ValidatedBuildCacheArtifact {
+        recorded: RecordedBuildCache {
+            receipt,
+            layout_directory: root.to_path_buf(),
+        },
+        entries,
+    })
+}
+
+pub(super) fn validate_config(
+    config: &CacheConfig,
+    identity: &BuildCacheExportIdentity,
+    layers: &[Descriptor],
+) -> Result<()> {
+    if config.schema != CACHE_CONFIG_SCHEMA
+        || config.key != identity.key
+        || config.source_digest != identity.source_digest
+        || config.plan_digest != identity.plan_digest
+        || config.platform != identity.platform
+        || config.entries.len() > MAX_CACHE_ENTRIES
+    {
+        return Err(cache_error("native cache config identity is invalid"));
+    }
+    let mut previous = None;
+    let mut expected_layers = BTreeMap::new();
+    let mut expected_diff_ids = BTreeMap::new();
+    for entry in &config.entries {
+        if previous.as_ref().is_some_and(|key| key >= &entry.key)
+            || canonical_sha256_digest_hex(&entry.key).is_err()
+            || canonical_sha256_digest_hex(&entry.diff_id).is_err()
+            || canonical_sha256_digest_hex(&entry.layer.digest).is_err()
+            || entry.layer.media_type != MediaType::ImageLayerGzip.as_ref()
+            || entry.layer.size == 0
+        {
+            return Err(cache_error("native cache config entry is invalid"));
+        }
+        previous = Some(entry.key.clone());
+        let layer_identity = (entry.layer.media_type.clone(), entry.layer.size);
+        if expected_layers
+            .insert(entry.layer.digest.clone(), layer_identity.clone())
+            .is_some_and(|existing| existing != layer_identity)
+            || expected_diff_ids
+                .insert(entry.layer.digest.clone(), entry.diff_id.clone())
+                .is_some_and(|existing| existing != entry.diff_id)
+        {
+            return Err(cache_error(
+                "native cache entries disagree about one layer identity",
+            ));
+        }
+    }
+    let actual_layers = layers
+        .iter()
+        .map(|layer| {
+            (
+                layer.digest().to_string(),
+                (layer.media_type().as_ref().to_string(), layer.size()),
+            )
+        })
+        .collect::<Vec<_>>();
+    let expected_layers = expected_layers.into_iter().collect::<Vec<_>>();
+    if actual_layers != expected_layers {
+        return Err(cache_error(
+            "native cache manifest layers differ from the cache config",
+        ));
+    }
+    Ok(())
+}
+
+fn require_index(index: &ImageIndex, platform: &Platform) -> Result<()> {
+    if index.schema_version() != SCHEMA_VERSION
+        || index.media_type().as_ref() != Some(&MediaType::ImageIndex)
+        || index.artifact_type().as_ref() != Some(&MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
+        || index.subject().is_some()
+        || index.annotations().is_some()
+        || index.manifests().len() != 1
+    {
+        return Err(cache_error("native cache OCI index shape is invalid"));
+    }
+    let descriptor = &index.manifests()[0];
+    require_descriptor(descriptor, MediaType::ImageManifest, true)?;
+    let Some(actual) = descriptor.platform() else {
+        return Err(cache_error("native cache root descriptor has no platform"));
+    };
+    if actual.os().to_string() != platform.os
+        || actual.architecture().to_string() != platform.architecture
+        || actual.variant() != &platform.variant
+        || descriptor.artifact_type().as_ref()
+            != Some(&MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
+    {
+        return Err(cache_error("native cache root platform is invalid"));
+    }
+    Ok(())
+}
+
+fn require_manifest(manifest: &ImageManifest) -> Result<()> {
+    if manifest.schema_version() != SCHEMA_VERSION
+        || manifest.media_type().as_ref() != Some(&MediaType::ImageManifest)
+        || manifest.artifact_type().as_ref()
+            != Some(&MediaType::from(BUILD_CACHE_ARTIFACT_MEDIA_TYPE))
+        || manifest.subject().is_some()
+        || manifest.annotations().is_some()
+        || manifest.config().media_type().as_ref() != BUILD_CACHE_CONFIG_MEDIA_TYPE
+    {
+        return Err(cache_error("native cache OCI manifest shape is invalid"));
+    }
+    require_descriptor(
+        manifest.config(),
+        MediaType::from(BUILD_CACHE_CONFIG_MEDIA_TYPE),
+        false,
+    )?;
+    for layer in manifest.layers() {
+        require_descriptor(layer, MediaType::ImageLayerGzip, false)?;
+    }
+    Ok(())
+}
+
+pub(super) fn require_descriptor(
+    descriptor: &Descriptor,
+    media_type: MediaType,
+    root: bool,
+) -> Result<()> {
+    if descriptor.media_type() != &media_type
+        || descriptor.size() == 0
+        || canonical_sha256_digest_hex(descriptor.digest().as_ref()).is_err()
+        || descriptor.urls().is_some()
+        || descriptor.annotations().is_some()
+        || descriptor.data().is_some()
+        || (!root && descriptor.platform().is_some())
+        || (!root && descriptor.artifact_type().is_some())
+    {
+        return Err(cache_error("native cache OCI descriptor is invalid"));
+    }
+    Ok(())
+}
+
+fn read_descriptor(
+    root: &Path,
+    descriptor: &Descriptor,
+    limit: u64,
+    label: &str,
+) -> Result<Vec<u8>> {
+    let size = i64::try_from(descriptor.size())
+        .map_err(|_| cache_error(format!("{label} size exceeds the supported range")))?;
+    read_verified_oci_blob(root, descriptor.digest().as_ref(), size, limit, label)
+}
+
+fn verify_descriptor_file(root: &Path, descriptor: &Descriptor, label: &str) -> Result<()> {
+    let size = i64::try_from(descriptor.size())
+        .map_err(|_| cache_error(format!("{label} size exceeds the supported range")))?;
+    verify_oci_blob_file(
+        root,
+        descriptor.digest().as_ref(),
+        size,
+        MAX_OCI_LAYER_BLOB_BYTES,
+        label,
+    )
+    .map(|_| ())
+}

--- a/src/runtime/src/oci/build/cache/import.rs
+++ b/src/runtime/src/oci/build/cache/import.rs
@@ -1,0 +1,304 @@
+//! Hydration of a validated portable cache artifact into `BuildCache`.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use a3s_box_core::error::{BoxError, Result};
+
+use super::export::{validate_build_cache_artifact, ValidatedCacheEntry};
+use super::{
+    configured_max_bytes, BuildCache, BuildCacheExportIdentity, BuildCacheReceipt, CachedLayer,
+    RecordedBuildCache,
+};
+use crate::oci::build::layer::LayerInfo;
+
+/// Revalidate one portable cache artifact and hydrate it into the sole native
+/// [`BuildCache`] authority.
+///
+/// The artifact is validated before the cache lock is acquired. Hydration then
+/// serializes with native cache hits and stores through that existing lock.
+/// Existing identical entries are idempotent; an existing valid key that maps
+/// to different content is rejected before any imported key is published.
+pub async fn hydrate_recorded_build_cache(
+    recorded: &RecordedBuildCache,
+) -> Result<BuildCacheReceipt> {
+    let recorded = RecordedBuildCache {
+        receipt: recorded.receipt.clone(),
+        layout_directory: recorded.layout_directory.clone(),
+    };
+    tokio::task::spawn_blocking(move || {
+        let cache = BuildCache::open().ok_or_else(|| {
+            hydration_error("the native BuildCache directory could not be opened")
+        })?;
+        cache.hydrate_recorded(&recorded)
+    })
+    .await
+    .map_err(|error| hydration_error(format!("cache hydration task failed: {error}")))?
+}
+
+impl BuildCache {
+    fn hydrate_recorded(&self, recorded: &RecordedBuildCache) -> Result<BuildCacheReceipt> {
+        let identity = BuildCacheExportIdentity::new(
+            recorded.receipt.source_digest.clone(),
+            recorded.receipt.plan_digest.clone(),
+            recorded.receipt.platform.clone(),
+        )?;
+        let artifact = validate_build_cache_artifact(
+            &recorded.layout_directory,
+            &identity,
+            Some(&recorded.receipt),
+        )?;
+        let layers = artifact
+            .entries
+            .iter()
+            .map(|entry| (entry.digest.clone(), entry.size))
+            .collect::<BTreeMap<_, _>>();
+        let required_bytes = layers.values().try_fold(0_u64, |total, size| {
+            total
+                .checked_add(*size)
+                .ok_or_else(|| hydration_error("the imported cache layer byte count overflowed"))
+        })?;
+        let capacity = configured_max_bytes();
+        if required_bytes > capacity {
+            return Err(hydration_error(format!(
+                "the artifact requires {required_bytes} layer bytes but the BuildCache cap is {capacity}"
+            )));
+        }
+        let _lock = self
+            .lock()
+            .map_err(|error| hydration_error(format!("failed to lock BuildCache: {error}")))?;
+
+        for entry in &artifact.entries {
+            if let Some(existing) = self.lookup_unlocked(&entry.key) {
+                if !entry_matches(entry, &existing) {
+                    return Err(hydration_error(format!(
+                        "cache key sha256:{} already maps to different verified content",
+                        entry.key
+                    )));
+                }
+            }
+        }
+
+        for entry in &artifact.entries {
+            let layer = LayerInfo {
+                path: entry.blob_path.clone(),
+                digest: entry.digest.clone(),
+                size: entry.size,
+            };
+            if !self.publish_entry_unlocked(&entry.key, &layer, &entry.diff_id) {
+                return Err(hydration_error(format!(
+                    "failed to publish cache key sha256:{} through BuildCache",
+                    entry.key
+                )));
+            }
+            let hydrated = self.lookup_unlocked(&entry.key).ok_or_else(|| {
+                hydration_error(format!(
+                    "failed to publish cache key sha256:{} through BuildCache",
+                    entry.key
+                ))
+            })?;
+            if !entry_matches(entry, &hydrated) {
+                return Err(hydration_error(format!(
+                    "cache key sha256:{} changed while it was being hydrated",
+                    entry.key
+                )));
+            }
+        }
+
+        let preserved = layers.into_keys().collect::<BTreeSet<_>>();
+        if !self.prune_to_unlocked_preserving(capacity, &preserved) {
+            return Err(hydration_error(format!(
+                "the BuildCache cap of {capacity} bytes could not be enforced while retaining the imported artifact"
+            )));
+        }
+
+        for entry in &artifact.entries {
+            let hydrated = self.lookup_unlocked(&entry.key).ok_or_else(|| {
+                hydration_error(format!(
+                    "cache key sha256:{} was evicted before hydration completed",
+                    entry.key
+                ))
+            })?;
+            if !entry_matches(entry, &hydrated) {
+                return Err(hydration_error(format!(
+                    "cache key sha256:{} differs after hydration completed",
+                    entry.key
+                )));
+            }
+        }
+
+        Ok(artifact.recorded.receipt)
+    }
+}
+
+fn entry_matches(expected: &ValidatedCacheEntry, actual: &CachedLayer) -> bool {
+    actual.digest == expected.digest
+        && actual.diff_id == expected.diff_id
+        && actual.size == expected.size
+}
+
+fn hydration_error(message: impl Into<String>) -> BoxError {
+    BoxError::BuildError(format!(
+        "native BuildCache hydration failed: {}",
+        message.into()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use a3s_box_core::platform::Platform;
+    use tempfile::TempDir;
+
+    use super::super::{BuildCacheTrace, CachedLayer};
+    use super::*;
+    use crate::oci::build::layer::{sha256_bytes, LayerInfo};
+
+    struct CacheFixture {
+        recorded: RecordedBuildCache,
+        first_key: String,
+        first_layer: CachedLayer,
+        second_key: String,
+        second_layer: CachedLayer,
+    }
+
+    fn store_layer(
+        cache: &BuildCache,
+        root: &Path,
+        name: &str,
+        key: &str,
+        contents: &[u8],
+    ) -> CachedLayer {
+        let path = root.join(name);
+        fs::write(&path, contents).unwrap();
+        let layer = LayerInfo {
+            path,
+            digest: sha256_bytes(contents),
+            size: contents.len() as u64,
+        };
+        cache.store(
+            key,
+            &layer,
+            &sha256_bytes(format!("{name}-diff").as_bytes()),
+        );
+        cache.lookup(key).expect("stored cache entry")
+    }
+
+    fn export_fixture(root: &Path) -> CacheFixture {
+        let source = BuildCache::open_in(root.join("source-cache")).unwrap();
+        let first_key = BuildCache::chain("", "COPY first /first", Some("first"));
+        let second_key = BuildCache::chain(&first_key, "RUN second", None);
+        let first_layer = store_layer(
+            &source,
+            root,
+            "first-layer.tar.gz",
+            &first_key,
+            b"first portable layer",
+        );
+        let second_layer = store_layer(
+            &source,
+            root,
+            "second-layer.tar.gz",
+            &second_key,
+            b"second portable layer",
+        );
+        let mut trace = BuildCacheTrace::default();
+        trace.record(&first_key, &first_layer).unwrap();
+        trace.record(&second_key, &second_layer).unwrap();
+        let identity = BuildCacheExportIdentity::new(
+            format!("sha256:{}", "1".repeat(64)),
+            format!("sha256:{}", "2".repeat(64)),
+            Platform::linux_amd64(),
+        )
+        .unwrap();
+        let recorded = source
+            .stage_export(&trace, &identity, &root.join("cache-artifact"))
+            .unwrap();
+        CacheFixture {
+            recorded,
+            first_key,
+            first_layer,
+            second_key,
+            second_layer,
+        }
+    }
+
+    #[test]
+    fn hydrate_revalidates_and_populates_the_existing_cache_authority() {
+        let tmp = TempDir::new().unwrap();
+        let fixture = export_fixture(tmp.path());
+        let target = BuildCache::open_in(tmp.path().join("target-cache")).unwrap();
+
+        let receipt = target
+            .hydrate_recorded(&fixture.recorded)
+            .expect("hydrate validated cache artifact");
+
+        assert_eq!(receipt, fixture.recorded.receipt);
+        assert_eq!(
+            target.lookup(&fixture.first_key).unwrap().digest,
+            fixture.first_layer.digest
+        );
+        assert_eq!(
+            target.lookup(&fixture.second_key).unwrap().digest,
+            fixture.second_layer.digest
+        );
+
+        fs::remove_dir_all(&fixture.recorded.layout_directory).unwrap();
+        assert!(target.lookup(&fixture.first_key).is_some());
+        assert!(target.lookup(&fixture.second_key).is_some());
+    }
+
+    #[test]
+    fn hydrate_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let fixture = export_fixture(tmp.path());
+        let target_dir = tmp.path().join("target-cache");
+        let target = BuildCache::open_in(target_dir.clone()).unwrap();
+
+        let first = target.hydrate_recorded(&fixture.recorded).unwrap();
+        let second = target.hydrate_recorded(&fixture.recorded).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(fs::read_dir(target_dir.join("keys")).unwrap().count(), 2);
+        assert_eq!(fs::read_dir(target_dir.join("blobs")).unwrap().count(), 2);
+    }
+
+    #[test]
+    fn hydrate_rejects_artifact_tampering_before_writing_keys() {
+        let tmp = TempDir::new().unwrap();
+        let fixture = export_fixture(tmp.path());
+        let target = BuildCache::open_in(tmp.path().join("target-cache")).unwrap();
+        let layer = fixture
+            .recorded
+            .layout_directory
+            .join("blobs/sha256")
+            .join(&fixture.first_layer.digest);
+        fs::write(layer, b"tampered").unwrap();
+
+        assert!(target.hydrate_recorded(&fixture.recorded).is_err());
+        assert!(target.lookup(&fixture.first_key).is_none());
+        assert!(target.lookup(&fixture.second_key).is_none());
+    }
+
+    #[test]
+    fn hydrate_rejects_a_valid_local_key_conflict_without_partial_import() {
+        let tmp = TempDir::new().unwrap();
+        let fixture = export_fixture(tmp.path());
+        let target = BuildCache::open_in(tmp.path().join("target-cache")).unwrap();
+        let conflict = store_layer(
+            &target,
+            tmp.path(),
+            "conflicting-layer.tar.gz",
+            &fixture.first_key,
+            b"different deterministic output",
+        );
+
+        assert!(target.hydrate_recorded(&fixture.recorded).is_err());
+        assert_eq!(
+            target.lookup(&fixture.first_key).unwrap().digest,
+            conflict.digest
+        );
+        assert!(target.lookup(&fixture.second_key).is_none());
+    }
+}

--- a/src/runtime/src/oci/build/cache/tests.rs
+++ b/src/runtime/src/oci/build/cache/tests.rs
@@ -197,6 +197,38 @@ fn test_prune_evicts_until_under_cap() {
 }
 
 #[test]
+fn hydration_prune_preserves_the_imported_layer_set() {
+    let tmp = TempDir::new().unwrap();
+    let cache_dir = tmp.path().join("buildcache");
+    let cache = open_at(&cache_dir);
+    let mut digests = Vec::new();
+
+    for i in 0..3 {
+        let payload = vec![b'a' + i as u8; 100];
+        let src = tmp.path().join(format!("protected-src-{i}"));
+        fs::write(&src, &payload).unwrap();
+        let layer = LayerInfo {
+            path: src,
+            digest: sha256_bytes(&payload),
+            size: payload.len() as u64,
+        };
+        cache.store(
+            &BuildCache::chain("", &format!("COPY protected {i}"), None),
+            &layer,
+            "d",
+        );
+        digests.push(layer.digest);
+    }
+
+    let preserved = BTreeSet::from([digests[0].clone()]);
+    let _lock = cache.lock().unwrap();
+    assert!(cache.prune_to_unlocked_preserving(100, &preserved));
+    assert!(cache_dir.join("blobs").join(&digests[0]).exists());
+    assert!(!cache_dir.join("blobs").join(&digests[1]).exists());
+    assert!(!cache_dir.join("blobs").join(&digests[2]).exists());
+}
+
+#[test]
 fn test_hash_context_sources_missing_source_is_none() {
     let ctx = TempDir::new().unwrap();
     let srcs = vec!["does-not-exist".to_string()];

--- a/src/runtime/src/oci/build/execution.rs
+++ b/src/runtime/src/oci/build/execution.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use a3s_box_core::error::BoxError;
 use thiserror::Error;
 
-use super::cache::{inspect_build_cache_export, BuildCacheExportIdentity, RecordedBuildCache};
+use super::cache::{inspect_build_cache_artifact, BuildCacheExportIdentity, RecordedBuildCache};
 use super::engine::{build_supervised, BuildExecutionControl};
 use super::receipt::{
     inspect_stored_output, BuildExecutionLease, BuildOperationJournal, LockedBuildOperation,
@@ -888,7 +888,7 @@ async fn inspect_committed_cache(
         output.platform.clone(),
     )?;
     let operation = identity.operation_id().to_string();
-    tokio::task::spawn_blocking(move || inspect_build_cache_export(&path, &cache_identity, None))
+    tokio::task::spawn_blocking(move || inspect_build_cache_artifact(&path, &cache_identity, None))
         .await
         .map_err(|error| BuildReceiptError::Task {
             operation_id: operation.clone(),

--- a/src/runtime/src/oci/build/mod.rs
+++ b/src/runtime/src/oci/build/mod.rs
@@ -30,8 +30,8 @@ pub mod plan;
 mod receipt;
 
 pub use cache::{
-    BuildCacheReceipt, RecordedBuildCache, BUILD_CACHE_ARTIFACT_MEDIA_TYPE,
-    BUILD_CACHE_CONFIG_MEDIA_TYPE,
+    hydrate_recorded_build_cache, BuildCacheReceipt, RecordedBuildCache,
+    BUILD_CACHE_ARTIFACT_MEDIA_TYPE, BUILD_CACHE_CONFIG_MEDIA_TYPE,
 };
 pub use dockerfile::{Dockerfile, Instruction};
 pub use engine::{build, BuildConfig, BuildNetworkPolicy, BuildRunPoolConfig};

--- a/src/runtime/src/oci/build/receipt.rs
+++ b/src/runtime/src/oci/build/receipt.rs
@@ -15,7 +15,7 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use super::cache::{
-    inspect_build_cache_export, BuildCacheExportIdentity, BuildCacheReceipt, RecordedBuildCache,
+    inspect_build_cache_artifact, BuildCacheExportIdentity, BuildCacheReceipt, RecordedBuildCache,
 };
 use super::output::inspect_stored_build_output;
 use super::{BuildCachePolicy, BuildOutputDescriptor, BuildResult, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
@@ -688,7 +688,7 @@ impl BuildOutputReceipt {
         let root = layout_directory.to_path_buf();
         let operation = self.operation_id.to_string();
         tokio::task::spawn_blocking(move || {
-            inspect_build_cache_export(&root, &identity, Some(&expected))
+            inspect_build_cache_artifact(&root, &identity, Some(&expected))
         })
         .await
         .map_err(|error| BuildReceiptError::Task {

--- a/src/runtime/src/oci/mod.rs
+++ b/src/runtime/src/oci/mod.rs
@@ -39,14 +39,14 @@ pub mod store;
 
 #[cfg(feature = "build")]
 pub use build::{
-    cancel_recorded_build_plan, execute_recorded_build_plan, inspect_recorded_build_plan,
-    inspect_recorded_build_status, remove_recorded_build_plan, start_recorded_build_plan,
-    BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy, BuildCacheReceipt,
-    BuildCancellationOutcome, BuildConfig, BuildNetworkPolicy, BuildOperationIdentity,
-    BuildOutputDescriptor, BuildOutputReceipt, BuildPlanExecutionError, BuildReceiptError,
-    BuildReceiptOutput, BuildResult, BuildRunPoolConfig, Dockerfile, Instruction,
-    RecordedBuildCache, RecordedBuildResult, RecordedBuildStatus, BUILD_CACHE_ARTIFACT_MEDIA_TYPE,
-    BUILD_CACHE_CONFIG_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    cancel_recorded_build_plan, execute_recorded_build_plan, hydrate_recorded_build_cache,
+    inspect_recorded_build_plan, inspect_recorded_build_status, remove_recorded_build_plan,
+    start_recorded_build_plan, BoxBuildOptions, BoxBuildPlan, BoxBuildPlanError, BuildCachePolicy,
+    BuildCacheReceipt, BuildCancellationOutcome, BuildConfig, BuildNetworkPolicy,
+    BuildOperationIdentity, BuildOutputDescriptor, BuildOutputReceipt, BuildPlanExecutionError,
+    BuildReceiptError, BuildReceiptOutput, BuildResult, BuildRunPoolConfig, Dockerfile,
+    Instruction, RecordedBuildCache, RecordedBuildResult, RecordedBuildStatus,
+    BUILD_CACHE_ARTIFACT_MEDIA_TYPE, BUILD_CACHE_CONFIG_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 pub use credentials::CredentialStore;
 pub use image::{OciHealthCheck, OciImage, OciImageConfig};


### PR DESCRIPTION
## Summary

- add one typed `hydrate_recorded_build_cache` API for portable native cache artifacts
- reuse the exact receipt/OCI artifact validator used by replay
- hydrate through the existing `BuildCache` lock and sole blob/key publication boundary
- reject verified local key conflicts before imported keys are published
- preserve the complete imported layer set while enforcing the configured cache cap
- keep repeated hydration idempotent and copy imported blobs instead of linking them

## Single-authority design

- `BuildCache` remains the sole cache authority
- `publish_entry_unlocked` is the sole native blob/key writer
- `validate_build_cache_artifact` is the sole receipt, manifest, config, layer, inventory, and byte validator used by replay and hydration
- no cache importer service, cache store, queue, scheduler, lifecycle journal, or publisher was added
- the native Box engine, `BuildOperationJournal`, and `ImageStore` retain their existing ownership boundaries
- CI rejects duplicate cache authorities, validators, writers, services, stores, and queues

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p a3s-box-runtime`: 1,504 passed / 1 ignored
- `cargo clippy -p a3s-box-runtime --all-targets -- -D warnings`
- `A3S_DEPS_STUB=1 cargo clippy --workspace --all-targets -- -D warnings`
- local single-authority architecture gate

Advances #172.