### PR TITLE
Recover native OCI owner death across Box processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: a6f6242caf927f404f7e1f7f143fd3a350ce23b6
+  A3S_OCI_RUNTIME_REV: a6cdae7163db941aa1eae5a5d74c75c6ccc32b60
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────
@@ -395,6 +395,7 @@ jobs:
       A3S_BOX_OCI_RUNTIME_PATH: /tmp/a3s-local-sdk-smoke-runtime-conformance/bin/a3s-oci
       A3S_BOX_OCI_AGENT_PATH: /tmp/a3s-local-sdk-smoke-runtime-conformance/bin/a3s-oci-agent
       A3S_BOX_OCI_HOST_ROOT: /tmp/a3s-box-production-oci-host
+      A3S_BOX_OCI_OWNER_RECOVERY_REPORT: /tmp/a3s-box-native-owner-recovery.json
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Init submodules
@@ -530,6 +531,7 @@ jobs:
               A3S_BOX_OCI_HOST_ROOT="$A3S_BOX_OCI_HOST_ROOT" \
               A3S_BOX_OCI_RUNTIME_PATH="$A3S_BOX_OCI_RUNTIME_PATH" \
               A3S_BOX_OCI_AGENT_PATH="$A3S_BOX_OCI_AGENT_PATH" \
+              A3S_BOX_OCI_OWNER_RECOVERY_REPORT="$A3S_BOX_OCI_OWNER_RECOVERY_REPORT" \
               A3S_BOX_BINARY="$GITHUB_WORKSPACE/src/target/debug/a3s-box" \
               A3S_BOX_SHIM_BINARY="$GITHUB_WORKSPACE/src/target/debug/a3s-box-shim" \
               A3S_BOX_GUEST_INIT_BINARY="$GITHUB_WORKSPACE/src/target/x86_64-unknown-linux-musl/release/a3s-box-guest-init" \
@@ -537,6 +539,30 @@ jobs:
               PYTHON=python3 \
               GO=go \
               scripts/local-sdk-smoke.sh sandbox
+          test -s "$A3S_BOX_OCI_OWNER_RECOVERY_REPORT"
+          jq --exit-status \
+            '.schema_version == "a3s.box.native-linux-owner-recovery.v1"
+             and .status == "available" and .platform == "linux"
+             and (.sandbox_id | length > 0)
+             and (.runtime_container_id == ("a3s-box-" + .sandbox_id))
+             and (.new_box_generation == (.old_box_generation + 1))
+             and (.new_runtime_generation == (.old_runtime_generation + 1))
+             and (.old_owner.pid > 0) and (.new_owner.pid > 0)
+             and (.old_init.pid > 0) and (.new_init.pid > 0)
+             and (.old_owner != .new_owner) and (.old_init != .new_init)
+             and .old_owner_gone and .old_launcher_gone and .old_init_gone
+             and .socket_rebound and .stopped_without_invented_exit_status
+             and .old_generation_deleted and .old_executor_root_removed
+             and .replacement_generation_running' \
+            "$A3S_BOX_OCI_OWNER_RECOVERY_REPORT" >/dev/null
+      - name: Upload native OCI owner-recovery evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: a3s-box-native-owner-recovery
+          path: ${{ env.A3S_BOX_OCI_OWNER_RECOVERY_REPORT }}
+          if-no-files-found: warn
+          retention-days: 14
       - name: Verify cleanup
         if: always()
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,19 @@ All notable changes to A3S Box will be documented in this file.
   signal, wait, container reconciliation, and cleanup. The cross-process log
   records exactly one create, start, and exec. OCI Runtime independently proves
   the same session operations through its real durable `HostRuntimeService`.
-  Production owner wiring and real native Linux/WHPX driver qualification
-  remain open.
+  Real-driver transparent live-session retention and WHPX production
+  composition remain open.
+- **Native Linux production owner-death recovery.** The blocking SDK gate now
+  sends `SIGKILL` to the exact identity-fenced OCI owner while a real Sandbox
+  generation is running and proves its launcher and init identities terminate.
+  A subsequent synchronous SDK request runs in a fresh Box bridge process,
+  rebinds a distinct authenticated owner and socket, and reconciles the exact
+  runtime generation as stopped. The OCI adapter accepts unavailable wait
+  evidence only after the runtime has authoritatively reported that stopped
+  state, persists no fabricated exit code, performs stopped-only deletion and
+  cleans the old executor root. Another fresh Box process then restarts exactly
+  the next Box and OCI generations; CI retains a versioned JSON evidence
+  artifact for the complete transition.
 - **Retained local OCI runtime connection recovery.** Box now pins the SDK
   transport that preserves one logical `RuntimeClient` across a broken local
   stream. The request that observes the disconnect still fails without hidden

