### PR TITLE
ci: qualify OCI owner composition on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,8 +387,20 @@ jobs:
 
   # ── Real shared-kernel local SDK gate ──────────────────────────
   sdk-local-sandbox:
-    name: SDK Local Sandbox (A3S OCI Runtime)
-    runs-on: ubuntu-24.04
+    name: ${{ matrix.job_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - job_name: SDK Local Sandbox (A3S OCI Runtime)
+            os: ubuntu-24.04
+            guest_target: x86_64-unknown-linux-musl
+            recovery_artifact: a3s-box-native-owner-recovery
+          - job_name: SDK Local Sandbox (A3S OCI Runtime, aarch64)
+            os: ubuntu-24.04-arm
+            guest_target: aarch64-unknown-linux-musl
+            recovery_artifact: a3s-box-native-owner-recovery-aarch64
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
       A3S_HOME: /tmp/a3s-local-sdk-smoke-runtime-conformance
@@ -423,7 +435,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential musl-tools protobuf-compiler
-          rustup target add x86_64-unknown-linux-musl
+          rustup target add "${{ matrix.guest_target }}"
           sed -nE \
             's/^[[:space:]]*pub fn (krun_[A-Za-z0-9_]+).*/long \1(void) { return -1; }/p' \
             src/deps/libkrun-sys/src/lib.rs \
@@ -440,7 +452,7 @@ jobs:
           cd src
           cargo build --locked -p a3s-box-cli -p a3s-box-shim
           cargo build --locked --release -p a3s-box-guest-init \
-            --target x86_64-unknown-linux-musl
+            --target "${{ matrix.guest_target }}"
           cd ../oci-runtime
           cargo build --locked --release -p a3s-oci-cli -p a3s-oci-agent
       - name: Install R17 runtime artifacts and host identity ranges
@@ -449,7 +461,7 @@ jobs:
           sudo install -m 755 src/target/debug/a3s-box-shim \
             "$A3S_HOME/bin/a3s-box-shim"
           sudo install -m 755 \
-            src/target/x86_64-unknown-linux-musl/release/a3s-box-guest-init \
+            "src/target/${{ matrix.guest_target }}/release/a3s-box-guest-init" \
             "$A3S_HOME/bin/a3s-box-guest-init"
           sudo install -m 755 oci-runtime/target/release/a3s-oci "$A3S_BOX_OCI_RUNTIME_PATH"
           sudo install -m 755 oci-runtime/target/release/a3s-oci-agent "$A3S_BOX_OCI_AGENT_PATH"
@@ -534,7 +546,7 @@ jobs:
               A3S_BOX_OCI_OWNER_RECOVERY_REPORT="$A3S_BOX_OCI_OWNER_RECOVERY_REPORT" \
               A3S_BOX_BINARY="$GITHUB_WORKSPACE/src/target/debug/a3s-box" \
               A3S_BOX_SHIM_BINARY="$GITHUB_WORKSPACE/src/target/debug/a3s-box-shim" \
-              A3S_BOX_GUEST_INIT_BINARY="$GITHUB_WORKSPACE/src/target/x86_64-unknown-linux-musl/release/a3s-box-guest-init" \
+              A3S_BOX_GUEST_INIT_BINARY="$GITHUB_WORKSPACE/src/target/${{ matrix.guest_target }}/release/a3s-box-guest-init" \
               RUST_MIN_STACK=16777216 \
               PYTHON=python3 \
               GO=go \
@@ -559,7 +571,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: a3s-box-native-owner-recovery
+          name: ${{ matrix.recovery_artifact }}
           path: ${{ env.A3S_BOX_OCI_OWNER_RECOVERY_REPORT }}
           if-no-files-found: warn
           retention-days: 14

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/recovery_profile.rs
@@ -129,11 +129,13 @@ async fn create_before_ack_and_client_restart(
 }
 
 async fn cancelled_task_apply_is_replayable(fixture: &BoxRuntimeConformanceFixture) -> Result<()> {
-    let request = fixture.cases.task(
-        "recovery-cancelled-task",
-        "printf 'r17-cancelled-task\\n'; sleep 5",
-        30_000,
+    const RELEASE_MARKER: &str = "r17-cancelled-task-release";
+    let command = format!(
+        "printf 'r17-cancelled-task\\n'; while [ ! -e /workspace/{RELEASE_MARKER} ]; do sleep 1; done"
     );
+    let request = fixture
+        .cases
+        .task("recovery-cancelled-task", &command, 30_000);
     let client = Arc::new(fixture.client_with(fixture.driver.clone(), fixture.state.clone()));
     let apply = {
         let client = client.clone();
@@ -141,7 +143,7 @@ async fn cancelled_task_apply_is_replayable(fixture: &BoxRuntimeConformanceFixtu
         tokio::spawn(async move { client.apply(&request).await })
     };
 
-    let provider_id = tokio::time::timeout(Duration::from_secs(120), async {
+    let provider_record = tokio::time::timeout(Duration::from_secs(120), async {
         loop {
             let records = fixture.records_for(&fixture.driver, &request.spec).await?;
             require(
@@ -150,7 +152,7 @@ async fn cancelled_task_apply_is_replayable(fixture: &BoxRuntimeConformanceFixtu
             )?;
             if let Some(record) = records.first() {
                 match local_identity(record)?.2 {
-                    ManagedExecutionState::Running => break Ok(record.id.clone()),
+                    ManagedExecutionState::Running => break Ok(record.clone()),
                     ManagedExecutionState::Stopped | ManagedExecutionState::Failed => {
                         break Err(super::protocol(
                             "cancellation fixture Task became terminal before cancellation",
@@ -170,6 +172,7 @@ async fn cancelled_task_apply_is_replayable(fixture: &BoxRuntimeConformanceFixtu
     .await
     .map_err(|_| super::failure("cancellation fixture did not reach a running Sandbox"))??;
 
+    let provider_id = provider_record.id.clone();
     apply.abort();
     match apply.await {
         Err(error) if error.is_cancelled() => {}
@@ -190,6 +193,14 @@ async fn cancelled_task_apply_is_replayable(fixture: &BoxRuntimeConformanceFixtu
         pending.state == RuntimeRequestState::Pending,
         "cancelled Task apply did not preserve a replayable pending receipt",
     )?;
+    std::fs::write(
+        provider_record
+            .box_dir
+            .join("workspace")
+            .join(RELEASE_MARKER),
+        b"release\n",
+    )
+    .map_err(|error| super::external("release cancelled Task fixture", error))?;
 
     let restarted_driver = fixture.restarted_driver()?;
     let restarted = fixture.client_with(restarted_driver.clone(), fixture.state.clone());


### PR DESCRIPTION
## Summary
- run the complete real Box-to-OCI Sandbox qualification on native Linux x86_64 and aarch64 runners
- preserve the existing x86_64 check name while adding an independent aarch64 check
- parameterize the musl guest-init target and publish architecture-specific owner-recovery evidence

## Gate coverage per architecture
- pinned OCI Runtime native lifecycle/filesystem/attachment smoke
- advertised R17 profiles and private registry pull
- production Box-to-OCI owner composition
- Rust, Python, TypeScript, and Go SDK lifecycle
- real owner death, fresh Box-process rebind, stopped-only reconciliation, cleanup, and next-generation restart

## Local validation
- `cargo fmt --manifest-path src/Cargo.toml --all -- --check`
- `git diff --check`
- workflow target/reference invariant audit