### PR TITLE
feat(runtime): bind Box bundle handoff context

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,6 +105,17 @@ exec dispatch. OCI Runtime independently proves the same process target through
 its durable `HostRuntimeService` and operation journal across two processes.
 Real-driver promotion and production cutover gates remain below.
 
+The SDK boundary now also gives every bundle provider the exact runtime
+container ID, create operation context, requested isolation, and negotiated
+attachment capabilities before product mutation. A provider opting into
+`dev.a3s.bundle-handoff` resolves only
+`bundle-handoffs/<container>/<create-operation>/bundle`, binds that path and
+annotation into the submitted attachment digest, and fails before Box state or
+bundle preparation if the runtime does not advertise version 1. The same
+operation context is then sent unchanged in SDK `create`; Box never predicts
+the independently allocated runtime generation. This closes the product/runtime
+contract seam but does not claim the real Windows production lifecycle gate.
+
 The backend-neutral manager now also has one durable migration router with
 three explicit creation policies: retain both current paths, route only
 Sandbox through the unified OCI adapter, or route both isolation choices.
@@ -114,13 +125,15 @@ later lifecycle, session, observability, filesystem, restart, and cleanup calls
 use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
-`a6cdae7163db941aa1eae5a5d74c75c6ccc32b60` adds the matching long-lived,
-multi-container Native Linux host owner. Box now first validates the exact
-managed home and durably prepares snapshot-lower, named-volume, and network
-ownership. Its production provider then prepares the product-owned rootfs,
-mounts, resources, DNS/hostname files and OCI bundle while compiling the image
-process directly, without the legacy guest-init FD 3/4/5 contract. It resolves
-PATH, working directory, named or numeric users/groups, supplementary groups,
+`0451739d15795be5829a4774198e276f861561be` retains the matching long-lived,
+multi-container Native Linux host owner and adds the generation-safe bundle
+handoff used by the preparation context above. Box now first validates the
+exact managed home and durably prepares snapshot-lower, named-volume, and
+network ownership. Its production provider then prepares the product-owned
+rootfs, mounts, resources, DNS/hostname files and OCI bundle while compiling
+the image process directly, without the legacy guest-init FD 3/4/5 contract.
+It resolves PATH, working directory, named or numeric users/groups,
+supplementary groups,
 HOME and capabilities against the prepared rootfs before mutation is handed to
 Runtime. A provably failed launch rolls back every preparation-owned effect;
 unknown launch ownership retains them for exact reconciliation.
@@ -227,6 +240,9 @@ later gates.
   cleanup, endpoint rebinding, and next-generation restart without inventing
   terminal evidence.
 - [ ] Exercise the same Box-owned minimal bundle on Windows/WHPX.