--- a/README.md
+++ b/README.md
@@ -97,9 +97,14 @@ unchanged.
 > real-host gate now passes this
 > production owner composition through the Rust, Python, TypeScript, and Go SDK
 > lifecycle, exec, filesystem, route-aware stats, pause/resume, snapshot
-> restore, restart, and cleanup surfaces.
-> Real-driver owner/Box process restart, WHPX composition, cross-process
-> process/filesystem recovery, remaining CLI projections, and the broader
+> restore, restart, and cleanup surfaces. The same gate now kills the exact
+> authenticated OCI owner under a running Sandbox, proves its launcher and init
+> identities terminate, and uses fresh Box SDK-bridge processes to rebind the
+> owner endpoint, reconcile the generation as stopped without inventing an exit
+> status, delete its exact runtime tombstone, and restart the next Box and OCI
+> generations.
+> WHPX production composition, transparent process/filesystem-session recovery
+> across real driver-owner death, remaining CLI projections, and the broader
 > cutover gates remain open; the default split above is still authoritative.
 > Follow the checked gates in the [migration roadmap](ROADMAP.md).
 
@@ -198,6 +203,14 @@ startup and again before bundle mutation. The owner root is created with mode
 directory with that exact mode. A live owner is reused only when its PID start
 identity, endpoint, paths, and digests match. Unknown sockets and drifted
 artifacts fail closed.
+
+If this owner is terminated uncleanly, its parent-bound Native Linux process
+tree is terminated with it. The next explicit Box operation starts a distinct
+identity-fenced owner, treats the authenticated old generation as stopped,
+refuses to synthesize an unavailable exit status, removes only that exact
+generation, and permits an explicit restart to create the next Box and OCI
+generations. This is stopped-only crash recovery, not transparent continuation
+of live exec or filesystem sessions.
 
 Rust applications select the same path with
 `A3sBoxClient::with_configured_paths(...).await` or construct

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,7 +114,7 @@ later lifecycle, session, observability, filesystem, restart, and cleanup calls
 use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
-`a6f6242caf927f404f7e1f7f143fd3a350ce23b6` adds the matching long-lived,
+`a6cdae7163db941aa1eae5a5d74c75c6ccc32b60` adds the matching long-lived,
 multi-container Native Linux host owner. Box now first validates the exact
 managed home and durably prepares snapshot-lower, named-volume, and network
 ownership. Its production provider then prepares the product-owned rootfs,
@@ -141,6 +141,12 @@ of requiring Box guest sockets. The blocking native-Linux CI invocation now
 passes the Rust, Python, TypeScript, and Go Sandbox suites through this exact
 composition, including lifecycle, exec, filesystem, route-aware stats,
 pause/resume, snapshot restore, restart, and cleanup.
+That blocking gate also sends `SIGKILL` to the exact recorded Native Linux OCI
+owner while a real Sandbox generation is running. It verifies the owner,
+launcher, and init identities terminate; a fresh Box SDK-bridge process then
+rebinds a distinct owner and reconciles the exact runtime tombstone as stopped
+without a fabricated exit code before deleting only that stopped generation.
+A second fresh Box process restarts exactly the next Box and OCI generations.
 
 The same adapter now routes memory-retaining pause and resume through exact
 SDK targets. Every freezer mutation first requires the advertised operation,
@@ -216,6 +222,9 @@ later gates.
 - [x] Exercise the production composition on native Linux through the blocking
   real-host Rust, Python, TypeScript, and Go SDK lifecycle, session, snapshot,
   restart, and cleanup gate.
+- [x] Kill the real Native Linux owner under a running Sandbox and prove fresh
+  Box processes reconcile stopped-only state, exact cleanup, endpoint rebinding,
+  and next-generation restart without inventing terminal evidence.
 - [ ] Exercise the same Box-owned minimal bundle on Windows/WHPX.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
