### PR TITLE
feat: wire production native OCI sandbox execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: aac259224e89bef2b546fd0f8755ef1ba79570ce
+  A3S_OCI_RUNTIME_REV: a6f6242caf927f404f7e1f7f143fd3a350ce23b6
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,7 @@ jobs:
               CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" \
               A3S_DEPS_STUB=1 \
               A3S_HOME="$A3S_HOME" \
+              A3S_BOX_OCI_MIGRATION=sandbox \
               A3S_BOX_OCI_RUNTIME_PATH="$A3S_BOX_OCI_RUNTIME_PATH" \
               A3S_BOX_OCI_AGENT_PATH="$A3S_BOX_OCI_AGENT_PATH" \
               A3S_BOX_BINARY="$GITHUB_WORKSPACE/src/target/debug/a3s-box" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 24169ce7b0865e2a5de684882cffeb4811b1a3b9
+  A3S_OCI_RUNTIME_REV: aac259224e89bef2b546fd0f8755ef1ba79570ce
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────
@@ -394,6 +394,7 @@ jobs:
       A3S_HOME: /tmp/a3s-local-sdk-smoke-runtime-conformance
       A3S_BOX_OCI_RUNTIME_PATH: /tmp/a3s-local-sdk-smoke-runtime-conformance/bin/a3s-oci
       A3S_BOX_OCI_AGENT_PATH: /tmp/a3s-local-sdk-smoke-runtime-conformance/bin/a3s-oci-agent
+      A3S_BOX_OCI_HOST_ROOT: /tmp/a3s-box-production-oci-host
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Init submodules
@@ -495,6 +496,27 @@ jobs:
               cargo test --locked -p a3s-box-runtime --lib \
                 box_runtime_passes_all_advertised_profiles \
                 -- --ignored --nocapture --test-threads=1
+      - name: Exercise production Box-to-OCI owner composition
+        run: |
+          cd src
+          sudo env \
+              PATH="$PATH" \
+              HOME="$HOME" \
+              RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}" \
+              CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" \
+              A3S_DEPS_STUB=1 \
+              A3S_HOME="$A3S_HOME" \
+              A3S_BOX_OCI_MIGRATION=sandbox \
+              A3S_BOX_OCI_HOST_ROOT="$A3S_BOX_OCI_HOST_ROOT" \
+              A3S_BOX_OCI_RUNTIME_PATH="$A3S_BOX_OCI_RUNTIME_PATH" \
+              A3S_BOX_OCI_AGENT_PATH="$A3S_BOX_OCI_AGENT_PATH" \
+              A3S_BOX_SDK_LOCAL_SMOKE=1 \
+              A3S_BOX_SDK_SMOKE_ISOLATION=sandbox \
+              A3S_BOX_SDK_SMOKE_IMAGE='docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc' \
+              RUST_MIN_STACK=16777216 \
+              cargo test --locked -p a3s-box-sdk --test local_sandbox \
+                local_sandbox_exercises_real_runtime \
+                -- --ignored --nocapture --test-threads=1
       - name: Test Rust, Python, TypeScript, and Go SDKs without credentials
         run: |
           sudo env \
@@ -517,13 +539,49 @@ jobs:
         if: always()
         run: |
           cleanup_status=0
-          if pgrep -f 'a3s-box-shim|a3s-oci.*native-linux-service|a3s-oci-agent' >/dev/null; then
-            ps aux | grep -E 'a3s-box-shim|a3s-oci.*native-linux-service|a3s-oci-agent' | grep -v grep
+          sudo python3 - "$A3S_BOX_OCI_HOST_ROOT/box-owner.json" <<'PY' || cleanup_status=1
+          import json
+          import os
+          import pathlib
+          import signal
+          import sys
+          import time
+
+          record_path = pathlib.Path(sys.argv[1])
+          if not record_path.exists():
+              raise SystemExit(0)
+          record = json.loads(record_path.read_text(encoding="utf-8"))
+          pid = int(record["pid"])
+          expected_start = int(record["pid_start_time"])
+          stat_path = pathlib.Path(f"/proc/{pid}/stat")
+          if not stat_path.exists():
+              raise SystemExit(0)
+          raw = stat_path.read_text(encoding="utf-8")
+          actual_start = int(raw[raw.rfind(")") + 2:].split()[19])
+          if actual_start != expected_start:
+              raise RuntimeError("refusing to signal a reused OCI owner PID")
+          os.kill(pid, signal.SIGTERM)
+          for _ in range(200):
+              if not stat_path.exists():
+                  break
+              time.sleep(0.05)
+          else:
+              os.kill(pid, signal.SIGKILL)
+              for _ in range(100):
+                  if not stat_path.exists():
+                      break
+                  time.sleep(0.05)
+              else:
+                  raise RuntimeError("OCI owner remained after SIGKILL")
+          PY
+          if pgrep -f 'a3s-box-shim|a3s-oci.*native-linux-.*service|a3s-oci-agent' >/dev/null; then
+            ps aux | grep -E 'a3s-box-shim|a3s-oci.*native-linux-.*service|a3s-oci-agent' | grep -v grep
             cleanup_status=1
           fi
           if mountpoint -q "$A3S_HOME/runtime-secrets"; then
             sudo umount "$A3S_HOME/runtime-secrets" || cleanup_status=1
           fi
+          sudo rm -rf "$A3S_BOX_OCI_HOST_ROOT"
           sudo rm -rf "$A3S_HOME"
           exit "$cleanup_status"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,7 @@ jobs:
               A3S_DEPS_STUB=1 \
               A3S_HOME="$A3S_HOME" \
               A3S_BOX_OCI_MIGRATION=sandbox \
+              A3S_BOX_OCI_HOST_ROOT="$A3S_BOX_OCI_HOST_ROOT" \
               A3S_BOX_OCI_RUNTIME_PATH="$A3S_BOX_OCI_RUNTIME_PATH" \
               A3S_BOX_OCI_AGENT_PATH="$A3S_BOX_OCI_AGENT_PATH" \
               A3S_BOX_BINARY="$GITHUB_WORKSPACE/src/target/debug/a3s-box" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,12 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- **OCI-routed direct argv commands.** Captured exec, streaming exec, and PTY
+  sessions now resolve a relative `argv[0]` through the effective container
+  `PATH` against the prepared rootfs before SDK dispatch. Native Rust, Python,
+  TypeScript, and Go callers keep the documented shell-free `Argv("printf",
+  ...)` behavior while A3S OCI Runtime still receives a normalized absolute
+  Linux executable path.
 - **Sandbox cgroup namespace handoff.** Guest Init now accepts and verifies the
   runtime's pre-isolated control membership after the namespace is rooted at
   management and rejects a populated management envelope. The workload

--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ unchanged.
 > identity-fenced owner startup, and explicit CLI/SDK composition. Before bundle
 > construction, the resource guard validates the managed home, durably attaches
 > product volumes and networking, and installs a verified snapshot lower with
-> fail-closed rollback. The blocking Native Linux real-host gate now passes this
+> fail-closed rollback. Direct SDK argv commands use the effective container
+> `PATH` to resolve `argv[0]` against that prepared rootfs before OCI dispatch,
+> preserving shell-free `Argv("printf", ...)` behavior without weakening the
+> runtime's normalized-absolute-path contract. The blocking Native Linux
+> real-host gate now passes this
 > production owner composition through the Rust, Python, TypeScript, and Go SDK
 > lifecycle, exec, filesystem, route-aware stats, pause/resume, snapshot
 > restore, restart, and cleanup surfaces.

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ unchanged.
 > filesystem mutations reuse one operation identity for an explicitly
 > retryable lost response and are verified to take effect once; read responses
 > are size-bounded and rejected if the target or shape drifts. Resource intent
-> is persisted before mutation and recovered with the same operation identity,
-> while the original create identity remains immutable. A retained local SDK
-> client now exposes the first broken-stream result, then reconnects and
+> is persisted before mutation and recovered with the same operation identity.
+> Snapshot freezer claims also persist whether their runtime mutation has been
+> applied, so crash recovery never replays an already completed thaw, while the
+> original create identity remains immutable. A retained local SDK client now
+> exposes the first broken-stream result, then reconnects and
 > renegotiates on a later explicit reconciliation. The generic Box/OCI contract
 > also recovers one manager across two distinct runtime-owner test processes
 > with exactly one create, start, and exec; the original live process stream and
@@ -85,11 +87,15 @@ unchanged.
 > real native and utility-VM drivers before the Box SDK suite runs. The pinned
 > runtime now supplies a long-lived multi-container Native Linux host owner and
 > Box now supplies its production direct-process bundle compiler, protected
-> identity-fenced owner startup, and explicit CLI/SDK composition. Native Linux
-> real-host acceptance is a blocking CI gate. WHPX composition,
-> cross-process real-driver process/filesystem recovery, remaining CLI
-> projections, and the broader cutover gates remain open; the default split
-> above is still authoritative.
+> identity-fenced owner startup, and explicit CLI/SDK composition. Before bundle
+> construction, the resource guard validates the managed home, durably attaches
+> product volumes and networking, and installs a verified snapshot lower with
+> fail-closed rollback. The blocking Native Linux real-host gate now passes this
+> production owner composition through typed Rust SDK lifecycle, exec,
+> filesystem, stats, pause/resume, snapshot restore, restart, and cleanup.
+> Real-driver owner/Box process restart, WHPX composition, cross-process
+> process/filesystem recovery, remaining CLI projections, and the broader
+> cutover gates remain open; the default split above is still authoritative.
 > Follow the checked gates in the [migration roadmap](ROADMAP.md).
 
 ## Start with one workload

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ unchanged.
 > construction, the resource guard validates the managed home, durably attaches
 > product volumes and networking, and installs a verified snapshot lower with
 > fail-closed rollback. The blocking Native Linux real-host gate now passes this
-> production owner composition through typed Rust SDK lifecycle, exec,
-> filesystem, stats, pause/resume, snapshot restore, restart, and cleanup.
+> production owner composition through the Rust, Python, TypeScript, and Go SDK
+> lifecycle, exec, filesystem, route-aware stats, pause/resume, snapshot
+> restore, restart, and cleanup surfaces.
 > Real-driver owner/Box process restart, WHPX composition, cross-process
 > process/filesystem recovery, remaining CLI projections, and the broader
 > cutover gates remain open; the default split above is still authoritative.
@@ -300,7 +301,7 @@ error before dispatch.
 | Linux MicroVM | Primary local path through KVM/libkrun; self-hosted lifecycle, SDK, CRI, race, leak, snapshot-fork, and soak gate when `KVM_CI=true` | Hosted CI cannot prove a real KVM boot when the enrolled runner is absent |
 | macOS MicroVM | Apple Silicon/HVF build and packaging path | Real Apple Silicon/HVF release validation remains a separate host gate; Intel macOS is unsupported |
 | Windows MicroVM | Real x86_64 WHPX soak covering lifecycle, exec, copy, stats, ports, bind/named volumes, commit, snapshots, and cleanup | One vCPU; no interactive PTY, bridge networking, TEE, snapshot-fork, or CRI |
-| Linux Sandbox | Real A3S OCI Runtime CI profiles plus Rust, Python, TypeScript, and Go local SDK exercises | Shared-kernel preview; VM-only controls are rejected |
+| Linux Sandbox | Real A3S OCI Runtime CI profiles plus Rust, Python, TypeScript, and Go SDK exercises through the production owner route | Shared-kernel preview; VM-only controls are rejected |
 | Kubernetes | CRI v1 server and containerd runtime-v2 shim preview | Complete CRI conformance is not claimed |
 | TEE | SEV-SNP-oriented application and protocol flows | Simulation is not hardware security evidence |
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ The runtime crate now also exposes an explicit `OciMigrationPolicy` and
 with `box_vm` or `oci_sdk` before capability preflight and persist that choice
 with the reservation before launch side effects. Later policy changes cannot
 reroute their lifecycle, recovery, or cleanup, and a selected OCI failure is
-never retried on the Box backend. Shipped CLI and SDK construction still use
-the two current paths above until production bundle preparation is wired to the
-pinned runtime host owner.
+never retried on the Box backend. On Linux, the CLI, machine bridge, and the
+async Rust SDK constructor can now opt new Sandbox records into the production
+bundle provider and long-lived pinned runtime owner with
+`A3S_BOX_OCI_MIGRATION=sandbox`. With the setting absent, current behavior is
+unchanged.
 
 > [!NOTE]
 > The current SDK-only Sandbox adapter now covers four exact-generation rails:
@@ -82,10 +84,12 @@ pinned runtime host owner.
 > file transfer and descriptor-confined mkdir/stat/list/move/remove against its
 > real native and utility-VM drivers before the Box SDK suite runs. The pinned
 > runtime now supplies a long-lived multi-container Native Linux host owner and
-> Box supplies durable fail-closed migration routing. Production bundle/owner
-> composition, cross-process native Linux/WHPX process-and-filesystem recovery,
-> and the broader cutover gates remain open; the current split above is still
-> authoritative.
+> Box now supplies its production direct-process bundle compiler, protected
+> identity-fenced owner startup, and explicit CLI/SDK composition. Native Linux
+> real-host acceptance is a blocking CI gate. WHPX composition,
+> cross-process real-driver process/filesystem recovery, remaining CLI
+> projections, and the broader cutover gates remain open; the default split
+> above is still authoritative.
 > Follow the checked gates in the [migration roadmap](ROADMAP.md).
 
 ## Start with one workload
