### PR TITLE
docs: retain dual-architecture owner evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- **Native Linux aarch64 production-owner qualification.** Box revision
+  `a16772c3` now runs the same pinned OCI Runtime `a6cdae7` revision on native
+  x86_64 and aarch64 Ubuntu hosts, builds the architecture-matched musl guest
+  init, and drives the Rust, Python, TypeScript, and Go SDK surfaces through the
+  production owner route. Both blocking lanes also kill the exact owner and use
+  fresh Box processes to prove stopped-only reconciliation, exact cleanup, endpoint
+  rebinding, and next-generation restart. The cancellation replay scenario now
+  releases its retained workload with an explicit marker only after the caller
+  is cancelled and its durable receipt is observed, removing a host-speed race
+  without weakening the replay assertion.
 - **Durable fail-closed OCI migration routing.** New managed records can now be
   composed through `LegacyOnly`, `SandboxViaOci`, or `AllViaOci` policy. The
   router stamps `box_vm` or `oci_sdk` before capability preflight, persists it

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ unchanged.
 > `PATH` to resolve `argv[0]` against that prepared rootfs before OCI dispatch,
 > preserving shell-free `Argv("printf", ...)` behavior without weakening the
 > runtime's normalized-absolute-path contract. The blocking Native Linux
-> real-host gate now passes this
-> production owner composition through the Rust, Python, TypeScript, and Go SDK
+> x86_64 and aarch64 real-host lanes now pass this production owner composition
+> through the Rust, Python, TypeScript, and Go SDK
 > lifecycle, exec, filesystem, route-aware stats, pause/resume, snapshot
-> restore, restart, and cleanup surfaces. The same gate now kills the exact
-> authenticated OCI owner under a running Sandbox, proves its launcher and init
-> identities terminate, and uses fresh Box SDK-bridge processes to rebind the
+> restore, restart, and cleanup surfaces. Both lanes kill the exact
+> authenticated OCI owner under a running Sandbox, prove its launcher and init
+> identities terminate, and use fresh Box SDK-bridge processes to rebind the
 > owner endpoint, reconcile the generation as stopped without inventing an exit
 > status, delete its exact runtime tombstone, and restart the next Box and OCI
 > generations.
@@ -209,8 +209,9 @@ tree is terminated with it. The next explicit Box operation starts a distinct
 identity-fenced owner, treats the authenticated old generation as stopped,
 refuses to synthesize an unavailable exit status, removes only that exact
 generation, and permits an explicit restart to create the next Box and OCI
-generations. This is stopped-only crash recovery, not transparent continuation
-of live exec or filesystem sessions.
+generations. This stopped-only crash recovery is qualified on real x86_64 and
+aarch64 Linux hosts; it is not transparent continuation of live exec or
+filesystem sessions.
 
 Rust applications select the same path with
 `A3sBoxClient::with_configured_paths(...).await` or construct

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -137,12 +137,12 @@ bridge and async Rust SDK constructor honor the explicit
 `A3S_BOX_OCI_MIGRATION=sandbox` opt-in; no setting means no owner probe or
 startup and preserves the legacy route. Core lifecycle, run/exec/PTY, wait,
 pause/resume and cleanup commands now detect the persisted OCI route instead
-of requiring Box guest sockets. The blocking native-Linux CI invocation now
-passes the Rust, Python, TypeScript, and Go Sandbox suites through this exact
-composition, including lifecycle, exec, filesystem, route-aware stats,
+of requiring Box guest sockets. The blocking native-Linux x86_64 and aarch64 CI
+lanes now pass the Rust, Python, TypeScript, and Go Sandbox suites through this
+exact composition, including lifecycle, exec, filesystem, route-aware stats,
 pause/resume, snapshot restore, restart, and cleanup.
-That blocking gate also sends `SIGKILL` to the exact recorded Native Linux OCI
-owner while a real Sandbox generation is running. It verifies the owner,
+Both blocking lanes also send `SIGKILL` to the exact recorded Native Linux OCI
+owner while a real Sandbox generation is running. They verify the owner,
 launcher, and init identities terminate; a fresh Box SDK-bridge process then
 rebinds a distinct owner and reconciles the exact runtime tombstone as stopped
 without a fabricated exit code before deleting only that stopped generation.
@@ -219,12 +219,13 @@ later gates.
   digests required for reconciliation.
 - [x] Reopen the local runtime service and reconcile interrupted Box operations
   without launching a duplicate workload.