@@ -232,10 +241,11 @@ host service and journal reopen across processes. OCI Runtime now exposes the
 long-lived Native Linux owner, and Box now supplies fail-closed mixed-backend
 routing, verified product-resource preparation, a direct-process production
 bundle provider, protected owner startup, and explicit CLI/SDK construction.
-The real-host Native Linux production composition now passes. The remaining
-unchecked gates are owner/Box process restart on the real driver and the
-equivalent WHPX path; deterministic process evidence is not promoted as
-platform-driver evidence.
+The real-host Native Linux production composition and owner/Box process restart
+gate now pass. The remaining B1 platform gate is the equivalent WHPX production
+path; the deterministic live-session fixtures are not promoted as proof that a
+real driver can transparently retain process or filesystem sessions after its
+owner dies.
 
 ### B2 - Interactive And Observable Execution
 

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -46,7 +46,9 @@ Box now:
 
 - resolves every new `sandbox` request to `ExecutionBackend::A3sOci`;
 - exposes no public Sandbox runtime selector;
-- starts one authenticated A3S OCI native Linux owner per Box generation;
+- reuses one authenticated, identity-fenced A3S OCI multi-container Native
+  Linux owner across Box processes while binding each Sandbox to an exact OCI
+  generation;
 - packages the pinned `a3s-oci` and `a3s-oci-agent` artifacts in Linux
   releases;
 - records exact runtime and agent digests with the durable generation;
@@ -59,7 +61,7 @@ Box now:
 - rejects any reintroduction of the removed integration symbols in CI.
 
 The exact integration revision is
-`aac259224e89bef2b546fd0f8755ef1ba79570ce`, which retains the qualified
+`a6cdae7163db941aa1eae5a5d74c75c6ccc32b60`, which retains the qualified
 control/workload cgroup and read-only bind behavior and adds deterministic
 multi-driver registration, isolation selection, and durable recorded-driver
 routing required by the unified execution migration. Runtime service startup
@@ -114,7 +116,11 @@ must:
 5. cover image management, named volumes, files, logs, metrics, pause/resume,
    exact CPU/memory/PID enforcement, stop/restart, filesystem snapshots, and
    complete cleanup;
-6. prove no Box shim, OCI owner, agent, runtime root, socket, or Box directory
+6. kill the exact OCI owner under a running Sandbox, prove the launcher and init
+   terminate, then use distinct Box processes to rebind the endpoint, reconcile
+   stopped-only state without a synthetic exit status, delete the old
+   generation, and restart exactly the next Box and OCI generations;
+7. prove no Box shim, OCI owner, agent, runtime root, socket, or Box directory
    remains.
 
 ### Native configuration matrix

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -110,11 +110,223 @@ A3S_BOX_BINARY="$A3S_BOX_BINARY" \
     A3S_BOX_SDK_SMOKE_ISOLATION="$ISOLATION" \
     PYTHONPATH="$REPO_ROOT/sdk/python/src" \
     "$PYTHON" - <<'PY'
+import json
 import os
 import shutil
+import signal
+import stat
+import time
 from pathlib import Path
 
 from a3s_box import A3SBoxClient, Sandbox