@@ -159,6 +163,45 @@ a3s-box run --rm \
   --memory 512m \
   alpine:3.20 -- sh -lc 'id; cat /proc/self/status'
 ```
+
+### Opt into the long-lived OCI owner on Linux
+
+The production migration path is deliberately not the default yet. Install the
+pinned `a3s-oci` and `a3s-oci-agent` pair, then keep the same configuration in
+every process that manages the migrated records:
+
+```bash
+export A3S_BOX_OCI_MIGRATION=sandbox
+export A3S_BOX_OCI_RUNTIME_PATH=/absolute/path/to/a3s-oci
+export A3S_BOX_OCI_AGENT_PATH=/absolute/path/to/a3s-oci-agent
+# Optional; the default is a short, per-UID/per-A3S-home directory under /tmp.
+export A3S_BOX_OCI_HOST_ROOT=/absolute/private/runtime-root
+
+a3s-box run --rm --isolation sandbox alpine:3.20 -- sleep 5
+```
+
+When overriding artifact discovery, both artifact variables must be supplied
+together; each executable is capability-probed and SHA-256 fenced before owner
+startup and again before bundle mutation. The owner root is created with mode
+`0700`; an existing root must be an absolute normalized, real, same-UID
+directory with that exact mode. A live owner is reused only when its PID start
+identity, endpoint, paths, and digests match. Unknown sockets and drifted
+artifacts fail closed.
+
+Rust applications select the same path with
+`A3sBoxClient::with_configured_paths(...).await` or construct
+`NativeLinuxOciMigrationConfig` explicitly. The synchronous `new`,
+`from_home`, and `with_paths` constructors retain legacy behavior for API
+compatibility.
+
+Current opt-in limits are intentional: only new Linux Sandbox reservations are
+routed; `all`/MicroVM migration is rejected; image-declared anonymous volumes
+must be replaced by explicit named or bind mounts; and remaining socket-based
+CLI projections (`attach`, `cp`, `top`, `stats`, live `container-update`, plus
+init stdout/stderr projection into Box logs) are not yet promoted on this path.
+The typed SDK lifecycle, exec/PTY, file/filesystem, process inventory, stats,
+events, resource update, pause/resume, wait, restart, and cleanup contracts do
+route through the exact OCI generation.
 
 > [!IMPORTANT]
 > A shared-kernel Sandbox does not defend against a working host-kernel

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,13 +113,17 @@ later lifecycle, session, observability, filesystem, restart, and cleanup calls
 use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
-`aac259224e89bef2b546fd0f8755ef1ba79570ce` adds the matching long-lived,
+`a6f6242caf927f404f7e1f7f143fd3a350ce23b6` adds the matching long-lived,
 multi-container Native Linux host owner. Box now has a production provider that
 prepares the product-owned rootfs, mounts, resources, DNS/hostname files and
 OCI bundle while compiling the image process directly, without the legacy
 guest-init FD 3/4/5 contract. It resolves PATH, working directory, named or
 numeric users/groups, supplementary groups, HOME and capabilities against the
 prepared rootfs before mutation is handed to Runtime.
+The same pinned revision executes file and filesystem calls through a bounded,
+parent-bound helper inside the retained user and mount namespaces, so
+descriptor-confined operations preserve container IDs on rootfs, bind,
+ID-mapped and tmpfs mounts.
 
 The Linux owner composition validates an absolute private root, serializes
 startup across processes, records the exact PID start identity and pinned

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,8 +87,9 @@ versioned manifest for rootfs, mounts, networking, process I/O, secret
 classifications, and optional extensions, and persists exact
 endpoint/target/driver/configuration/attachment evidence. Create rejects
 missing or drifted attachment evidence and reconciles lost create/start
-responses without issuing a second create. This is migration scaffolding, not
-a production routing change. Its in-process contract suite covers both
+responses without issuing a second create. This contract began as migration
+scaffolding; Linux now has an explicit production Sandbox route, while the
+default route remains unchanged. Its in-process contract suite covers both
 isolation mappings, corrupt evidence, cleanup, adapter reopen, stopped-only
 deletion, and exact normal or signaled exit status. A separate local-transport
 contract now restarts the real Windows named-pipe or Unix-socket server behind
@@ -114,12 +115,15 @@ use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
 `a6f6242caf927f404f7e1f7f143fd3a350ce23b6` adds the matching long-lived,
-multi-container Native Linux host owner. Box now has a production provider that
-prepares the product-owned rootfs, mounts, resources, DNS/hostname files and
-OCI bundle while compiling the image process directly, without the legacy
-guest-init FD 3/4/5 contract. It resolves PATH, working directory, named or
-numeric users/groups, supplementary groups, HOME and capabilities against the
-prepared rootfs before mutation is handed to Runtime.
+multi-container Native Linux host owner. Box now first validates the exact
+managed home and durably prepares snapshot-lower, named-volume, and network
+ownership. Its production provider then prepares the product-owned rootfs,
+mounts, resources, DNS/hostname files and OCI bundle while compiling the image
+process directly, without the legacy guest-init FD 3/4/5 contract. It resolves
+PATH, working directory, named or numeric users/groups, supplementary groups,
+HOME and capabilities against the prepared rootfs before mutation is handed to
+Runtime. A provably failed launch rolls back every preparation-owned effect;
+unknown launch ownership retains them for exact reconciliation.
 The same pinned revision executes file and filesystem calls through a bounded,
 parent-bound helper inside the retained user and mount namespaces, so
 descriptor-confined operations preserve container IDs on rootfs, bind,
@@ -133,17 +137,20 @@ bridge and async Rust SDK constructor honor the explicit
 `A3S_BOX_OCI_MIGRATION=sandbox` opt-in; no setting means no owner probe or
 startup and preserves the legacy route. Core lifecycle, run/exec/PTY, wait,
 pause/resume and cleanup commands now detect the persisted OCI route instead
-of requiring Box guest sockets. A blocking native-Linux CI invocation runs the
-existing real Rust SDK Sandbox suite through this exact composition.
+of requiring Box guest sockets. The blocking native-Linux CI invocation now
+passes the existing real Rust SDK Sandbox suite through this exact composition,
+including lifecycle, exec, filesystem, stats, pause/resume, snapshot restore,
+restart, and cleanup.
 
 The same adapter now routes memory-retaining pause and resume through exact
 SDK targets. Every freezer mutation first requires the advertised operation,
-persists a claim-scoped mutation identity and combines it with the current Box
-generation without changing the runtime generation, validates the complete
-returned runtime binding, and reconciles a lost response after backend
-recreation without issuing the mutation twice. Filesystem-only pause continues
-to use the existing
-stop/reprepare lifecycle rather than being mislabeled as an OCI freezer action.
+persists a claim-scoped mutation identity and whether the freezer is currently
+applied, and combines the identity with the current Box generation without
+changing the runtime generation. Recovery reuses the identity while the
+mutation is pending and never replays thaw after its durable applied phase is
+cleared. Returned runtime bindings are validated in full. Filesystem-only pause
+continues to use the existing stop/reprepare lifecycle rather than being
+mislabeled as an OCI freezer action.
 
 The backend-neutral session boundary now also routes captured and streaming
 exec, stdin, cursor-checked stdout/stderr, signal/wait, PTY, and resize through
@@ -187,8 +194,9 @@ crate.
 
 The dependency check resolves only `a3s-oci-sdk` and its public core types from
 the OCI Runtime repository. The typed opt-in composition and durable selection
-now satisfy this boundary gate; production activation remains a B1 cutover
-gate and is not implied by compiling the router.
+now satisfy this boundary gate. Linux Sandbox production activation remains
+explicitly opt-in; default activation and the unified MicroVM cutover remain
+later gates.
 
 ### B1 - OCI Runtime Vertical Slice
 
@@ -201,8 +209,8 @@ gate and is not implied by compiling the router.
   digests required for reconciliation.
 - [x] Reopen the local runtime service and reconcile interrupted Box operations
   without launching a duplicate workload.
-- [ ] Exercise the production composition on native Linux; the blocking
-  real-host job is wired and must pass before this item is checked.
+- [x] Exercise the production composition on native Linux through the blocking
+  real-host Rust SDK lifecycle, session, snapshot, restart, and cleanup gate.
 - [ ] Exercise the same Box-owned minimal bundle on Windows/WHPX.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
@@ -217,11 +225,12 @@ process contract then replaces the owner with a distinct child process that
 reopens disk-backed state, while OCI Runtime separately proves the real durable
 host service and journal reopen across processes. OCI Runtime now exposes the
 long-lived Native Linux owner, and Box now supplies fail-closed mixed-backend
-routing, a direct-process production bundle provider, protected owner startup,
-and explicit CLI/SDK construction. The remaining unchecked gate is real-host
-evidence for that composition, owner/Box process restart, and the equivalent
-WHPX path; deterministic process evidence is not promoted as platform-driver
-evidence.
+routing, verified product-resource preparation, a direct-process production
+bundle provider, protected owner startup, and explicit CLI/SDK construction.
+The real-host Native Linux production composition now passes. The remaining
+unchecked gates are owner/Box process restart on the real driver and the
+equivalent WHPX path; deterministic process evidence is not promoted as
+platform-driver evidence.
 
 ### B2 - Interactive And Observable Execution
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -160,7 +160,11 @@ identity across a lost response and backend recreation. Initial and streaming
 stdin mutations are replay-safe, timeouts retain an exact SIGKILL watchdog even
 if the caller drops its future, and raw process output never enters Box's
 structured log store. Legacy VM records retain their existing socket transport,
-while OCI-bound sessions no longer depend on Unix-domain sockets.
+while OCI-bound sessions no longer depend on Unix-domain sockets. Relative
+direct-argv executables resolve through the request, image, or default container
+`PATH` against the prepared rootfs, then cross the SDK boundary as normalized
+absolute Linux paths; this applies equally to captured exec, streaming exec,
+and PTY sessions without invoking a shell.
 
 The same cross-platform session facade now maps file upload/download and
 filesystem stat, recursive mkdir, move, bounded listing, and recursive removal

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,7 +102,7 @@ input handle across the observed disconnect, then continues inventory, stdin,
 output, signal, exact wait, and cleanup through the replacement owner with one
 exec dispatch. OCI Runtime independently proves the same process target through
 its durable `HostRuntimeService` and operation journal across two processes.
-Real driver state and production owner wiring remain below.
+Real-driver promotion and production cutover gates remain below.
 
 The backend-neutral manager now also has one durable migration router with
 three explicit creation policies: retain both current paths, route only
@@ -114,9 +114,23 @@ use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
 `aac259224e89bef2b546fd0f8755ef1ba79570ce` adds the matching long-lived,
-multi-container Native Linux host owner. Shipped CLI/SDK construction still
-uses the current split until Box production bundle preparation is connected to
-that owner.
+multi-container Native Linux host owner. Box now has a production provider that
+prepares the product-owned rootfs, mounts, resources, DNS/hostname files and
+OCI bundle while compiling the image process directly, without the legacy
+guest-init FD 3/4/5 contract. It resolves PATH, working directory, named or
+numeric users/groups, supplementary groups, HOME and capabilities against the
+prepared rootfs before mutation is handed to Runtime.
+
+The Linux owner composition validates an absolute private root, serializes
+startup across processes, records the exact PID start identity and pinned
+runtime/agent paths plus SHA-256 digests, refuses an unowned socket or live
+artifact drift, and reuses only a launch-ready SDK endpoint. The CLI, machine
+bridge and async Rust SDK constructor honor the explicit
+`A3S_BOX_OCI_MIGRATION=sandbox` opt-in; no setting means no owner probe or
+startup and preserves the legacy route. Core lifecycle, run/exec/PTY, wait,
+pause/resume and cleanup commands now detect the persisted OCI route instead
+of requiring Box guest sockets. A blocking native-Linux CI invocation runs the
+existing real Rust SDK Sandbox suite through this exact composition.
 
 The same adapter now routes memory-retaining pause and resume through exact
 SDK targets. Every freezer mutation first requires the advertised operation,
@@ -183,7 +197,9 @@ gate and is not implied by compiling the router.
   digests required for reconciliation.
 - [x] Reopen the local runtime service and reconcile interrupted Box operations
   without launching a duplicate workload.
-- [ ] Exercise the path on native Linux and Windows/WHPX.
+- [ ] Exercise the production composition on native Linux; the blocking
+  real-host job is wired and must pass before this item is checked.
+- [ ] Exercise the same Box-owned minimal bundle on Windows/WHPX.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
 through Box on Linux and Windows, including Box and runtime process restart.
@@ -196,10 +212,11 @@ next-call reconnect plus exact reconciliation without duplicate launch. The
 process contract then replaces the owner with a distinct child process that
 reopens disk-backed state, while OCI Runtime separately proves the real durable
 host service and journal reopen across processes. OCI Runtime now exposes the
-long-lived Native Linux owner and Box now persists fail-closed mixed-backend
-routing. The remaining unchecked gate requires Box's production bundle
-provider/owner composition and the same bundle on real native Linux and WHPX
-hosts; deterministic process evidence is not promoted as platform-driver
+long-lived Native Linux owner, and Box now supplies fail-closed mixed-backend
+routing, a direct-process production bundle provider, protected owner startup,
+and explicit CLI/SDK construction. The remaining unchecked gate is real-host
+evidence for that composition, owner/Box process restart, and the equivalent
+WHPX path; deterministic process evidence is not promoted as platform-driver
 evidence.
 
 ### B2 - Interactive And Observable Execution
@@ -220,6 +237,9 @@ evidence.
   boundary.
 - [x] Preserve exact terminal status and Box/runtime generation fencing across
   backend recreation and keyed replay.
+- [ ] Route the remaining socket-oriented CLI projections (`attach`, `cp`,
+  `top`, `stats`, live `container-update`, and init stdout/stderr log
+  projection) through the persisted OCI route.
 - [ ] Prove process-session recovery across an out-of-process runtime-service
   restart on real native Linux and utility-VM drivers.
 
@@ -244,7 +264,10 @@ contract now keeps the original Box process stream and input handle alive,
 exposes the first broken request, reconnects to a replacement process, and
 continues inventory, stdin, output, close, signal, exact wait, and cleanup with
 one exec dispatch. Native Linux and utility-VM driver reattachment on real
-hosts remains part of the unchecked exit gate.
+hosts remains part of the unchecked exit gate. The production Linux smoke now
+drives the typed SDK lifecycle, exec, filesystem, stats, pause/resume, snapshot,
+restart and cleanup surfaces; the command-specific projections listed above
+remain deliberately unchecked.
 
 ### B3 - Storage And Networking Attachments
 
@@ -256,6 +279,11 @@ hosts remains part of the unchecked exit gate.
   ownership, mode, symlink, or read-only semantics.
 - [ ] Add quiesce/resume integration for consistent stopped and online product
   snapshots.
+
+The production provider currently accepts explicit bind/named/tmpfs mounts but
+rejects newly introduced image-declared anonymous volumes before Runtime
+mutation. That rejection remains until the complete B3 ownership and cleanup
+contract is qualified.
 
 Exit gate: image, volume, snapshot, commit, copy, bridge/service networking,
 and cleanup suites pass without Box accessing a runtime-owned VM handle or

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,9 +138,9 @@ bridge and async Rust SDK constructor honor the explicit
 startup and preserves the legacy route. Core lifecycle, run/exec/PTY, wait,
 pause/resume and cleanup commands now detect the persisted OCI route instead
 of requiring Box guest sockets. The blocking native-Linux CI invocation now
-passes the existing real Rust SDK Sandbox suite through this exact composition,
-including lifecycle, exec, filesystem, stats, pause/resume, snapshot restore,
-restart, and cleanup.
+passes the Rust, Python, TypeScript, and Go Sandbox suites through this exact
+composition, including lifecycle, exec, filesystem, route-aware stats,
+pause/resume, snapshot restore, restart, and cleanup.
 
 The same adapter now routes memory-retaining pause and resume through exact
 SDK targets. Every freezer mutation first requires the advertised operation,
@@ -210,7 +210,8 @@ later gates.
 - [x] Reopen the local runtime service and reconcile interrupted Box operations
   without launching a duplicate workload.
 - [x] Exercise the production composition on native Linux through the blocking
-  real-host Rust SDK lifecycle, session, snapshot, restart, and cleanup gate.
+  real-host Rust, Python, TypeScript, and Go SDK lifecycle, session, snapshot,
+  restart, and cleanup gate.
 - [ ] Exercise the same Box-owned minimal bundle on Windows/WHPX.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
@@ -278,9 +279,9 @@ exposes the first broken request, reconnects to a replacement process, and
 continues inventory, stdin, output, close, signal, exact wait, and cleanup with
 one exec dispatch. Native Linux and utility-VM driver reattachment on real
 hosts remains part of the unchecked exit gate. The production Linux smoke now
-drives the typed SDK lifecycle, exec, filesystem, stats, pause/resume, snapshot,
-restart and cleanup surfaces; the command-specific projections listed above
-remain deliberately unchecked.
+drives the Rust, Python, TypeScript, and Go SDK lifecycle, exec, filesystem,
+route-aware stats, pause/resume, snapshot, restart and cleanup surfaces; the
+command-specific projections listed above remain deliberately unchecked.
 
 ### B3 - Storage And Networking Attachments
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=aac259224e89bef2b546fd0f8755ef1ba79570ce#aac259224e89bef2b546fd0f8755ef1ba79570ce"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=a6f6242caf927f404f7e1f7f143fd3a350ce23b6#a6f6242caf927f404f7e1f7f143fd3a350ce23b6"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=aac259224e89bef2b546fd0f8755ef1ba79570ce#aac259224e89bef2b546fd0f8755ef1ba79570ce"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=a6f6242caf927f404f7e1f7f143fd3a350ce23b6#a6f6242caf927f404f7e1f7f143fd3a350ce23b6"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,7 +125,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "25caf65ffed7ff9b82cedc4e7156c79f396896f7" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "aac259224e89bef2b546fd0f8755ef1ba79570ce" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "a6f6242caf927f404f7e1f7f143fd3a350ce23b6" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -4,7 +4,6 @@ use a3s_box_core::{
     BoxConfig, CreateExecutionRequest, ExecutionManager, ExecutionRecordPolicy,
     ExecutionRestartPolicy, OperationId, ResourceConfig,
 };
-use a3s_box_runtime::LocalExecutionManager;
 use clap::Args;
 
 use super::common::{self, CommonBoxArgs};
@@ -166,7 +165,7 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         policy,
         rootfs_snapshot_id: None,
     };
-    let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), home);
+    let manager = super::configured_local_execution_manager(&home).await?;
     let reservation = manager.create(request, &operation_id).await?;
     let box_id = reservation.execution_id.to_string();
 

--- a/src/cli/src/commands/exec.rs
+++ b/src/cli/src/commands/exec.rs
@@ -79,6 +79,7 @@ pub(crate) async fn connect_pty_with_retry(
 
 pub async fn execute(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
     use a3s_box_core::exec::ExecRequest;
+    use a3s_box_core::{ExecutionId, ExecutionSessionManager};
     use a3s_box_runtime::ExecClient;
 
     let user = common::normalize_user_option(args.user.as_deref())
@@ -88,8 +89,15 @@ pub async fn execute(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let state = StateFile::load_default()?;
     let record = resolve::resolve(&state, &args.r#box)?;
-    crate::socket_paths::require_running(record, "exec")
-        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let oci_session = uses_oci_session(record);
+    if oci_session {
+        if record.status != "running" {
+            return Err(format!("Box {} is not running", record.name).into());
+        }
+    } else {
+        crate::socket_paths::require_running(record, "exec")
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    }
 
     // If -t is specified, use interactive PTY mode
     if args.tty {
@@ -100,17 +108,12 @@ pub async fn execute(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
         ));
 
         #[cfg(not(windows))]
-        return execute_pty(args, record, user).await;
+        return if oci_session {
+            execute_managed_pty(args, record, user).await
+        } else {
+            execute_pty(args, record, user).await
+        };
     }
-
-    // Non-interactive mode (original behavior)
-    let exec_socket_path = crate::socket_paths::require_runtime_socket(
-        record,
-        crate::socket_paths::RuntimeSocket::Exec,
-    )
-    .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-
-    let client = ExecClient::connect(&exec_socket_path).await?;
 
     let timeout_ns = timeout_secs_to_ns(args.timeout);
 
@@ -141,7 +144,29 @@ pub async fn execute(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
         streaming: false,
     };
 
-    let output = client.exec_command(&request).await?;
+    let output = if oci_session {
+        let metadata = record
+            .managed_execution
+            .as_ref()
+            .ok_or_else(|| format!("Box {} lost managed execution metadata", record.name))?;
+        let home = a3s_box_core::dirs_home();
+        let manager = super::configured_local_execution_manager(&home).await?;
+        manager
+            .execute(
+                &ExecutionId::new(record.id.clone())?,
+                metadata.generation,
+                request,
+            )
+            .await?
+    } else {
+        let exec_socket_path = crate::socket_paths::require_runtime_socket(
+            record,
+            crate::socket_paths::RuntimeSocket::Exec,
+        )
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        let client = ExecClient::connect(&exec_socket_path).await?;
+        client.exec_command(&request).await?
+    };
     // Record that an exec happened (best-effort) before the exit-code branch
     // below may std::process::exit. The container command's own exit code is
     // separate from whether the exec was delivered.
@@ -169,6 +194,13 @@ pub async fn execute(args: ExecArgs) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn uses_oci_session(record: &crate::state::BoxRecord) -> bool {
+    record.managed_execution.as_ref().is_some_and(|metadata| {
+        metadata.runtime_route == a3s_box_runtime::ManagedRuntimeRoute::OciSdk
+            || metadata.oci_runtime.is_some()
+    })
+}
+
 fn timeout_secs_to_ns(timeout_secs: u64) -> u64 {
     if timeout_secs == 0 {
         a3s_box_core::exec::DEFAULT_EXEC_TIMEOUT_NS
@@ -177,6 +209,137 @@ fn timeout_secs_to_ns(timeout_secs: u64) -> u64 {
         // timeout in release builds.
         timeout_secs.saturating_mul(NANOS_PER_SECOND)
     }
+}
+
+#[cfg(not(windows))]
+async fn execute_managed_pty(
+    args: ExecArgs,
+    record: &crate::state::BoxRecord,
+    user: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use a3s_box_core::pty::PtyRequest;
+    use a3s_box_core::{ExecutionId, ExecutionSessionManager};
+
+    let metadata = record
+        .managed_execution
+        .as_ref()
+        .ok_or_else(|| format!("Box {} lost managed execution metadata", record.name))?;
+    let (cols, rows) = crate::terminal::size().unwrap_or((80, 24));
+    let home = a3s_box_core::dirs_home();
+    let manager = super::configured_local_execution_manager(&home).await?;
+    let process = manager
+        .start_pty(
+            &ExecutionId::new(record.id.clone())?,
+            metadata.generation,
+            PtyRequest {
+                cmd: args.cmd,
+                env: args.envs,
+                working_dir: args.workdir,
+                rootfs: None,
+                user,
+                cols,
+                rows,
+            },
+        )
+        .await?;
+    crate::audit::record(
+        a3s_box_core::audit::AuditAction::ExecCommand,
+        a3s_box_core::audit::AuditOutcome::Success,
+        &record.id,
+        &format!("exec (managed pty) in box {}", record.name),
+    );
+
+    let exit_code = {
+        let _raw_mode = crate::terminal::raw_mode()?;
+        run_managed_pty_session(process).await
+    };
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+pub(crate) async fn run_managed_pty_session(mut process: a3s_box_core::ExecutionProcess) -> i32 {
+    use a3s_box_core::{ExecEvent, StreamType};
+
+    let input = process.input();
+    let reader_task = tokio::spawn(async move {
+        loop {
+            match process.next_event().await {
+                Ok(Some(ExecEvent::Chunk(chunk))) => {
+                    use tokio::io::AsyncWriteExt as _;
+                    let result = match chunk.stream {
+                        StreamType::Stdout => {
+                            let mut output = tokio::io::stdout();
+                            let result = output.write_all(&chunk.data).await;
+                            let _ = output.flush().await;
+                            result
+                        }
+                        StreamType::Stderr => {
+                            let mut output = tokio::io::stderr();
+                            let result = output.write_all(&chunk.data).await;
+                            let _ = output.flush().await;
+                            result
+                        }
+                    };
+                    if result.is_err() {
+                        return -1;
+                    }
+                }
+                Ok(Some(ExecEvent::FlushAck)) => {}
+                Ok(Some(ExecEvent::Exit(status))) => return status.exit_code,
+                Ok(None) | Err(_) => return -1,
+            }
+        }
+    });
+
+    let writer_task = tokio::spawn(async move {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+        std::thread::spawn(move || {
+            use std::io::Read as _;
+            let mut stdin = std::io::stdin();
+            let mut buffer = [0u8; 4096];
+            loop {
+                match stdin.read(&mut buffer) {
+                    Ok(0) | Err(_) => break,
+                    Ok(count) if sender.blocking_send(buffer[..count].to_vec()).is_err() => break,
+                    Ok(_) => {}
+                }
+            }
+        });
+        let mut sigwinch =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change()).ok();
+        loop {
+            tokio::select! {
+                data = receiver.recv() => match data {
+                    Some(data) => {
+                        if input.write_stdin(&data).await.is_err() {
+                            break;
+                        }
+                    }
+                    None => {
+                        let _ = input.close_stdin().await;
+                        break;
+                    }
+                },
+                _ = async {
+                    match sigwinch {
+                        Some(ref mut signal) => { signal.recv().await; }
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    if let Ok((cols, rows)) = crate::terminal::size() {
+                        let _ = input.resize_pty(cols, rows).await;
+                    }
+                }
+            }
+        }
+    });
+
+    let exit_code = reader_task.await.unwrap_or(1);
+    writer_task.abort();
+    exit_code
 }
 
 /// Execute a command with an interactive PTY session.

--- a/src/cli/src/commands/kill.rs
+++ b/src/cli/src/commands/kill.rs
@@ -3,7 +3,7 @@
 use clap::Args;
 
 use a3s_box_core::{ExecutionGeneration, ExecutionId, ExecutionManager, KillExecutionOptions};
-use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionState};
+use a3s_box_runtime::ManagedExecutionState;
 
 use crate::cleanup;
 use crate::lifecycle;
@@ -118,7 +118,7 @@ async fn kill_one(
         } => {
             drop(lifecycle_lock.take());
             let home = a3s_box_core::dirs_home();
-            let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+            let manager = super::configured_local_execution_manager(&home).await?;
             manager.pause(&execution_id, generation, true).await?;
             println!("{}", record.name);
             return Ok(());
@@ -129,7 +129,7 @@ async fn kill_one(
         } => {
             drop(lifecycle_lock.take());
             let home = a3s_box_core::dirs_home();
-            let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+            let manager = super::configured_local_execution_manager(&home).await?;
             manager.resume(&execution_id, generation).await?;
             println!("{}", record.name);
             return Ok(());
@@ -142,7 +142,7 @@ async fn kill_one(
             let auto_remove = record.auto_remove;
             drop(lifecycle_lock.take());
             let home = a3s_box_core::dirs_home();
-            let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+            let manager = super::configured_local_execution_manager(&home).await?;
             manager
                 .kill_with_options(
                     &execution_id,

--- a/src/cli/src/commands/mod.rs
+++ b/src/cli/src/commands/mod.rs
@@ -62,7 +62,7 @@ mod version;
 pub mod volume;
 mod wait;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 
@@ -205,6 +205,20 @@ pub enum Command {
 /// Return the path to the image store directory (~/.a3s/images).
 pub(crate) fn images_dir() -> PathBuf {
     a3s_box_core::dirs_home().join("images")
+}
+
+/// Construct the canonical local lifecycle facade. OCI migration remains a
+/// process-wide explicit opt-in; an absent setting preserves the VM backend.
+pub(crate) async fn configured_local_execution_manager(
+    home: &Path,
+) -> Result<a3s_box_runtime::LocalExecutionManager, Box<dyn std::error::Error>> {
+    Ok(
+        a3s_box_runtime::LocalExecutionManager::with_configured_backend(
+            home.join("boxes.json"),
+            home,
+        )
+        .await?,
+    )
 }
 
 /// Open the shared image store.

--- a/src/cli/src/commands/monitor.rs
+++ b/src/cli/src/commands/monitor.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use a3s_box_core::{ExecutionGeneration, ExecutionManager, OperationId, RestartExecutionOptions};
-use a3s_box_runtime::{LocalExecutionManager, ManagedRestartOutcome};
+use a3s_box_runtime::ManagedRestartOutcome;
 use clap::Args;
 
 use crate::boot;
@@ -476,7 +476,7 @@ async fn restart_managed_candidate(
         None => OperationId::new(format!("monitor-restart-{}", uuid::Uuid::new_v4()))?,
     };
     let home = a3s_box_core::dirs_home();
-    let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+    let manager = super::configured_local_execution_manager(&home).await?;
     let lease = manager
         .restart_with_options(
             &execution_id,

--- a/src/cli/src/commands/pause.rs
+++ b/src/cli/src/commands/pause.rs
@@ -4,7 +4,7 @@
 //! legacy state records.
 
 use a3s_box_core::{ExecutionGeneration, ExecutionId, ExecutionManager};
-use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionState};
+use a3s_box_runtime::ManagedExecutionState;
 use clap::Args;
 
 use crate::lifecycle;
@@ -55,7 +55,7 @@ async fn pause_one(state: &StateFile, query: &str) -> Result<(), Box<dyn std::er
         // the A3S OCI owner and the durable generation advances exactly once.
         drop(lifecycle_lock);
         let home = a3s_box_core::dirs_home();
-        let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+        let manager = super::configured_local_execution_manager(&home).await?;
         manager.pause(&execution_id, generation, true).await?;
         println!("{}", record.name);
         return Ok(());

--- a/src/cli/src/commands/port_forward.rs
+++ b/src/cli/src/commands/port_forward.rs
@@ -48,7 +48,6 @@ pub async fn execute(_args: PortForwardArgs) -> Result<(), Box<dyn std::error::E
 pub async fn execute(args: PortForwardArgs) -> Result<(), Box<dyn std::error::Error>> {
     use std::io::Write as _;
 
-    use a3s_box_runtime::LocalExecutionManager;
     use tokio::net::TcpListener;
     use tokio::sync::Semaphore;
 
@@ -80,10 +79,7 @@ pub async fn execute(args: PortForwardArgs) -> Result<(), Box<dyn std::error::Er
     };
 
     let home = a3s_box_core::dirs_home();
-    let connector = Arc::new(LocalExecutionManager::with_vm_backend(
-        home.join("boxes.json"),
-        &home,
-    ));
+    let connector = Arc::new(super::configured_local_execution_manager(&home).await?);
     let bind_address =
         std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, args.host_port.get()));
     let listener = TcpListener::bind(bind_address).await.map_err(|error| {

--- a/src/cli/src/commands/restart.rs
+++ b/src/cli/src/commands/restart.rs
@@ -6,7 +6,7 @@
 use a3s_box_core::{
     ExecutionGeneration, ExecutionId, ExecutionManager, OperationId, RestartExecutionOptions,
 };
-use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionOperation, ManagedExecutionState};
+use a3s_box_runtime::{ManagedExecutionOperation, ManagedExecutionState};
 use clap::Args;
 
 use crate::boot;
@@ -86,7 +86,7 @@ async fn restart_one(
             None => OperationId::new(format!("cli-restart-{}", uuid::Uuid::new_v4()))?,
         };
         let home = a3s_box_core::dirs_home();
-        let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+        let manager = super::configured_local_execution_manager(&home).await?;
         manager
             .restart_with_options(
                 &execution_id,

--- a/src/cli/src/commands/rm.rs
+++ b/src/cli/src/commands/rm.rs
@@ -3,7 +3,7 @@
 use clap::Args;
 
 use a3s_box_core::{ExecutionGeneration, ExecutionId, ExecutionManager, KillExecutionOptions};
-use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionState};
+use a3s_box_runtime::ManagedExecutionState;
 
 use crate::cleanup;
 use crate::resolve;
@@ -64,7 +64,7 @@ async fn rm_one(
         let name = record.name.clone();
         drop(lifecycle_lock);
         let home = a3s_box_core::dirs_home();
-        let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+        let manager = super::configured_local_execution_manager(&home).await?;
         if terminate {
             manager
                 .kill_with_options(

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -8,7 +8,7 @@ use a3s_box_core::{
     CreateExecutionRequest, ExecutionGeneration, ExecutionId, ExecutionManager,
     ExecutionRecordPolicy, ExecutionRestartPolicy, ExecutionState, OperationId,
 };
-use a3s_box_runtime::{LocalExecutionManager, VmLocalExecutionBackend};
+use a3s_box_runtime::LocalExecutionManager;
 use clap::{Args, ValueEnum};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -418,8 +418,7 @@ use setup::{
 async fn run_tty(mut ctx: RunContext, args: &RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     use crate::terminal;
     use a3s_box_core::pty::PtyRequest;
-
-    let pty_socket_path = ctx.pty_socket_path.clone();
+    use a3s_box_core::ExecutionSessionManager;
 
     let entrypoint_override = args
         .common
@@ -442,23 +441,30 @@ async fn run_tty(mut ctx: RunContext, args: &RunArgs) -> Result<(), Box<dyn std:
         .into_iter()
         .map(|(key, value)| format!("{key}={value}"))
         .collect();
-    let mut client =
-        super::exec::connect_pty_with_retry(&pty_socket_path, std::time::Duration::from_secs(10))
+    let request = PtyRequest {
+        cmd: pty_cmd,
+        env,
+        working_dir: args.common.workdir.clone(),
+        rootfs: None,
+        user,
+        cols,
+        rows,
+    };
+    let exit_code = if run_context_uses_oci(&ctx) {
+        let process = ctx
+            .manager
+            .start_pty(&ctx.execution_id, ctx.generation, request)
             .await?;
-    client
-        .send_request(&PtyRequest {
-            cmd: pty_cmd,
-            env,
-            working_dir: args.common.workdir.clone(),
-            rootfs: None,
-            user,
-            cols,
-            rows,
-        })
+        let _raw_mode = terminal::raw_mode()?;
+        super::exec::run_managed_pty_session(process).await
+    } else {
+        let mut client = super::exec::connect_pty_with_retry(
+            &ctx.pty_socket_path,
+            std::time::Duration::from_secs(10),
+        )
         .await?;
-
-    let (read_half, write_half) = client.into_split();
-    let exit_code = {
+        client.send_request(&request).await?;
+        let (read_half, write_half) = client.into_split();
         let _raw_mode = terminal::raw_mode()?;
         super::exec::run_pty_session(read_half, write_half).await
     };
@@ -508,6 +514,7 @@ const FOREGROUND_SIGTERM: i32 = 15;
 
 const FOREGROUND_LOG_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const FOREGROUND_EXIT_POLL: std::time::Duration = std::time::Duration::from_millis(20);
+const FOREGROUND_OCI_EXIT_POLL: std::time::Duration = std::time::Duration::from_millis(100);
 const FOREGROUND_HEALTH_POLL: std::time::Duration = std::time::Duration::from_millis(500);
 const FOREGROUND_LOG_DRAIN_QUIET: std::time::Duration = std::time::Duration::from_millis(50);
 const FOREGROUND_LOG_DRAIN_POLL: std::time::Duration = std::time::Duration::from_millis(10);
@@ -611,7 +618,14 @@ async fn run_foreground(
     // VM health check is comparatively expensive and only needs the existing
     // 500 ms cadence. Keeping independent timers avoids adding a fixed half
     // second to every no-op without polling health more aggressively.
-    let mut exit_poll = tokio::time::interval(FOREGROUND_EXIT_POLL);
+    let exit_poll_period = if run_context_uses_oci(&ctx) {
+        // OCI inspection crosses the SDK/service boundary; a 100 ms cadence
+        // remains responsive without issuing 50 control requests per second.
+        FOREGROUND_OCI_EXIT_POLL
+    } else {
+        FOREGROUND_EXIT_POLL
+    };
+    let mut exit_poll = tokio::time::interval(exit_poll_period);
     exit_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut health_poll = tokio::time::interval_at(
         tokio::time::Instant::now() + FOREGROUND_HEALTH_POLL,
@@ -633,7 +647,7 @@ async fn run_foreground(
                 break ForegroundStopReason::TimedOut;
             }
             _ = exit_poll.tick() => {
-                if !managed_process_alive(&ctx) {
+                if !managed_process_alive(&mut ctx).await {
                     break ForegroundStopReason::ProcessExited;
                 }
             }
@@ -728,7 +742,7 @@ async fn run_foreground(
 async fn wait_for_sandbox_structured_log_drain(
     ctx: &RunContext,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if !ctx.record.isolation.is_sandbox() {
+    if !ctx.record.isolation.is_sandbox() || run_context_uses_oci(ctx) {
         return Ok(());
     }
     let box_dir = ctx.box_dir.clone();
@@ -827,15 +841,42 @@ fn foreground_workload_exit_code(
     a3s_box_runtime::rootfs::read_persisted_exit_code(box_dir).or(recorded_exit_code)
 }
 
-fn managed_process_alive(ctx: &RunContext) -> bool {
-    ctx.record.pid.is_some_and(|pid| {
-        a3s_box_runtime::is_process_alive_with_identity(pid, ctx.record.pid_start_time)
-    })
+async fn managed_process_alive(ctx: &mut RunContext) -> bool {
+    if run_context_uses_oci(ctx) {
+        match ctx.manager.inspect(&ctx.execution_id).await {
+            Ok(status)
+                if matches!(
+                    status.state,
+                    ExecutionState::Running | ExecutionState::Paused
+                ) =>
+            {
+                true
+            }
+            Ok(_) => {
+                if let Ok(state) = StateFile::load_readonly() {
+                    if let Some(record) = state.find_by_id(&ctx.box_id) {
+                        ctx.record = record.clone();
+                    }
+                }
+                false
+            }
+            Err(_) => false,
+        }
+    } else {
+        ctx.record.pid.is_some_and(|pid| {
+            a3s_box_runtime::is_process_alive_with_identity(pid, ctx.record.pid_start_time)
+        })
+    }
 }
 
 #[cfg(unix)]
 async fn managed_runtime_healthy(ctx: &RunContext) -> bool {
-    if !managed_process_alive(ctx) {
+    if run_context_uses_oci(ctx) {
+        return true;
+    }
+    if !ctx.record.pid.is_some_and(|pid| {
+        a3s_box_runtime::is_process_alive_with_identity(pid, ctx.record.pid_start_time)
+    }) {
         return false;
     }
     let probe = async {
@@ -853,7 +894,23 @@ async fn managed_runtime_healthy(ctx: &RunContext) -> bool {
 
 #[cfg(not(unix))]
 async fn managed_runtime_healthy(ctx: &RunContext) -> bool {
-    managed_process_alive(ctx)
+    if run_context_uses_oci(ctx) {
+        true
+    } else {
+        ctx.record.pid.is_some_and(|pid| {
+            a3s_box_runtime::is_process_alive_with_identity(pid, ctx.record.pid_start_time)
+        })
+    }
+}
+
+fn run_context_uses_oci(ctx: &RunContext) -> bool {
+    ctx.record
+        .managed_execution
+        .as_ref()
+        .is_some_and(|metadata| {
+            metadata.runtime_route == a3s_box_runtime::ManagedRuntimeRoute::OciSdk
+                || metadata.oci_runtime.is_some()
+        })
 }
 
 fn foreground_completion_message(

--- a/src/cli/src/commands/run/setup.rs
+++ b/src/cli/src/commands/run/setup.rs
@@ -144,9 +144,12 @@ pub(super) async fn setup_and_boot(
         },
     );
     let home = a3s_box_core::dirs_home();
-    let backend = VmLocalExecutionBackend::new(&home).with_pull_progress_fn(pull_progress_fn);
-    let manager =
-        LocalExecutionManager::new(home.join("boxes.json"), &home, std::sync::Arc::new(backend));
+    let manager = LocalExecutionManager::with_configured_backend_and_pull_progress(
+        home.join("boxes.json"),
+        &home,
+        Some(pull_progress_fn),
+    )
+    .await?;
     let reserve_start = std::time::Instant::now();
     let reservation = manager.create(request, &operation_id).await?;
     a3s_box_core::lifecycle_profile::record_lifecycle_phase("cli.reserve", reserve_start.elapsed());

--- a/src/cli/src/commands/run/tests.rs
+++ b/src/cli/src/commands/run/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use a3s_box_runtime::VmLocalExecutionBackend;
 
 // --- build_resource_limits tests (using new struct layout) ---
 

--- a/src/cli/src/commands/start.rs
+++ b/src/cli/src/commands/start.rs
@@ -3,7 +3,7 @@
 use a3s_box_core::{
     ExecutionGeneration, ExecutionId, ExecutionManager, OperationId, RestartExecutionOptions,
 };
-use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionOperation, ManagedExecutionState};
+use a3s_box_runtime::{ManagedExecutionOperation, ManagedExecutionState};
 use clap::Args;
 
 use crate::boot;
@@ -93,7 +93,7 @@ async fn start_one(state: &StateFile, query: &str) -> Result<(), Box<dyn std::er
             // runtime crate, covering CLI, SDK, and reconcile entry points.
             drop(lifecycle_lock.take());
             let home = a3s_box_core::dirs_home();
-            let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+            let manager = super::configured_local_execution_manager(&home).await?;
             let start_result = match managed_plan {
                 StartPlan::Managed {
                     execution_id,

--- a/src/cli/src/commands/stop.rs
+++ b/src/cli/src/commands/stop.rs
@@ -6,7 +6,7 @@ use a3s_box_core::{
     vmm::parse_signal_name, ExecutionGeneration, ExecutionId, ExecutionManager,
     KillExecutionOptions,
 };
-use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionState};
+use a3s_box_runtime::ManagedExecutionState;
 
 use crate::cleanup;
 use crate::lifecycle;
@@ -70,7 +70,7 @@ async fn stop_one(
         let auto_remove = record.auto_remove;
         drop(lifecycle_lock);
         let home = a3s_box_core::dirs_home();
-        let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+        let manager = super::configured_local_execution_manager(&home).await?;
         manager
             .kill_with_options(&execution_id, generation, options)
             .await?;

--- a/src/cli/src/commands/unpause.rs
+++ b/src/cli/src/commands/unpause.rs
@@ -4,7 +4,7 @@
 //! legacy state records.
 
 use a3s_box_core::{ExecutionGeneration, ExecutionId, ExecutionManager};
-use a3s_box_runtime::{LocalExecutionManager, ManagedExecutionState};
+use a3s_box_runtime::ManagedExecutionState;
 use clap::Args;
 
 use crate::lifecycle;
@@ -54,7 +54,7 @@ async fn unpause_one(state: &StateFile, query: &str) -> Result<(), Box<dyn std::
         // current records. Keep direct SIGCONT only for legacy state files.
         drop(lifecycle_lock);
         let home = a3s_box_core::dirs_home();
-        let manager = LocalExecutionManager::with_vm_backend(home.join("boxes.json"), &home);
+        let manager = super::configured_local_execution_manager(&home).await?;
         manager.resume(&execution_id, generation).await?;
         println!("{}", record.name);
         return Ok(());

--- a/src/cli/src/commands/wait.rs
+++ b/src/cli/src/commands/wait.rs
@@ -36,7 +36,10 @@ async fn wait_one(
     query: &str,
     heartbeat_interval: Option<std::time::Duration>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    use a3s_box_core::{ExecutionId, ExecutionManager, ExecutionState};
+
     let mut heartbeat = WaitHeartbeat::new(heartbeat_interval);
+    let mut oci_manager = None;
     loop {
         let state = StateFile::load_default()?;
         let record = match resolve::resolve(&state, query) {
@@ -51,6 +54,33 @@ async fn wait_one(
             Err(error) => return Err(error.into()),
         };
 
+        if uses_oci_runtime(record) {
+            if oci_manager.is_none() {
+                let home = a3s_box_core::dirs_home();
+                oci_manager = Some(super::configured_local_execution_manager(&home).await?);
+            }
+            let status = oci_manager
+                .as_ref()
+                .expect("OCI manager initialized")
+                .inspect(&ExecutionId::new(record.id.clone())?)
+                .await?;
+            match status.state {
+                ExecutionState::Stopped | ExecutionState::Failed => {
+                    // inspect persisted the exact terminal result; reload it
+                    // before printing so the provider exit code is authoritative.
+                    let refreshed = StateFile::load_default()?;
+                    let refreshed = resolve::resolve(&refreshed, query)?;
+                    println!("{}", wait_exit_code(refreshed));
+                    return Ok(());
+                }
+                ExecutionState::Created | ExecutionState::Creating => {}
+                ExecutionState::Running | ExecutionState::Paused => {}
+            }
+            heartbeat.maybe_emit(query);
+            tokio::time::sleep(tokio::time::Duration::from_millis(WAIT_POLL_MILLIS)).await;
+            continue;
+        }
+
         match wait_poll_action(record) {
             WaitPollAction::Finish(exit_code) => {
                 println!("{exit_code}");
@@ -62,6 +92,13 @@ async fn wait_one(
             }
         }
     }
+}
+
+fn uses_oci_runtime(record: &BoxRecord) -> bool {
+    record.managed_execution.as_ref().is_some_and(|metadata| {
+        metadata.runtime_route == a3s_box_runtime::ManagedRuntimeRoute::OciSdk
+            || metadata.oci_runtime.is_some()
+    })
 }
 
 fn archived_wait_exit_code(query: &str) -> Result<Option<i32>, String> {

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -425,6 +425,14 @@ pub enum ManagedExecutionOperation {
     Snapshot {
         snapshot_id: ExecutionSnapshotId,
         source_state: ManagedExecutionState,
+        /// Stable backend mutation identity for this exact snapshot attempt.
+        ///
+        /// One snapshot claim can drive both a pause and a resume. The backend
+        /// operation name keeps those mutations distinct while this seed makes
+        /// crash recovery replay each mutation exactly once. Older records did
+        /// not persist the seed, so the field remains optional for recovery.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        operation_id: Option<OperationId>,
     },
     Kill {
         #[serde(default)]

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -433,6 +433,14 @@ pub enum ManagedExecutionOperation {
         /// not persist the seed, so the field remains optional for recovery.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         operation_id: Option<OperationId>,
+        /// The runtime freeze was confirmed before snapshot capture began.
+        ///
+        /// This phase fence distinguishes an initial running claim from a
+        /// container that was already thawed after capture. Without it, crash
+        /// recovery could replay a completed pause journal entry while the
+        /// actual container remained running.
+        #[serde(default)]
+        freezer_applied: bool,
     },
     Kill {
         #[serde(default)]
@@ -692,7 +700,12 @@ fn validate_pending_operation(
         }
         validate_stop_timeout(*stop_timeout_secs)?;
     }
-    if let Some(ManagedExecutionOperation::Snapshot { source_state, .. }) = operation {
+    if let Some(ManagedExecutionOperation::Snapshot {
+        source_state,
+        freezer_applied,
+        ..
+    }) = operation
+    {
         if state != ManagedExecutionState::Snapshotting
             || !matches!(
                 source_state,
@@ -701,6 +714,11 @@ fn validate_pending_operation(
         {
             return Err(a3s_box_core::BoxError::StateError(
                 "snapshot operation has an invalid source state".to_string(),
+            ));
+        }
+        if *freezer_applied && *source_state != ManagedExecutionState::Running {
+            return Err(a3s_box_core::BoxError::StateError(
+                "paused-source snapshot cannot carry a runtime freezer phase".to_string(),
             ));
         }
     }
@@ -934,6 +952,12 @@ mod tests {
         .unwrap();
         let resume: ManagedExecutionOperation =
             serde_json::from_value(serde_json::json!({ "kind": "resume" })).unwrap();
+        let snapshot: ManagedExecutionOperation = serde_json::from_value(serde_json::json!({
+            "kind": "snapshot",
+            "snapshot_id": "legacy-snapshot",
+            "source_state": "running"
+        }))
+        .unwrap();
 
         assert_eq!(
             pause,
@@ -945,6 +969,15 @@ mod tests {
         assert_eq!(
             resume,
             ManagedExecutionOperation::Resume { operation_id: None }
+        );
+        assert_eq!(
+            snapshot,
+            ManagedExecutionOperation::Snapshot {
+                snapshot_id: ExecutionSnapshotId::new("legacy-snapshot").unwrap(),
+                source_state: ManagedExecutionState::Running,
+                operation_id: None,
+                freezer_applied: false,
+            }
         );
     }
 

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -74,14 +74,16 @@ pub use box_record::{
     ManagedRestartOutcome, ManagedRuntimeRoute,
 };
 pub use box_state::BoxStateStore;
-#[cfg(feature = "vm")]
-pub use local_execution::VmLocalExecutionBackend;
 pub use local_execution::{
     acquire_execution_lifecycle_lock, ExecutionLifecycleLock, LocalExecutionBackend,
     LocalExecutionBackendRouter, LocalExecutionHandle, LocalExecutionManager,
     LocalExecutionObservation, LocalExecutionTermination, OciBundleProvider, OciLifecycleAdapter,
     OciLocalExecutionBackend, OciMigrationPolicy, OciPreparedExecution, OciRuntimeBinding,
     OciRuntimeEndpoint, OciRuntimeLaunch, OCI_RUNTIME_BINDING_SCHEMA_VERSION,
+};
+#[cfg(feature = "vm")]
+pub use local_execution::{
+    NativeLinuxOciBundleProvider, NativeLinuxOciMigrationConfig, VmLocalExecutionBackend,
 };
 pub use managed_execution_store::{
     ManagedExecutionReservation, ManagedExecutionStore, ManagedExecutionStoreError,

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -30,6 +30,7 @@ pub mod managed_execution_store;
 pub mod network;
 pub mod oci;
 pub mod process;
+mod process_path;
 pub mod prom;
 pub mod resize;
 mod resolved_image;

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -11,6 +11,12 @@ pub use lifecycle_lock::{
 };
 mod logs;
 mod oci_backend;
+#[cfg(feature = "vm")]
+mod oci_migration;
+#[cfg(all(feature = "vm", target_os = "linux"))]
+mod oci_owner;
+#[cfg(feature = "vm")]
+mod oci_production;
 mod oci_session;
 mod operations;
 mod port;
@@ -53,6 +59,10 @@ pub use oci_backend::{
     OciPreparedExecution, OciRuntimeBinding, OciRuntimeEndpoint, OciRuntimeLaunch,
     OCI_RUNTIME_BINDING_SCHEMA_VERSION,
 };
+#[cfg(feature = "vm")]
+pub use oci_migration::NativeLinuxOciMigrationConfig;
+#[cfg(feature = "vm")]
+pub use oci_production::NativeLinuxOciBundleProvider;
 use record::{build_managed_record, status_from_record};
 pub use router::{LocalExecutionBackendRouter, OciMigrationPolicy};
 use store::RuntimeUpdate;
@@ -179,9 +189,29 @@ impl LocalExecutionManager {
         oci_backend: Arc<dyn LocalExecutionBackend>,
         policy: OciMigrationPolicy,
     ) -> Self {
+        Self::with_oci_migration_backend_and_pull_progress(
+            state_path,
+            home_dir,
+            oci_backend,
+            policy,
+            None,
+        )
+    }
+
+    #[cfg(feature = "vm")]
+    fn with_oci_migration_backend_and_pull_progress(
+        state_path: impl Into<PathBuf>,
+        home_dir: impl Into<PathBuf>,
+        oci_backend: Arc<dyn LocalExecutionBackend>,
+        policy: OciMigrationPolicy,
+        pull_progress_fn: Option<crate::PullProgressFn>,
+    ) -> Self {
         let home_dir = home_dir.into();
-        let legacy: Arc<dyn LocalExecutionBackend> =
-            Arc::new(VmLocalExecutionBackend::new(home_dir.clone()));
+        let mut legacy_backend = VmLocalExecutionBackend::new(home_dir.clone());
+        if let Some(pull_progress_fn) = pull_progress_fn {
+            legacy_backend = legacy_backend.with_pull_progress_fn(pull_progress_fn);
+        }
+        let legacy: Arc<dyn LocalExecutionBackend> = Arc::new(legacy_backend);
         let router = LocalExecutionBackendRouter::new(legacy, oci_backend, policy);
         Self::new(state_path, home_dir, Arc::new(router))
     }

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -34,6 +34,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use super::resources::ExecutionResourceGuard;
 use super::{
     LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation,
     LocalExecutionTermination,
@@ -1129,6 +1130,42 @@ impl OciLocalExecutionBackend {
     }
 }
 
+fn managed_resource_home(record: &BoxRecord) -> ExecutionManagerResult<PathBuf> {
+    let boxes = record.box_dir.parent().ok_or_else(|| {
+        ExecutionManagerError::Internal(format!(
+            "managed OCI execution {} has no boxes directory",
+            record.id
+        ))
+    })?;
+    let home = boxes.parent().ok_or_else(|| {
+        ExecutionManagerError::Internal(format!(
+            "managed OCI execution {} has no runtime home directory",
+            record.id
+        ))
+    })?;
+    if boxes.file_name().and_then(|name| name.to_str()) != Some("boxes")
+        || home.join("boxes").join(&record.id) != record.box_dir
+    {
+        return Err(ExecutionManagerError::Internal(format!(
+            "managed OCI execution {} has an unexpected host directory {}",
+            record.id,
+            record.box_dir.display()
+        )));
+    }
+    Ok(home.to_path_buf())
+}
+
+async fn rollback_execution_resources(resources: ExecutionResourceGuard, record: &BoxRecord) {
+    let execution_id = record.id.clone();
+    if let Err(error) = tokio::task::spawn_blocking(move || resources.rollback()).await {
+        tracing::warn!(
+            %execution_id,
+            %error,
+            "Managed OCI resource rollback task failed"
+        );
+    }
+}
+
 #[async_trait]
 impl LocalExecutionBackend for OciLocalExecutionBackend {
     fn route_for_create(
@@ -1166,9 +1203,29 @@ impl LocalExecutionBackend for OciLocalExecutionBackend {
         }
 
         let info = self.adapter.require_isolation(record.isolation).await?;
-        let prepared = self.provider.prepare(record).await?;
+        let resource_home = managed_resource_home(record)?;
+        let resource_record = record.clone();
+        let resources = tokio::task::spawn_blocking(move || {
+            ExecutionResourceGuard::prepare(&resource_home, &resource_record)
+        })
+        .await
+        .map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "managed OCI resource preparation task failed for {}: {error}",
+                record.id
+            ))
+        })??;
+        let prepared = match self.provider.prepare(record).await {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                rollback_execution_resources(resources, record).await;
+                return Err(error);
+            }
+        };
         if let Err(error) = prepared.validate_for(record) {
-            return match self.provider.cleanup(record).await {
+            let cleanup = self.provider.cleanup(record).await;
+            rollback_execution_resources(resources, record).await;
+            return match cleanup {
                 Ok(()) => Err(error),
                 Err(cleanup) => Err(ExecutionManagerError::Internal(format!(
                     "{error}; Box OCI preparation cleanup also failed: {cleanup}"
@@ -1190,25 +1247,37 @@ impl LocalExecutionBackend for OciLocalExecutionBackend {
             .await;
         match launch {
             Ok(launch) if *launch.record.state.status() == ContainerState::Running => {
+                resources.disarm();
                 Ok(self.handle(record, launch.binding, console_log, anonymous_volumes))
             }
-            Ok(_) => Err(ExecutionManagerError::Unavailable(format!(
-                "execution {execution_id} completed while A3S OCI startup was being published"
-            ))),
+            Ok(_) => {
+                // A runtime generation exists and owns the prepared rootfs even
+                // when it completed before Box could publish Running. Terminal
+                // reconciliation performs the normal provider/resource cleanup.
+                resources.disarm();
+                Err(ExecutionManagerError::Unavailable(format!(
+                    "execution {execution_id} completed while A3S OCI startup was being published"
+                )))
+            }
             Err(error) => {
                 // Unknown create/start outcomes must be reconciled, not erased.
                 // Cleanup product preparation only when the runtime proves no
                 // current generation exists for the deterministic ID.
                 match self.adapter.state_current(&execution_id).await {
-                    Ok(Some(_)) => return Err(error),
+                    Ok(Some(_)) => {
+                        resources.disarm();
+                        return Err(error);
+                    }
                     Err(reconcile_error) => {
+                        resources.disarm();
                         return Err(ExecutionManagerError::Unavailable(format!(
                             "{error}; A3S OCI launch ownership could not be reconciled and Box preparation was retained: {reconcile_error}"
-                        )))
+                        )));
                     }
                     Ok(None) => {}
                 }
                 let cleanup = self.provider.cleanup(record).await;
+                rollback_execution_resources(resources, record).await;
                 match cleanup {
                     Ok(()) => Err(error),
                     Err(cleanup) => Err(ExecutionManagerError::Internal(format!(

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -1651,6 +1651,7 @@ fn freezer_operation_seed(
                 snapshot_id,
                 source_state: ManagedExecutionState::Running,
                 operation_id,
+                ..
             }),
         ) => Ok(operation_id
             .as_ref()

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -1633,24 +1633,33 @@ fn freezer_operation_seed(
         .managed_execution
         .as_ref()
         .and_then(|metadata| metadata.pending_operation.as_ref());
-    let operation_id = match (paused, operation) {
+    match (paused, operation) {
         (true, Some(crate::ManagedExecutionOperation::Pause { operation_id, .. }))
         | (false, Some(crate::ManagedExecutionOperation::Resume { operation_id })) => {
-            operation_id.as_ref()
+            // Legacy transitional records predate explicit freezer mutation
+            // IDs. OCI routing did not exist when they were written, so the
+            // exact Box identity remains a safe one-time recovery seed.
+            Ok(operation_id
+                .as_ref()
+                .map(|operation_id| operation_id.as_str())
+                .unwrap_or_else(|| execution_id.as_str())
+                .to_string())
         }
-        _ => {
-            return Err(ExecutionManagerError::Internal(format!(
-                "execution {execution_id} has no matching durable OCI freezer claim"
-            )))
-        }
-    };
-    // Legacy transitional records predate explicit freezer mutation IDs. OCI
-    // routing did not exist when they were written, so the exact Box identity
-    // and generation remain a safe one-time recovery seed.
-    Ok(operation_id
-        .map(|operation_id| operation_id.as_str())
-        .unwrap_or_else(|| execution_id.as_str())
-        .to_string())
+        (
+            _,
+            Some(crate::ManagedExecutionOperation::Snapshot {
+                snapshot_id,
+                source_state: ManagedExecutionState::Running,
+                operation_id,
+            }),
+        ) => Ok(operation_id
+            .as_ref()
+            .map(|operation_id| operation_id.as_str().to_string())
+            .unwrap_or_else(|| format!("legacy-snapshot-{execution_id}-{snapshot_id}"))),
+        _ => Err(ExecutionManagerError::Internal(format!(
+            "execution {execution_id} has no matching durable OCI freezer claim"
+        ))),
+    }
 }
 
 pub(super) fn operation_context(

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -1233,12 +1233,42 @@ struct FakeBundleProvider {
     prepares: AtomicUsize,
     cleanups: AtomicUsize,
     invalid_console: AtomicBool,
+    expected_snapshot_lower: Mutex<Option<std::path::PathBuf>>,
+    snapshot_lower_observed: AtomicBool,
+    last_box_dir: Mutex<Option<std::path::PathBuf>>,
 }
 
 #[async_trait]
 impl OciBundleProvider for FakeBundleProvider {
     async fn prepare(&self, record: &BoxRecord) -> ExecutionManagerResult<OciPreparedExecution> {
         self.prepares.fetch_add(1, Ordering::SeqCst);
+        *self
+            .last_box_dir
+            .lock()
+            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))? =
+            Some(record.box_dir.clone());
+        if let Some(expected) = self
+            .expected_snapshot_lower
+            .lock()
+            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?
+            .as_ref()
+        {
+            let marker = std::fs::read_to_string(record.box_dir.join(".snapshot-lower")).map_err(
+                |error| {
+                    ExecutionManagerError::Internal(format!(
+                        "OCI bundle preparation did not receive a snapshot lower marker: {error}"
+                    ))
+                },
+            )?;
+            if std::path::Path::new(marker.trim()) != expected {
+                return Err(ExecutionManagerError::Internal(format!(
+                    "OCI bundle preparation received snapshot lower {} instead of {}",
+                    marker.trim(),
+                    expected.display()
+                )));
+            }
+            self.snapshot_lower_observed.store(true, Ordering::SeqCst);
+        }
         let spec = serde_json::from_value(json!({
             "ociVersion": "1.3.0",
             "process": {
@@ -1503,23 +1533,72 @@ async fn preflight_requires_attachment_v1_before_store_or_preparation() {
 }
 
 #[tokio::test]
+async fn snapshot_restore_prepares_the_managed_lower_before_oci_bundle_creation() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let home = directory.path().join("home");
+    let snapshot_id = install_managed_snapshot(&home, "oci-restore-source");
+    let expected_lower = home
+        .join("snapshots")
+        .join(snapshot_id.as_str())
+        .join("rootfs")
+        .canonicalize()
+        .expect("canonical snapshot rootfs");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let provider = Arc::new(FakeBundleProvider::default());
+    *provider
+        .expected_snapshot_lower
+        .lock()
+        .expect("expected snapshot lower lock") = Some(expected_lower.clone());
+    let manager = manager(&directory, test_endpoint(), service, provider.clone());
+    let mut restore = request("snapshot-restore", ExecutionIsolation::Sandbox);
+    restore.rootfs_snapshot_id = Some(snapshot_id);
+
+    let lease = manager
+        .create_and_start(restore, &box_operation("snapshot-restore-operation"))
+        .await
+        .expect("snapshot-backed OCI start");
+    let record = persisted(&manager, &lease.execution_id);
+
+    assert!(provider.snapshot_lower_observed.load(Ordering::SeqCst));
+    assert_eq!(
+        std::path::PathBuf::from(
+            std::fs::read_to_string(record.box_dir.join(".snapshot-lower"))
+                .expect("persisted snapshot lower marker")
+                .trim()
+        ),
+        expected_lower
+    );
+}
+
+#[tokio::test]
 async fn invalid_preparation_is_cleaned_before_runtime_create() {
     let directory = tempfile::tempdir().expect("temporary directory");
+    let home = directory.path().join("home");
+    let snapshot_id = install_managed_snapshot(&home, "invalid-oci-restore-source");
+    let expected_lower = home
+        .join("snapshots")
+        .join(snapshot_id.as_str())
+        .join("rootfs")
+        .canonicalize()
+        .expect("canonical snapshot rootfs");
     let service = Arc::new(FakeRuntimeService::launch_ready());
     let provider = Arc::new(FakeBundleProvider::default());
     provider.invalid_console.store(true, Ordering::SeqCst);
+    *provider
+        .expected_snapshot_lower
+        .lock()
+        .expect("expected snapshot lower lock") = Some(expected_lower);
     let manager = manager(
         &directory,
         test_endpoint(),
         service.clone(),
         provider.clone(),
     );
+    let mut restore = request("invalid-preparation", ExecutionIsolation::Sandbox);
+    restore.rootfs_snapshot_id = Some(snapshot_id);
 
     let error = manager
-        .create_and_start(
-            request("invalid-preparation", ExecutionIsolation::Sandbox),
-            &box_operation("invalid-preparation-operation"),
-        )
+        .create_and_start(restore, &box_operation("invalid-preparation-operation"))
         .await
         .expect_err("provider must not change durable preparation fields");
 
@@ -1531,6 +1610,13 @@ async fn invalid_preparation_is_cleaned_before_runtime_create() {
     assert_eq!(provider.cleanups.load(Ordering::SeqCst), 1);
     assert!(service.create_requests().is_empty());
     assert_eq!(service.container_count(), 0);
+    let box_dir = provider
+        .last_box_dir
+        .lock()
+        .expect("last box directory lock")
+        .clone()
+        .expect("prepared box directory");
+    assert!(!box_dir.join(".snapshot-lower").exists());
 }
 
 #[tokio::test]
@@ -4012,6 +4098,25 @@ fn persisted(manager: &LocalExecutionManager, execution_id: &ExecutionId) -> Box
         .get(execution_id)
         .expect("read managed store")
         .expect("persisted execution")
+}
+
+fn install_managed_snapshot(home: &std::path::Path, id: &str) -> ExecutionSnapshotId {
+    let snapshot_id = ExecutionSnapshotId::new(id).expect("snapshot ID");
+    let source = home.join(format!("{id}-rootfs-source"));
+    std::fs::create_dir_all(&source).expect("snapshot source rootfs");
+    std::fs::write(source.join("captured.txt"), b"captured").expect("snapshot source marker");
+    let mut metadata = a3s_box_core::SnapshotMetadata::new(
+        id.to_string(),
+        id.to_string(),
+        "source-execution".to_string(),
+        "alpine:3.20".to_string(),
+    );
+    metadata.image_config = Some(a3s_box_core::SnapshotImageConfig::default());
+    crate::SnapshotStore::new(&home.join("snapshots"))
+        .expect("snapshot store")
+        .save(metadata, &source)
+        .expect("published managed snapshot");
+    snapshot_id
 }
 
 fn request(external_id: &str, isolation: ExecutionIsolation) -> CreateExecutionRequest {

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -1878,6 +1878,54 @@ async fn captured_exec_replays_after_lost_response_and_backend_reopen() {
 }
 
 #[tokio::test]
+async fn relative_exec_resolves_against_the_prepared_rootfs_path() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let manager = manager(
+        &directory,
+        test_endpoint(),
+        service.clone(),
+        Arc::new(FakeBundleProvider::default()),
+    );
+    let lease = manager
+        .create_and_start(
+            request("relative-exec", ExecutionIsolation::Sandbox),
+            &box_operation("relative-exec-create"),
+        )
+        .await
+        .expect("initial launch");
+    let rootfs = directory
+        .path()
+        .join("home")
+        .join("boxes")
+        .join(lease.execution_id.as_str())
+        .join("rootfs");
+    std::fs::create_dir_all(rootfs.join("usr/bin")).expect("create rootfs PATH directory");
+    let executable = rootfs.join("usr/bin/printf");
+    std::fs::write(&executable, b"fake executable").expect("create rootfs executable");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755))
+            .expect("mark rootfs command executable");
+    }
+
+    let mut exec = box_exec_request(Some("relative-path-command"));
+    exec.cmd = vec!["printf".to_string(), "sdk-ok".to_string()];
+    manager
+        .execute(&lease.execution_id, lease.generation, exec)
+        .await
+        .expect("relative exec through OCI backend");
+
+    let calls = service.exec_requests();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0].process.args().as_ref().expect("process args"),
+        &["/usr/bin/printf", "sdk-ok"]
+    );
+}
+
+#[tokio::test]
 async fn file_and_filesystem_sessions_preserve_exact_targets_and_replay_mutations_once() {
     let directory = tempfile::tempdir().expect("temporary directory");
     let service = Arc::new(FakeRuntimeService::launch_ready());

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -2809,6 +2809,83 @@ async fn running_snapshot_uses_a_durable_freezer_identity_per_attempt() {
 }
 
 #[tokio::test]
+async fn snapshot_recovery_does_not_replay_a_completed_pause_after_thaw() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let provider = Arc::new(FakeBundleProvider::default());
+    let first = manager(
+        &directory,
+        test_endpoint(),
+        service.clone(),
+        provider.clone(),
+    );
+    let create_operation = box_operation("snapshot-thaw-recovery-create");
+    let running = first
+        .create_and_start(
+            request("snapshot-thaw-recovery", ExecutionIsolation::Sandbox),
+            &create_operation,
+        )
+        .await
+        .expect("initial launch");
+    let snapshot_id = ExecutionSnapshotId::new("snapshot-thaw-recovery").unwrap();
+    let record = persisted(&first, &running.execution_id);
+    let claimed = first
+        .transition(
+            &record,
+            ManagedExecutionState::Running,
+            ManagedExecutionState::Snapshotting,
+            RuntimeUpdate::SnapshotClaim {
+                snapshot_id: snapshot_id.clone(),
+                source_state: ManagedExecutionState::Running,
+                operation_id: box_operation("snapshot-thaw-freezer"),
+            },
+        )
+        .await
+        .expect("persist snapshot claim");
+    first
+        .backend
+        .pause(&claimed, true)
+        .await
+        .expect("freeze snapshot source");
+    let frozen = first
+        .mark_snapshot_freezer_applied(&claimed)
+        .await
+        .expect("persist frozen phase");
+    first
+        .backend
+        .resume(&frozen)
+        .await
+        .expect("simulate thaw before Box completion");
+    drop(first);
+
+    let recovered = manager(&directory, test_endpoint(), service.clone(), provider);
+    let error = recovered
+        .reconcile(&create_operation)
+        .await
+        .expect_err("an unpublished thawed snapshot must roll back");
+    assert!(error
+        .to_string()
+        .contains("was thawed before filesystem snapshot"));
+    assert_eq!(service.pause_requests().len(), 1);
+    assert_eq!(service.resume_requests().len(), 1);
+    let rolled_back = persisted(&recovered, &running.execution_id);
+    assert_eq!(
+        rolled_back.status,
+        ManagedExecutionState::Running.as_status()
+    );
+    assert_eq!(
+        rolled_back.managed_execution.as_ref().unwrap().generation,
+        running.generation
+    );
+    assert!(rolled_back
+        .managed_execution
+        .as_ref()
+        .unwrap()
+        .pending_operation
+        .is_none());
+}
+
+#[tokio::test]
 async fn pause_requires_advertised_sdk_operation_before_runtime_mutation() {
     let directory = tempfile::tempdir().expect("temporary directory");
     let service = Arc::new(FakeRuntimeService::without_operation(

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -7,8 +7,8 @@ use a3s_box_core::pty::PtyRequest;
 use a3s_box_core::{
     BoxConfig, CreateExecutionRequest, ExecEvent, ExecutionEventsRequest, ExecutionGeneration,
     ExecutionId, ExecutionIsolation, ExecutionManager, ExecutionManagerError,
-    ExecutionProcessSignal, ExecutionResourceUpdate, ExecutionSessionManager, ExecutionState,
-    FileOp as BoxFileOp, FileRequest as BoxFileRequest,
+    ExecutionProcessSignal, ExecutionResourceUpdate, ExecutionSessionManager, ExecutionSnapshotId,
+    ExecutionState, FileOp as BoxFileOp, FileRequest as BoxFileRequest,
     FilesystemEntryKind as BoxFilesystemEntryKind, FilesystemOp as BoxFilesystemOp,
     FilesystemRequest as BoxFilesystemRequest, KillExecutionOptions, KillOutcome, NetworkMode,
     OperationId as BoxOperationId, ReconcileOutcome,
@@ -2747,6 +2747,65 @@ async fn pause_resume_use_exact_runtime_target_and_unique_box_generations() {
     assert_eq!(service.start_requests().len(), 1);
     assert_eq!(provider.prepares.load(Ordering::SeqCst), 1);
     assert_eq!(provider.cleanups.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn running_snapshot_uses_a_durable_freezer_identity_per_attempt() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let provider = Arc::new(FakeBundleProvider::default());
+    let manager = manager(&directory, test_endpoint(), service.clone(), provider);
+    let running = manager
+        .create_and_start(
+            request("snapshot-freezer", ExecutionIsolation::Sandbox),
+            &box_operation("snapshot-freezer-create"),
+        )
+        .await
+        .expect("initial launch");
+    let snapshot_id = ExecutionSnapshotId::new("snapshot-freezer-attempt").unwrap();
+
+    for attempt in 0..2 {
+        let error = manager
+            .create_filesystem_snapshot(&running.execution_id, running.generation, &snapshot_id)
+            .await
+            .expect_err("an empty fake rootfs cannot be captured");
+        assert!(error
+            .to_string()
+            .contains("has no populated managed rootfs to snapshot"));
+
+        let pauses = service.pause_requests();
+        let resumes = service.resume_requests();
+        assert_eq!(pauses.len(), attempt + 1);
+        assert_eq!(resumes.len(), attempt + 1);
+        assert_eq!(pauses[attempt].target, resumes[attempt].target);
+        assert_ne!(
+            pauses[attempt].context.operation_id,
+            resumes[attempt].context.operation_id
+        );
+        if attempt > 0 {
+            assert_ne!(
+                pauses[attempt - 1].context.operation_id,
+                pauses[attempt].context.operation_id
+            );
+            assert_ne!(
+                resumes[attempt - 1].context.operation_id,
+                resumes[attempt].context.operation_id
+            );
+        }
+
+        let restored = persisted(&manager, &running.execution_id);
+        assert_eq!(restored.status, ManagedExecutionState::Running.as_status());
+        assert_eq!(
+            restored.managed_execution.as_ref().unwrap().generation,
+            running.generation
+        );
+        assert!(restored
+            .managed_execution
+            .as_ref()
+            .unwrap()
+            .pending_operation
+            .is_none());
+    }
 }
 
 #[tokio::test]

--- a/src/runtime/src/local_execution/oci_migration.rs
+++ b/src/runtime/src/local_execution/oci_migration.rs
@@ -147,13 +147,13 @@ impl LocalExecutionManager {
             }
             let provider = Arc::new(provider);
             let oci = Arc::new(OciLocalExecutionBackend::connect(endpoint, provider).await?);
-            return Ok(Self::with_oci_migration_backend_and_pull_progress(
+            Ok(Self::with_oci_migration_backend_and_pull_progress(
                 state_path,
                 home_dir,
                 oci,
                 OciMigrationPolicy::SandboxViaOci,
                 pull_progress_fn,
-            ));
+            ))
         }
 
         #[cfg(not(target_os = "linux"))]
@@ -266,8 +266,7 @@ fn default_service_root(home_dir: &Path) -> PathBuf {
         let digest = Sha256::digest(home_dir.as_os_str().as_bytes());
         // SAFETY: geteuid has no preconditions or failure result.
         let uid = unsafe { libc::geteuid() };
-        return std::env::temp_dir()
-            .join(format!("a3s-box-oci-{uid}-{}", hex::encode(&digest[..6])));
+        std::env::temp_dir().join(format!("a3s-box-oci-{uid}-{}", hex::encode(&digest[..6])))
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/runtime/src/local_execution/oci_migration.rs
+++ b/src/runtime/src/local_execution/oci_migration.rs
@@ -1,0 +1,339 @@
+//! Explicit production composition for Sandbox migration to A3S OCI Runtime.
+
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+#[cfg(target_os = "linux")]
+use a3s_box_core::ExecutionBackend;
+use a3s_box_core::{ExecutionManagerError, ExecutionManagerResult};
+#[cfg(target_os = "linux")]
+use sha2::{Digest, Sha256};
+
+use super::LocalExecutionManager;
+#[cfg(target_os = "linux")]
+use super::{NativeLinuxOciBundleProvider, OciLocalExecutionBackend, OciMigrationPolicy};
+
+pub const OCI_MIGRATION_ENV: &str = "A3S_BOX_OCI_MIGRATION";
+pub const OCI_HOST_ROOT_ENV: &str = "A3S_BOX_OCI_HOST_ROOT";
+pub const OCI_RUNTIME_PATH_ENV: &str = "A3S_BOX_OCI_RUNTIME_PATH";
+pub const OCI_AGENT_PATH_ENV: &str = "A3S_BOX_OCI_AGENT_PATH";
+
+/// Explicit native-Linux owner and artifact selection for Sandbox migration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeLinuxOciMigrationConfig {
+    service_root: PathBuf,
+    runtime_path: Option<PathBuf>,
+    agent_path: Option<PathBuf>,
+}
+
+impl NativeLinuxOciMigrationConfig {
+    pub fn new(service_root: impl Into<PathBuf>) -> ExecutionManagerResult<Self> {
+        let config = Self {
+            service_root: service_root.into(),
+            runtime_path: None,
+            agent_path: None,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn with_artifacts(
+        mut self,
+        runtime_path: impl Into<PathBuf>,
+        agent_path: impl Into<PathBuf>,
+    ) -> ExecutionManagerResult<Self> {
+        self.runtime_path = Some(runtime_path.into());
+        self.agent_path = Some(agent_path.into());
+        self.validate()?;
+        Ok(self)
+    }
+
+    pub fn service_root(&self) -> &Path {
+        &self.service_root
+    }
+
+    pub fn runtime_path(&self) -> Option<&Path> {
+        self.runtime_path.as_deref()
+    }
+
+    pub fn agent_path(&self) -> Option<&Path> {
+        self.agent_path.as_deref()
+    }
+
+    /// Parse the process-wide opt-in. An absent/off value preserves the
+    /// existing VM backend without probing or starting an OCI owner.
+    pub fn from_environment(home_dir: &Path) -> ExecutionManagerResult<Option<Self>> {
+        parse_environment(
+            std::env::var_os(OCI_MIGRATION_ENV),
+            std::env::var_os(OCI_HOST_ROOT_ENV),
+            std::env::var_os(OCI_RUNTIME_PATH_ENV),
+            std::env::var_os(OCI_AGENT_PATH_ENV),
+            home_dir,
+        )
+    }
+
+    fn validate(&self) -> ExecutionManagerResult<()> {
+        validate_absolute_normalized(&self.service_root, "OCI host root")?;
+        match (&self.runtime_path, &self.agent_path) {
+            (Some(runtime), Some(agent)) => {
+                validate_absolute_normalized(runtime, "OCI runtime path")?;
+                validate_absolute_normalized(agent, "OCI agent path")?;
+            }
+            (None, None) => {}
+            _ => {
+                return Err(ExecutionManagerError::InvalidRequest(
+                    "OCI runtime and agent paths must be supplied together".to_string(),
+                ))
+            }
+        }
+        Ok(())
+    }
+}
+
+impl LocalExecutionManager {
+    /// Compose the retained VM backend with the production native-Linux OCI
+    /// owner and bundle provider. Only new Sandbox reservations use OCI.
+    pub async fn with_native_linux_oci_migration(
+        state_path: impl Into<PathBuf>,
+        home_dir: impl Into<PathBuf>,
+        config: NativeLinuxOciMigrationConfig,
+    ) -> ExecutionManagerResult<Self> {
+        Self::with_native_linux_oci_migration_and_pull_progress(
+            state_path.into(),
+            home_dir.into(),
+            config,
+            None,
+        )
+        .await
+    }
+
+    async fn with_native_linux_oci_migration_and_pull_progress(
+        state_path: PathBuf,
+        home_dir: PathBuf,
+        config: NativeLinuxOciMigrationConfig,
+        pull_progress_fn: Option<crate::PullProgressFn>,
+    ) -> ExecutionManagerResult<Self> {
+        config.validate()?;
+
+        #[cfg(target_os = "linux")]
+        {
+            let capabilities = crate::sandbox::probe_sandbox_capabilities_for(
+                ExecutionBackend::A3sOci,
+                config.runtime_path(),
+                config.agent_path(),
+            );
+            capabilities.require_ready().map_err(|error| {
+                ExecutionManagerError::Unavailable(format!(
+                    "native Linux OCI migration preflight failed: {error}"
+                ))
+            })?;
+            let artifacts = capabilities.a3s_oci.as_ref().ok_or_else(|| {
+                ExecutionManagerError::Unavailable(
+                    "native Linux OCI migration preflight returned no runtime artifacts"
+                        .to_string(),
+                )
+            })?;
+            let endpoint =
+                super::oci_owner::ensure_native_linux_oci_owner(config.service_root(), artifacts)
+                    .await?;
+            let mut provider = NativeLinuxOciBundleProvider::new(
+                home_dir.clone(),
+                artifacts.runtime_path.clone(),
+                artifacts.agent_path.clone(),
+            );
+            if let Some(progress) = pull_progress_fn.as_ref() {
+                provider = provider.with_pull_progress_fn(progress.clone());
+            }
+            let provider = Arc::new(provider);
+            let oci = Arc::new(OciLocalExecutionBackend::connect(endpoint, provider).await?);
+            return Ok(Self::with_oci_migration_backend_and_pull_progress(
+                state_path,
+                home_dir,
+                oci,
+                OciMigrationPolicy::SandboxViaOci,
+                pull_progress_fn,
+            ));
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (state_path, home_dir, config, pull_progress_fn);
+            Err(ExecutionManagerError::Unavailable(
+                "native Linux OCI migration is supported only on Linux".to_string(),
+            ))
+        }
+    }
+
+    /// Select the production migration composition only when explicitly opted
+    /// in through `A3S_BOX_OCI_MIGRATION=sandbox`.
+    pub async fn with_configured_backend(
+        state_path: impl Into<PathBuf>,
+        home_dir: impl Into<PathBuf>,
+    ) -> ExecutionManagerResult<Self> {
+        Self::with_configured_backend_and_pull_progress(state_path, home_dir, None).await
+    }
+
+    /// Configured construction retaining the CLI's image-pull progress hook on
+    /// both the legacy and migrated preparation paths.
+    pub async fn with_configured_backend_and_pull_progress(
+        state_path: impl Into<PathBuf>,
+        home_dir: impl Into<PathBuf>,
+        pull_progress_fn: Option<crate::PullProgressFn>,
+    ) -> ExecutionManagerResult<Self> {
+        let state_path = state_path.into();
+        let home_dir = home_dir.into();
+        match NativeLinuxOciMigrationConfig::from_environment(&home_dir)? {
+            Some(config) => {
+                Self::with_native_linux_oci_migration_and_pull_progress(
+                    state_path,
+                    home_dir,
+                    config,
+                    pull_progress_fn,
+                )
+                .await
+            }
+            None => {
+                let mut backend = crate::local_execution::VmLocalExecutionBackend::new(&home_dir);
+                if let Some(progress) = pull_progress_fn {
+                    backend = backend.with_pull_progress_fn(progress);
+                }
+                Ok(Self::new(state_path, home_dir, Arc::new(backend)))
+            }
+        }
+    }
+}
+
+fn parse_environment(
+    mode: Option<OsString>,
+    service_root: Option<OsString>,
+    runtime_path: Option<OsString>,
+    agent_path: Option<OsString>,
+    home_dir: &Path,
+) -> ExecutionManagerResult<Option<NativeLinuxOciMigrationConfig>> {
+    let Some(mode) = mode.filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let mode = mode.to_str().ok_or_else(|| {
+        ExecutionManagerError::InvalidRequest(format!(
+            "{OCI_MIGRATION_ENV} must contain UTF-8 text"
+        ))
+    })?;
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "" | "0" | "false" | "off" | "disabled" | "legacy" => return Ok(None),
+        "1" | "true" | "on" | "sandbox" | "sandbox-via-oci" => {}
+        "all" | "all-via-oci" => {
+            return Err(ExecutionManagerError::InvalidRequest(
+                "all-via-OCI migration is not qualified yet; use sandbox".to_string(),
+            ))
+        }
+        value => {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "unsupported {OCI_MIGRATION_ENV} value {value:?}; expected off or sandbox"
+            )))
+        }
+    }
+
+    let root = service_root
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default_service_root(home_dir));
+    let mut config = NativeLinuxOciMigrationConfig::new(root)?;
+    match (
+        runtime_path.filter(|value| !value.is_empty()),
+        agent_path.filter(|value| !value.is_empty()),
+    ) {
+        (Some(runtime), Some(agent)) => {
+            config = config.with_artifacts(PathBuf::from(runtime), PathBuf::from(agent))?;
+        }
+        (None, None) => {}
+        _ => {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "{OCI_RUNTIME_PATH_ENV} and {OCI_AGENT_PATH_ENV} must be set together"
+            )))
+        }
+    }
+    Ok(Some(config))
+}
+
+fn default_service_root(home_dir: &Path) -> PathBuf {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        // Keep runtime.sock below the small sockaddr_un limit while separating
+        // different A3S homes owned by the same UID.
+        let digest = Sha256::digest(home_dir.as_os_str().as_bytes());
+        // SAFETY: geteuid has no preconditions or failure result.
+        let uid = unsafe { libc::geteuid() };
+        return std::env::temp_dir()
+            .join(format!("a3s-box-oci-{uid}-{}", hex::encode(&digest[..6])));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    home_dir.join("run").join("oci-host")
+}
+
+fn validate_absolute_normalized(path: &Path, label: &str) -> ExecutionManagerResult<()> {
+    if !path.is_absolute()
+        || path.parent().is_none()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+    {
+        return Err(ExecutionManagerError::InvalidRequest(format!(
+            "{label} must be an absolute normalized non-root path: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn absolute(name: &str) -> PathBuf {
+        std::env::temp_dir().join(name)
+    }
+
+    #[test]
+    fn environment_is_opt_in_and_rejects_unqualified_all_policy() {
+        let home = absolute("a3s-oci-config-home");
+        assert_eq!(
+            parse_environment(None, None, None, None, &home).unwrap(),
+            None
+        );
+        assert_eq!(
+            parse_environment(Some(OsString::from("off")), None, None, None, &home).unwrap(),
+            None
+        );
+        assert!(parse_environment(Some(OsString::from("all")), None, None, None, &home).is_err());
+    }
+
+    #[test]
+    fn environment_requires_artifact_pair_and_accepts_sandbox() {
+        let home = absolute("a3s-oci-config-home");
+        let runtime = absolute("a3s-oci");
+        let agent = absolute("a3s-oci-agent");
+        assert!(parse_environment(
+            Some(OsString::from("sandbox")),
+            None,
+            Some(runtime.clone().into_os_string()),
+            None,
+            &home
+        )
+        .is_err());
+        let config = parse_environment(
+            Some(OsString::from("sandbox")),
+            Some(absolute("a3s-oci-root").into_os_string()),
+            Some(runtime.clone().into_os_string()),
+            Some(agent.clone().into_os_string()),
+            &home,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(config.runtime_path(), Some(runtime.as_path()));
+        assert_eq!(config.agent_path(), Some(agent.as_path()));
+    }
+}

--- a/src/runtime/src/local_execution/oci_owner.rs
+++ b/src/runtime/src/local_execution/oci_owner.rs
@@ -1,0 +1,488 @@
+//! Identity-fenced startup and reuse of the long-lived native Linux OCI owner.
+
+use std::os::unix::fs::{DirBuilderExt, FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::process::CommandExt;
+use std::path::{Component, Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use a3s_box_core::{ExecutionIsolation, ExecutionManagerError, ExecutionManagerResult};
+use serde::{Deserialize, Serialize};
+
+use super::{OciLifecycleAdapter, OciRuntimeEndpoint};
+use crate::file_lock::FileLock;
+use crate::sandbox::CertifiedA3sOci;
+
+const OWNER_RECORD_SCHEMA: &str = "a3s.box.native-linux-oci-owner.v1";
+const OWNER_RECORD_NAME: &str = "box-owner.json";
+const OWNER_LOCK_TARGET: &str = "box-owner";
+const OWNER_SOCKET_NAME: &str = "runtime.sock";
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+const STARTUP_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativeLinuxOwnerRecord {
+    schema: String,
+    pid: u32,
+    pid_start_time: u64,
+    runtime_path: PathBuf,
+    runtime_sha256: String,
+    agent_path: PathBuf,
+    agent_sha256: String,
+    socket_path: PathBuf,
+}
+
+impl NativeLinuxOwnerRecord {
+    fn new(
+        pid: u32,
+        pid_start_time: u64,
+        artifacts: &CertifiedA3sOci,
+        socket_path: PathBuf,
+    ) -> Self {
+        Self {
+            schema: OWNER_RECORD_SCHEMA.to_string(),
+            pid,
+            pid_start_time,
+            runtime_path: artifacts.runtime_path.clone(),
+            runtime_sha256: artifacts.runtime_sha256.clone(),
+            agent_path: artifacts.agent_path.clone(),
+            agent_sha256: artifacts.agent_sha256.clone(),
+            socket_path,
+        }
+    }
+
+    fn validate(&self, expected_socket: &Path) -> ExecutionManagerResult<()> {
+        if self.schema != OWNER_RECORD_SCHEMA
+            || self.pid == 0
+            || self.pid_start_time == 0
+            || self.socket_path != expected_socket
+            || !self.runtime_path.is_absolute()
+            || !self.agent_path.is_absolute()
+            || !is_sha256_hex(&self.runtime_sha256)
+            || !is_sha256_hex(&self.agent_sha256)
+        {
+            return Err(ExecutionManagerError::Internal(
+                "native Linux OCI owner record is malformed or belongs to another endpoint"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn artifacts_match(&self, expected: &CertifiedA3sOci) -> bool {
+        self.runtime_path == expected.runtime_path
+            && self.runtime_sha256 == expected.runtime_sha256
+            && self.agent_path == expected.agent_path
+            && self.agent_sha256 == expected.agent_sha256
+    }
+
+    fn is_alive(&self) -> bool {
+        crate::process::is_process_alive_with_identity(self.pid, Some(self.pid_start_time))
+    }
+}
+
+pub(crate) async fn ensure_native_linux_oci_owner(
+    service_root: &Path,
+    artifacts: &CertifiedA3sOci,
+) -> ExecutionManagerResult<OciRuntimeEndpoint> {
+    validate_service_root(service_root)?;
+    let root = service_root.to_path_buf();
+    tokio::task::spawn_blocking(move || prepare_service_root(&root))
+        .await
+        .map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "native Linux OCI owner root task failed: {error}"
+            ))
+        })??;
+
+    let lock_target = service_root.join(OWNER_LOCK_TARGET);
+    let lock = tokio::task::spawn_blocking(move || FileLock::acquire(&lock_target))
+        .await
+        .map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "native Linux OCI owner lock task failed: {error}"
+            ))
+        })?
+        .map_err(|error| {
+            ExecutionManagerError::Unavailable(format!(
+                "failed to acquire native Linux OCI owner lock: {error}"
+            ))
+        })?;
+
+    let socket_path = service_root.join(OWNER_SOCKET_NAME);
+    let endpoint = OciRuntimeEndpoint::unix_socket(socket_path.clone())?;
+    let record_path = service_root.join(OWNER_RECORD_NAME);
+    if let Some(record) = load_owner_record(&record_path, &socket_path)? {
+        if record.is_alive() {
+            if !record.artifacts_match(artifacts) {
+                return Err(ExecutionManagerError::Unavailable(
+                    "the live native Linux OCI owner uses different runtime artifacts; stop it explicitly before changing artifacts"
+                        .to_string(),
+                ));
+            }
+            let result = wait_until_ready(&endpoint, None).await;
+            drop(lock);
+            return result.map(|()| endpoint);
+        }
+        reclaim_dead_owner_socket(&socket_path)?;
+    } else if path_exists_no_follow(&socket_path)? {
+        return Err(ExecutionManagerError::Unavailable(format!(
+            "refusing to reclaim unowned native Linux OCI socket {} without an identity record",
+            socket_path.display()
+        )));
+    }
+
+    let mut child = spawn_owner(service_root, artifacts)?;
+    let pid = child.id();
+    let pid_start_time = crate::process::pid_start_time(pid).ok_or_else(|| {
+        let _ = child.kill();
+        let _ = child.wait();
+        ExecutionManagerError::Unavailable(format!(
+            "could not capture native Linux OCI owner identity for PID {pid}"
+        ))
+    })?;
+    let record = NativeLinuxOwnerRecord::new(pid, pid_start_time, artifacts, socket_path.clone());
+    if let Err(error) = write_owner_record(&record_path, &record) {
+        let _ = child.kill();
+        let _ = child.wait();
+        reclaim_dead_owner_socket(&socket_path)?;
+        return Err(error);
+    }
+
+    let ready = wait_until_ready(&endpoint, Some(&mut child)).await;
+    if let Err(error) = ready {
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = remove_record_if_same(&record_path, &record);
+        let _ = reclaim_dead_owner_socket(&socket_path);
+        return Err(error);
+    }
+    // A short-lived CLI will naturally hand the owner to init, while a
+    // long-lived embedding process must still reap an owner that later exits.
+    // Retaining the Child in this waiter prevents a persistent SDK host from
+    // accumulating a zombie without tying the owner's lifetime to the caller.
+    std::thread::Builder::new()
+        .name("a3s-oci-owner-reaper".to_string())
+        .spawn(move || {
+            let _ = child.wait();
+        })
+        .map_err(|error| {
+            ExecutionManagerError::Unavailable(format!(
+                "failed to start native Linux OCI owner reaper: {error}"
+            ))
+        })?;
+    drop(lock);
+    Ok(endpoint)
+}
+
+async fn wait_until_ready(
+    endpoint: &OciRuntimeEndpoint,
+    mut child: Option<&mut Child>,
+) -> ExecutionManagerResult<()> {
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    let mut last_error = None;
+    loop {
+        if let Some(child) = child.as_deref_mut() {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    return Err(ExecutionManagerError::Unavailable(format!(
+                        "native Linux OCI owner exited during startup with {status}"
+                    )))
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    return Err(ExecutionManagerError::Unavailable(format!(
+                        "failed to inspect native Linux OCI owner startup: {error}"
+                    )))
+                }
+            }
+        }
+        match OciLifecycleAdapter::connect(endpoint.clone()).await {
+            Ok(adapter) => match adapter.require_isolation(ExecutionIsolation::Sandbox).await {
+                Ok(_) => return Ok(()),
+                Err(error) => last_error = Some(error.to_string()),
+            },
+            Err(error) => last_error = Some(error.to_string()),
+        }
+        if Instant::now() >= deadline {
+            return Err(ExecutionManagerError::Unavailable(format!(
+                "native Linux OCI owner did not publish a launch-ready SDK endpoint within {} ms: {}",
+                STARTUP_TIMEOUT.as_millis(),
+                last_error.unwrap_or_else(|| "endpoint unavailable".to_string())
+            )));
+        }
+        tokio::time::sleep(STARTUP_POLL_INTERVAL).await;
+    }
+}
+
+fn spawn_owner(service_root: &Path, artifacts: &CertifiedA3sOci) -> ExecutionManagerResult<Child> {
+    let stdout = open_owner_log(&service_root.join("owner.stdout.log"))?;
+    let stderr = open_owner_log(&service_root.join("owner.stderr.log"))?;
+    let mut command = Command::new(&artifacts.runtime_path);
+    command
+        .arg("native-linux-host-service")
+        .arg("--root")
+        .arg(service_root)
+        .arg("--agent")
+        .arg(&artifacts.agent_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    // SAFETY: the closure performs only the async-signal-safe setsid syscall
+    // between fork and exec and does not access shared Rust state.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    command.spawn().map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to spawn native Linux OCI owner {}: {error}",
+            artifacts.runtime_path.display()
+        ))
+    })
+}
+
+fn open_owner_log(path: &Path) -> ExecutionManagerResult<std::fs::File> {
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|error| {
+            ExecutionManagerError::Unavailable(format!(
+                "failed to open native Linux OCI owner log {}: {error}",
+                path.display()
+            ))
+        })?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to protect native Linux OCI owner log {}: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(file)
+}
+
+fn validate_service_root(path: &Path) -> ExecutionManagerResult<()> {
+    if !path.is_absolute()
+        || path.parent().is_none()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+    {
+        return Err(ExecutionManagerError::InvalidRequest(format!(
+            "native Linux OCI service root must be an absolute normalized non-root path: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn prepare_service_root(path: &Path) -> ExecutionManagerResult<()> {
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700);
+    builder.create(path).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to create native Linux OCI service root {}: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to inspect native Linux OCI service root {}: {error}",
+            path.display()
+        ))
+    })?;
+    // SAFETY: geteuid has no preconditions or failure result.
+    let effective_uid = unsafe { libc::geteuid() };
+    if !metadata.is_dir()
+        || metadata.file_type().is_symlink()
+        || metadata.uid() != effective_uid
+        || metadata.mode() & 0o777 != 0o700
+    {
+        return Err(ExecutionManagerError::Unavailable(format!(
+            "native Linux OCI service root {} must be a real UID {effective_uid}-owned directory with mode 0700",
+            path.display()
+        )));
+    }
+    let canonical = std::fs::canonicalize(path).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to canonicalize native Linux OCI service root {}: {error}",
+            path.display()
+        ))
+    })?;
+    if canonical != path {
+        return Err(ExecutionManagerError::Unavailable(format!(
+            "native Linux OCI service root resolves through an alias: {} -> {}",
+            path.display(),
+            canonical.display()
+        )));
+    }
+    Ok(())
+}
+
+fn load_owner_record(
+    path: &Path,
+    expected_socket: &Path,
+) -> ExecutionManagerResult<Option<NativeLinuxOwnerRecord>> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(ExecutionManagerError::Unavailable(format!(
+                "failed to inspect native Linux OCI owner record {}: {error}",
+                path.display()
+            )))
+        }
+    };
+    // SAFETY: geteuid has no preconditions or failure result.
+    let effective_uid = unsafe { libc::geteuid() };
+    if !metadata.is_file()
+        || metadata.file_type().is_symlink()
+        || metadata.uid() != effective_uid
+        || metadata.mode() & 0o777 != 0o600
+        || metadata.len() > 16 * 1024
+    {
+        return Err(ExecutionManagerError::Unavailable(format!(
+            "native Linux OCI owner record {} is not a protected bounded regular file",
+            path.display()
+        )));
+    }
+    let bytes = std::fs::read(path).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to read native Linux OCI owner record {}: {error}",
+            path.display()
+        ))
+    })?;
+    let record: NativeLinuxOwnerRecord = serde_json::from_slice(&bytes).map_err(|error| {
+        ExecutionManagerError::Internal(format!(
+            "native Linux OCI owner record {} is invalid: {error}",
+            path.display()
+        ))
+    })?;
+    record.validate(expected_socket)?;
+    Ok(Some(record))
+}
+
+fn write_owner_record(path: &Path, record: &NativeLinuxOwnerRecord) -> ExecutionManagerResult<()> {
+    let bytes = serde_json::to_vec_pretty(record).map_err(|error| {
+        ExecutionManagerError::Internal(format!(
+            "failed to encode native Linux OCI owner record: {error}"
+        ))
+    })?;
+    let temporary = path.with_extension(format!("tmp-{}", uuid::Uuid::new_v4().simple()));
+    let result = (|| -> std::io::Result<()> {
+        use std::io::Write as _;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        std::fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if let Err(error) = result {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(ExecutionManagerError::Unavailable(format!(
+            "failed to persist native Linux OCI owner record {}: {error}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn remove_record_if_same(
+    path: &Path,
+    expected: &NativeLinuxOwnerRecord,
+) -> ExecutionManagerResult<()> {
+    let current = load_owner_record(path, &expected.socket_path)?;
+    if current.as_ref() == Some(expected) {
+        std::fs::remove_file(path).map_err(|error| {
+            ExecutionManagerError::Unavailable(format!(
+                "failed to remove failed native Linux OCI owner record {}: {error}",
+                path.display()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn reclaim_dead_owner_socket(path: &Path) -> ExecutionManagerResult<()> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(ExecutionManagerError::Unavailable(format!(
+                "failed to inspect stale native Linux OCI socket {}: {error}",
+                path.display()
+            )))
+        }
+    };
+    // SAFETY: geteuid has no preconditions or failure result.
+    let effective_uid = unsafe { libc::geteuid() };
+    if !metadata.file_type().is_socket() || metadata.uid() != effective_uid {
+        return Err(ExecutionManagerError::Unavailable(format!(
+            "refusing to remove stale native Linux OCI path {} because it is not a socket owned by UID {effective_uid}",
+            path.display()
+        )));
+    }
+    std::fs::remove_file(path).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to remove stale native Linux OCI socket {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn path_exists_no_follow(path: &Path) -> ExecutionManagerResult<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(ExecutionManagerError::Unavailable(format!(
+            "failed to inspect native Linux OCI path {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_record_fences_endpoint_and_artifacts() {
+        let artifacts = CertifiedA3sOci {
+            runtime_path: PathBuf::from("/opt/a3s/a3s-oci"),
+            runtime_sha256: "a".repeat(64),
+            agent_path: PathBuf::from("/opt/a3s/a3s-oci-agent"),
+            agent_sha256: "b".repeat(64),
+        };
+        let socket = PathBuf::from("/tmp/a3s-owner/runtime.sock");
+        let record = NativeLinuxOwnerRecord::new(42, 7, &artifacts, socket.clone());
+        record.validate(&socket).unwrap();
+        assert!(record.artifacts_match(&artifacts));
+        assert!(record.validate(Path::new("/tmp/other.sock")).is_err());
+    }
+
+    #[test]
+    fn service_root_rejects_relative_and_parent_paths() {
+        assert!(validate_service_root(Path::new("relative")).is_err());
+        assert!(validate_service_root(Path::new("/tmp/a/../b")).is_err());
+        assert!(validate_service_root(Path::new("/")).is_err());
+    }
+}

--- a/src/runtime/src/local_execution/oci_owner.rs
+++ b/src/runtime/src/local_execution/oci_owner.rs
@@ -181,7 +181,6 @@ async fn wait_until_ready(
     mut child: Option<&mut Child>,
 ) -> ExecutionManagerResult<()> {
     let deadline = Instant::now() + STARTUP_TIMEOUT;
-    let mut last_error = None;
     loop {
         if let Some(child) = child.as_deref_mut() {
             match child.try_wait() {
@@ -198,18 +197,18 @@ async fn wait_until_ready(
                 }
             }
         }
-        match OciLifecycleAdapter::connect(endpoint.clone()).await {
+        let last_error = match OciLifecycleAdapter::connect(endpoint.clone()).await {
             Ok(adapter) => match adapter.require_isolation(ExecutionIsolation::Sandbox).await {
                 Ok(_) => return Ok(()),
-                Err(error) => last_error = Some(error.to_string()),
+                Err(error) => error.to_string(),
             },
-            Err(error) => last_error = Some(error.to_string()),
-        }
+            Err(error) => error.to_string(),
+        };
         if Instant::now() >= deadline {
             return Err(ExecutionManagerError::Unavailable(format!(
                 "native Linux OCI owner did not publish a launch-ready SDK endpoint within {} ms: {}",
                 STARTUP_TIMEOUT.as_millis(),
-                last_error.unwrap_or_else(|| "endpoint unavailable".to_string())
+                last_error
             )));
         }
         tokio::time::sleep(STARTUP_POLL_INTERVAL).await;
@@ -250,7 +249,6 @@ fn spawn_owner(service_root: &Path, artifacts: &CertifiedA3sOci) -> ExecutionMan
 
 fn open_owner_log(path: &Path) -> ExecutionManagerResult<std::fs::File> {
     let file = std::fs::OpenOptions::new()
-        .write(true)
         .create(true)
         .append(true)
         .mode(0o600)

--- a/src/runtime/src/local_execution/oci_production.rs
+++ b/src/runtime/src/local_execution/oci_production.rs
@@ -1,0 +1,169 @@
+//! Production Box-owned bundle preparation for the native Linux OCI service.
+
+use std::path::{Path, PathBuf};
+
+use a3s_box_core::{
+    BoxError, ExecutionBackend, ExecutionIsolation, ExecutionManagerError, ExecutionManagerResult,
+};
+use a3s_oci_sdk::{CreateAttachments, IoMode, OciBundle, ProcessIo};
+use async_trait::async_trait;
+
+use super::{OciBundleProvider, OciPreparedExecution, VmLocalExecutionBackend};
+use crate::sandbox::probe_sandbox_capabilities_for;
+use crate::BoxRecord;
+
+/// Prepares immutable bundles from Box image/rootfs policy while the separate
+/// A3S OCI Runtime service owns container lifecycle and I/O.
+#[derive(Clone)]
+pub struct NativeLinuxOciBundleProvider {
+    preparer: VmLocalExecutionBackend,
+    runtime_path: PathBuf,
+    agent_path: PathBuf,
+}
+
+impl NativeLinuxOciBundleProvider {
+    pub fn new(
+        home_dir: impl Into<PathBuf>,
+        runtime_path: impl Into<PathBuf>,
+        agent_path: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            preparer: VmLocalExecutionBackend::new(home_dir),
+            runtime_path: runtime_path.into(),
+            agent_path: agent_path.into(),
+        }
+    }
+
+    pub fn runtime_path(&self) -> &Path {
+        &self.runtime_path
+    }
+
+    pub fn agent_path(&self) -> &Path {
+        &self.agent_path
+    }
+
+    pub fn with_pull_progress_fn(mut self, pull_progress_fn: crate::PullProgressFn) -> Self {
+        self.preparer = self.preparer.with_pull_progress_fn(pull_progress_fn);
+        self
+    }
+}
+
+#[async_trait]
+impl OciBundleProvider for NativeLinuxOciBundleProvider {
+    async fn prepare(&self, record: &BoxRecord) -> ExecutionManagerResult<OciPreparedExecution> {
+        if record.isolation != ExecutionIsolation::Sandbox {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "native Linux OCI migration only prepares Sandbox executions, got {:?}",
+                record.isolation
+            )));
+        }
+        let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "execution {} has no managed lifecycle metadata",
+                record.id
+            ))
+        })?;
+        metadata
+            .validate()
+            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
+        if metadata.plan.backend != ExecutionBackend::A3sOci {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "execution {} did not resolve to the A3S OCI Sandbox backend",
+                record.id
+            )));
+        }
+
+        // Re-hash the exact configured artifacts immediately before rootfs or
+        // bundle mutations. Owner startup and bundle evidence use this same pair.
+        let capabilities = probe_sandbox_capabilities_for(
+            ExecutionBackend::A3sOci,
+            Some(&self.runtime_path),
+            Some(&self.agent_path),
+        );
+        capabilities
+            .require_ready()
+            .map_err(|error| preparation_error("capability preflight", error))?;
+
+        let mut manager = self.preparer.new_oci_preparation_manager(record)?;
+        let prepared = manager
+            .prepare_runtime_owned_sandbox_bundle(&metadata.plan, &capabilities)
+            .await
+            .map_err(|error| preparation_error("prepare bundle", error))?;
+        let bundle = match OciBundle::load(&prepared.bundle_dir).await {
+            Ok(bundle) => bundle,
+            Err(error) => {
+                let cleanup = manager.cleanup_runtime_owned_sandbox_bundle();
+                return Err(match cleanup {
+                    Ok(()) => ExecutionManagerError::Internal(format!(
+                        "failed to load the generated OCI bundle: {error}"
+                    )),
+                    Err(cleanup) => ExecutionManagerError::Internal(format!(
+                        "failed to load the generated OCI bundle: {error}; cleanup also failed: {cleanup}"
+                    )),
+                });
+            }
+        };
+        let io = ProcessIo {
+            stdin: if metadata.request.config.stdin_open {
+                IoMode::Pipe
+            } else {
+                IoMode::Null
+            },
+            stdout: IoMode::Capture,
+            stderr: IoMode::Capture,
+            terminal_size: None,
+        };
+        let attachments = match CreateAttachments::from_bundle(&bundle, io) {
+            Ok(attachments) => attachments,
+            Err(error) => {
+                return Err(cleanup_after_prepare_failure(
+                    &manager,
+                    format!("failed to derive generated OCI bundle attachments: {error}"),
+                ));
+            }
+        };
+        let mut result = match OciPreparedExecution::with_attachments(
+            bundle,
+            attachments,
+            prepared.console_output,
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                return Err(cleanup_after_prepare_failure(
+                    &manager,
+                    format!("failed to validate generated OCI bundle attachments: {error}"),
+                ));
+            }
+        };
+        result.anonymous_volumes = prepared.anonymous_volumes;
+        Ok(result)
+    }
+
+    async fn cleanup(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {
+        let manager = self.preparer.new_oci_preparation_manager(record)?;
+        manager
+            .cleanup_runtime_owned_sandbox_bundle()
+            .map_err(|error| preparation_error("cleanup bundle", error))
+    }
+}
+
+fn preparation_error(action: &str, error: BoxError) -> ExecutionManagerError {
+    match error {
+        BoxError::ConfigError(message) => ExecutionManagerError::InvalidRequest(message),
+        error => {
+            ExecutionManagerError::Unavailable(format!("native Linux OCI {action} failed: {error}"))
+        }
+    }
+}
+
+fn cleanup_after_prepare_failure(
+    manager: &crate::VmManager,
+    message: String,
+) -> ExecutionManagerError {
+    match manager.cleanup_runtime_owned_sandbox_bundle() {
+        Ok(()) => ExecutionManagerError::Internal(message),
+        Err(cleanup) => {
+            ExecutionManagerError::Internal(format!("{message}; cleanup also failed: {cleanup}"))
+        }
+    }
+}

--- a/src/runtime/src/local_execution/oci_session.rs
+++ b/src/runtime/src/local_execution/oci_session.rs
@@ -28,6 +28,9 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use super::oci_backend::{exit_code, operation_context, sdk_error, OciLocalExecutionBackend};
+use crate::process_path::{
+    normalize_linux_guest_path, resolve_runtime_executable, DEFAULT_CONTAINER_PATH,
+};
 use crate::BoxRecord;
 
 const OUTPUT_POLL_BYTES: u32 = 64 * 1024;
@@ -227,8 +230,15 @@ async fn launch_process(
     })?;
     binding.validate_for(&execution_id)?;
     let terminal = matches!(launch.io.stdin, IoMode::Terminal);
+    let mut args = launch.args;
+    resolve_exec_executable(
+        record,
+        &mut args,
+        &launch.env,
+        launch.working_dir.as_deref(),
+    )?;
     let process = build_process(
-        launch.args,
+        args,
         launch.env,
         launch.working_dir,
         launch.rootfs,
@@ -341,6 +351,67 @@ async fn launch_process(
         done: false,
         empty_polls_after_exit: 0,
     })
+}
+
+fn resolve_exec_executable(
+    record: &BoxRecord,
+    args: &mut [String],
+    env: &[String],
+    working_dir: Option<&str>,
+) -> ExecutionManagerResult<()> {
+    let Some(command) = args.first_mut() else {
+        return Ok(());
+    };
+    if command.starts_with('/') {
+        *command = normalize_linux_guest_path("/", command, "exec process executable")
+            .map_err(exec_path_request_error)?;
+        return Ok(());
+    }
+
+    let cwd = working_dir.unwrap_or("/");
+    let request_path = env
+        .iter()
+        .rev()
+        .find_map(|entry| entry.strip_prefix("PATH="));
+    let image_config = if request_path.is_none() {
+        crate::load_resolved_image_config(&record.box_dir).map_err(|error| {
+            ExecutionManagerError::Unavailable(format!(
+                "cannot load resolved image environment for A3S OCI exec in {}: {error}",
+                record.id
+            ))
+        })?
+    } else {
+        None
+    };
+    let path = request_path
+        .or_else(|| {
+            image_config.as_ref().and_then(|config| {
+                config
+                    .env
+                    .iter()
+                    .rev()
+                    .find_map(|(key, value)| (key == "PATH").then_some(value.as_str()))
+            })
+        })
+        .unwrap_or(DEFAULT_CONTAINER_PATH);
+    *command = resolve_runtime_executable(&record.box_dir.join("rootfs"), cwd, path, command)
+        .map_err(exec_path_request_error)?;
+    Ok(())
+}
+
+fn exec_path_request_error(error: a3s_box_core::BoxError) -> ExecutionManagerError {
+    match error {
+        a3s_box_core::BoxError::ConfigError(message) => {
+            ExecutionManagerError::InvalidRequest(message)
+        }
+        a3s_box_core::BoxError::BoxBootError { message, hint } => {
+            let message = hint.map_or(message.clone(), |hint| format!("{message} ({hint})"));
+            ExecutionManagerError::InvalidRequest(message)
+        }
+        error => ExecutionManagerError::Unavailable(format!(
+            "failed to inspect the prepared rootfs for A3S OCI exec: {error}"
+        )),
+    }
 }
 
 fn spawn_timeout_watchdog(

--- a/src/runtime/src/local_execution/router.rs
+++ b/src/runtime/src/local_execution/router.rs
@@ -76,29 +76,7 @@ impl LocalExecutionBackendRouter {
     }
 
     fn route_for_record(&self, record: &BoxRecord) -> ExecutionManagerResult<ManagedRuntimeRoute> {
-        let metadata = record.managed_execution.as_ref().ok_or_else(|| {
-            ExecutionManagerError::Internal(format!(
-                "execution {} has no managed lifecycle metadata for backend routing",
-                record.id
-            ))
-        })?;
-        metadata
-            .validate()
-            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
-        match metadata.runtime_route {
-            ManagedRuntimeRoute::BoxVm => Ok(ManagedRuntimeRoute::BoxVm),
-            ManagedRuntimeRoute::OciSdk => Ok(ManagedRuntimeRoute::OciSdk),
-            ManagedRuntimeRoute::Unspecified if metadata.oci_runtime.is_some() => {
-                Ok(ManagedRuntimeRoute::OciSdk)
-            }
-            // OCI handles deliberately store no Box-owned exec socket. This
-            // preserves stopped pre-routing OCI records after their live
-            // binding has been cleared during teardown.
-            ManagedRuntimeRoute::Unspecified if record.exec_socket_path.as_os_str().is_empty() => {
-                Ok(ManagedRuntimeRoute::OciSdk)
-            }
-            ManagedRuntimeRoute::Unspecified => Ok(ManagedRuntimeRoute::BoxVm),
-        }
+        resolved_runtime_route(record)
     }
 
     fn backend_for_record(
@@ -110,6 +88,36 @@ impl LocalExecutionBackendRouter {
             ManagedRuntimeRoute::OciSdk => Ok(&self.oci),
             ManagedRuntimeRoute::Unspecified => unreachable!("route inference is exhaustive"),
         }
+    }
+}
+
+/// Resolve records written before the route field was introduced using the
+/// same durable evidence for both router dispatch and concrete backend checks.
+pub(super) fn resolved_runtime_route(
+    record: &BoxRecord,
+) -> ExecutionManagerResult<ManagedRuntimeRoute> {
+    let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+        ExecutionManagerError::Internal(format!(
+            "execution {} has no managed lifecycle metadata for backend routing",
+            record.id
+        ))
+    })?;
+    metadata
+        .validate()
+        .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
+    match metadata.runtime_route {
+        ManagedRuntimeRoute::BoxVm => Ok(ManagedRuntimeRoute::BoxVm),
+        ManagedRuntimeRoute::OciSdk => Ok(ManagedRuntimeRoute::OciSdk),
+        ManagedRuntimeRoute::Unspecified if metadata.oci_runtime.is_some() => {
+            Ok(ManagedRuntimeRoute::OciSdk)
+        }
+        // OCI handles deliberately store no Box-owned exec socket. This
+        // preserves stopped pre-routing OCI records after their live binding
+        // has been cleared during teardown.
+        ManagedRuntimeRoute::Unspecified if record.exec_socket_path.as_os_str().is_empty() => {
+            Ok(ManagedRuntimeRoute::OciSdk)
+        }
+        ManagedRuntimeRoute::Unspecified => Ok(ManagedRuntimeRoute::BoxVm),
     }
 }
 

--- a/src/runtime/src/local_execution/snapshot.rs
+++ b/src/runtime/src/local_execution/snapshot.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use a3s_box_core::snapshot::SnapshotMetadata;
 use a3s_box_core::{
     ExecutionGeneration, ExecutionId, ExecutionLease, ExecutionManagerError,
-    ExecutionManagerResult, ExecutionSnapshot, ExecutionSnapshotId, ExecutionState,
+    ExecutionManagerResult, ExecutionSnapshot, ExecutionSnapshotId, ExecutionState, OperationId,
 };
 
 use super::record::lease_from_record;
@@ -69,6 +69,10 @@ impl LocalExecutionManager {
             });
         }
 
+        let backend_operation_id = OperationId::new(format!(
+            "managed-snapshot-{}",
+            uuid::Uuid::new_v4().simple()
+        ))?;
         let claimed = self
             .transition(
                 &record,
@@ -77,6 +81,7 @@ impl LocalExecutionManager {
                 RuntimeUpdate::SnapshotClaim {
                     snapshot_id: snapshot_id.clone(),
                     source_state,
+                    operation_id: backend_operation_id,
                 },
             )
             .await?;
@@ -445,6 +450,7 @@ fn snapshot_operation(
         Some(ManagedExecutionOperation::Snapshot {
             snapshot_id,
             source_state,
+            ..
         }) if matches!(
             source_state,
             ManagedExecutionState::Running | ManagedExecutionState::Paused

--- a/src/runtime/src/local_execution/snapshot.rs
+++ b/src/runtime/src/local_execution/snapshot.rs
@@ -29,7 +29,7 @@ impl LocalExecutionManager {
         require_generation(&record, execution_id, expected_generation)?;
         let source_state = managed_state(&record)?;
         if source_state == ManagedExecutionState::Snapshotting {
-            let (pending_snapshot_id, _) = snapshot_operation(&record)?;
+            let (pending_snapshot_id, _, _) = snapshot_operation(&record)?;
             if &pending_snapshot_id != snapshot_id {
                 return Err(state_conflict(&record, execution_id, "snapshot"));
             }
@@ -112,7 +112,8 @@ impl LocalExecutionManager {
     }
 
     async fn drive_snapshot(&self, record: BoxRecord) -> ExecutionManagerResult<ExecutionSnapshot> {
-        let (snapshot_id, source_state) = snapshot_operation(&record)?;
+        let (snapshot_id, source_state, freezer_applied) = snapshot_operation(&record)?;
+        let mut record = record;
         let execution_id = ExecutionId::new(record.id.clone())?;
         if source_state == ManagedExecutionState::Paused
             && !paused_with_memory(&record, &execution_id)?
@@ -123,20 +124,54 @@ impl LocalExecutionManager {
         observation.validate(&execution_id)?;
         let mut handle = required_handle(&observation, &execution_id)?;
 
-        match (source_state, observation.state) {
-            (ManagedExecutionState::Running, ExecutionState::Running) => {
-                handle = self.pause_for_snapshot(&record, &execution_id).await?;
+        match (source_state, observation.state, freezer_applied) {
+            (ManagedExecutionState::Running, ExecutionState::Running, true) => {
+                let published = self.load_snapshot(&snapshot_id).await?;
+                if published
+                    .as_ref()
+                    .is_some_and(|snapshot| snapshot.source_box_id != record.id)
+                {
+                    return Err(ExecutionManagerError::Unavailable(format!(
+                        "filesystem snapshot {snapshot_id} belongs to another execution"
+                    )));
+                }
+                let completed = self
+                    .complete_with_handle(
+                        &record,
+                        ManagedExecutionState::Snapshotting,
+                        ManagedExecutionState::Running,
+                        handle,
+                    )
+                    .await?;
+                return match published {
+                    Some(published) => Ok(ExecutionSnapshot {
+                        snapshot_id,
+                        size_bytes: published.size_bytes,
+                        state: ExecutionState::Running,
+                        lease: lease_from_record(&completed)?,
+                    }),
+                    None => Err(ExecutionManagerError::Unavailable(format!(
+                        "execution {execution_id} was thawed before filesystem snapshot {snapshot_id} was published; the snapshot claim was rolled back"
+                    ))),
+                };
             }
-            (ManagedExecutionState::Running, ExecutionState::Paused)
-            | (ManagedExecutionState::Paused, ExecutionState::Paused) => {}
-            (ManagedExecutionState::Paused, ExecutionState::Running) => {
+            (ManagedExecutionState::Running, ExecutionState::Running, false) => {
+                handle = self.pause_for_snapshot(&record, &execution_id).await?;
+                record = self.mark_snapshot_freezer_applied(&record).await?;
+            }
+            (ManagedExecutionState::Running, ExecutionState::Paused, false) => {
+                record = self.mark_snapshot_freezer_applied(&record).await?;
+            }
+            (ManagedExecutionState::Running, ExecutionState::Paused, true)
+            | (ManagedExecutionState::Paused, ExecutionState::Paused, false) => {}
+            (ManagedExecutionState::Paused, ExecutionState::Running, false) => {
                 return Err(ExecutionManagerError::Conflict {
                     execution_id,
                     message: "a paused execution resumed while its filesystem snapshot was pending"
                         .to_string(),
                 })
             }
-            (_, state) => {
+            (_, state, _) => {
                 return Err(ExecutionManagerError::Conflict {
                     execution_id,
                     message: format!(
@@ -441,7 +476,7 @@ impl LocalExecutionManager {
 
 fn snapshot_operation(
     record: &BoxRecord,
-) -> ExecutionManagerResult<(ExecutionSnapshotId, ManagedExecutionState)> {
+) -> ExecutionManagerResult<(ExecutionSnapshotId, ManagedExecutionState, bool)> {
     match record
         .managed_execution
         .as_ref()
@@ -450,13 +485,14 @@ fn snapshot_operation(
         Some(ManagedExecutionOperation::Snapshot {
             snapshot_id,
             source_state,
+            freezer_applied,
             ..
         }) if matches!(
             source_state,
             ManagedExecutionState::Running | ManagedExecutionState::Paused
         ) =>
         {
-            Ok((snapshot_id.clone(), *source_state))
+            Ok((snapshot_id.clone(), *source_state, *freezer_applied))
         }
         _ => Err(ExecutionManagerError::Internal(format!(
             "execution {} has invalid snapshot recovery metadata",

--- a/src/runtime/src/local_execution/store.rs
+++ b/src/runtime/src/local_execution/store.rs
@@ -187,6 +187,7 @@ impl LocalExecutionManager {
                             snapshot_id,
                             source_state,
                             operation_id: Some(operation_id),
+                            freezer_applied: false,
                         });
                     }
                 }
@@ -280,6 +281,41 @@ impl LocalExecutionManager {
         let execution_id = execution_id(record)?;
         let generation = generation(record, &execution_id)?;
         run_store(move || store.finish_resource_update(&execution_id, generation)).await
+    }
+
+    pub(super) async fn mark_snapshot_freezer_applied(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<BoxRecord> {
+        let store = self.store.clone();
+        let execution_id = execution_id(record)?;
+        let generation = generation(record, &execution_id)?;
+        let (snapshot_id, operation_id) = match record
+            .managed_execution
+            .as_ref()
+            .and_then(|metadata| metadata.pending_operation.as_ref())
+        {
+            Some(ManagedExecutionOperation::Snapshot {
+                snapshot_id,
+                source_state: ManagedExecutionState::Running,
+                operation_id,
+                ..
+            }) => (snapshot_id.clone(), operation_id.clone()),
+            _ => {
+                return Err(ExecutionManagerError::Internal(format!(
+                    "execution {execution_id} has no running snapshot freezer claim"
+                )))
+            }
+        };
+        run_store(move || {
+            store.mark_snapshot_freezer_applied(
+                &execution_id,
+                generation,
+                &snapshot_id,
+                operation_id.as_ref(),
+            )
+        })
+        .await
     }
 }
 

--- a/src/runtime/src/local_execution/store.rs
+++ b/src/runtime/src/local_execution/store.rs
@@ -180,11 +180,13 @@ impl LocalExecutionManager {
                 RuntimeUpdate::SnapshotClaim {
                     snapshot_id,
                     source_state,
+                    operation_id,
                 } => {
                     if let Some(metadata) = record.managed_execution.as_mut() {
                         metadata.pending_operation = Some(ManagedExecutionOperation::Snapshot {
                             snapshot_id,
                             source_state,
+                            operation_id: Some(operation_id),
                         });
                     }
                 }
@@ -301,6 +303,7 @@ pub(super) enum RuntimeUpdate {
     SnapshotClaim {
         snapshot_id: ExecutionSnapshotId,
         source_state: ManagedExecutionState,
+        operation_id: OperationId,
     },
     RestartClaim {
         operation_id: OperationId,

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -2742,6 +2742,7 @@ async fn reconcile_recovers_a_crash_after_snapshot_pause() {
             RuntimeUpdate::SnapshotClaim {
                 snapshot_id: snapshot_id.clone(),
                 source_state: ManagedExecutionState::Running,
+                operation_id: operation("recovered-snapshot-freezer"),
             },
         )
         .await

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -77,6 +77,14 @@ impl VmLocalExecutionBackend {
         &self,
         record: &'a BoxRecord,
     ) -> ExecutionManagerResult<&'a ManagedExecutionMetadata> {
+        self.metadata_for_route(record, crate::ManagedRuntimeRoute::BoxVm)
+    }
+
+    fn metadata_for_route<'a>(
+        &self,
+        record: &'a BoxRecord,
+        expected_route: crate::ManagedRuntimeRoute,
+    ) -> ExecutionManagerResult<&'a ManagedExecutionMetadata> {
         uuid::Uuid::parse_str(&record.id).map_err(|error| {
             ExecutionManagerError::Internal(format!(
                 "managed execution has an invalid internal ID {}: {error}",
@@ -100,10 +108,11 @@ impl VmLocalExecutionBackend {
         metadata
             .validate()
             .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
-        if metadata.runtime_route == crate::ManagedRuntimeRoute::OciSdk {
+        let resolved_route = super::router::resolved_runtime_route(record)?;
+        if resolved_route != expected_route {
             return Err(ExecutionManagerError::Internal(format!(
-                "managed execution {} is pinned to the A3S OCI SDK route",
-                record.id
+                "managed execution {} is pinned to {:?}, not {:?}",
+                record.id, resolved_route, expected_route
             )));
         }
         if record.isolation != metadata.request.config.isolation {
@@ -117,6 +126,22 @@ impl VmLocalExecutionBackend {
 
     fn new_manager(&self, record: &BoxRecord) -> ExecutionManagerResult<VmManager> {
         let metadata = self.metadata(record)?;
+        self.new_manager_from_metadata(record, metadata)
+    }
+
+    pub(super) fn new_oci_preparation_manager(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<VmManager> {
+        let metadata = self.metadata_for_route(record, crate::ManagedRuntimeRoute::OciSdk)?;
+        self.new_manager_from_metadata(record, metadata)
+    }
+
+    fn new_manager_from_metadata(
+        &self,
+        record: &BoxRecord,
+        metadata: &ManagedExecutionMetadata,
+    ) -> ExecutionManagerResult<VmManager> {
         let mut config = metadata.request.config.clone();
         // Network connect/disconnect is intentionally mutable while an
         // execution is inactive. The managed creation request remains the

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -916,6 +916,7 @@ mod tests {
                         Some(ManagedExecutionOperation::Snapshot {
                             snapshot_id: snapshot_id.clone(),
                             source_state: ManagedExecutionState::Running,
+                            operation_id: Some(OperationId::new("snapshot-operation-1").unwrap()),
                         });
                 },
             )
@@ -934,7 +935,9 @@ mod tests {
             Some(ManagedExecutionOperation::Snapshot {
                 snapshot_id,
                 source_state: ManagedExecutionState::Running,
+                operation_id: Some(operation_id),
             }) if snapshot_id.as_str() == "snapshot-1"
+                && operation_id.as_str() == "snapshot-operation-1"
         ));
 
         let reopened = ManagedExecutionStore::new(store.path().to_path_buf());

--- a/src/runtime/src/managed_execution_store.rs
+++ b/src/runtime/src/managed_execution_store.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use a3s_box_core::{ExecutionGeneration, ExecutionId, OperationId};
+use a3s_box_core::{ExecutionGeneration, ExecutionId, ExecutionSnapshotId, OperationId};
 use thiserror::Error;
 
 use crate::{
@@ -446,6 +446,69 @@ impl ManagedExecutionStore {
                 | ManagedExecutionState::Stopped
                 | ManagedExecutionState::Failed => None,
             };
+            Ok(record.clone())
+        })
+    }
+
+    /// Persist that a running snapshot claim reached the frozen runtime phase.
+    ///
+    /// The exact snapshot and backend operation identities fence a delayed
+    /// writer from marking a newer same-generation attempt. Repeating the same
+    /// write is idempotent so a lost store response remains recoverable.
+    pub fn mark_snapshot_freezer_applied(
+        &self,
+        execution_id: &ExecutionId,
+        expected_generation: ExecutionGeneration,
+        expected_snapshot_id: &ExecutionSnapshotId,
+        expected_operation_id: Option<&OperationId>,
+    ) -> ManagedExecutionStoreResult<BoxRecord> {
+        let execution_id = execution_id.clone();
+        let expected_snapshot_id = expected_snapshot_id.clone();
+        let expected_operation_id = expected_operation_id.cloned();
+        BoxStateStore::transact(&self.path, move |store| {
+            let record = store
+                .find_by_id_mut(execution_id.as_str())
+                .ok_or_else(|| ManagedExecutionStoreError::NotFound(execution_id.clone()))?;
+            let state = record
+                .managed_state()
+                .map_err(|error| ManagedExecutionStoreError::InvalidRecord(error.to_string()))?
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+            let metadata = record
+                .managed_execution
+                .as_mut()
+                .ok_or_else(|| ManagedExecutionStoreError::Unmanaged(execution_id.clone()))?;
+            if state != ManagedExecutionState::Snapshotting
+                || metadata.generation != expected_generation
+            {
+                return Err(ManagedExecutionStoreError::Conflict {
+                    execution_id: execution_id.clone(),
+                    message: format!(
+                        "expected snapshotting generation {}, found {state} generation {}",
+                        expected_generation.get(),
+                        metadata.generation.get()
+                    ),
+                });
+            }
+            match metadata.pending_operation.as_mut() {
+                Some(ManagedExecutionOperation::Snapshot {
+                    snapshot_id,
+                    source_state: ManagedExecutionState::Running,
+                    operation_id,
+                    freezer_applied,
+                }) if snapshot_id == &expected_snapshot_id
+                    && operation_id == &expected_operation_id =>
+                {
+                    *freezer_applied = true;
+                }
+                _ => {
+                    return Err(ManagedExecutionStoreError::Conflict {
+                        execution_id: execution_id.clone(),
+                        message: format!(
+                            "snapshot freezer phase does not match claim {expected_snapshot_id}"
+                        ),
+                    })
+                }
+            }
             Ok(record.clone())
         })
     }
@@ -917,6 +980,7 @@ mod tests {
                             snapshot_id: snapshot_id.clone(),
                             source_state: ManagedExecutionState::Running,
                             operation_id: Some(OperationId::new("snapshot-operation-1").unwrap()),
+                            freezer_applied: false,
                         });
                 },
             )
@@ -936,8 +1000,55 @@ mod tests {
                 snapshot_id,
                 source_state: ManagedExecutionState::Running,
                 operation_id: Some(operation_id),
+                freezer_applied: false,
             }) if snapshot_id.as_str() == "snapshot-1"
                 && operation_id.as_str() == "snapshot-operation-1"
+        ));
+
+        let snapshot_operation_id = OperationId::new("snapshot-operation-1").unwrap();
+        let marked = store
+            .mark_snapshot_freezer_applied(
+                &id,
+                ExecutionGeneration::INITIAL,
+                &snapshot_id,
+                Some(&snapshot_operation_id),
+            )
+            .unwrap();
+        assert!(matches!(
+            marked
+                .managed_execution
+                .as_ref()
+                .unwrap()
+                .pending_operation
+                .as_ref(),
+            Some(ManagedExecutionOperation::Snapshot {
+                freezer_applied: true,
+                ..
+            })
+        ));
+        let replayed = store
+            .mark_snapshot_freezer_applied(
+                &id,
+                ExecutionGeneration::INITIAL,
+                &snapshot_id,
+                Some(&snapshot_operation_id),
+            )
+            .unwrap();
+        assert_eq!(
+            replayed.managed_execution.as_ref().unwrap().generation,
+            marked.managed_execution.as_ref().unwrap().generation
+        );
+        assert!(matches!(
+            replayed
+                .managed_execution
+                .as_ref()
+                .unwrap()
+                .pending_operation
+                .as_ref(),
+            Some(ManagedExecutionOperation::Snapshot {
+                freezer_applied: true,
+                ..
+            })
         ));
 
         let reopened = ManagedExecutionStore::new(store.path().to_path_buf());
@@ -946,6 +1057,18 @@ mod tests {
             persisted.managed_state().unwrap(),
             Some(ManagedExecutionState::Snapshotting)
         );
+        assert!(matches!(
+            persisted
+                .managed_execution
+                .as_ref()
+                .unwrap()
+                .pending_operation
+                .as_ref(),
+            Some(ManagedExecutionOperation::Snapshot {
+                freezer_applied: true,
+                ..
+            })
+        ));
         let completed = reopened
             .transition(
                 &id,

--- a/src/runtime/src/process_path.rs
+++ b/src/runtime/src/process_path.rs
@@ -1,0 +1,113 @@
+//! Linux guest process path validation shared by initial launch and exec.
+
+use std::path::Path;
+
+use a3s_box_core::error::{BoxError, Result};
+
+pub(crate) const DEFAULT_CONTAINER_PATH: &str =
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+pub(crate) fn resolve_runtime_executable(
+    rootfs: &Path,
+    cwd: &str,
+    path: &str,
+    command: &str,
+) -> Result<String> {
+    if command.is_empty() || command.contains('\0') {
+        return Err(BoxError::ConfigError(
+            "Sandbox runtime-owned executable must be non-empty and contain no NUL".to_string(),
+        ));
+    }
+
+    if command.contains('/') {
+        let candidate = normalize_linux_guest_path(cwd, command, "process executable")?;
+        require_runtime_executable(rootfs, &candidate)?;
+        return Ok(candidate);
+    }
+
+    for directory in path.split(':') {
+        let directory = if directory.is_empty() { cwd } else { directory };
+        let directory = normalize_linux_guest_path(cwd, directory, "PATH entry")?;
+        let candidate =
+            normalize_linux_guest_path(&directory, command, "PATH-resolved process executable")?;
+        if runtime_executable_exists(rootfs, &candidate)? {
+            return Ok(candidate);
+        }
+    }
+    Err(BoxError::BoxBootError {
+        message: format!(
+            "Sandbox executable {command:?} was not found as an executable file in the prepared rootfs PATH"
+        ),
+        hint: Some("Use an absolute command or include it in the container PATH".to_string()),
+    })
+}
+
+fn require_runtime_executable(rootfs: &Path, guest_path: &str) -> Result<()> {
+    if runtime_executable_exists(rootfs, guest_path)? {
+        Ok(())
+    } else {
+        Err(BoxError::BoxBootError {
+            message: format!(
+                "Sandbox executable {guest_path:?} is missing, not regular, or not executable in the prepared rootfs"
+            ),
+            hint: None,
+        })
+    }
+}
+
+fn runtime_executable_exists(rootfs: &Path, guest_path: &str) -> Result<bool> {
+    let host_path =
+        crate::oci::rootfs::resolve_guest_file_path(rootfs, guest_path.trim_start_matches('/'))?;
+    let metadata = match std::fs::metadata(&host_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(BoxError::IoError(error)),
+    };
+    if !metadata.is_file() {
+        return Ok(false);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+pub(crate) fn normalize_linux_guest_path(base: &str, value: &str, label: &str) -> Result<String> {
+    if value.is_empty() || value.contains('\0') {
+        return Err(BoxError::ConfigError(format!(
+            "Sandbox {label} must be non-empty and contain no NUL"
+        )));
+    }
+    if !base.starts_with('/') {
+        return Err(BoxError::ConfigError(format!(
+            "Sandbox {label} base is not absolute: {base:?}"
+        )));
+    }
+
+    let mut components = if value.starts_with('/') {
+        Vec::new()
+    } else {
+        base.split('/')
+            .filter(|component| !component.is_empty())
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+    };
+    for component in value.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                if components.pop().is_none() {
+                    return Err(BoxError::ConfigError(format!(
+                        "Sandbox {label} escapes the container root: {value:?}"
+                    )));
+                }
+            }
+            component => components.push(component.to_string()),
+        }
+    }
+    Ok(format!("/{}", components.join("/")))
+}

--- a/src/runtime/src/sandbox/mod.rs
+++ b/src/runtime/src/sandbox/mod.rs
@@ -143,8 +143,8 @@ impl a3s_box_core::vmm::VmHandler for A3sOciHandler {
     }
 }
 pub use oci::{
-    compile_oci_spec, SandboxBundleSpec, SandboxMount, SandboxResources, SandboxTmpfs,
-    DEFAULT_SANDBOX_PIDS_LIMIT,
+    compile_oci_spec, compile_runtime_owned_oci_spec, SandboxBundleSpec, SandboxMount,
+    SandboxResources, SandboxRuntimeProcess, SandboxTmpfs, DEFAULT_SANDBOX_PIDS_LIMIT,
 };
 pub use path_access::prepare_sandbox_path_access;
 pub use rootfs::{

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -199,16 +199,27 @@ pub struct SandboxBundleSpec {
     pub runtime_digest: String,
 }
 
+/// Container process compiled for the long-lived A3S OCI Runtime owner.
+///
+/// The executable, user and working directory are resolved against the
+/// prepared rootfs before this value reaches the compiler. Bootstrap listener
+/// descriptors deliberately have no representation here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxRuntimeProcess {
+    pub args: Vec<String>,
+    pub environment: Vec<(String, String)>,
+    pub cwd: PathBuf,
+    pub uid: u32,
+    pub gid: u32,
+    pub additional_gids: Vec<u32>,
+    pub dropped_capabilities: Vec<String>,
+}
+
 /// Compile a complete OCI config. Arbitrary caller-provided OCI JSON is never
 /// accepted by this backend.
 pub fn compile_oci_spec(input: &SandboxBundleSpec) -> Result<Spec> {
-    validate_box_id(&input.box_id)?;
-    validate_rootfs_path(&input.rootfs_path)?;
-    validate_hostname(&input.hostname)?;
+    validate_bundle_input(input)?;
     validate_init_path(&input.init_path)?;
-    validate_digest("execution plan", &input.execution_plan_digest)?;
-    validate_digest("runtime", &input.runtime_digest)?;
-    validate_id_mapping_plan(&input.id_mappings)?;
 
     let process = ProcessBuilder::default()
         .terminal(false)
@@ -227,6 +238,56 @@ pub fn compile_oci_spec(input: &SandboxBundleSpec) -> Result<Spec> {
         .build()
         .map_err(oci_error)?;
 
+    compile_spec(input, process, "guest-init")
+}
+
+/// Compile a complete OCI config whose PID 1 and I/O are owned directly by
+/// A3S OCI Runtime. The legacy guest-init listener variables are removed even
+/// if an image attempts to provide them.
+pub fn compile_runtime_owned_oci_spec(
+    input: &SandboxBundleSpec,
+    runtime_process: &SandboxRuntimeProcess,
+) -> Result<Spec> {
+    validate_bundle_input(input)?;
+    validate_runtime_process(runtime_process, &input.id_mappings)?;
+
+    let user = UserBuilder::default()
+        .uid(runtime_process.uid)
+        .gid(runtime_process.gid)
+        .additional_gids(runtime_process.additional_gids.clone())
+        .build()
+        .map_err(oci_error)?;
+    let process = ProcessBuilder::default()
+        .terminal(false)
+        .user(user)
+        .args(runtime_process.args.clone())
+        .env(compile_runtime_environment(&runtime_process.environment)?)
+        .cwd(runtime_process.cwd.clone())
+        .capabilities(compile_workload_capabilities(
+            &input.requested_capabilities,
+            &runtime_process.dropped_capabilities,
+        )?)
+        .no_new_privileges(true)
+        .build()
+        .map_err(oci_error)?;
+
+    compile_spec(input, process, "a3s-oci-runtime")
+}
+
+fn validate_bundle_input(input: &SandboxBundleSpec) -> Result<()> {
+    validate_box_id(&input.box_id)?;
+    validate_rootfs_path(&input.rootfs_path)?;
+    validate_hostname(&input.hostname)?;
+    validate_digest("execution plan", &input.execution_plan_digest)?;
+    validate_digest("runtime", &input.runtime_digest)?;
+    validate_id_mapping_plan(&input.id_mappings)
+}
+
+fn compile_spec(
+    input: &SandboxBundleSpec,
+    process: oci_spec::runtime::Process,
+    owner: &str,
+) -> Result<Spec> {
     let linux = LinuxBuilder::default()
         .uid_mappings(compile_id_mappings(&input.id_mappings.uid_mappings)?)
         .gid_mappings(compile_id_mappings(&input.id_mappings.gid_mappings)?)
@@ -258,6 +319,7 @@ pub fn compile_oci_spec(input: &SandboxBundleSpec) -> Result<Spec> {
         "com.a3s.box.isolation-class".to_string(),
         "shared-kernel".to_string(),
     );
+    annotations.insert("com.a3s.box.process-owner".to_string(), owner.to_string());
     annotations.insert(
         CONTROL_WORKLOAD_CGROUP_LAYOUT_ANNOTATION.to_string(),
         CONTROL_WORKLOAD_CGROUP_LAYOUT_V1.to_string(),
@@ -293,7 +355,16 @@ pub fn compile_oci_spec(input: &SandboxBundleSpec) -> Result<Spec> {
         .map_err(oci_error)
 }
 
-fn compile_environment(environment: &[(String, String)]) -> Result<Vec<String>> {
+const RESERVED_BOOTSTRAP_ENVIRONMENT: &[&str] = &[
+    "A3S_BOOTSTRAP_MODE",
+    "A3S_EXEC_LISTENER_FD",
+    "A3S_PTY_LISTENER_FD",
+    "A3S_INIT_LOG_FD",
+];
+
+fn validated_environment(
+    environment: &[(String, String)],
+) -> Result<std::collections::BTreeMap<String, String>> {
     let mut values = std::collections::BTreeMap::new();
     for (key, value) in environment {
         if key.is_empty() || key.contains(['=', '\0']) || value.contains('\0') {
@@ -306,6 +377,11 @@ fn compile_environment(environment: &[(String, String)]) -> Result<Vec<String>> 
     values.entry("PATH".to_string()).or_insert_with(|| {
         "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string()
     });
+    Ok(values)
+}
+
+fn compile_environment(environment: &[(String, String)]) -> Result<Vec<String>> {
+    let mut values = validated_environment(environment)?;
     values.insert("A3S_BOOTSTRAP_MODE".to_string(), "host-sandbox".to_string());
     values.insert("A3S_EXEC_LISTENER_FD".to_string(), "3".to_string());
     values.insert("A3S_PTY_LISTENER_FD".to_string(), "4".to_string());
@@ -315,6 +391,48 @@ fn compile_environment(environment: &[(String, String)]) -> Result<Vec<String>> 
         .into_iter()
         .map(|(key, value)| format!("{key}={value}"))
         .collect())
+}
+
+fn compile_runtime_environment(environment: &[(String, String)]) -> Result<Vec<String>> {
+    let mut values = validated_environment(environment)?;
+    for reserved in RESERVED_BOOTSTRAP_ENVIRONMENT {
+        values.remove(*reserved);
+    }
+    Ok(values
+        .into_iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect())
+}
+
+fn validate_runtime_process(
+    process: &SandboxRuntimeProcess,
+    id_mappings: &SandboxIdMappingPlan,
+) -> Result<()> {
+    let executable = process.args.first().ok_or_else(|| {
+        BoxError::ConfigError("Sandbox runtime-owned process requires an executable".to_string())
+    })?;
+    validate_linux_absolute_normalized(Path::new(executable), "process executable")?;
+    if process.args.iter().any(|argument| argument.contains('\0')) {
+        return Err(BoxError::ConfigError(
+            "Sandbox process arguments must not contain NUL".to_string(),
+        ));
+    }
+    validate_linux_absolute_normalized(&process.cwd, "process working directory")?;
+    if process.uid > id_mappings.maximum_container_uid {
+        return Err(BoxError::ConfigError(format!(
+            "Sandbox process UID {} exceeds the mapped maximum {}",
+            process.uid, id_mappings.maximum_container_uid
+        )));
+    }
+    for gid in std::iter::once(&process.gid).chain(process.additional_gids.iter()) {
+        if *gid > id_mappings.maximum_container_gid {
+            return Err(BoxError::ConfigError(format!(
+                "Sandbox process GID {gid} exceeds the mapped maximum {}",
+                id_mappings.maximum_container_gid
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn compile_capabilities(requested: &[String]) -> Result<oci_spec::runtime::LinuxCapabilities> {
@@ -351,13 +469,68 @@ fn compile_capabilities(requested: &[String]) -> Result<oci_spec::runtime::Linux
         .map_err(oci_error)
 }
 
-fn parse_allowed_capability(value: &str) -> Result<Capability> {
-    let normalized = value
-        .trim()
-        .to_ascii_uppercase()
+fn compile_workload_capabilities(
+    added: &[String],
+    dropped: &[String],
+) -> Result<oci_spec::runtime::LinuxCapabilities> {
+    let mut names: std::collections::BTreeSet<String> = [
+        "CHOWN",
+        "DAC_OVERRIDE",
+        "FOWNER",
+        "FSETID",
+        "KILL",
+        "NET_BIND_SERVICE",
+        "SETGID",
+        "SETPCAP",
+        "SETUID",
+        "SYS_CHROOT",
+    ]
+    .into_iter()
+    .map(ToString::to_string)
+    .collect();
+
+    for capability in added {
+        let normalized = normalize_capability_name(capability);
+        parse_allowed_capability(&normalized)?;
+        names.insert(normalized);
+    }
+    if dropped
+        .iter()
+        .any(|capability| normalize_capability_name(capability) == "ALL")
+    {
+        names.clear();
+    } else {
+        for capability in dropped {
+            let normalized = normalize_capability_name(capability);
+            parse_allowed_capability(&normalized)?;
+            names.remove(&normalized);
+        }
+    }
+
+    let capabilities = names
+        .iter()
+        .map(|capability| parse_allowed_capability(capability))
+        .collect::<Result<Capabilities>>()?;
+    LinuxCapabilitiesBuilder::default()
+        .bounding(capabilities.clone())
+        .effective(capabilities.clone())
+        .permitted(capabilities)
+        .inheritable(HashSet::<Capability>::new())
+        .ambient(HashSet::<Capability>::new())
+        .build()
+        .map_err(oci_error)
+}
+
+fn normalize_capability_name(value: &str) -> String {
+    let normalized = value.trim().to_ascii_uppercase();
+    normalized
         .strip_prefix("CAP_")
-        .map(ToString::to_string)
-        .unwrap_or_else(|| value.trim().to_ascii_uppercase());
+        .unwrap_or(&normalized)
+        .to_string()
+}
+
+fn parse_allowed_capability(value: &str) -> Result<Capability> {
+    let normalized = normalize_capability_name(value);
     let capability = match normalized.as_str() {
         "AUDIT_WRITE" => Capability::AuditWrite,
         "CHOWN" => Capability::Chown,
@@ -1342,6 +1515,79 @@ mod tests {
 
     fn as_json(spec: &Spec) -> Value {
         serde_json::to_value(spec).unwrap()
+    }
+
+    fn sample_runtime_process() -> SandboxRuntimeProcess {
+        SandboxRuntimeProcess {
+            args: vec!["/usr/bin/example".to_string(), "--serve".to_string()],
+            environment: vec![
+                ("APP_MODE".to_string(), "production".to_string()),
+                ("A3S_EXEC_LISTENER_FD".to_string(), "99".to_string()),
+                ("A3S_PTY_LISTENER_FD".to_string(), "98".to_string()),
+                ("A3S_INIT_LOG_FD".to_string(), "97".to_string()),
+                ("A3S_BOOTSTRAP_MODE".to_string(), "image-value".to_string()),
+            ],
+            cwd: PathBuf::from("/workspace"),
+            uid: 123,
+            gid: 456,
+            additional_gids: vec![789],
+            dropped_capabilities: vec!["SETUID".to_string()],
+        }
+    }
+
+    #[test]
+    fn runtime_owned_compiler_uses_direct_process_without_bootstrap_descriptors() {
+        let value = as_json(
+            &compile_runtime_owned_oci_spec(&sample_input(), &sample_runtime_process()).unwrap(),
+        );
+        assert_eq!(
+            value["process"]["args"],
+            serde_json::json!(["/usr/bin/example", "--serve"])
+        );
+        assert_eq!(value["process"]["cwd"], "/workspace");
+        assert_eq!(value["process"]["user"]["uid"], 123);
+        assert_eq!(value["process"]["user"]["gid"], 456);
+        assert_eq!(
+            value["process"]["user"]["additionalGids"],
+            serde_json::json!([789])
+        );
+        assert_eq!(
+            value["annotations"]["com.a3s.box.process-owner"],
+            "a3s-oci-runtime"
+        );
+        let environment = value["process"]["env"].as_array().unwrap();
+        assert!(environment
+            .iter()
+            .any(|value| value == "APP_MODE=production"));
+        for reserved in RESERVED_BOOTSTRAP_ENVIRONMENT {
+            assert!(
+                !environment.iter().any(|value| value
+                    .as_str()
+                    .is_some_and(|value| value.starts_with(&format!("{reserved}=")))),
+                "runtime-owned process retained {reserved}"
+            );
+        }
+        let bounding = value["process"]["capabilities"]["bounding"]
+            .as_array()
+            .unwrap();
+        assert!(!bounding.iter().any(|value| value == "CAP_SETUID"));
+        assert!(bounding.iter().any(|value| value == "CAP_CHOWN"));
+    }
+
+    #[test]
+    fn runtime_owned_compiler_rejects_relative_executable_and_unmapped_user() {
+        let input = sample_input();
+        let mut process = sample_runtime_process();
+        process.args[0] = "example".to_string();
+        assert!(compile_runtime_owned_oci_spec(&input, &process).is_err());
+
+        process.args[0] = "/usr/bin/example".to_string();
+        process.uid = input.id_mappings.maximum_container_uid + 1;
+        assert!(compile_runtime_owned_oci_spec(&input, &process).is_err());
+
+        process.uid = 0;
+        process.dropped_capabilities = vec!["NOT_A_CAPABILITY".to_string()];
+        assert!(compile_runtime_owned_oci_spec(&input, &process).is_err());
     }
 
     #[test]

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -215,6 +215,25 @@ pub struct SandboxRuntimeProcess {
     pub dropped_capabilities: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SandboxProcessOwner {
+    GuestInit,
+    RuntimeOwned,
+}
+
+impl SandboxProcessOwner {
+    const fn annotation(self) -> &'static str {
+        match self {
+            Self::GuestInit => "guest-init",
+            Self::RuntimeOwned => "a3s-oci-runtime",
+        }
+    }
+
+    const fn uses_control_workload_cgroup(self) -> bool {
+        matches!(self, Self::GuestInit)
+    }
+}
+
 /// Compile a complete OCI config. Arbitrary caller-provided OCI JSON is never
 /// accepted by this backend.
 pub fn compile_oci_spec(input: &SandboxBundleSpec) -> Result<Spec> {
@@ -238,7 +257,7 @@ pub fn compile_oci_spec(input: &SandboxBundleSpec) -> Result<Spec> {
         .build()
         .map_err(oci_error)?;
 
-    compile_spec(input, process, "guest-init")
+    compile_spec(input, process, SandboxProcessOwner::GuestInit)
 }
 
 /// Compile a complete OCI config whose PID 1 and I/O are owned directly by
@@ -271,7 +290,7 @@ pub fn compile_runtime_owned_oci_spec(
         .build()
         .map_err(oci_error)?;
 
-    compile_spec(input, process, "a3s-oci-runtime")
+    compile_spec(input, process, SandboxProcessOwner::RuntimeOwned)
 }
 
 fn validate_bundle_input(input: &SandboxBundleSpec) -> Result<()> {
@@ -286,7 +305,7 @@ fn validate_bundle_input(input: &SandboxBundleSpec) -> Result<()> {
 fn compile_spec(
     input: &SandboxBundleSpec,
     process: oci_spec::runtime::Process,
-    owner: &str,
+    owner: SandboxProcessOwner,
 ) -> Result<Spec> {
     let linux = LinuxBuilder::default()
         .uid_mappings(compile_id_mappings(&input.id_mappings.uid_mappings)?)
@@ -319,23 +338,28 @@ fn compile_spec(
         "com.a3s.box.isolation-class".to_string(),
         "shared-kernel".to_string(),
     );
-    annotations.insert("com.a3s.box.process-owner".to_string(), owner.to_string());
     annotations.insert(
-        CONTROL_WORKLOAD_CGROUP_LAYOUT_ANNOTATION.to_string(),
-        CONTROL_WORKLOAD_CGROUP_LAYOUT_V1.to_string(),
+        "com.a3s.box.process-owner".to_string(),
+        owner.annotation().to_string(),
     );
-    annotations.insert(
-        CONTROL_CGROUP_MEMORY_HEADROOM_ANNOTATION.to_string(),
-        SANDBOX_CONTROL_MEMORY_HEADROOM_BYTES.to_string(),
-    );
-    annotations.insert(
-        CONTROL_CGROUP_CPU_HEADROOM_ANNOTATION.to_string(),
-        input.resources.cpu_period.to_string(),
-    );
-    annotations.insert(
-        CONTROL_CGROUP_PIDS_HEADROOM_ANNOTATION.to_string(),
-        SANDBOX_CONTROL_PIDS_HEADROOM.to_string(),
-    );
+    if owner.uses_control_workload_cgroup() {
+        annotations.insert(
+            CONTROL_WORKLOAD_CGROUP_LAYOUT_ANNOTATION.to_string(),
+            CONTROL_WORKLOAD_CGROUP_LAYOUT_V1.to_string(),
+        );
+        annotations.insert(
+            CONTROL_CGROUP_MEMORY_HEADROOM_ANNOTATION.to_string(),
+            SANDBOX_CONTROL_MEMORY_HEADROOM_BYTES.to_string(),
+        );
+        annotations.insert(
+            CONTROL_CGROUP_CPU_HEADROOM_ANNOTATION.to_string(),
+            input.resources.cpu_period.to_string(),
+        );
+        annotations.insert(
+            CONTROL_CGROUP_PIDS_HEADROOM_ANNOTATION.to_string(),
+            SANDBOX_CONTROL_PIDS_HEADROOM.to_string(),
+        );
+    }
 
     SpecBuilder::default()
         .version("1.1.0".to_string())
@@ -1554,6 +1578,22 @@ mod tests {
         assert_eq!(
             value["annotations"]["com.a3s.box.process-owner"],
             "a3s-oci-runtime"
+        );
+        let annotations = value["annotations"].as_object().unwrap();
+        for annotation in [
+            CONTROL_WORKLOAD_CGROUP_LAYOUT_ANNOTATION,
+            CONTROL_CGROUP_MEMORY_HEADROOM_ANNOTATION,
+            CONTROL_CGROUP_CPU_HEADROOM_ANNOTATION,
+            CONTROL_CGROUP_PIDS_HEADROOM_ANNOTATION,
+        ] {
+            assert!(
+                !annotations.contains_key(annotation),
+                "runtime-owned process retained guest-init cgroup annotation {annotation}"
+            );
+        }
+        assert_eq!(
+            value["linux"]["resources"]["memory"]["limit"],
+            512 * 1024 * 1024i64
         );
         let environment = value["process"]["env"].as_array().unwrap();
         assert!(environment

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -17,14 +17,22 @@ use crate::sandbox::rootfs::{
 };
 use crate::sandbox::A3sOciController;
 use crate::sandbox::{
-    compile_oci_spec, plan_id_mappings, prepare_managed_mount_source,
-    prepare_managed_secret_mount_source, prepare_sandbox_path_access,
+    compile_oci_spec, compile_runtime_owned_oci_spec, plan_id_mappings,
+    prepare_managed_mount_source, prepare_managed_secret_mount_source, prepare_sandbox_path_access,
     probe_sandbox_capabilities_for, stage_read_only_mount_aliases, validate_external_mount_access,
-    write_bundle, SandboxBundleSpec, SandboxLaunchSpec, SandboxMount, SandboxResources,
-    SandboxTmpfs,
+    write_bundle, SandboxBundleSpec, SandboxCapabilitySnapshot, SandboxLaunchSpec, SandboxMount,
+    SandboxResources, SandboxRuntimeProcess, SandboxTmpfs,
 };
 
 use super::{BoxState, VmManager};
+
+/// Product-owned bundle ready to be loaded through the public A3S OCI SDK.
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeOwnedSandboxBundle {
+    pub bundle_dir: PathBuf,
+    pub console_output: PathBuf,
+    pub anonymous_volumes: Vec<String>,
+}
 
 impl VmManager {
     pub(super) async fn boot_sandbox(
@@ -301,6 +309,175 @@ impl VmManager {
             "sandbox.start_total",
             boot_start.elapsed(),
         );
+        Ok(())
+    }
+
+    /// Prepare a Sandbox bundle for a long-lived OCI Runtime service. The
+    /// runtime owns PID 1 and process I/O, so this path compiles the image
+    /// process directly instead of launching Box guest-init with inherited FDs.
+    pub(crate) async fn prepare_runtime_owned_sandbox_bundle(
+        &mut self,
+        execution_plan: &ResolvedExecutionPlan,
+        capabilities: &SandboxCapabilitySnapshot,
+    ) -> Result<RuntimeOwnedSandboxBundle> {
+        if execution_plan.backend != a3s_box_core::ExecutionBackend::A3sOci {
+            return Err(BoxError::BoxBootError {
+                message: "A3S OCI Runtime is the only supported Sandbox backend".to_string(),
+                hint: None,
+            });
+        }
+        capabilities.require_ready()?;
+        let runtime = capabilities
+            .a3s_oci
+            .as_ref()
+            .ok_or_else(|| BoxError::BoxBootError {
+                message: "Sandbox capability probe returned no A3S OCI artifacts".to_string(),
+                hint: None,
+            })?;
+        let user_namespace =
+            capabilities
+                .user_namespace
+                .as_ref()
+                .ok_or_else(|| BoxError::BoxBootError {
+                    message: "Sandbox capability probe did not return user-namespace evidence"
+                        .to_string(),
+                    hint: None,
+                })?;
+        let runtime_digest =
+            combined_runtime_digest(&runtime.runtime_sha256, &runtime.agent_sha256);
+        let original_anonymous_volumes = self.anonymous_volumes.clone();
+        let box_dir = self.home_dir.join("boxes").join(&self.box_id);
+        let bundle_dir = box_dir.join("sandbox").join("oci-sdk-bundle");
+
+        let layout = match self.prepare_layout().await {
+            Ok(layout) => layout,
+            Err(error) => {
+                self.cleanup_boot_failure().await;
+                return Err(error);
+            }
+        };
+        self.image_config = layout.oci_config.clone();
+
+        let prepare = (|| -> Result<RuntimeOwnedSandboxBundle> {
+            a3s_box_core::rootfs_metadata::stage_terminal_rootfs_metadata_for_boot(
+                &layout.rootfs_path,
+            )?;
+            let resolv_content = a3s_box_core::dns::generate_resolv_conf(&self.config.dns);
+            crate::oci::rootfs::write_guest_file(
+                &layout.rootfs_path,
+                "etc/resolv.conf",
+                resolv_content,
+            )?;
+            self.write_hostname_file(&layout)?;
+            self.write_standalone_hosts_file(&layout)?;
+
+            let resources = SandboxResources::from_box_config(&self.config)?;
+            let instance_spec = self.build_runtime_owned_instance_spec(&layout)?;
+            if self.anonymous_volumes != original_anonymous_volumes {
+                return Err(BoxError::ConfigError(
+                    "OCI migration does not yet introduce image-declared anonymous volumes; create an explicit named or bind mount before enabling migration"
+                        .to_string(),
+                ));
+            }
+            let runtime_process = resolve_runtime_owned_process(
+                &layout.rootfs_path,
+                &instance_spec,
+                &self.config.cap_drop,
+            )?;
+            let (mut mounts, tmpfs) = self.compile_sandbox_mounts(&layout, &instance_spec)?;
+            ensure_mount_destinations(&layout.rootfs_path, &mounts, &tmpfs)?;
+
+            let rootfs_ids = inspect_rootfs_identity_requirements_with_preference(
+                &layout.rootfs_path,
+                layout.prefer_image_rootfs_metadata,
+            )?;
+            let (account_uid, account_gid) = maximum_account_ids(&layout.rootfs_path)?;
+            let process_uid = runtime_process.uid;
+            let process_gid = std::iter::once(runtime_process.gid)
+                .chain(runtime_process.additional_gids.iter().copied())
+                .max()
+                .unwrap_or(0);
+            let maximum_uid = rootfs_ids.maximum_uid.max(account_uid).max(process_uid);
+            let maximum_gid = rootfs_ids.maximum_gid.max(account_gid).max(process_gid);
+            let id_mappings = plan_id_mappings(user_namespace, maximum_uid, maximum_gid)?;
+
+            self.prepare_sandbox_mount_sources(&layout, &mut mounts, &id_mappings)?;
+            prepare_rootfs_ownership_with_preference(
+                &layout.rootfs_path,
+                &id_mappings,
+                user_namespace.effective_uid,
+                self.config.read_only,
+                layout.prefer_image_rootfs_metadata,
+            )?;
+
+            let bundle_spec = SandboxBundleSpec {
+                box_id: self.box_id.clone(),
+                rootfs_path: layout.rootfs_path.clone(),
+                rootfs_read_only: self.config.read_only,
+                hostname: self
+                    .config
+                    .hostname
+                    .clone()
+                    .unwrap_or_else(|| self.box_id.clone()),
+                // Unused by the runtime-owned compiler, but retained in the
+                // shared bundle input so mount/resource policy has one source.
+                init_path: "/sbin/init".to_string(),
+                init_environment: Vec::new(),
+                mounts,
+                tmpfs,
+                id_mappings,
+                resources,
+                requested_capabilities: self.config.cap_add.clone(),
+                execution_plan_digest: digest_json(execution_plan)?,
+                runtime_digest,
+            };
+            let oci_spec = compile_runtime_owned_oci_spec(&bundle_spec, &runtime_process)?;
+            write_bundle(&bundle_dir, &oci_spec, execution_plan, capabilities)?;
+            prepare_sandbox_path_access(
+                &self.home_dir,
+                &self.box_id,
+                &bundle_dir,
+                &layout.rootfs_path,
+                &bundle_spec.mounts,
+                &bundle_spec.id_mappings,
+            )?;
+            self.create_diff_baseline(&layout);
+
+            Ok(RuntimeOwnedSandboxBundle {
+                bundle_dir,
+                console_output: instance_spec
+                    .console_output
+                    .unwrap_or_else(|| box_dir.join("logs").join("console.log")),
+                anonymous_volumes: self.anonymous_volumes.clone(),
+            })
+        })();
+
+        match prepare {
+            Ok(prepared) => Ok(prepared),
+            Err(error) => {
+                self.cleanup_boot_failure().await;
+                Err(error)
+            }
+        }
+    }
+
+    /// Detach preparation-owned mounts after the OCI Runtime has deleted the
+    /// exact generation. Persistent writable data follows normal Box policy.
+    pub(crate) fn cleanup_runtime_owned_sandbox_bundle(&self) -> Result<()> {
+        let box_dir = self.home_dir.join("boxes").join(&self.box_id);
+        crate::sandbox::cleanup_sandbox_mount_aliases(&self.home_dir, &self.box_id)?;
+        self.rootfs_provider
+            .cleanup(&box_dir, self.config.persistent)?;
+        for path in [
+            box_dir.join("sandbox").join("oci-sdk-bundle"),
+            self.socket_dir(),
+        ] {
+            match std::fs::remove_dir_all(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(BoxError::IoError(error)),
+            }
+        }
         Ok(())
     }
 
@@ -718,6 +895,321 @@ fn ensure_mount_destination(rootfs: &Path, destination: &Path, file: bool) -> Re
     Ok(())
 }
 
+const DEFAULT_CONTAINER_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+#[derive(Debug, Clone)]
+struct RuntimePasswdEntry {
+    name: String,
+    uid: u32,
+    gid: u32,
+    home: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeGroupEntry {
+    name: String,
+    gid: u32,
+    members: Vec<String>,
+}
+
+fn resolve_runtime_owned_process(
+    rootfs: &Path,
+    instance_spec: &crate::vmm::InstanceSpec,
+    dropped_capabilities: &[String],
+) -> Result<SandboxRuntimeProcess> {
+    let cwd = normalize_linux_guest_path("/", &instance_spec.workdir, "working directory")?;
+    crate::oci::rootfs::ensure_guest_directory(rootfs, cwd.trim_start_matches('/'))?;
+
+    let mut environment = instance_spec.entrypoint.env.clone();
+    let path = environment
+        .iter()
+        .rev()
+        .find_map(|(key, value)| (key == "PATH").then_some(value.as_str()))
+        .unwrap_or(DEFAULT_CONTAINER_PATH);
+    let executable =
+        resolve_runtime_executable(rootfs, &cwd, path, &instance_spec.entrypoint.executable)?;
+    let identity = resolve_runtime_identity(rootfs, instance_spec.user.as_deref())?;
+    if !environment.iter().any(|(key, _)| key == "HOME") {
+        if let Some(home) = identity.home.as_ref() {
+            environment.push(("HOME".to_string(), home.clone()));
+        }
+    }
+    let mut args = Vec::with_capacity(instance_spec.entrypoint.args.len() + 1);
+    args.push(executable);
+    args.extend(instance_spec.entrypoint.args.iter().cloned());
+
+    Ok(SandboxRuntimeProcess {
+        args,
+        environment,
+        cwd: PathBuf::from(cwd),
+        uid: identity.uid,
+        gid: identity.gid,
+        additional_gids: identity.additional_gids,
+        dropped_capabilities: dropped_capabilities.to_vec(),
+    })
+}
+
+fn resolve_runtime_executable(
+    rootfs: &Path,
+    cwd: &str,
+    path: &str,
+    command: &str,
+) -> Result<String> {
+    if command.is_empty() || command.contains('\0') {
+        return Err(BoxError::ConfigError(
+            "Sandbox runtime-owned executable must be non-empty and contain no NUL".to_string(),
+        ));
+    }
+
+    if command.contains('/') {
+        let candidate = normalize_linux_guest_path(cwd, command, "process executable")?;
+        require_runtime_executable(rootfs, &candidate)?;
+        return Ok(candidate);
+    }
+
+    for directory in path.split(':') {
+        let directory = if directory.is_empty() { cwd } else { directory };
+        let directory = normalize_linux_guest_path(cwd, directory, "PATH entry")?;
+        let candidate =
+            normalize_linux_guest_path(&directory, command, "PATH-resolved process executable")?;
+        if runtime_executable_exists(rootfs, &candidate)? {
+            return Ok(candidate);
+        }
+    }
+    Err(BoxError::BoxBootError {
+        message: format!(
+            "Sandbox executable {command:?} was not found as an executable file in the prepared rootfs PATH"
+        ),
+        hint: Some("Use an absolute image ENTRYPOINT or include it in PATH".to_string()),
+    })
+}
+
+fn require_runtime_executable(rootfs: &Path, guest_path: &str) -> Result<()> {
+    if runtime_executable_exists(rootfs, guest_path)? {
+        Ok(())
+    } else {
+        Err(BoxError::BoxBootError {
+            message: format!(
+                "Sandbox executable {guest_path:?} is missing, not regular, or not executable in the prepared rootfs"
+            ),
+            hint: None,
+        })
+    }
+}
+
+fn runtime_executable_exists(rootfs: &Path, guest_path: &str) -> Result<bool> {
+    let host_path =
+        crate::oci::rootfs::resolve_guest_file_path(rootfs, guest_path.trim_start_matches('/'))?;
+    let metadata = match std::fs::metadata(&host_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(BoxError::IoError(error)),
+    };
+    if !metadata.is_file() {
+        return Ok(false);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn normalize_linux_guest_path(base: &str, value: &str, label: &str) -> Result<String> {
+    if value.is_empty() || value.contains('\0') {
+        return Err(BoxError::ConfigError(format!(
+            "Sandbox {label} must be non-empty and contain no NUL"
+        )));
+    }
+    if !base.starts_with('/') {
+        return Err(BoxError::ConfigError(format!(
+            "Sandbox {label} base is not absolute: {base:?}"
+        )));
+    }
+
+    let mut components = if value.starts_with('/') {
+        Vec::new()
+    } else {
+        base.split('/')
+            .filter(|component| !component.is_empty())
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+    };
+    for component in value.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                if components.pop().is_none() {
+                    return Err(BoxError::ConfigError(format!(
+                        "Sandbox {label} escapes the container root: {value:?}"
+                    )));
+                }
+            }
+            component => components.push(component.to_string()),
+        }
+    }
+    Ok(format!("/{}", components.join("/")))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeIdentity {
+    uid: u32,
+    gid: u32,
+    additional_gids: Vec<u32>,
+    home: Option<String>,
+}
+
+fn resolve_runtime_identity(rootfs: &Path, requested: Option<&str>) -> Result<RuntimeIdentity> {
+    let passwd = runtime_passwd_entries(rootfs)?;
+    let groups = runtime_group_entries(rootfs)?;
+    let Some(requested) = requested.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(RuntimeIdentity {
+            uid: 0,
+            gid: 0,
+            additional_gids: Vec::new(),
+            home: None,
+        });
+    };
+    if requested.matches(':').count() > 1 {
+        return Err(BoxError::ConfigError(format!(
+            "Invalid Sandbox user {requested:?}; expected user[:group]"
+        )));
+    }
+    let (user_part, group_part) = requested
+        .split_once(':')
+        .map_or((requested, None), |(user, group)| (user, Some(group)));
+    if user_part.is_empty() || group_part.is_some_and(str::is_empty) {
+        return Err(BoxError::ConfigError(format!(
+            "Invalid Sandbox user {requested:?}; user and group must be non-empty"
+        )));
+    }
+
+    let passwd_entry = if user_part == "root" {
+        passwd.iter().find(|entry| entry.uid == 0)
+    } else if let Ok(uid) = user_part.parse::<u32>() {
+        passwd.iter().find(|entry| entry.uid == uid)
+    } else {
+        Some(
+            passwd
+                .iter()
+                .find(|entry| entry.name == user_part)
+                .ok_or_else(|| {
+                    BoxError::ConfigError(format!(
+                "Sandbox user {user_part:?} is not present in the prepared rootfs /etc/passwd"
+            ))
+                })?,
+        )
+    };
+    let uid = if user_part == "root" {
+        0
+    } else {
+        user_part
+            .parse::<u32>()
+            .ok()
+            .or_else(|| passwd_entry.map(|entry| entry.uid))
+            .ok_or_else(|| {
+                BoxError::ConfigError(format!("Sandbox user {user_part:?} cannot be resolved"))
+            })?
+    };
+    let gid = match group_part {
+        Some("root") => 0,
+        Some(group) => group
+            .parse::<u32>()
+            .ok()
+            .or_else(|| {
+                groups
+                    .iter()
+                    .find(|entry| entry.name == group)
+                    .map(|entry| entry.gid)
+            })
+            .ok_or_else(|| {
+                BoxError::ConfigError(format!(
+                    "Sandbox group {group:?} is not present in the prepared rootfs /etc/group"
+                ))
+            })?,
+        None => passwd_entry.map(|entry| entry.gid).unwrap_or(0),
+    };
+    let username = if user_part.parse::<u32>().is_ok() || user_part == "root" {
+        passwd_entry.map(|entry| entry.name.as_str())
+    } else {
+        Some(user_part)
+    };
+    let mut additional_gids = groups
+        .iter()
+        .filter(|entry| {
+            entry.gid != gid
+                && username
+                    .is_some_and(|username| entry.members.iter().any(|member| member == username))
+        })
+        .map(|entry| entry.gid)
+        .collect::<Vec<_>>();
+    additional_gids.sort_unstable();
+    additional_gids.dedup();
+
+    let home = passwd_entry
+        .and_then(|entry| entry.home.as_deref())
+        .map(|home| normalize_linux_guest_path("/", home, "user home"))
+        .transpose()?;
+    Ok(RuntimeIdentity {
+        uid,
+        gid,
+        additional_gids,
+        home,
+    })
+}
+
+fn runtime_passwd_entries(rootfs: &Path) -> Result<Vec<RuntimePasswdEntry>> {
+    let Some(contents) = crate::oci::rootfs::read_guest_file_to_string(rootfs, "etc/passwd")?
+    else {
+        return Ok(Vec::new());
+    };
+    Ok(contents
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .filter_map(|line| {
+            let fields = line.split(':').collect::<Vec<_>>();
+            if fields.len() < 7 || fields[0].is_empty() {
+                return None;
+            }
+            Some(RuntimePasswdEntry {
+                name: fields[0].to_string(),
+                uid: fields[2].parse().ok()?,
+                gid: fields[3].parse().ok()?,
+                home: (!fields[5].is_empty()).then(|| fields[5].to_string()),
+            })
+        })
+        .collect())
+}
+
+fn runtime_group_entries(rootfs: &Path) -> Result<Vec<RuntimeGroupEntry>> {
+    let Some(contents) = crate::oci::rootfs::read_guest_file_to_string(rootfs, "etc/group")? else {
+        return Ok(Vec::new());
+    };
+    Ok(contents
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .filter_map(|line| {
+            let fields = line.split(':').collect::<Vec<_>>();
+            if fields.len() < 4 || fields[0].is_empty() {
+                return None;
+            }
+            Some(RuntimeGroupEntry {
+                name: fields[0].to_string(),
+                gid: fields[2].parse().ok()?,
+                members: fields[3]
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|member| !member.is_empty())
+                    .map(ToString::to_string)
+                    .collect(),
+            })
+        })
+        .collect())
+}
+
 fn maximum_account_ids(rootfs: &Path) -> Result<(u32, u32)> {
     let mut maximum_uid = 0u32;
     let mut maximum_gid = 0u32;
@@ -851,6 +1343,57 @@ mod tests {
     use a3s_box_core::{volume::VolumeConfig, BoxConfig, EventEmitter};
 
     use super::*;
+
+    #[test]
+    fn runtime_owned_process_resolves_path_and_named_identity_from_rootfs() {
+        let rootfs = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(rootfs.path().join("usr/local/bin")).unwrap();
+        std::fs::create_dir_all(rootfs.path().join("etc")).unwrap();
+        let executable = rootfs.path().join("usr/local/bin/example");
+        std::fs::write(&executable, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        std::fs::write(
+            rootfs.path().join("etc/passwd"),
+            "root:x:0:0:root:/root:/bin/sh\napp:x:1001:1002:App:/home/app:/bin/sh\n",
+        )
+        .unwrap();
+        std::fs::write(
+            rootfs.path().join("etc/group"),
+            "app:x:1002:\nmetrics:x:1003:app\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_runtime_executable(
+                rootfs.path(),
+                "/workspace",
+                "/usr/local/bin:/bin",
+                "example"
+            )
+            .unwrap(),
+            "/usr/local/bin/example"
+        );
+        assert_eq!(
+            resolve_runtime_identity(rootfs.path(), Some("app")).unwrap(),
+            RuntimeIdentity {
+                uid: 1001,
+                gid: 1002,
+                additional_gids: vec![1003],
+                home: Some("/home/app".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_owned_process_rejects_root_escape_and_unknown_named_user() {
+        let rootfs = tempfile::tempdir().unwrap();
+        assert!(normalize_linux_guest_path("/", "../../host", "test").is_err());
+        assert!(resolve_runtime_identity(rootfs.path(), Some("missing")).is_err());
+    }
 
     #[test]
     fn parses_volume_and_tmpfs_without_shell_interpretation() {

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -12,6 +12,9 @@ use a3s_box_core::guest_exec::{
 use base64::Engine;
 use sha2::{Digest, Sha256};
 
+use crate::process_path::{
+    normalize_linux_guest_path, resolve_runtime_executable, DEFAULT_CONTAINER_PATH,
+};
 use crate::sandbox::rootfs::{
     inspect_rootfs_identity_requirements_with_preference, prepare_rootfs_ownership_with_preference,
 };
@@ -892,8 +895,6 @@ fn ensure_mount_destination(rootfs: &Path, destination: &Path, file: bool) -> Re
     Ok(())
 }
 
-const DEFAULT_CONTAINER_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-
 #[derive(Debug, Clone)]
 struct RuntimePasswdEntry {
     name: String,
@@ -944,111 +945,6 @@ fn resolve_runtime_owned_process(
         additional_gids: identity.additional_gids,
         dropped_capabilities: dropped_capabilities.to_vec(),
     })
-}
-
-fn resolve_runtime_executable(
-    rootfs: &Path,
-    cwd: &str,
-    path: &str,
-    command: &str,
-) -> Result<String> {
-    if command.is_empty() || command.contains('\0') {
-        return Err(BoxError::ConfigError(
-            "Sandbox runtime-owned executable must be non-empty and contain no NUL".to_string(),
-        ));
-    }
-
-    if command.contains('/') {
-        let candidate = normalize_linux_guest_path(cwd, command, "process executable")?;
-        require_runtime_executable(rootfs, &candidate)?;
-        return Ok(candidate);
-    }
-
-    for directory in path.split(':') {
-        let directory = if directory.is_empty() { cwd } else { directory };
-        let directory = normalize_linux_guest_path(cwd, directory, "PATH entry")?;
-        let candidate =
-            normalize_linux_guest_path(&directory, command, "PATH-resolved process executable")?;
-        if runtime_executable_exists(rootfs, &candidate)? {
-            return Ok(candidate);
-        }
-    }
-    Err(BoxError::BoxBootError {
-        message: format!(
-            "Sandbox executable {command:?} was not found as an executable file in the prepared rootfs PATH"
-        ),
-        hint: Some("Use an absolute image ENTRYPOINT or include it in PATH".to_string()),
-    })
-}
-
-fn require_runtime_executable(rootfs: &Path, guest_path: &str) -> Result<()> {
-    if runtime_executable_exists(rootfs, guest_path)? {
-        Ok(())
-    } else {
-        Err(BoxError::BoxBootError {
-            message: format!(
-                "Sandbox executable {guest_path:?} is missing, not regular, or not executable in the prepared rootfs"
-            ),
-            hint: None,
-        })
-    }
-}
-
-fn runtime_executable_exists(rootfs: &Path, guest_path: &str) -> Result<bool> {
-    let host_path =
-        crate::oci::rootfs::resolve_guest_file_path(rootfs, guest_path.trim_start_matches('/'))?;
-    let metadata = match std::fs::metadata(&host_path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(BoxError::IoError(error)),
-    };
-    if !metadata.is_file() {
-        return Ok(false);
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if metadata.permissions().mode() & 0o111 == 0 {
-            return Ok(false);
-        }
-    }
-    Ok(true)
-}
-
-fn normalize_linux_guest_path(base: &str, value: &str, label: &str) -> Result<String> {
-    if value.is_empty() || value.contains('\0') {
-        return Err(BoxError::ConfigError(format!(
-            "Sandbox {label} must be non-empty and contain no NUL"
-        )));
-    }
-    if !base.starts_with('/') {
-        return Err(BoxError::ConfigError(format!(
-            "Sandbox {label} base is not absolute: {base:?}"
-        )));
-    }
-
-    let mut components = if value.starts_with('/') {
-        Vec::new()
-    } else {
-        base.split('/')
-            .filter(|component| !component.is_empty())
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-    };
-    for component in value.split('/') {
-        match component {
-            "" | "." => {}
-            ".." => {
-                if components.pop().is_none() {
-                    return Err(BoxError::ConfigError(format!(
-                        "Sandbox {label} escapes the container root: {value:?}"
-                    )));
-                }
-            }
-            component => components.push(component.to_string()),
-        }
-    }
-    Ok(format!("/{}", components.join("/")))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -347,7 +347,7 @@ impl VmManager {
             combined_runtime_digest(&runtime.runtime_sha256, &runtime.agent_sha256);
         let original_anonymous_volumes = self.anonymous_volumes.clone();
         let box_dir = self.home_dir.join("boxes").join(&self.box_id);
-        let bundle_dir = box_dir.join("sandbox").join("oci-sdk-bundle");
+        let bundle_dir = box_dir.join("sandbox").join("bundle");
 
         let layout = match self.prepare_layout().await {
             Ok(layout) => layout,
@@ -468,10 +468,7 @@ impl VmManager {
         crate::sandbox::cleanup_sandbox_mount_aliases(&self.home_dir, &self.box_id)?;
         self.rootfs_provider
             .cleanup(&box_dir, self.config.persistent)?;
-        for path in [
-            box_dir.join("sandbox").join("oci-sdk-bundle"),
-            self.socket_dir(),
-        ] {
+        for path in [box_dir.join("sandbox").join("bundle"), self.socket_dir()] {
             match std::fs::remove_dir_all(&path) {
                 Ok(()) => {}
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}

--- a/src/runtime/src/vm/spec.rs
+++ b/src/runtime/src/vm/spec.rs
@@ -53,6 +53,24 @@ fn secure_guest_control_file(path: &Path) -> Result<()> {
 impl VmManager {
     /// Build InstanceSpec from config and layout.
     pub(crate) fn build_instance_spec(&mut self, layout: &BoxLayout) -> Result<InstanceSpec> {
+        self.build_instance_spec_with_bootstrap(layout, true)
+    }
+
+    /// Build the image process and filesystem view for an OCI runtime that owns
+    /// PID 1 and all process I/O itself. Unlike the VM bootstrap path, this must
+    /// not select the packaged guest init or inject its host-control variables.
+    pub(crate) fn build_runtime_owned_instance_spec(
+        &mut self,
+        layout: &BoxLayout,
+    ) -> Result<InstanceSpec> {
+        self.build_instance_spec_with_bootstrap(layout, false)
+    }
+
+    fn build_instance_spec_with_bootstrap(
+        &mut self,
+        layout: &BoxLayout,
+        include_guest_controls: bool,
+    ) -> Result<InstanceSpec> {
         // Build filesystem mounts
         let mut fs_mounts = vec![FsMount {
             tag: "workspace".to_string(),
@@ -149,7 +167,9 @@ impl VmManager {
 
         // Determine whether guest init is installed (it becomes PID 1 and
         // launches the container entrypoint from runtime control data).
-        let guest_init_exec = Self::guest_init_exec_path(&layout.rootfs_path);
+        let guest_init_exec = include_guest_controls
+            .then(|| Self::guest_init_exec_path(&layout.rootfs_path))
+            .flatten();
         // When guest init is PID 1 it applies the staged container user to the
         // main process itself; the shim must then NOT call libkrun set_uid
         // (which would drop PID 1 and break init). Only the legacy
@@ -453,46 +473,48 @@ impl VmManager {
                 .push(("A3S_TEE_SIMULATE".to_string(), "1".to_string()));
         }
 
-        #[cfg(target_os = "windows")]
-        {
-            // WHPX named-pipe mappings are guest-initiated. Keep the shared
-            // Windows host-control channel connected even without published
-            // ports so stop requests can reach guest init.
+        if include_guest_controls {
+            #[cfg(target_os = "windows")]
+            {
+                // WHPX named-pipe mappings are guest-initiated. Keep the shared
+                // Windows host-control channel connected even without published
+                // ports so stop requests can reach guest init.
+                entrypoint
+                    .env
+                    .push(("BOX_WINDOWS_PORT_FWD".to_string(), "1".to_string()));
+            }
+
+            #[cfg(not(target_os = "windows"))]
             entrypoint
                 .env
-                .push(("BOX_WINDOWS_PORT_FWD".to_string(), "1".to_string()));
-        }
+                .push(("BOX_CRI_PORT_FWD".to_string(), "1".to_string()));
 
-        #[cfg(not(target_os = "windows"))]
-        entrypoint
-            .env
-            .push(("BOX_CRI_PORT_FWD".to_string(), "1".to_string()));
+            if self.config.persistent {
+                entrypoint
+                    .env
+                    .push(("BOX_PERSIST_ROOTFS_METADATA".to_string(), "1".to_string()));
+            }
 
-        if self.config.persistent {
-            entrypoint
-                .env
-                .push(("BOX_PERSIST_ROOTFS_METADATA".to_string(), "1".to_string()));
-        }
-
-        // Inject sidecar configuration so guest-init can launch the sidecar process
-        if let Some(ref sidecar) = self.config.sidecar {
-            entrypoint
-                .env
-                .push(("BOX_SIDECAR_IMAGE".to_string(), sidecar.image.clone()));
-            entrypoint.env.push((
-                "BOX_SIDECAR_VSOCK_PORT".to_string(),
-                sidecar.vsock_port.to_string(),
-            ));
-            for (i, (key, value)) in sidecar.env.iter().enumerate() {
+            // Inject sidecar configuration so guest-init can launch the sidecar process.
+            if let Some(ref sidecar) = self.config.sidecar {
+                entrypoint
+                    .env
+                    .push(("BOX_SIDECAR_IMAGE".to_string(), sidecar.image.clone()));
                 entrypoint.env.push((
-                    format!("BOX_SIDECAR_ENV_{}", i),
-                    format!("{}={}", key, value),
+                    "BOX_SIDECAR_VSOCK_PORT".to_string(),
+                    sidecar.vsock_port.to_string(),
+                ));
+                for (i, (key, value)) in sidecar.env.iter().enumerate() {
+                    entrypoint.env.push((
+                        format!("BOX_SIDECAR_ENV_{}", i),
+                        format!("{}={}", key, value),
+                    ));
+                }
+                entrypoint.env.push((
+                    "BOX_SIDECAR_ENV_COUNT".to_string(),
+                    sidecar.env.len().to_string(),
                 ));
             }
-            entrypoint.env.push((
-                "BOX_SIDECAR_ENV_COUNT".to_string(),
-                sidecar.env.len().to_string(),
-            ));
         }
 
         // The CLI validates this up front; this also guards compose, CRI, SDK,

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -230,6 +230,25 @@ println!(
 Use `A3sBoxClient::from_home(path)` for tests or tools that should operate on a
 non-default a3s-box state directory.
 
+On Linux, applications participating in the opt-in long-lived OCI owner
+migration should use the async configured constructor:
+
+```rust
+use a3s_box_sdk::{A3sBoxClient, A3sBoxPaths};
+
+# async fn configured() -> Result<(), a3s_box_sdk::ClientError> {
+let paths = A3sBoxPaths::from_home("/var/lib/a3s-box");
+let client = A3sBoxClient::with_configured_paths(paths).await?;
+# let _ = client;
+# Ok(()) }
+```
+
+It honors `A3S_BOX_OCI_MIGRATION=sandbox` and the paired
+`A3S_BOX_OCI_RUNTIME_PATH`/`A3S_BOX_OCI_AGENT_PATH` overrides. For an
+environment-independent embedding, construct `NativeLinuxOciMigrationConfig`
+and pass it to `A3sBoxClient::with_native_linux_oci_migration`. Synchronous
+constructors intentionally retain the legacy backend.
+
 ## Managed Lifecycle
 
 The SDK submits lifecycle requests directly to the same generation-fenced

--- a/src/sdk/src/bridge.rs
+++ b/src/sdk/src/bridge.rs
@@ -213,7 +213,16 @@ pub async fn dispatch_json(input: &str) -> BridgeResponse {
             })
         }
     };
-    handle_request(&A3sBoxClient::new(), request).await
+    let client = match A3sBoxClient::with_configured_paths(crate::A3sBoxPaths::default()).await {
+        Ok(client) => client,
+        Err(error) => {
+            return BridgeResponse::failure(BridgeFailure {
+                code: "runtime_error",
+                message: format!("failed to configure local execution: {error}"),
+            })
+        }
+    };
+    handle_request(&client, request).await
 }
 
 pub async fn handle_request(client: &A3sBoxClient, request: BridgeRequest) -> BridgeResponse {

--- a/src/sdk/src/client/config.rs
+++ b/src/sdk/src/client/config.rs
@@ -44,6 +44,46 @@ impl A3sBoxClient {
         }
     }
 
+    /// Create a client that honors the explicit process-wide OCI migration
+    /// setting. With no opt-in this is equivalent to [`Self::with_paths`].
+    pub async fn with_configured_paths(paths: A3sBoxPaths) -> Result<Self> {
+        let local_execution_manager = Arc::new(
+            a3s_box_runtime::LocalExecutionManager::with_configured_backend(
+                paths.boxes_file.clone(),
+                paths.home.clone(),
+            )
+            .await?,
+        );
+        Ok(Self {
+            paths,
+            image_cache_size: a3s_box_runtime::DEFAULT_IMAGE_CACHE_SIZE,
+            execution_manager: local_execution_manager.clone(),
+            execution_session_manager: Some(local_execution_manager),
+        })
+    }
+
+    /// Create a client with a programmatic native-Linux Sandbox migration
+    /// configuration, independent of process environment parsing.
+    pub async fn with_native_linux_oci_migration(
+        paths: A3sBoxPaths,
+        config: a3s_box_runtime::NativeLinuxOciMigrationConfig,
+    ) -> Result<Self> {
+        let local_execution_manager = Arc::new(
+            a3s_box_runtime::LocalExecutionManager::with_native_linux_oci_migration(
+                paths.boxes_file.clone(),
+                paths.home.clone(),
+                config,
+            )
+            .await?,
+        );
+        Ok(Self {
+            paths,
+            image_cache_size: a3s_box_runtime::DEFAULT_IMAGE_CACHE_SIZE,
+            execution_manager: local_execution_manager.clone(),
+            execution_session_manager: Some(local_execution_manager),
+        })
+    }
+
     /// Create a client with an explicit backend-neutral execution manager.
     ///
     /// This keeps lifecycle calls on the canonical facade while allowing an

--- a/src/sdk/src/client/core.rs
+++ b/src/sdk/src/client/core.rs
@@ -216,6 +216,52 @@ impl A3sBoxClient {
         Ok(collect_box_stats(&[record]).into_iter().next())
     }
 
+    /// Collect the compatibility Sandbox stats shape from the record's exact
+    /// lifecycle owner.
+    pub(crate) async fn get_sandbox_stats(
+        &self,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> Result<Option<BoxStatsSummary>> {
+        let state = self.load_state()?;
+        let record = state
+            .find_by_id(execution_id.as_str())
+            .cloned()
+            .ok_or_else(|| ClientError::BoxNotFound(execution_id.to_string()))?;
+        if !record.is_active() {
+            return Ok(None);
+        }
+
+        let Some(metadata) = record.managed_execution.as_ref() else {
+            return self.get_box_stats(execution_id.as_str());
+        };
+        if metadata.runtime_route != ManagedRuntimeRoute::OciSdk {
+            return self.get_box_stats(execution_id.as_str());
+        }
+        if metadata.generation != generation {
+            return Err(ClientError::Execution(
+                a3s_box_core::ExecutionManagerError::Conflict {
+                    execution_id: execution_id.clone(),
+                    message: format!(
+                        "expected generation {}, received {}",
+                        metadata.generation.get(),
+                        generation.get()
+                    ),
+                },
+            ));
+        }
+
+        let first = self.execution_stats(execution_id, generation).await?;
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let second = self.execution_stats(execution_id, generation).await?;
+        let processes = self
+            .list_execution_processes(execution_id, generation)
+            .await?;
+        Ok(Some(project_runtime_box_stats(
+            &record, &first, &second, &processes,
+        )))
+    }
+
     /// List cached images from the runtime image store.
     pub async fn list_images(&self) -> Result<Vec<ImageSummary>> {
         let store = self.open_image_store()?;

--- a/src/sdk/src/client/mod.rs
+++ b/src/sdk/src/client/mod.rs
@@ -32,9 +32,9 @@ use a3s_box_runtime::is_process_alive;
 use a3s_box_runtime::oci::BuildResult as RuntimeBuildResult;
 use a3s_box_runtime::{
     is_process_alive_with_identity, load_resolved_image_config, BuildConfig as RuntimeBuildConfig,
-    BuildNetworkPolicy, ImagePuller, ImageReference, ImageStore, NetworkStore, OciImage,
-    PushResult, RegistryAuth, RegistryProtocol, RegistryPusher, SignaturePolicy, SnapshotStore,
-    VolumeStore,
+    BuildNetworkPolicy, ImagePuller, ImageReference, ImageStore, ManagedRuntimeRoute, NetworkStore,
+    OciImage, PushResult, RegistryAuth, RegistryProtocol, RegistryPusher, SignaturePolicy,
+    SnapshotStore, VolumeStore,
 };
 use serde::{Deserialize, Serialize};
 use sysinfo::{Pid, System};

--- a/src/sdk/src/client/summaries.rs
+++ b/src/sdk/src/client/summaries.rs
@@ -56,7 +56,7 @@ pub struct BoxLogLine {
     pub message: String,
 }
 
-/// Host-side resource usage snapshot for one active box.
+/// Compatibility resource usage snapshot for one active box.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BoxStatsSummary {
     pub id: String,

--- a/src/sdk/src/client/support.rs
+++ b/src/sdk/src/client/support.rs
@@ -735,6 +735,60 @@ fn build_box_stats(system: &System, record: &BoxRecord) -> Option<BoxStatsSummar
     })
 }
 
+fn project_runtime_box_stats(
+    record: &BoxRecord,
+    first: &ExecutionStats,
+    second: &ExecutionStats,
+    processes: &ExecutionProcessInventory,
+) -> BoxStatsSummary {
+    let elapsed_ns = second
+        .timestamp_unix_ns
+        .saturating_sub(first.timestamp_unix_ns);
+    let usage_ns = second.cpu.usage_ns.saturating_sub(first.cpu.usage_ns);
+    let cpus = record.cpus.max(1);
+    let cpu_percent = if elapsed_ns == 0 {
+        0.0
+    } else {
+        (usage_ns as f64 / elapsed_ns as f64 * 100.0).min(f64::from(cpus) * 100.0)
+    };
+    let memory_limit_bytes = second
+        .memory
+        .limit_bytes
+        .unwrap_or(u64::from(record.memory_mb) * 1024 * 1024);
+    let memory_percent = if memory_limit_bytes == 0 {
+        0.0
+    } else {
+        second.memory.usage_bytes as f64 / memory_limit_bytes as f64 * 100.0
+    };
+    let pid = processes
+        .processes
+        .iter()
+        .find(|process| process.process_id == "init")
+        .and_then(|process| process.pid)
+        .or_else(|| processes.processes.iter().find_map(|process| process.pid))
+        .or(record.pid)
+        .unwrap_or_default();
+    let network = collect_network_stats(record);
+
+    BoxStatsSummary {
+        id: record.id.clone(),
+        short_id: record.short_id.clone(),
+        name: record.name.clone(),
+        status: record.status.clone(),
+        pid,
+        cpus: record.cpus,
+        cpu_percent: cpu_percent as f32,
+        cpu_percent_scaled: cpu_percent / f64::from(cpus),
+        memory_bytes: second.memory.usage_bytes,
+        memory_limit_bytes,
+        memory_percent,
+        network_rx_bytes: network.rx_bytes,
+        network_tx_bytes: network.tx_bytes,
+        block_read_bytes: 0,
+        block_write_bytes: 0,
+    }
+}
+
 fn collect_network_stats(record: &BoxRecord) -> NetworkStats {
     read_network_stats_file(&record.box_dir.join("sockets").join("net.stats.json"))
         .unwrap_or_default()

--- a/src/sdk/src/client/tests/lifecycle.rs
+++ b/src/sdk/src/client/tests/lifecycle.rs
@@ -114,16 +114,38 @@ impl a3s_box_core::ExecutionManager for RecordingExecutionManager {
         execution_id: &a3s_box_core::ExecutionId,
         generation: a3s_box_core::ExecutionGeneration,
     ) -> a3s_box_core::ExecutionManagerResult<a3s_box_core::ExecutionStats> {
-        self.calls.lock().unwrap().push(LifecycleCall::Stats {
-            execution_id: execution_id.to_string(),
-            generation: generation.get(),
-        });
+        let sample = {
+            let mut calls = self.calls.lock().unwrap();
+            let sample = calls
+                .iter()
+                .filter(|call| matches!(call, LifecycleCall::Stats { .. }))
+                .count();
+            calls.push(LifecycleCall::Stats {
+                execution_id: execution_id.to_string(),
+                generation: generation.get(),
+            });
+            sample
+        };
+        let (timestamp_unix_ns, usage_ns, user_ns, system_ns) = if sample == 0 {
+            (1_000_000_000, 100_000_000, 60_000_000, 40_000_000)
+        } else {
+            (1_200_000_000, 300_000_000, 180_000_000, 120_000_000)
+        };
         Ok(a3s_box_core::ExecutionStats {
             execution_id: execution_id.clone(),
             generation,
-            timestamp_unix_ns: 1,
-            cpu: Default::default(),
-            memory: Default::default(),
+            timestamp_unix_ns,
+            cpu: a3s_box_core::ExecutionCpuStats {
+                usage_ns,
+                user_ns,
+                system_ns,
+                throttled_ns: 0,
+            },
+            memory: a3s_box_core::ExecutionMemoryStats {
+                usage_bytes: 256 * 1024 * 1024,
+                limit_bytes: Some(512 * 1024 * 1024),
+                peak_bytes: Some(300 * 1024 * 1024),
+            },
             process_count: 1,
             metrics: Default::default(),
         })
@@ -392,6 +414,116 @@ async fn lifecycle_calls_preserve_complete_request_and_fencing_identity() {
             && operation_id == "sdk-resource-update"
             && update == &resource_update
     ));
+}
+
+#[tokio::test]
+async fn oci_sandbox_stats_project_exact_runtime_counters() {
+    use std::sync::Arc;
+
+    use a3s_box_core::{
+        resolve_execution, BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionId,
+        ExecutionIsolation, ExecutionLease, ExecutionReservation, OperationId,
+    };
+    use a3s_box_runtime::{ManagedExecutionMetadata, ManagedRuntimeRoute};
+    use chrono::Utc;
+
+    let temp = tempfile::tempdir().unwrap();
+    let execution_id = ExecutionId::new("11111111-1111-4111-8111-111111111111").unwrap();
+    let mut config = BoxConfig {
+        image: "alpine:3.20".to_string(),
+        isolation: ExecutionIsolation::Sandbox,
+        ..BoxConfig::default()
+    };
+    config.resources.vcpus = 2;
+    config.resources.memory_mb = 512;
+    let request = CreateExecutionRequest {
+        external_sandbox_id: "sdk-runtime-stats".to_string(),
+        config: config.clone(),
+        labels: Default::default(),
+        policy: Default::default(),
+        rootfs_snapshot_id: None,
+    };
+    let plan = resolve_execution(&config).unwrap();
+    let reservation = ExecutionReservation {
+        execution_id: execution_id.clone(),
+        generation: ExecutionGeneration::INITIAL,
+        plan: plan.clone(),
+        resources: config.resources.clone(),
+        created_at: Utc::now(),
+    };
+    let lease = ExecutionLease {
+        execution_id: execution_id.clone(),
+        generation: ExecutionGeneration::INITIAL,
+        plan,
+        resources: config.resources,
+        started_at: Utc::now(),
+    };
+    let manager = Arc::new(RecordingExecutionManager {
+        calls: std::sync::Mutex::new(Vec::new()),
+        reservation,
+        lease,
+    });
+    let client = A3sBoxClient::with_execution_manager(
+        A3sBoxPaths::from_home(temp.path()),
+        manager.clone(),
+    );
+    let mut record = box_record(execution_id.as_str(), "api", "running");
+    let mut metadata = ManagedExecutionMetadata::new(
+        OperationId::new("sdk-runtime-stats-create").unwrap(),
+        ExecutionGeneration::INITIAL,
+        request,
+    )
+    .unwrap();
+    metadata.runtime_route = ManagedRuntimeRoute::OciSdk;
+    record.managed_execution = Some(metadata);
+    record.isolation = ExecutionIsolation::Sandbox;
+    record.pid = None;
+    record.cpus = 2;
+    record.memory_mb = 512;
+    write_boxes(&client, &[record]);
+
+    let stats = client
+        .get_sandbox_stats(&execution_id, ExecutionGeneration::INITIAL)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(stats.id, execution_id.as_str());
+    assert_eq!(stats.pid, 42);
+    assert_eq!(stats.cpus, 2);
+    assert_eq!(stats.cpu_percent, 100.0);
+    assert_eq!(stats.cpu_percent_scaled, 50.0);
+    assert_eq!(stats.memory_bytes, 256 * 1024 * 1024);
+    assert_eq!(stats.memory_limit_bytes, 512 * 1024 * 1024);
+    assert_eq!(stats.memory_percent, 50.0);
+
+    let error = client
+        .get_sandbox_stats(
+            &execution_id,
+            ExecutionGeneration::new(2).expect("second generation"),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        ClientError::Execution(a3s_box_core::ExecutionManagerError::Conflict { .. })
+    ));
+
+    let calls = manager.calls.lock().unwrap();
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| matches!(call, LifecycleCall::Stats { .. }))
+            .count(),
+        2
+    );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| matches!(call, LifecycleCall::Processes { .. }))
+            .count(),
+        1
+    );
 }
 
 #[tokio::test]

--- a/src/sdk/src/lib.rs
+++ b/src/sdk/src/lib.rs
@@ -42,7 +42,9 @@ pub use a3s_box_core::{
     PortMapping, PortProtocol, ReconcileOutcome, RestartExecutionOptions,
     MAX_EXECUTION_EVENT_BATCH_ITEMS,
 };
-pub use a3s_box_runtime::{RegistryAuth, RegistryProtocol, SignaturePolicy};
+pub use a3s_box_runtime::{
+    NativeLinuxOciMigrationConfig, RegistryAuth, RegistryProtocol, SignaturePolicy,
+};
 
 #[cfg(unix)]
 pub use a3s_box_runtime::{

--- a/src/sdk/src/sandbox/lifecycle.rs
+++ b/src/sdk/src/sandbox/lifecycle.rs
@@ -154,7 +154,7 @@ impl Sandbox {
         Ok(entries)
     }
 
-    /// Read one bounded host resource-usage snapshot when locally available.
+    /// Read one bounded resource-usage snapshot from the Sandbox lifecycle owner.
     pub async fn stats(&self) -> Result<Option<BoxStatsSummary>> {
         let state = self.inner.state();
         if state.closed {
@@ -166,6 +166,9 @@ impl Sandbox {
             .inspect_execution(&self.inner.execution_id)
             .await?;
         self.inner.update(status.generation, status.state);
-        self.inner.client.get_box_stats(self.id())
+        self.inner
+            .client
+            .get_sandbox_stats(&self.inner.execution_id, status.generation)
+            .await
     }
 }

--- a/src/sdk/tests/local_sandbox.rs
+++ b/src/sdk/tests/local_sandbox.rs
@@ -4,9 +4,9 @@ use std::error::Error;
 use std::path::PathBuf;
 
 use a3s_box_sdk::{
-    A3sBoxClient, ClientError, ExecutionIsolation, ExecutionSnapshotId, ListBoxesOptions,
-    OperationId, Sandbox, SandboxCreateOptions, SandboxLogOptions, SandboxNetwork,
-    SandboxRestartOptions, TagImage,
+    A3sBoxClient, A3sBoxPaths, ClientError, ExecutionIsolation, ExecutionSnapshotId,
+    ListBoxesOptions, OperationId, Sandbox, SandboxCreateOptions, SandboxLogOptions,
+    SandboxNetwork, SandboxRestartOptions, TagImage,
 };
 
 type AnyError = Box<dyn Error + Send + Sync>;
@@ -22,7 +22,10 @@ async fn local_sandbox_exercises_real_runtime() -> Result<(), AnyError> {
     let isolation = requested_isolation()?;
     let base_image =
         std::env::var("A3S_BOX_SDK_SMOKE_IMAGE").unwrap_or_else(|_| "alpine:3.20".to_string());
-    let client = A3sBoxClient::from_home(&home);
+    // This async constructor is deliberately exercised even without migration:
+    // it must preserve the legacy backend when the opt-in is absent and select
+    // the production OCI composition when CI supplies it.
+    let client = A3sBoxClient::with_configured_paths(A3sBoxPaths::from_home(&home)).await?;
     let diagnostics = client.runtime_diagnostics();
     require(
         diagnostics.home == home,

--- a/src/sdk/tests/local_sandbox.rs
+++ b/src/sdk/tests/local_sandbox.rs
@@ -202,10 +202,27 @@ async fn exercise(
     sandbox.files.remove(directory).await?;
     let logs = sandbox.logs(SandboxLogOptions::tail(20)).await?;
     require(logs.len() <= 20, "Sandbox logs exceeded the requested tail")?;
-    require(
-        sandbox.stats().await?.is_some(),
-        "running Sandbox did not expose a stats snapshot",
-    )?;
+    if expected_isolation == ExecutionIsolation::Sandbox {
+        let info = sandbox.info();
+        let stats = sandbox.runtime_stats().await?;
+        require(
+            stats.execution_id.as_str() == sandbox.id(),
+            "runtime stats targeted a different Sandbox",
+        )?;
+        require(
+            stats.generation.get() == info.generation,
+            "runtime stats targeted a different Sandbox generation",
+        )?;
+        require(
+            stats.timestamp_unix_ns > 0 && stats.process_count > 0,
+            "running Sandbox returned an invalid runtime stats snapshot",
+        )?;
+    } else {
+        require(
+            sandbox.stats().await?.is_some(),
+            "running MicroVM did not expose a host stats snapshot",
+        )?;
+    }
 
     if expected_isolation == ExecutionIsolation::Sandbox {
         exercise_filesystem_snapshot(sandbox, client, image).await?;


### PR DESCRIPTION
## Summary

- prepare production OCI bundles from Box image and rootfs policy
- securely start or reuse the long-lived native Linux OCI owner with exact artifact identity fencing
- route explicitly opted-in Sandbox lifecycle calls through the public OCI SDK while preserving legacy VM records
- wire CLI and async SDK construction, document intentional limits, and add an Ubuntu real-runtime composition gate
- persist snapshot freezer identities and phases so pause/resume and crash recovery remain replay-safe
- prepare verified snapshot, named-volume, and network resources before OCI bundle creation with exact launch rollback semantics
- project exact-generation OCI runtime stats into the compatibility Sandbox stats shape used by Rust, Python, TypeScript, and Go
- resolve shell-free direct argv commands from the effective container PATH against the prepared rootfs before OCI dispatch
- certify the four language SDK smokes through the same production OCI owner route and clean up that exact owner root

## Local verification

- `cargo check --locked -p a3s-box-runtime -p a3s-box-sdk --all-features`
- `cargo clippy --locked -p a3s-box-runtime --all-targets --all-features -- -D warnings`
- `cargo clippy --locked -p a3s-box-sdk --all-targets --all-features -- -D warnings`
- `cargo test --locked -p a3s-box-runtime --lib` (1300 passed, 1 ignored)
- `cargo test -p a3s-box-cli --lib --all-features` (788 passed)
- `cargo test --locked -p a3s-box-sdk --all-features` (75 unit tests and all non-host suites passed)
- `cargo fmt --all -- --check`
- `git diff --check`

The Linux-only owner and real production composition are intentionally validated by this PR's Ubuntu CI because the development host is Windows.