-- [x] Exercise the production composition on native Linux through the blocking
-  real-host Rust, Python, TypeScript, and Go SDK lifecycle, session, snapshot,
-  restart, and cleanup gate.
-- [x] Kill the real Native Linux owner under a running Sandbox and prove fresh
-  Box processes reconcile stopped-only state, exact cleanup, endpoint rebinding,
-  and next-generation restart without inventing terminal evidence.
+- [x] Exercise the production composition on native Linux x86_64 and aarch64
+  through the blocking real-host Rust, Python, TypeScript, and Go SDK lifecycle,
+  session, snapshot, restart, and cleanup lanes.
+- [x] Kill the real Native Linux owner under a running Sandbox on x86_64 and
+  aarch64 and prove fresh Box processes reconcile stopped-only state, exact
+  cleanup, endpoint rebinding, and next-generation restart without inventing
+  terminal evidence.
 - [ ] Exercise the same Box-owned minimal bundle on Windows/WHPX.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
@@ -241,11 +242,11 @@ host service and journal reopen across processes. OCI Runtime now exposes the
 long-lived Native Linux owner, and Box now supplies fail-closed mixed-backend
 routing, verified product-resource preparation, a direct-process production
 bundle provider, protected owner startup, and explicit CLI/SDK construction.
-The real-host Native Linux production composition and owner/Box process restart
-gate now pass. The remaining B1 platform gate is the equivalent WHPX production
-path; the deterministic live-session fixtures are not promoted as proof that a
-real driver can transparently retain process or filesystem sessions after its
-owner dies.
+The real-host Native Linux x86_64 and aarch64 production composition and
+owner/Box process restart lanes now pass. The remaining B1 platform gate is the
+equivalent WHPX production path; the deterministic live-session fixtures are
+not promoted as proof that a real driver can transparently retain process or
+filesystem sessions after its owner dies.
 
 ### B2 - Interactive And Observable Execution
 

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -106,8 +106,9 @@ generations are unaffected.
 
 ### Box integration gate
 
-The `SDK Local Sandbox (A3S OCI Runtime)` job runs on Ubuntu without KVM and
-must:
+The `SDK Local Sandbox (A3S OCI Runtime)` and
+`SDK Local Sandbox (A3S OCI Runtime, aarch64)` checks run on native Ubuntu
+x86_64 and aarch64 hosts without KVM. Each must:
 
 1. check out the exact pinned OCI Runtime revision;
 2. run its native Linux qualification script;
@@ -142,8 +143,9 @@ The pinned OCI Runtime qualification must exercise real containers for:
 - PID, mount, cgroup, namespace, owner, and session cleanup.
 
 The same script runs on Linux x86_64 and Linux aarch64 in the OCI Runtime
-repository. Box additionally runs it for the exact dependency revision on its
-Linux x86_64 integration lane.
+repository. Box additionally runs it for the exact dependency revision on both
+native architecture integration lanes before exercising the production owner
+composition.
 
 ### Cross-platform gates
 
@@ -189,10 +191,17 @@ The replacement is complete when all of the following are true:
 - [x] Linux x86_64/aarch64, macOS arm64, and Windows x86_64 builds remain gated.
 - [x] The change's pull-request and main-branch CI runs are green.
 
-The accepted replacement evidence is Box
+The accepted production-adapter evidence remains Box
 `2cbe588b2bc6255ffa700bd0f9dbce451dafe02e`: its
 [pull-request CI run](https://github.com/A3S-Lab/Box/actions/runs/30747729543)
 and its
 [main-branch CI run](https://github.com/A3S-Lab/Box/actions/runs/30748314872)
-both completed successfully. Later documentation-only commits do not replace
-that qualified code revision.
+both completed successfully. The dual-architecture qualification evidence is
+Box `a16772c399528a6c4eaf584767f6000ca4e53f16`: its
+[pull-request CI run](https://github.com/A3S-Lab/Box/actions/runs/30754808084)
+and its
+[main-branch CI run](https://github.com/A3S-Lab/Box/actions/runs/30755797650)
+both completed successfully with the x86_64 and aarch64 real-host lanes. That
+later revision changes only the CI matrix, deterministic recovery conformance
+fixture, and plan documentation relative to the qualified production adapter.
+Later documentation-only commits do not replace either evidence revision.


### PR DESCRIPTION
Record the successful native x86_64 and aarch64 Box-to-OCI production-owner qualification, link the retained PR/main CI evidence, document deterministic cancellation replay, and keep WHPX/live-session/default-cutover gates explicitly open.