+
+
+def read_private_json(path: Path) -> dict:
+    metadata = path.lstat()
+    assert stat.S_ISREG(metadata.st_mode), f"{path} is not a regular file"
+    assert not path.is_symlink(), f"{path} is a symlink"
+    assert metadata.st_uid == 0, f"{path} is not root-owned"
+    assert stat.S_IMODE(metadata.st_mode) == 0o600, f"{path} is not mode 0600"
+    payload = path.read_bytes()
+    assert len(payload) <= 64 * 1024, f"{path} exceeds the evidence bound"
+    value = json.loads(payload)
+    assert isinstance(value, dict), f"{path} does not contain a JSON object"
+    return value
+
+
+def process_start_time(pid: int) -> int | None:
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    closing = raw.rfind(") ")
+    assert closing >= 0, f"process {pid} has malformed stat evidence"
+    fields = raw[closing + 2 :].split()
+    assert len(fields) > 19, f"process {pid} has incomplete stat evidence"
+    assert len(fields[0]) == 1, f"process {pid} has invalid state evidence"
+    if fields[0] in {"Z", "X", "x"}:
+        return None
+    return int(fields[19])
+
+
+def require_live_identity(label: str, identity: dict) -> tuple[int, int]:
+    pid = int(identity["pid"])
+    start_time = int(identity["startTimeTicks"])
+    assert pid > 0 and start_time > 0, f"{label} has an invalid process identity"
+    assert process_start_time(pid) == start_time, f"{label} is not alive with its recorded identity"
+    return pid, start_time
+
+
+def wait_identity_gone(label: str, identity: tuple[int, int]) -> None:
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        observed = process_start_time(identity[0])
+        if observed is None or observed != identity[1]:
+            return
+        time.sleep(0.025)
+    raise AssertionError(f"{label} remained alive after OCI owner SIGKILL")
+
+
+def load_owner_record(host_root: Path) -> dict:
+    root_metadata = host_root.lstat()
+    assert stat.S_ISDIR(root_metadata.st_mode), f"{host_root} is not a directory"
+    assert root_metadata.st_uid == 0, f"{host_root} is not root-owned"
+    assert stat.S_IMODE(root_metadata.st_mode) == 0o700, f"{host_root} is not mode 0700"
+    record = read_private_json(host_root / "box-owner.json")
+    assert set(record) == {
+        "schema",
+        "pid",
+        "pid_start_time",
+        "runtime_path",
+        "runtime_sha256",
+        "agent_path",
+        "agent_sha256",
+        "socket_path",
+    }
+    assert record["schema"] == "a3s.box.native-linux-oci-owner.v1"
+    assert Path(record["runtime_path"]).resolve() == Path(os.environ["A3S_BOX_OCI_RUNTIME_PATH"]).resolve()
+    assert Path(record["agent_path"]).resolve() == Path(os.environ["A3S_BOX_OCI_AGENT_PATH"]).resolve()
+    assert Path(record["socket_path"]) == host_root / "runtime.sock"
+    for field in ("runtime_sha256", "agent_sha256"):
+        digest = record[field]
+        assert len(digest) == 64 and all(character in "0123456789abcdef" for character in digest)
+    owner_identity = {
+        "pid": record["pid"],
+        "startTimeTicks": record["pid_start_time"],
+    }
+    require_live_identity("OCI owner", owner_identity)
+    socket_metadata = (host_root / "runtime.sock").lstat()
+    assert stat.S_ISSOCK(socket_metadata.st_mode), "OCI endpoint is not a Unix socket"
+    assert socket_metadata.st_uid == 0, "OCI endpoint is not root-owned"
+    return record
+
+
+def executor_root(host_root: Path, owner: dict) -> Path:
+    return host_root / "executor" / (
+        f"a3s-oci-agent-{int(owner['pid'])}-{int(owner['pid_start_time']):016x}"
+    )
+
+
+def load_runtime_record(host_root: Path, container_id: str) -> tuple[Path, dict]:
+    path = host_root / "state" / "containers" / container_id / "record.json"
+    record = read_private_json(path)
+    assert record["schemaVersion"] == "a3s.oci.container-record.v1"
+    assert record["id"] == container_id
+    assert record["record"]["state"]["id"] == container_id
+    return path, record
+
+
+def load_recovery_record(host_root: Path, owner: dict, container_id: str) -> tuple[Path, dict]:
+    root = executor_root(host_root, owner)
+    candidates = list(root.glob("c-*/recovery.json"))
+    assert len(candidates) == 1, f"expected one live recovery record below {root}, found {len(candidates)}"
+    recovery = read_private_json(candidates[0])
+    assert recovery["schemaVersion"] == "a3s.oci.native-linux-recovery.v1"
+    assert recovery["target"]["id"] == container_id
+    assert int(recovery["owner"]["pid"]) == int(owner["pid"])
+    assert int(recovery["owner"]["startTimeTicks"]) == int(owner["pid_start_time"])
+    return candidates[0], recovery
+
+
+def exercise_owner_death_recovery(sandbox: Sandbox) -> None:
+    host_root = Path(os.environ["A3S_BOX_OCI_HOST_ROOT"])
+    container_id = f"a3s-box-{sandbox.id}"
+    old_box_generation = sandbox.generation
+    old_owner = load_owner_record(host_root)
+    old_owner_identity = (int(old_owner["pid"]), int(old_owner["pid_start_time"]))
+    old_socket_descriptor = os.open(
+        host_root / "runtime.sock",
+        os.O_PATH | os.O_CLOEXEC | os.O_NOFOLLOW,
+    )
+    old_socket_metadata = os.fstat(old_socket_descriptor)
+    old_socket_identity = (old_socket_metadata.st_dev, old_socket_metadata.st_ino)
+    old_executor_root = executor_root(host_root, old_owner)
+    runtime_path, runtime = load_runtime_record(host_root, container_id)
+    recovery_path, recovery = load_recovery_record(host_root, old_owner, container_id)
+    old_runtime_generation = int(runtime["record"]["generation"])
+    assert runtime["record"]["state"]["status"] == "running"
+    assert int(runtime["record"]["state"]["pid"]) == int(recovery["init"]["pid"])
+    assert int(recovery["target"]["generation"]) == old_runtime_generation
+    old_launcher = require_live_identity("old OCI launcher", recovery["launcher"])
+    old_init = require_live_identity("old OCI init", recovery["init"])
+    assert recovery_path.is_file()
+
+    os.kill(old_owner_identity[0], signal.SIGKILL)
+    wait_identity_gone("old OCI owner", old_owner_identity)
+    wait_identity_gone("old OCI launcher", old_launcher)
+    wait_identity_gone("old OCI init", old_init)
+
+    # Every synchronous SDK request launches a distinct `a3s-box sdk-bridge`
+    # process. This inspection therefore forces a fresh Box process to reclaim
+    # the stale endpoint and reconcile the stopped OCI tombstone.
+    assert not sandbox.is_running(), "owner-death reconciliation still reports the Sandbox running"
+    assert sandbox.state == "stopped", "owner-death reconciliation did not persist stopped"
+    assert sandbox.generation == old_box_generation, "owner-death changed the Box generation"
+
+    new_owner = load_owner_record(host_root)
+    new_owner_identity = (int(new_owner["pid"]), int(new_owner["pid_start_time"]))
+    assert new_owner_identity != old_owner_identity, "replacement OCI owner reused the old identity"
+    for field in ("runtime_path", "runtime_sha256", "agent_path", "agent_sha256", "socket_path"):
+        assert new_owner[field] == old_owner[field], f"replacement OCI owner changed {field}"
+    new_socket_metadata = (host_root / "runtime.sock").stat()
+    new_socket_identity = (new_socket_metadata.st_dev, new_socket_metadata.st_ino)
+    assert new_socket_identity != old_socket_identity, "stale OCI socket was not rebound"
+    os.close(old_socket_descriptor)
+    assert not runtime_path.exists(), "stopped OCI generation remained after Box reconciliation"
+    assert not old_executor_root.exists(), "old OCI executor root remained after stopped-only delete"
+
+    # A second fresh Box process must build exactly the next Box and OCI
+    # generations rather than replaying the terminated workload.
+    sandbox.restart(
+        operation_id=f"python-owner-death-restart-{sandbox.id}",
+        stop_timeout=5,
+    )
+    assert sandbox.generation == old_box_generation + 1
+    assert sandbox.is_running(), "replacement Sandbox generation is not running"
+    new_runtime_path, new_runtime = load_runtime_record(host_root, container_id)
+    _, new_recovery = load_recovery_record(host_root, new_owner, container_id)
+    new_runtime_generation = int(new_runtime["record"]["generation"])
+    assert new_runtime["record"]["state"]["status"] == "running"
+    assert new_runtime_generation == old_runtime_generation + 1
+    assert int(new_recovery["target"]["generation"]) == new_runtime_generation
+    new_init = require_live_identity("replacement OCI init", new_recovery["init"])
+    assert new_init != old_init, "replacement Sandbox reused the terminated init identity"
+    assert new_runtime_path.is_file()
+
+    report = {
+        "schema_version": "a3s.box.native-linux-owner-recovery.v1",
+        "status": "available",
+        "platform": "linux",
+        "sandbox_id": sandbox.id,
+        "runtime_container_id": container_id,
+        "old_box_generation": old_box_generation,
+        "new_box_generation": sandbox.generation,
+        "old_runtime_generation": old_runtime_generation,
+        "new_runtime_generation": new_runtime_generation,
+        "old_owner": {"pid": old_owner_identity[0], "start_time_ticks": old_owner_identity[1]},
+        "new_owner": {"pid": new_owner_identity[0], "start_time_ticks": new_owner_identity[1]},
+        "old_init": {"pid": old_init[0], "start_time_ticks": old_init[1]},
+        "new_init": {"pid": new_init[0], "start_time_ticks": new_init[1]},
+        "old_owner_gone": True,
+        "old_launcher_gone": True,
+        "old_init_gone": True,
+        "socket_rebound": True,
+        "stopped_without_invented_exit_status": True,
+        "old_generation_deleted": True,
+        "old_executor_root_removed": True,
+        "replacement_generation_running": True,
+    }
+    report_path = os.environ.get("A3S_BOX_OCI_OWNER_RECOVERY_REPORT")
+    if report_path:
+        destination = Path(report_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(
+        "owner-recovery "
+        f"owner={old_owner_identity[0]}->{new_owner_identity[0]} "
+        f"box-generation={old_box_generation}->{sandbox.generation} "
+        f"runtime-generation={old_runtime_generation}->{new_runtime_generation}"
+    )
 
 client = A3SBoxClient()
 isolation = os.environ["A3S_BOX_SDK_SMOKE_ISOLATION"]
@@ -213,6 +425,8 @@ try:
                     raise AssertionError("active restored Sandbox did not fence snapshot deletion")
             assert Sandbox.delete_filesystem_snapshot(snapshot.snapshot_id)
             assert Sandbox.filesystem_snapshot_size(snapshot.snapshot_id) is None
+        if isolation == "sandbox":
+            exercise_owner_death_recovery(sandbox)
         previous_generation = sandbox.generation
         sandbox.stop()
         assert not sandbox.is_running()

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=a6f6242caf927f404f7e1f7f143fd3a350ce23b6#a6f6242caf927f404f7e1f7f143fd3a350ce23b6"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=a6cdae7163db941aa1eae5a5d74c75c6ccc32b60#a6cdae7163db941aa1eae5a5d74c75c6ccc32b60"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=a6f6242caf927f404f7e1f7f143fd3a350ce23b6#a6f6242caf927f404f7e1f7f143fd3a350ce23b6"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=a6cdae7163db941aa1eae5a5d74c75c6ccc32b60#a6cdae7163db941aa1eae5a5d74c75c6ccc32b60"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,7 +125,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "25caf65ffed7ff9b82cedc4e7156c79f396896f7" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "a6f6242caf927f404f7e1f7f143fd3a350ce23b6" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "a6cdae7163db941aa1eae5a5d74c75c6ccc32b60" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -612,6 +612,42 @@ impl OciLifecycleAdapter {
         Ok(status)
     }
 