+  - [x] Negotiate the required handoff extension and bind provider preparation
+    to the exact runtime container/create-operation path without coupling Box
+    and runtime generations.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
 through Box on Linux and Windows, including Box and runtime process restart.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=a6cdae7163db941aa1eae5a5d74c75c6ccc32b60#a6cdae7163db941aa1eae5a5d74c75c6ccc32b60"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0451739d15795be5829a4774198e276f861561be#0451739d15795be5829a4774198e276f861561be"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=a6cdae7163db941aa1eae5a5d74c75c6ccc32b60#a6cdae7163db941aa1eae5a5d74c75c6ccc32b60"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0451739d15795be5829a4774198e276f861561be#0451739d15795be5829a4774198e276f861561be"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,7 +125,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "25caf65ffed7ff9b82cedc4e7156c79f396896f7" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "a6cdae7163db941aa1eae5a5d74c75c6ccc32b60" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "0451739d15795be5829a4774198e276f861561be" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -78,9 +78,10 @@ pub use box_state::BoxStateStore;
 pub use local_execution::{
     acquire_execution_lifecycle_lock, ExecutionLifecycleLock, LocalExecutionBackend,
     LocalExecutionBackendRouter, LocalExecutionHandle, LocalExecutionManager,
-    LocalExecutionObservation, LocalExecutionTermination, OciBundleProvider, OciLifecycleAdapter,
-    OciLocalExecutionBackend, OciMigrationPolicy, OciPreparedExecution, OciRuntimeBinding,
-    OciRuntimeEndpoint, OciRuntimeLaunch, OCI_RUNTIME_BINDING_SCHEMA_VERSION,
+    LocalExecutionObservation, LocalExecutionTermination, OciBundlePreparationContext,
+    OciBundleProvider, OciLifecycleAdapter, OciLocalExecutionBackend, OciMigrationPolicy,
+    OciPreparedExecution, OciRuntimeBinding, OciRuntimeEndpoint, OciRuntimeLaunch,
+    OCI_RUNTIME_BINDING_SCHEMA_VERSION,
 };
 #[cfg(feature = "vm")]
 pub use local_execution::{

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -55,9 +55,9 @@ pub use backend::{
     LocalExecutionTermination,
 };
 pub use oci_backend::{
-    oci_isolation_request, OciBundleProvider, OciLifecycleAdapter, OciLocalExecutionBackend,
-    OciPreparedExecution, OciRuntimeBinding, OciRuntimeEndpoint, OciRuntimeLaunch,
-    OCI_RUNTIME_BINDING_SCHEMA_VERSION,
+    oci_isolation_request, OciBundlePreparationContext, OciBundleProvider, OciLifecycleAdapter,
+    OciLocalExecutionBackend, OciPreparedExecution, OciRuntimeBinding, OciRuntimeEndpoint,
+    OciRuntimeLaunch, OCI_RUNTIME_BINDING_SCHEMA_VERSION,
 };
 #[cfg(feature = "vm")]
 pub use oci_migration::NativeLinuxOciMigrationConfig;

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -1,7 +1,7 @@
 //! Public-SDK-only A3S OCI lifecycle boundary for managed local execution.
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use a3s_box_core::{
@@ -17,16 +17,20 @@ use a3s_box_core::{
 };
 use a3s_oci_sdk::oci_spec::runtime::ContainerState;
 use a3s_oci_sdk::{
-    ContainerId, ContainerOperationRequest, ContainerRecord, ContainerTarget, CreateAttachments,
-    CreateRequest, DeleteMode, DeleteRequest, DriverKind, ErrorCode, EventsRequest, ExitStatus,
-    FileOp as OciFileOp, FileRequest as OciFileRequest, FileResponse as OciFileResponse,
-    FilesystemEntry as OciFilesystemEntry, FilesystemEntryKind as OciFilesystemEntryKind,
-    FilesystemOp as OciFilesystemOp, FilesystemRequest as OciFilesystemRequest,
-    FilesystemResponse as OciFilesystemResponse, IoMode, IsolationClass, IsolationRequest,
-    KillRequest, LinuxResources, LocalIpcEndpoint, OciBundle, OperationContext,
-    OperationId as OciOperationId, ProcessIo, ProcessRecord, ProcessesRequest, RuntimeClient,
-    RuntimeEventKind, RuntimeInfo, RuntimeOperation, Signal, StartRequest, StateRequest,
-    StatsRequest, UpdateRequest, WaitRequest, ATTACHMENT_SCHEMA_V1, MAX_FILE_TRANSFER_BYTES,
+    runtime_bundle_handoff_directory as sdk_runtime_bundle_handoff_directory,
+    AttachmentCapabilities, ContainerId, ContainerOperationRequest, ContainerRecord,
+    ContainerTarget, CreateAttachments, CreateRequest, DeleteMode, DeleteRequest, DriverKind,
+    ErrorCode, EventsRequest, ExitStatus, FileOp as OciFileOp, FileRequest as OciFileRequest,
+    FileResponse as OciFileResponse, FilesystemEntry as OciFilesystemEntry,
+    FilesystemEntryKind as OciFilesystemEntryKind, FilesystemOp as OciFilesystemOp,
+    FilesystemRequest as OciFilesystemRequest, FilesystemResponse as OciFilesystemResponse, IoMode,
+    IsolationClass, IsolationRequest, KillRequest, LinuxResources, LocalIpcEndpoint, OciBundle,
+    OperationContext, OperationId as OciOperationId, ProcessIo, ProcessRecord, ProcessesRequest,
+    RuntimeClient, RuntimeEventKind, RuntimeInfo, RuntimeOperation, Signal, StartRequest,
+    StateRequest, StatsRequest, UpdateRequest, WaitRequest, ATTACHMENT_SCHEMA_V1,
+    MAX_FILE_TRANSFER_BYTES, RUNTIME_BUNDLE_HANDOFF_BUNDLE_DIRECTORY,
+    RUNTIME_BUNDLE_HANDOFF_EXTENSION, RUNTIME_BUNDLE_HANDOFF_EXTENSION_VERSION,
+    RUNTIME_BUNDLE_HANDOFF_ROOT_DIRECTORY,
 };
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
@@ -233,6 +237,100 @@ impl OciRuntimeBinding {
     }
 }
 
+/// Stable runtime identities and negotiated capabilities available to product preparation.
+#[derive(Debug, Clone)]
+pub struct OciBundlePreparationContext {
+    runtime_container_id: ContainerId,
+    create_context: OperationContext,
+    isolation: IsolationRequest,
+    attachment_capabilities: AttachmentCapabilities,
+    execution_generation: ExecutionGeneration,
+    operation_seed: BoxOperationId,
+}
+
+impl OciBundlePreparationContext {
+    /// Exact runtime container identity derived from the Box execution identity.
+    pub fn runtime_container_id(&self) -> &ContainerId {
+        &self.runtime_container_id
+    }
+
+    /// Exact create operation context that will be sent to OCI Runtime.
+    pub fn create_context(&self) -> &OperationContext {
+        &self.create_context
+    }
+
+    /// Minimum isolation requested from OCI Runtime.
+    pub fn isolation(&self) -> &IsolationRequest {
+        &self.isolation
+    }
+
+    /// Attachment extensions advertised by the connected runtime service.
+    pub fn attachment_capabilities(&self) -> &AttachmentCapabilities {
+        &self.attachment_capabilities
+    }
+
+    /// Resolve the only operation-scoped directory accepted for bundle ownership handoff.
+    pub fn runtime_bundle_handoff_directory(
+        &self,
+        runtime_root: impl AsRef<Path>,
+    ) -> ExecutionManagerResult<PathBuf> {
+        if !self.attachment_capabilities.supports_extension(
+            RUNTIME_BUNDLE_HANDOFF_EXTENSION,
+            RUNTIME_BUNDLE_HANDOFF_EXTENSION_VERSION,
+        ) {
+            return Err(ExecutionManagerError::Unavailable(format!(
+                "A3S OCI Runtime does not advertise {RUNTIME_BUNDLE_HANDOFF_EXTENSION} version {RUNTIME_BUNDLE_HANDOFF_EXTENSION_VERSION}"
+            )));
+        }
+        sdk_runtime_bundle_handoff_directory(
+            runtime_root,
+            &self.runtime_container_id,
+            &self.create_context.operation_id,
+        )
+        .map_err(|error| sdk_error("resolve bundle handoff", error))
+    }
+
+    /// Verify that a claimed handoff directory has the exact negotiated suffix.
+    pub fn validate_runtime_bundle_handoff_directory(
+        &self,
+        directory: &Path,
+    ) -> ExecutionManagerResult<()> {
+        let operation_directory = directory.parent();
+        let container_directory = operation_directory.and_then(Path::parent);
+        let handoff_root = container_directory.and_then(Path::parent);
+        let runtime_root = handoff_root.and_then(Path::parent);
+        let exact_shape = directory.is_absolute()
+            && directory.file_name().and_then(|name| name.to_str())
+                == Some(RUNTIME_BUNDLE_HANDOFF_BUNDLE_DIRECTORY)
+            && operation_directory
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                == Some(self.create_context.operation_id.as_str())
+            && container_directory
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                == Some(self.runtime_container_id.as_str())
+            && handoff_root
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                == Some(RUNTIME_BUNDLE_HANDOFF_ROOT_DIRECTORY);
+        let Some(runtime_root) = runtime_root.filter(|_| exact_shape) else {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "A3S OCI bundle handoff does not match the exact runtime/container/create-operation layout: {}",
+                directory.display()
+            )));
+        };
+        let expected = self.runtime_bundle_handoff_directory(runtime_root)?;
+        if directory != expected {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "A3S OCI bundle handoff path is not normalized: {}",
+                directory.display()
+            )));
+        }
+        Ok(())
+    }
+}
+
 /// Product-owned OCI bundle and host bookkeeping required before lifecycle launch.
 #[derive(Debug, Clone)]
 pub struct OciPreparedExecution {
@@ -273,10 +371,42 @@ impl OciPreparedExecution {
         })
     }
 