+    /// Read terminal evidence only after the runtime has authoritatively
+    /// reported this exact generation as stopped. A recovered runtime is
+    /// allowed to refuse an exact exit result when no authenticated reaper
+    /// survived owner death; Box must preserve that uncertainty rather than
+    /// inventing an exit code.
+    async fn wait_stopped(
+        &self,
+        record: &ContainerRecord,
+        binding: &OciRuntimeBinding,
+    ) -> ExecutionManagerResult<Option<ExitStatus>> {
+        binding.validate_record(record)?;
+        if *record.state.status() != ContainerState::Stopped {
+            return Err(ExecutionManagerError::Internal(format!(
+                "A3S OCI terminal wait was requested for non-stopped container {}",
+                binding.target.id
+            )));
+        }
+        match self
+            .client
+            .wait(WaitRequest {
+                target: binding.target.clone(),
+                timeout_ms: Some(0),
+            })
+            .await
+        {
+            Ok(status) => {
+                status
+                    .validate()
+                    .map_err(|error| sdk_error("wait", error))?;
+                Ok(Some(status))
+            }
+            Err(error) if error.code == ErrorCode::FailedPrecondition => Ok(None),
+            Err(error) => Err(sdk_error("wait", error)),
+        }
+    }
+
     async fn wait_until(
         &self,
         binding: &OciRuntimeBinding,
@@ -1113,11 +1149,12 @@ impl OciLocalExecutionBackend {
     async fn terminal_observation(
         &self,
         record: &BoxRecord,
+        runtime: &ContainerRecord,
         binding: &OciRuntimeBinding,
     ) -> ExecutionManagerResult<LocalExecutionObservation> {
         let execution_id = self.execution_id(record)?;
         let generation = self.metadata(record)?.generation;
-        let status = self.adapter.wait(binding, Some(0)).await?;
+        let status = self.adapter.wait_stopped(runtime, binding).await?;
         self.adapter
             .delete(&execution_id, generation, binding, DeleteMode::StoppedOnly)
             .await?;
@@ -1125,7 +1162,7 @@ impl OciLocalExecutionBackend {
         Ok(LocalExecutionObservation {
             state: ExecutionState::Stopped,
             handle: None,
-            exit_code: Some(exit_code(&status)?),
+            exit_code: status.as_ref().map(exit_code).transpose()?,
         })
     }
 }
@@ -1352,7 +1389,7 @@ impl LocalExecutionBackend for OciLocalExecutionBackend {
                 )),
                 exit_code: None,
             }),
-            ContainerState::Stopped => self.terminal_observation(record, &binding).await,
+            ContainerState::Stopped => self.terminal_observation(record, &runtime, &binding).await,
         }
     }
 

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -234,6 +234,23 @@ impl FakeRuntimeService {
         container.exit_status = Some(status);
     }
 
+    fn mark_stopped_without_exit_evidence(&self, execution_id: &ExecutionId) {
+        let id = runtime_container_id(execution_id).expect("runtime container ID");
+        let mut containers = self.containers.lock().expect("container lock");
+        let container = containers.get_mut(id.as_str()).expect("runtime exists");
+        container.record = runtime_record(
+            &id,
+            container.record.generation,
+            ContainerState::Stopped,
+            container.record.driver,
+            container.record.isolation,
+            &container.record.config_digest,
+            container.record.attachments_digest.as_deref(),
+        )
+        .expect("stopped runtime record");
+        container.exit_status = None;
+    }
+
     fn create_requests(&self) -> Vec<CreateRequest> {
         self.create_requests.lock().expect("create lock").clone()
     }
@@ -1220,11 +1237,19 @@ impl OciRuntimeService for FakeRuntimeService {
             .get(request.target.id.as_str())
             .ok_or_else(|| oci_error(ErrorCode::NotFound, "wait", "fake runtime is absent"))?;
         validate_target(&request.target, &container.record, "wait")?;
-        container.exit_status.clone().ok_or_else(|| {
-            Error::new(ErrorCode::DeadlineExceeded, "fake runtime is still running")
-                .for_operation("wait")
-                .retryable(true)
-        })
+        match container.exit_status.clone() {
+            Some(status) => Ok(status),
+            None if *container.record.state.status() == ContainerState::Stopped => Err(Error::new(
+                ErrorCode::FailedPrecondition,
+                "fake stopped runtime has no exact terminal evidence",
+            )
+            .for_operation("wait")),
+            None => Err(
+                Error::new(ErrorCode::DeadlineExceeded, "fake runtime is still running")
+                    .for_operation("wait")
+                    .retryable(true),
+            ),
+        }
     }
 }
 