-    fn validate_for(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {
+    /// Bind a portable bundle prepared at the negotiated operation-scoped handoff path.
+    pub fn with_runtime_bundle_handoff(
+        mut self,
+        context: &OciBundlePreparationContext,
+        runtime_root: impl AsRef<Path>,
+    ) -> ExecutionManagerResult<Self> {
+        let expected = context.runtime_bundle_handoff_directory(runtime_root)?;
+        if self.bundle.directory() != expected {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "A3S OCI bundle handoff must use exact operation path {}: {}",
+                expected.display(),
+                self.bundle.directory().display()
+            )));
+        }
+        self.attachments = self
+            .attachments
+            .clone()
+            .with_runtime_bundle_handoff(&self.bundle)
+            .map_err(|error| sdk_error("prepare bundle handoff", error))?;
+        self.attachments
+            .validate(&self.bundle)
+            .map_err(|error| sdk_error("validate bundle handoff", error))?;
+        Ok(self)
+    }
+
+    fn validate_for(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<()> {
         self.attachments
             .validate(&self.bundle)
             .map_err(|error| sdk_error("validate attachments", error))?;
+        if self.attachments.uses_runtime_bundle_handoff() {
+            context.validate_runtime_bundle_handoff_directory(self.bundle.directory())?;
+        }
         if self.console_log != record.console_log {
             return Err(ExecutionManagerError::InvalidRequest(format!(
                 "A3S OCI preparation changed the durable console path for {}",
@@ -296,8 +426,21 @@ impl OciPreparedExecution {
 /// Product-owned preparation boundary consumed by the OCI lifecycle backend.
 #[async_trait]
 pub trait OciBundleProvider: Send + Sync {
+    /// Reject a runtime/provider mismatch before product or runtime mutation.
+    fn preflight(
+        &self,
+        _record: &BoxRecord,
+        _context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<()> {
+        Ok(())
+    }
+
     /// Prepare one immutable OCI bundle after runtime capability preflight.
-    async fn prepare(&self, record: &BoxRecord) -> ExecutionManagerResult<OciPreparedExecution>;
+    async fn prepare(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<OciPreparedExecution>;
 
     /// Remove only Box-owned preparation artifacts after runtime cleanup.
     async fn cleanup(&self, _record: &BoxRecord) -> ExecutionManagerResult<()> {
@@ -398,13 +541,11 @@ impl OciLifecycleAdapter {
         &self,
         info: &RuntimeInfo,
         execution_id: &ExecutionId,
-        execution_generation: ExecutionGeneration,
-        operation_seed: &BoxOperationId,
+        preparation: OciBundlePreparationContext,
         prepared: OciPreparedExecution,
-        isolation: ExecutionIsolation,
     ) -> ExecutionManagerResult<OciRuntimeLaunch> {
-        let id = runtime_container_id(execution_id)?;
-        let requested = oci_isolation_request(isolation);
+        let id = preparation.runtime_container_id.clone();
+        let requested = preparation.isolation.clone();
         let expected_config_digest = prepared.bundle.config_digest().to_string();
         let expected_attachments_digest = prepared
             .attachments
@@ -413,12 +554,7 @@ impl OciLifecycleAdapter {
         let created = self
             .client
             .create(CreateRequest {
-                context: operation_context(
-                    operation_seed.as_str(),
-                    execution_generation,
-                    "create",
-                    requested.class(),
-                )?,
+                context: preparation.create_context,
                 id: id.clone(),
                 bundle: prepared.bundle,
                 isolation: requested.clone(),
@@ -436,7 +572,7 @@ impl OciLifecycleAdapter {
         ) {
             self.cleanup_failed_launch(
                 execution_id,
-                execution_generation,
+                preparation.execution_generation,
                 &created,
                 requested.class(),
             )
@@ -449,8 +585,8 @@ impl OciLifecycleAdapter {
             .client
             .start(StartRequest {
                 context: operation_context(
-                    operation_seed.as_str(),
-                    execution_generation,
+                    preparation.operation_seed.as_str(),
+                    preparation.execution_generation,
                     "start",
                     requested.class(),
                 )?,
@@ -469,7 +605,7 @@ impl OciLifecycleAdapter {
         {
             self.cleanup_failed_launch(
                 execution_id,
-                execution_generation,
+                preparation.execution_generation,
                 &created,
                 requested.class(),
             )
@@ -1096,6 +1232,30 @@ impl OciLocalExecutionBackend {
         self.adapter.client()
     }
 
+    fn preparation_context(
+        &self,
+        record: &BoxRecord,
+        info: &RuntimeInfo,
+    ) -> ExecutionManagerResult<OciBundlePreparationContext> {
+        let execution_id = self.execution_id(record)?;
+        let metadata = self.metadata(record)?;
+        let isolation = oci_isolation_request(record.isolation);
+        let create_context = operation_context(
+            metadata.operation_id.as_str(),
+            metadata.generation,
+            "create",
+            isolation.class(),
+        )?;
+        Ok(OciBundlePreparationContext {
+            runtime_container_id: runtime_container_id(&execution_id)?,
+            create_context,
+            isolation,
+            attachment_capabilities: info.attachments.clone(),
+            execution_generation: metadata.generation,
+            operation_seed: metadata.operation_id.clone(),
+        })
+    }
+
     fn handle(
         &self,
         record: &BoxRecord,
@@ -1214,13 +1374,14 @@ impl LocalExecutionBackend for OciLocalExecutionBackend {
 
     async fn preflight(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {
         self.metadata(record)?;
-        self.adapter.require_isolation(record.isolation).await?;
-        Ok(())
+        let info = self.adapter.require_isolation(record.isolation).await?;
+        let context = self.preparation_context(record, &info)?;
+        self.provider.preflight(record, &context)
     }
 
     async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
         let execution_id = self.execution_id(record)?;
-        let metadata = self.metadata(record)?;
+        self.metadata(record)?;
         if let Some((runtime, binding)) = self.current_runtime(record).await? {
             if *runtime.state.status() == ContainerState::Running {
                 return Ok(self.handle(
@@ -1240,6 +1401,8 @@ impl LocalExecutionBackend for OciLocalExecutionBackend {
         }
 
         let info = self.adapter.require_isolation(record.isolation).await?;
+        let preparation = self.preparation_context(record, &info)?;
+        self.provider.preflight(record, &preparation)?;
         let resource_home = managed_resource_home(record)?;
         let resource_record = record.clone();
         let resources = tokio::task::spawn_blocking(move || {
@@ -1252,14 +1415,14 @@ impl LocalExecutionBackend for OciLocalExecutionBackend {
                 record.id
             ))
         })??;
-        let prepared = match self.provider.prepare(record).await {
+        let prepared = match self.provider.prepare(record, &preparation).await {
             Ok(prepared) => prepared,
             Err(error) => {
                 rollback_execution_resources(resources, record).await;
                 return Err(error);
             }
         };
-        if let Err(error) = prepared.validate_for(record) {
+        if let Err(error) = prepared.validate_for(record, &preparation) {
             let cleanup = self.provider.cleanup(record).await;
             rollback_execution_resources(resources, record).await;
             return match cleanup {
@@ -1273,14 +1436,7 @@ impl LocalExecutionBackend for OciLocalExecutionBackend {
         let anonymous_volumes = prepared.anonymous_volumes.clone();
         let launch = self
             .adapter
-            .launch_preflighted(
-                &info,
-                &execution_id,
-                metadata.generation,
-                &metadata.operation_id,
-                prepared,
-                record.isolation,
-            )
+            .launch_preflighted(&info, &execution_id, preparation, prepared)
             .await;
         match launch {
             Ok(launch) if *launch.record.state.status() == ContainerState::Running => {

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -27,7 +28,7 @@ use a3s_oci_sdk::{
     ProcessesRequest, ReadOutputRequest, ResizeRequest, Result as OciResult, RuntimeClient,
     RuntimeEvent, RuntimeEventKind, RuntimeInfo, RuntimeOperation, SignalProcessRequest,
     StartRequest, StateRequest, StatsRequest, TerminalSize, UpdateRequest, WaitProcessRequest,
-    WaitRequest, WriteStdinRequest, PAUSED_STATE_ANNOTATION,
+    WaitRequest, WriteStdinRequest, PAUSED_STATE_ANNOTATION, RUNTIME_BUNDLE_HANDOFF_MOVE_V1,
 };
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::Utc;
@@ -126,6 +127,14 @@ impl FakeRuntimeService {
         let mut service = Self::launch_ready();
         let mut info = serde_json::to_value(&service.info).expect("encode runtime info");
         info["attachments"]["schemas"] = json!([]);
+        service.info = serde_json::from_value(info).expect("decode runtime info");
+        service
+    }
+
+    fn with_bundle_handoff() -> Self {
+        let mut service = Self::launch_ready();
+        let mut info = serde_json::to_value(&service.info).expect("encode runtime info");
+        info["attachments"]["extensions"][RUNTIME_BUNDLE_HANDOFF_EXTENSION] = json!([1]);
         service.info = serde_json::from_value(info).expect("decode runtime info");
         service
     }
@@ -1265,7 +1274,11 @@ struct FakeBundleProvider {
 
 #[async_trait]
 impl OciBundleProvider for FakeBundleProvider {
-    async fn prepare(&self, record: &BoxRecord) -> ExecutionManagerResult<OciPreparedExecution> {
+    async fn prepare(
+        &self,
+        record: &BoxRecord,
+        _context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<OciPreparedExecution> {
         self.prepares.fetch_add(1, Ordering::SeqCst);
         *self
             .last_box_dir
@@ -1320,6 +1333,81 @@ impl OciBundleProvider for FakeBundleProvider {
     async fn cleanup(&self, _record: &BoxRecord) -> ExecutionManagerResult<()> {
         self.cleanups.fetch_add(1, Ordering::SeqCst);
         Ok(())
+    }
+}
+
+struct RuntimeBundleHandoffProvider {
+    runtime_root: PathBuf,
+    preflights: AtomicUsize,
+    prepares: AtomicUsize,
+}
+
+impl RuntimeBundleHandoffProvider {
+    fn new(runtime_root: PathBuf) -> Self {
+        Self {
+            runtime_root,
+            preflights: AtomicUsize::new(0),
+            prepares: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl OciBundleProvider for RuntimeBundleHandoffProvider {
+    fn preflight(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<()> {
+        self.preflights.fetch_add(1, Ordering::SeqCst);
+        if record.isolation != ExecutionIsolation::Microvm {
+            return Err(ExecutionManagerError::InvalidRequest(
+                "runtime bundle handoff fixture requires MicroVM isolation".to_string(),
+            ));
+        }
+        context
+            .runtime_bundle_handoff_directory(&self.runtime_root)
+            .map(|_| ())
+    }
+
+    async fn prepare(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<OciPreparedExecution> {
+        self.prepares.fetch_add(1, Ordering::SeqCst);
+        let directory = context.runtime_bundle_handoff_directory(&self.runtime_root)?;
+        std::fs::create_dir_all(directory.join("rootfs")).map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "failed to create portable bundle handoff: {error}"
+            ))
+        })?;
+        let config = json!({
+            "ociVersion": "1.3.0",
+            "process": {
+                "terminal": false,
+                "user": { "uid": 0, "gid": 0 },
+                "args": ["/bin/true"],
+                "cwd": "/"
+            },
+            "root": { "path": "rootfs", "readonly": false },
+            "annotations": {
+                RUNTIME_BUNDLE_HANDOFF_EXTENSION: RUNTIME_BUNDLE_HANDOFF_MOVE_V1
+            }
+        });
+        let config = serde_json::to_string_pretty(&config)
+            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
+        std::fs::write(directory.join("config.json"), config.as_bytes()).map_err(|error| {
+            ExecutionManagerError::Internal(format!(
+                "failed to write portable bundle handoff: {error}"
+            ))
+        })?;
+        let bundle = OciBundle::from_json(directory, config)
+            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
+        let mut prepared = OciPreparedExecution::new(bundle, record.console_log.clone())?
+            .with_runtime_bundle_handoff(context, &self.runtime_root)?;
+        prepared.anonymous_volumes = record.anonymous_volumes.clone();
+        Ok(prepared)
     }
 }
 
@@ -1555,6 +1643,82 @@ async fn preflight_requires_attachment_v1_before_store_or_preparation() {
     assert!(!manager.state_path().exists());
     assert_eq!(provider.prepares.load(Ordering::SeqCst), 0);
     assert!(service.create_requests().is_empty());
+}
+
+#[tokio::test]
+async fn bundle_handoff_capability_fails_before_store_or_preparation() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let provider = Arc::new(RuntimeBundleHandoffProvider::new(
+        directory.path().join("oci-runtime"),
+    ));
+    let manager = manager_with_provider(
+        &directory,
+        test_endpoint(),
+        service.clone(),
+        provider.clone(),
+    );
+    let operation = box_operation("missing-bundle-handoff-create");
+
+    let error = manager
+        .create(
+            request("missing-bundle-handoff", ExecutionIsolation::Microvm),
+            &operation,
+        )
+        .await
+        .expect_err("handoff-unaware runtime must fail before mutation");
+
+    assert!(matches!(
+        error,
+        ExecutionManagerError::Unavailable(message)
+            if message.contains(RUNTIME_BUNDLE_HANDOFF_EXTENSION)
+    ));
+    assert!(!manager.state_path().exists());
+    assert_eq!(provider.preflights.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.prepares.load(Ordering::SeqCst), 0);
+    assert!(service.create_requests().is_empty());
+}
+
+#[tokio::test]
+async fn bundle_handoff_uses_the_exact_context_sent_to_runtime_create() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let runtime_root = directory.path().join("oci-runtime");
+    let service = Arc::new(FakeRuntimeService::with_bundle_handoff());
+    let provider = Arc::new(RuntimeBundleHandoffProvider::new(runtime_root.clone()));
+    let manager = manager_with_provider(
+        &directory,
+        test_endpoint(),
+        service.clone(),
+        provider.clone(),
+    );
+    let operation = box_operation("bundle-handoff-create");
+
+    let lease = manager
+        .create_and_start(
+            request("bundle-handoff", ExecutionIsolation::Microvm),
+            &operation,
+        )
+        .await
+        .expect("launch handoff-backed execution");
+
+    let creates = service.create_requests();
+    assert_eq!(creates.len(), 1);
+    let create = &creates[0];
+    let expected_directory = a3s_oci_sdk::runtime_bundle_handoff_directory(
+        &runtime_root,
+        &create.id,
+        &create.context.operation_id,
+    )
+    .expect("exact handoff path");
+    assert_eq!(create.bundle.directory(), expected_directory);
+    assert!(create.attachments.uses_runtime_bundle_handoff());
+    assert_eq!(
+        create.id,
+        runtime_container_id(&lease.execution_id).expect("runtime container ID")
+    );
+    assert_ne!(lease.generation.get(), RUNTIME_GENERATION.0);
+    assert!(provider.preflights.load(Ordering::SeqCst) >= 2);
+    assert_eq!(provider.prepares.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]
@@ -4128,6 +4292,15 @@ fn manager(
     endpoint: OciRuntimeEndpoint,
     service: Arc<FakeRuntimeService>,
     provider: Arc<FakeBundleProvider>,
+) -> LocalExecutionManager {
+    manager_with_provider(directory, endpoint, service, provider)
+}
+
+fn manager_with_provider(
+    directory: &tempfile::TempDir,
+    endpoint: OciRuntimeEndpoint,
+    service: Arc<FakeRuntimeService>,
+    provider: Arc<dyn OciBundleProvider>,
 ) -> LocalExecutionManager {
     let runtime_service: Arc<dyn OciRuntimeService> = service;
     let backend = OciLocalExecutionBackend::from_client(

--- a/src/runtime/src/local_execution/oci_production.rs
+++ b/src/runtime/src/local_execution/oci_production.rs
@@ -8,7 +8,9 @@ use a3s_box_core::{
 use a3s_oci_sdk::{CreateAttachments, IoMode, OciBundle, ProcessIo};
 use async_trait::async_trait;
 
-use super::{OciBundleProvider, OciPreparedExecution, VmLocalExecutionBackend};
+use super::{
+    OciBundlePreparationContext, OciBundleProvider, OciPreparedExecution, VmLocalExecutionBackend,
+};
 use crate::sandbox::probe_sandbox_capabilities_for;
 use crate::BoxRecord;
 
@@ -50,7 +52,11 @@ impl NativeLinuxOciBundleProvider {
 
 #[async_trait]
 impl OciBundleProvider for NativeLinuxOciBundleProvider {
-    async fn prepare(&self, record: &BoxRecord) -> ExecutionManagerResult<OciPreparedExecution> {
+    async fn prepare(
+        &self,
+        record: &BoxRecord,
+        _context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<OciPreparedExecution> {
         if record.isolation != ExecutionIsolation::Sandbox {
             return Err(ExecutionManagerError::InvalidRequest(format!(
                 "native Linux OCI migration only prepares Sandbox executions, got {:?}",


### PR DESCRIPTION
## Summary
- pin the SDK to OCI Runtime main commit 0451739d
- give bundle providers the exact runtime container/create-operation context and negotiated attachment capabilities
- preflight the bundle-handoff extension before Box state or product preparation
- bind handoff bundles to the exact operation-scoped path and reuse the same context for SDK create
- retain independent Box and Runtime generations

## Validation
- cargo fmt --all -- --check
- cargo check -p a3s-box-runtime --all-targets
- cargo clippy -p a3s-box-runtime --all-targets -- -D warnings
- cargo test -p a3s-box-runtime -j 1 (1303 passed, 1 ignored)
- cargo check --workspace --all-targets --exclude a3s-box-cri
- cargo clippy --workspace --all-targets --exclude a3s-box-cri -- -D warnings
- cargo test --workspace --exclude a3s-box-cri -j 1

The local host does not have protoc, so the CRI build is left to CI, whose environment installs protobuf-compiler.