@@ -3583,6 +3608,47 @@ async fn reopened_backend_observes_natural_terminal_status_before_stopped_only_d
     assert_eq!(service.delete_modes(), vec![DeleteMode::StoppedOnly]);
     assert_eq!(service.container_count(), 0);
     assert_eq!(provider.cleanups.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn reopened_backend_cleans_stopped_generation_without_inventing_exit_status() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let provider = Arc::new(FakeBundleProvider::default());
+    let endpoint = test_endpoint();
+    let first = manager(
+        &directory,
+        endpoint.clone(),
+        service.clone(),
+        provider.clone(),
+    );
+    let lease = first
+        .create_and_start(
+            request("owner-death", ExecutionIsolation::Sandbox),
+            &box_operation("owner-death-operation"),
+        )
+        .await
+        .expect("initial launch");
+    service.mark_stopped_without_exit_evidence(&lease.execution_id);
+    let reopened = manager(&directory, endpoint, service.clone(), provider.clone());
+
+    let status = reopened
+        .inspect(&lease.execution_id)
+        .await
+        .expect("owner-death terminal inspection");
+    let record = persisted(&reopened, &lease.execution_id);
+
+    assert_eq!(status.state, ExecutionState::Stopped);
+    assert_eq!(record.exit_code, None);
+    assert_eq!(record.status, ManagedExecutionState::Stopped.as_status());
+    assert_eq!(service.delete_modes(), vec![DeleteMode::StoppedOnly]);
+    assert_eq!(service.container_count(), 0);
+    assert_eq!(provider.cleanups.load(Ordering::SeqCst), 1);
+    assert!(record
+        .managed_execution
+        .as_ref()
+        .and_then(|metadata| metadata.oci_runtime.as_ref())
+        .is_none());
 }
 
 #[tokio::test]

--- a/src/runtime/src/local_execution/oci_owner.rs
+++ b/src/runtime/src/local_execution/oci_owner.rs
@@ -78,7 +78,7 @@ impl NativeLinuxOwnerRecord {
     }
 
     fn is_alive(&self) -> bool {
-        crate::process::is_process_alive_with_identity(self.pid, Some(self.pid_start_time))
+        crate::process::is_process_running_with_identity(self.pid, Some(self.pid_start_time))
     }
 }
 
@@ -460,6 +460,8 @@ fn is_sha256_hex(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
     use super::*;
 
     #[test]
@@ -482,5 +484,39 @@ mod tests {
         assert!(validate_service_root(Path::new("relative")).is_err());
         assert!(validate_service_root(Path::new("/tmp/a/../b")).is_err());
         assert!(validate_service_root(Path::new("/")).is_err());
+    }
+
+    #[test]
+    fn completed_zombie_owner_is_not_reused() {
+        let artifacts = CertifiedA3sOci {
+            runtime_path: PathBuf::from("/opt/a3s/a3s-oci"),
+            runtime_sha256: "a".repeat(64),
+            agent_path: PathBuf::from("/opt/a3s/a3s-oci-agent"),
+            agent_sha256: "b".repeat(64),
+        };
+        let mut child = Command::new("/bin/true")
+            .spawn()
+            .expect("spawn completed owner fixture");
+        let pid = child.id();
+        let start_time = crate::process::pid_start_time(pid).expect("capture owner identity");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while crate::process::is_process_running_with_identity(pid, Some(start_time))
+            && Instant::now() < deadline
+        {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(
+            crate::process::is_process_alive_with_identity(pid, Some(start_time)),
+            "unreaped fixture must remain addressable as a zombie"
+        );
+
+        let record = NativeLinuxOwnerRecord::new(
+            pid,
+            start_time,
+            &artifacts,
+            PathBuf::from("/tmp/a3s-owner/runtime.sock"),
+        );
+        assert!(!record.is_alive(), "a zombie owner must be reclaimed");
+        child.wait().expect("reap completed owner fixture");
     }
 }

--- a/src/runtime/src/process.rs
+++ b/src/runtime/src/process.rs
@@ -81,7 +81,7 @@ pub fn is_process_running_with_identity(pid: u32, expected_start_time: Option<u6
         return false;
     };
     linux_process_identity_from_stat(&stat).is_some_and(|(state, start_time)| {
-        state != 'Z'
+        is_linux_process_state_running(state)
             && expected_start_time
                 .map(|expected| expected == start_time)
                 .unwrap_or(true)
@@ -191,6 +191,11 @@ fn linux_process_identity_from_stat(stat: &str) -> Option<(char, u64)> {
     Some((state, start_time))
 }
 
+#[cfg(target_os = "linux")]
+const fn is_linux_process_state_running(state: char) -> bool {
+    !matches!(state, 'Z' | 'X' | 'x')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,9 +235,17 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn parses_zombie_state_for_completion_waiters() {
-        let stat = "123 (completed worker) Z 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 4242";
-        assert_eq!(linux_process_identity_from_stat(stat), Some(('Z', 4242)));
+    fn classifies_zombie_and_dead_states_as_completed() {
+        for state in ['Z', 'X', 'x'] {
+            let stat = format!(
+                "123 (completed worker) {state} 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 4242"
+            );
+            assert_eq!(linux_process_identity_from_stat(&stat), Some((state, 4242)));
+            assert!(!is_linux_process_state_running(state));
+        }
+        for state in ['R', 'S', 'D', 'T', 't', 'I'] {
+            assert!(is_linux_process_state_running(state));
+        }
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary
- reconcile an authoritatively stopped OCI generation after the native runtime owner dies without inventing an exit status
- make Linux owner reuse reject zombie/dead process identities
- add a blocking real-host owner SIGKILL, socket rebind, exact cleanup, and next-generation restart gate
- pin A3S OCI Runtime main at a6cdae7163db941aa1eae5a5d74c75c6ccc32b60 and update README/roadmap evidence

## Local verification
- cargo test --locked -p a3s-box-runtime --lib (1301 passed, 1 ignored)
- cargo clippy --locked -p a3s-box-runtime --all-targets -- -D warnings
- cargo fmt --all -- --check
- bash -n scripts/local-sdk-smoke.sh
- git diff --check