### PR TITLE
feat(runtime): produce portable WHPX OCI bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: a6cdae7163db941aa1eae5a5d74c75c6ccc32b60
+  A3S_OCI_RUNTIME_REV: 6223f2b957f88d348a27b3542541261b1f0ffb55
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 6b9e0cf2137f1ab9da52e71f566267c97fd9cfa2
+  A3S_OCI_RUNTIME_REV: 6223f2b957f88d348a27b3542541261b1f0ffb55
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ never retried on the Box backend. On Linux, the CLI, machine bridge, and the
 async Rust SDK constructor can now opt new Sandbox records into the production
 bundle provider and long-lived pinned runtime owner with
 `A3S_BOX_OCI_MIGRATION=sandbox`. With the setting absent, current behavior is
-unchanged.
+unchanged. Windows x86_64 also has an explicit qualification-only
+`microvm`/`all` composition for the externally launched OCI Runtime WHPX
+service; it is not enabled by default and is not yet a production claim.
 
 > [!NOTE]
 > The current SDK-only Sandbox adapter now covers four exact-generation rails:
@@ -219,11 +221,37 @@ Rust applications select the same path with
 `from_home`, and `with_paths` constructors retain legacy behavior for API
 compatibility.
 
-Current opt-in limits are intentional: only new Linux Sandbox reservations are
-routed; `all`/MicroVM migration is rejected; image-declared anonymous volumes
-must be replaced by explicit named or bind mounts; and remaining socket-based
-CLI projections (`attach`, `cp`, `top`, `stats`, live `container-update`, plus
-init stdout/stderr projection into Box logs) are not yet promoted on this path.
+### Exercise the qualification-only WHPX handoff on Windows
+
+Start the pinned OCI Runtime `box-whpx-qualification-service` with its shim,
+protected runtime root, utility-VM rootfs, state root, named pipe, and readiness
+file. Then configure every Box process that owns the test record:
+
+```powershell
+$env:A3S_BOX_OCI_MIGRATION = 'microvm'
+$env:A3S_BOX_OCI_HOST_ROOT = 'C:\absolute\a3s-oci-runtime-root'
+$env:A3S_BOX_OCI_WHPX_ENDPOINT = '\\.\pipe\a3s-oci-box-qualification'
+
+a3s-box run --rm --cpus 1 --memory 512m --network none alpine:3.20 -- /bin/true
+```
+
+This profile accepts only a fresh writable Linux amd64 rootfs, one vCPU,
+512 MiB, `network=none`, and no TEE, host mounts, volumes, devices, sidecars,
+Snapshot, custom security controls, or persistence. Box copies the prepared
+rootfs into the exact operation-scoped SDK handoff, converts its image metadata
+to `a3s.oci.rootfs-metadata.v1`, emits a relative `rootfs` OCI specification
+without a user namespace, and atomically publishes the bundle. OCI Runtime
+then moves that bundle into the exact WHPX generation share. Missing extension
+support or any unqualified option fails before image preparation. The endpoint
+must be supplied explicitly so this experimental service can never activate by
+accident.
+
+Current Linux opt-in limits are intentional: only new Sandbox reservations are
+routed there; `all`/MicroVM migration is rejected on Linux; image-declared
+anonymous volumes must be replaced by explicit named or bind mounts; and
+remaining socket-based CLI projections (`attach`, `cp`, `top`, `stats`, live
+`container-update`, plus init stdout/stderr projection into Box logs) are not
+yet promoted on this path.
 The typed SDK lifecycle, exec/PTY, file/filesystem, process inventory, stats,
 events, resource update, pause/resume, wait, restart, and cleanup contracts do
 route through the exact OCI generation.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,7 +143,7 @@ later lifecycle, session, observability, filesystem, restart, and cleanup calls
 use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
-`0451739d15795be5829a4774198e276f861561be` retains the matching long-lived,
+`6223f2b957f88d348a27b3542541261b1f0ffb55` retains the matching long-lived,
 multi-container Native Linux host owner and adds the generation-safe bundle
 handoff used by the preparation context above. Box now first validates the
 exact managed home and durably prepares snapshot-lower, named-volume, and
@@ -261,6 +261,12 @@ later gates.
   - [x] Negotiate the required handoff extension and bind provider preparation
     to the exact runtime container/create-operation path without coupling Box
     and runtime generations.
+  - [x] Produce the operation-scoped portable bundle from Box image policy,
+    convert bounded rootfs metadata to the public OCI schema, and expose an
+    explicit named-pipe qualification composition with a fail-closed feature
+    profile.
+  - [ ] Run the Box-owned bundle through a real Windows WHPX create/start/wait/
+    delete gate and retain machine-readable evidence in blocking CI.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
 through Box on Linux and Windows, including Box and runtime process restart.
@@ -277,10 +283,12 @@ long-lived Native Linux owner, and Box now supplies fail-closed mixed-backend
 routing, verified product-resource preparation, a direct-process production
 bundle provider, protected owner startup, and explicit CLI/SDK construction.
 The real-host Native Linux x86_64 and aarch64 production composition and
-owner/Box process restart lanes now pass. The remaining B1 platform gate is the
-equivalent WHPX production path; the deterministic live-session fixtures are
-not promoted as proof that a real driver can transparently retain process or
-filesystem sessions after its owner dies.
+owner/Box process restart lanes now pass. Box now also owns the portable WHPX
+bundle producer and explicit qualification-only named-pipe composition. The
+remaining B1 platform gate is execution of that exact path on a real WHPX host;
+the deterministic live-session fixtures are not promoted as proof that a real
+driver can transparently retain process or filesystem sessions after its owner
+dies.
 
 ### B2 - Interactive And Observable Execution
 

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -61,7 +61,7 @@ Box now:
 - rejects any reintroduction of the removed integration symbols in CI.
 
 The exact integration revision is
-`a6cdae7163db941aa1eae5a5d74c75c6ccc32b60`, which retains the qualified
+`6223f2b957f88d348a27b3542541261b1f0ffb55`, which retains the qualified
 control/workload cgroup and read-only bind behavior and adds deterministic
 multi-driver registration, isolation selection, and durable recorded-driver
 routing required by the unified execution migration. Runtime service startup

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0451739d15795be5829a4774198e276f861561be#0451739d15795be5829a4774198e276f861561be"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=6223f2b957f88d348a27b3542541261b1f0ffb55#6223f2b957f88d348a27b3542541261b1f0ffb55"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0451739d15795be5829a4774198e276f861561be#0451739d15795be5829a4774198e276f861561be"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=6223f2b957f88d348a27b3542541261b1f0ffb55#6223f2b957f88d348a27b3542541261b1f0ffb55"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,7 +125,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "061cde95e16eb4cbd9f58724e6cbb60de6ace77e" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "0451739d15795be5829a4774198e276f861561be" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "6223f2b957f88d348a27b3542541261b1f0ffb55" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -86,6 +86,7 @@ pub use local_execution::{
 #[cfg(feature = "vm")]
 pub use local_execution::{
     NativeLinuxOciBundleProvider, NativeLinuxOciMigrationConfig, VmLocalExecutionBackend,
+    WindowsWhpxOciBundleProvider, WindowsWhpxOciMigrationConfig,
 };
 pub use managed_execution_store::{
     ManagedExecutionReservation, ManagedExecutionStore, ManagedExecutionStoreError,

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -16,6 +16,8 @@ mod oci_migration;
 #[cfg(all(feature = "vm", target_os = "linux"))]
 mod oci_owner;
 #[cfg(feature = "vm")]
+pub(crate) mod oci_portable_rootfs;
+#[cfg(feature = "vm")]
 mod oci_production;
 mod oci_session;
 mod operations;
@@ -60,9 +62,9 @@ pub use oci_backend::{
     OciRuntimeLaunch, OCI_RUNTIME_BINDING_SCHEMA_VERSION,
 };
 #[cfg(feature = "vm")]
-pub use oci_migration::NativeLinuxOciMigrationConfig;
+pub use oci_migration::{NativeLinuxOciMigrationConfig, WindowsWhpxOciMigrationConfig};
 #[cfg(feature = "vm")]
-pub use oci_production::NativeLinuxOciBundleProvider;
+pub use oci_production::{NativeLinuxOciBundleProvider, WindowsWhpxOciBundleProvider};
 use record::{build_managed_record, status_from_record};
 pub use router::{LocalExecutionBackendRouter, OciMigrationPolicy};
 use store::RuntimeUpdate;

--- a/src/runtime/src/local_execution/oci_migration.rs
+++ b/src/runtime/src/local_execution/oci_migration.rs
@@ -18,6 +18,8 @@ pub const OCI_MIGRATION_ENV: &str = "A3S_BOX_OCI_MIGRATION";
 pub const OCI_HOST_ROOT_ENV: &str = "A3S_BOX_OCI_HOST_ROOT";
 pub const OCI_RUNTIME_PATH_ENV: &str = "A3S_BOX_OCI_RUNTIME_PATH";
 pub const OCI_AGENT_PATH_ENV: &str = "A3S_BOX_OCI_AGENT_PATH";
+pub const OCI_WHPX_ENDPOINT_ENV: &str = "A3S_BOX_OCI_WHPX_ENDPOINT";
+pub const DEFAULT_OCI_WHPX_ENDPOINT: &str = r"\\.\pipe\a3s-oci-box-qualification";
 
 /// Explicit native-Linux owner and artifact selection for Sandbox migration.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,6 +27,56 @@ pub struct NativeLinuxOciMigrationConfig {
     service_root: PathBuf,
     runtime_path: Option<PathBuf>,
     agent_path: Option<PathBuf>,
+}
+
+/// Explicit connection to an externally owned qualification-only WHPX service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowsWhpxOciMigrationConfig {
+    runtime_root: PathBuf,
+    endpoint: super::OciRuntimeEndpoint,
+}
+
+impl WindowsWhpxOciMigrationConfig {
+    pub fn new(
+        runtime_root: impl Into<PathBuf>,
+        endpoint: impl Into<String>,
+    ) -> ExecutionManagerResult<Self> {
+        let config = Self {
+            runtime_root: runtime_root.into(),
+            endpoint: super::OciRuntimeEndpoint::windows_named_pipe(endpoint)?,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn runtime_root(&self) -> &Path {
+        &self.runtime_root
+    }
+
+    pub fn endpoint(&self) -> &super::OciRuntimeEndpoint {
+        &self.endpoint
+    }
+
+    pub fn from_environment(home_dir: &Path) -> ExecutionManagerResult<Option<Self>> {
+        parse_windows_environment(
+            std::env::var_os(OCI_MIGRATION_ENV),
+            std::env::var_os(OCI_HOST_ROOT_ENV),
+            std::env::var_os(OCI_WHPX_ENDPOINT_ENV),
+            home_dir,
+        )
+    }
+
+    fn validate(&self) -> ExecutionManagerResult<()> {
+        validate_absolute_normalized(&self.runtime_root, "WHPX OCI runtime root")?;
+        match &self.endpoint {
+            super::OciRuntimeEndpoint::WindowsNamedPipe { .. } => Ok(()),
+            super::OciRuntimeEndpoint::UnixSocket { .. } => {
+                Err(ExecutionManagerError::InvalidRequest(
+                    "WHPX OCI qualification requires a Windows named-pipe endpoint".to_string(),
+                ))
+            }
+        }
+    }
 }
 
 impl NativeLinuxOciMigrationConfig {
@@ -165,6 +217,61 @@ impl LocalExecutionManager {
         }
     }
 
+    /// Compose the retained backend with the externally launched Box/WHPX OCI service.
+    pub async fn with_windows_whpx_oci_qualification(
+        state_path: impl Into<PathBuf>,
+        home_dir: impl Into<PathBuf>,
+        config: WindowsWhpxOciMigrationConfig,
+    ) -> ExecutionManagerResult<Self> {
+        Self::with_windows_whpx_oci_qualification_and_pull_progress(
+            state_path.into(),
+            home_dir.into(),
+            config,
+            None,
+        )
+        .await
+    }
+
+    async fn with_windows_whpx_oci_qualification_and_pull_progress(
+        state_path: PathBuf,
+        home_dir: PathBuf,
+        config: WindowsWhpxOciMigrationConfig,
+        pull_progress_fn: Option<crate::PullProgressFn>,
+    ) -> ExecutionManagerResult<Self> {
+        config.validate()?;
+
+        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+        {
+            let mut provider =
+                super::WindowsWhpxOciBundleProvider::new(home_dir.clone(), config.runtime_root());
+            if let Some(progress) = pull_progress_fn.as_ref() {
+                provider = provider.with_pull_progress_fn(progress.clone());
+            }
+            let oci = Arc::new(
+                super::OciLocalExecutionBackend::connect(
+                    config.endpoint().clone(),
+                    Arc::new(provider),
+                )
+                .await?,
+            );
+            Ok(Self::with_oci_migration_backend_and_pull_progress(
+                state_path,
+                home_dir,
+                oci,
+                super::OciMigrationPolicy::AllViaOci,
+                pull_progress_fn,
+            ))
+        }
+
+        #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+        {
+            let _ = (state_path, home_dir, config, pull_progress_fn);
+            Err(ExecutionManagerError::Unavailable(
+                "Box/WHPX OCI qualification requires Windows x86_64".to_string(),
+            ))
+        }
+    }
+
     /// Select the production migration composition only when explicitly opted
     /// in through `A3S_BOX_OCI_MIGRATION=sandbox`.
     pub async fn with_configured_backend(
@@ -183,25 +290,55 @@ impl LocalExecutionManager {
     ) -> ExecutionManagerResult<Self> {
         let state_path = state_path.into();
         let home_dir = home_dir.into();
-        match NativeLinuxOciMigrationConfig::from_environment(&home_dir)? {
-            Some(config) => {
-                Self::with_native_linux_oci_migration_and_pull_progress(
-                    state_path,
-                    home_dir,
-                    config,
-                    pull_progress_fn,
-                )
-                .await
-            }
-            None => {
-                let mut backend = crate::local_execution::VmLocalExecutionBackend::new(&home_dir);
-                if let Some(progress) = pull_progress_fn {
-                    backend = backend.with_pull_progress_fn(progress);
+
+        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+        {
+            return match WindowsWhpxOciMigrationConfig::from_environment(&home_dir)? {
+                Some(config) => {
+                    Self::with_windows_whpx_oci_qualification_and_pull_progress(
+                        state_path,
+                        home_dir,
+                        config,
+                        pull_progress_fn,
+                    )
+                    .await
                 }
-                Ok(Self::new(state_path, home_dir, Arc::new(backend)))
+                None => legacy_backend(state_path, home_dir, pull_progress_fn),
+            };
+        }
+
+        #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+        {
+            match NativeLinuxOciMigrationConfig::from_environment(&home_dir)? {
+                Some(config) => {
+                    Self::with_native_linux_oci_migration_and_pull_progress(
+                        state_path,
+                        home_dir,
+                        config,
+                        pull_progress_fn,
+                    )
+                    .await
+                }
+                None => legacy_backend(state_path, home_dir, pull_progress_fn),
             }
         }
     }
+}
+
+fn legacy_backend(
+    state_path: PathBuf,
+    home_dir: PathBuf,
+    pull_progress_fn: Option<crate::PullProgressFn>,
+) -> ExecutionManagerResult<LocalExecutionManager> {
+    let mut backend = crate::local_execution::VmLocalExecutionBackend::new(&home_dir);
+    if let Some(progress) = pull_progress_fn {
+        backend = backend.with_pull_progress_fn(progress);
+    }
+    Ok(LocalExecutionManager::new(
+        state_path,
+        home_dir,
+        Arc::new(backend),
+    ))
 }
 
 fn parse_environment(
@@ -254,6 +391,56 @@ fn parse_environment(
         }
     }
     Ok(Some(config))
+}
+
+fn parse_windows_environment(
+    mode: Option<OsString>,
+    runtime_root: Option<OsString>,
+    endpoint: Option<OsString>,
+    home_dir: &Path,
+) -> ExecutionManagerResult<Option<WindowsWhpxOciMigrationConfig>> {
+    let Some(mode) = mode.filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let mode = mode.to_str().ok_or_else(|| {
+        ExecutionManagerError::InvalidRequest(format!(
+            "{OCI_MIGRATION_ENV} must contain UTF-8 text"
+        ))
+    })?;
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "" | "0" | "false" | "off" | "disabled" | "legacy" => return Ok(None),
+        "all" | "all-via-oci" | "microvm" | "microvm-via-oci" | "whpx" => {}
+        "1" | "true" | "on" | "sandbox" | "sandbox-via-oci" => {
+            return Err(ExecutionManagerError::InvalidRequest(
+                "Windows OCI qualification supports only MicroVM/WHPX routing; use all or microvm"
+                    .to_string(),
+            ))
+        }
+        value => {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "unsupported {OCI_MIGRATION_ENV} value {value:?}; expected off, microvm, or all"
+            )))
+        }
+    }
+
+    let runtime_root = runtime_root
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default_service_root(home_dir));
+    let endpoint = endpoint
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            ExecutionManagerError::InvalidRequest(format!(
+            "{OCI_WHPX_ENDPOINT_ENV} must be set explicitly for the qualification-only WHPX service"
+        ))
+        })?
+        .into_string()
+        .map_err(|_| {
+            ExecutionManagerError::InvalidRequest(format!(
+                "{OCI_WHPX_ENDPOINT_ENV} must contain UTF-8 text"
+            ))
+        })?;
+    WindowsWhpxOciMigrationConfig::new(runtime_root, endpoint).map(Some)
 }
 
 fn default_service_root(home_dir: &Path) -> PathBuf {
@@ -334,5 +521,29 @@ mod tests {
         .unwrap();
         assert_eq!(config.runtime_path(), Some(runtime.as_path()));
         assert_eq!(config.agent_path(), Some(agent.as_path()));
+    }
+
+    #[test]
+    fn windows_environment_requires_explicit_pipe_and_accepts_microvm() {
+        let home = absolute("a3s-oci-config-home");
+        assert!(
+            parse_windows_environment(Some(OsString::from("all")), None, None, &home,).is_err()
+        );
+
+        let config = parse_windows_environment(
+            Some(OsString::from("microvm")),
+            Some(absolute("a3s-oci-whpx-root").into_os_string()),
+            Some(OsString::from(DEFAULT_OCI_WHPX_ENDPOINT)),
+            &home,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            config.endpoint(),
+            &crate::local_execution::OciRuntimeEndpoint::windows_named_pipe(
+                DEFAULT_OCI_WHPX_ENDPOINT,
+            )
+            .unwrap()
+        );
     }
 }

--- a/src/runtime/src/local_execution/oci_migration.rs
+++ b/src/runtime/src/local_execution/oci_migration.rs
@@ -19,7 +19,8 @@ pub const OCI_HOST_ROOT_ENV: &str = "A3S_BOX_OCI_HOST_ROOT";
 pub const OCI_RUNTIME_PATH_ENV: &str = "A3S_BOX_OCI_RUNTIME_PATH";
 pub const OCI_AGENT_PATH_ENV: &str = "A3S_BOX_OCI_AGENT_PATH";
 pub const OCI_WHPX_ENDPOINT_ENV: &str = "A3S_BOX_OCI_WHPX_ENDPOINT";
-pub const DEFAULT_OCI_WHPX_ENDPOINT: &str = r"\\.\pipe\a3s-oci-box-qualification";
+#[cfg(test)]
+const DEFAULT_OCI_WHPX_ENDPOINT: &str = r"\\.\pipe\a3s-oci-box-qualification";
 
 /// Explicit native-Linux owner and artifact selection for Sandbox migration.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/runtime/src/local_execution/oci_portable_rootfs.rs
+++ b/src/runtime/src/local_execution/oci_portable_rootfs.rs
@@ -64,7 +64,7 @@ pub(crate) fn publish_portable_rootfs_metadata(rootfs: &Path) -> Result<()> {
         )));
     }
     let mut bytes = Vec::with_capacity(length as usize);
-    file.by_ref()
+    Read::by_ref(&mut file)
         .take(MAX_SOURCE_METADATA_BYTES + 1)
         .read_to_end(&mut bytes)
         .map_err(BoxError::IoError)?;

--- a/src/runtime/src/local_execution/oci_portable_rootfs.rs
+++ b/src/runtime/src/local_execution/oci_portable_rootfs.rs
@@ -1,0 +1,564 @@
+//! Conversion from Box image metadata to the portable OCI guest contract.
+
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::Path;
+
+use a3s_box_core::rootfs_metadata::{
+    RootfsEntryKind, RootfsMetadataManifest, IMAGE_ROOTFS_METADATA_PATH,
+    IMAGE_ROOTFS_METADATA_TEMP_PATH,
+};
+use a3s_box_core::{BoxError, Result};
+use a3s_oci_sdk::{
+    PortableRootfsEntryKind, PortableRootfsMetadataEntry, PortableRootfsMetadataManifest,
+    PORTABLE_ROOTFS_METADATA_FILE, PORTABLE_ROOTFS_METADATA_MAX_BYTES,
+    PORTABLE_ROOTFS_METADATA_MAX_ENTRIES,
+};
+use base64::Engine as _;
+use oci_spec::runtime::Spec;
+
+const MAX_SOURCE_METADATA_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_ENCODED_PATH_BYTES: usize = 16 * 1024;
+const MAX_DECODED_PATH_BYTES: usize = 4_096;
+const PORTABLE_ROOTFS_METADATA_TEMP_FILE: &str = ".a3s-oci-rootfs-metadata.v1.json.tmp";
+
+const RUNTIME_INTERNAL_ROOT_ENTRIES: &[&[u8]] = &[
+    b".a3s-box-env",
+    b".a3s-box-exec.json",
+    b".a3s_exit_code",
+    b".a3s_host_live_logs_drained",
+    b".a3s_host_result_collected",
+    b".a3s_image_metadata_v1.json",
+    b".a3s_image_metadata_v1.json.tmp",
+    b".a3s_rootfs_metadata_v1.json",
+    b".a3s_rootfs_metadata_v1.json.tmp",
+    b".a3s_rootfs_metadata_v1.previous.json",
+    b".a3s-oci-rootfs-metadata.v1.json",
+    b".a3s-oci-rootfs-metadata.v1.json.tmp",
+    b"guest-init.stderr.log",
+    b"guest-init.stdout.log",
+    b"init-rust.log",
+    b"init.krun.log",
+    b"init.trace.log",
+];
+
+/// Publish the one-shot OCI metadata manifest inside a portable rootfs.
+///
+/// The Box image manifest is consumed only after the replacement contract is
+/// durably encoded. Callers must invoke this on the copied handoff rootfs, not
+/// on Box's retained image/cache generation.
+pub(crate) fn publish_portable_rootfs_metadata(rootfs: &Path) -> Result<()> {
+    validate_plain_directory(rootfs, "portable rootfs")?;
+
+    let source = rootfs.join(IMAGE_ROOTFS_METADATA_PATH.trim_start_matches('/'));
+    let source_temporary = rootfs.join(IMAGE_ROOTFS_METADATA_TEMP_PATH.trim_start_matches('/'));
+    ensure_absent(&source_temporary, "Box image metadata temporary")?;
+
+    let mut file = open_plain_file(&source, "Box image metadata")?;
+    let length = file.metadata().map_err(BoxError::IoError)?.len();
+    if length > MAX_SOURCE_METADATA_BYTES {
+        return Err(metadata_error(format!(
+            "Box image metadata exceeds the {MAX_SOURCE_METADATA_BYTES}-byte input limit: {}",
+            source.display()
+        )));
+    }
+    let mut bytes = Vec::with_capacity(length as usize);
+    file.by_ref()
+        .take(MAX_SOURCE_METADATA_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(BoxError::IoError)?;
+    if bytes.len() as u64 > MAX_SOURCE_METADATA_BYTES {
+        return Err(metadata_error(
+            "Box image metadata grew beyond its input limit while reading".to_string(),
+        ));
+    }
+
+    let source_manifest: RootfsMetadataManifest =
+        serde_json::from_slice(&bytes).map_err(|error| {
+            metadata_error(format!(
+                "invalid Box image metadata {}: {error}",
+                source.display()
+            ))
+        })?;
+    source_manifest.validate().map_err(metadata_error)?;
+    let encoded = encode_portable_manifest(source_manifest)?;
+
+    let destination = rootfs.join(PORTABLE_ROOTFS_METADATA_FILE);
+    let temporary = rootfs.join(PORTABLE_ROOTFS_METADATA_TEMP_FILE);
+    ensure_absent(&destination, "portable rootfs metadata")?;
+    ensure_absent(&temporary, "portable rootfs metadata temporary")?;
+
+    let publish = (|| -> Result<()> {
+        let mut output = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+            .map_err(BoxError::IoError)?;
+        output.write_all(&encoded).map_err(BoxError::IoError)?;
+        output.sync_all().map_err(BoxError::IoError)?;
+        drop(output);
+        std::fs::rename(&temporary, &destination).map_err(BoxError::IoError)?;
+        remove_plain_file(&source, "consumed Box image metadata")?;
+        sync_directory(rootfs).map_err(BoxError::IoError)
+    })();
+
+    if let Err(error) = publish {
+        let _ = remove_path_no_follow(&temporary);
+        let _ = remove_path_no_follow(&destination);
+        return Err(error);
+    }
+    Ok(())
+}
+
+/// Copy a prepared Box rootfs and atomically publish one operation-scoped OCI bundle.
+pub(crate) fn publish_portable_bundle(
+    source_rootfs: &Path,
+    spec: &Spec,
+    bundle_directory: &Path,
+) -> Result<()> {
+    let operation_directory = bundle_directory.parent().ok_or_else(|| {
+        metadata_error(format!(
+            "portable OCI bundle has no operation parent: {}",
+            bundle_directory.display()
+        ))
+    })?;
+    std::fs::create_dir_all(operation_directory).map_err(BoxError::IoError)?;
+    validate_plain_directory(operation_directory, "portable OCI operation directory")?;
+    ensure_absent(bundle_directory, "portable OCI bundle")?;
+
+    let pending = operation_directory.join("bundle.pending");
+    ensure_absent(&pending, "portable OCI bundle temporary")?;
+    std::fs::create_dir(&pending).map_err(BoxError::IoError)?;
+
+    let publish = (|| -> Result<()> {
+        let rootfs = pending.join("rootfs");
+        crate::cache::layer_cache::copy_dir_recursive(source_rootfs, &rootfs)?;
+        make_owner_writable(&rootfs)?;
+        publish_portable_rootfs_metadata(&rootfs)?;
+
+        let config = pending.join("config.json");
+        let encoded = serde_json::to_vec_pretty(spec)
+            .map_err(|error| metadata_error(format!("failed to encode OCI bundle: {error}")))?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&config)
+            .map_err(BoxError::IoError)?;
+        file.write_all(&encoded).map_err(BoxError::IoError)?;
+        file.sync_all().map_err(BoxError::IoError)?;
+        drop(file);
+        sync_directory(&pending).map_err(BoxError::IoError)?;
+
+        std::fs::rename(&pending, bundle_directory).map_err(BoxError::IoError)?;
+        sync_directory(operation_directory).map_err(BoxError::IoError)
+    })();
+
+    if let Err(error) = publish {
+        let _ = remove_plain_directory_tree(&pending, operation_directory);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn encode_portable_manifest(source: RootfsMetadataManifest) -> Result<Vec<u8>> {
+    if source.entries.len() > PORTABLE_ROOTFS_METADATA_MAX_ENTRIES {
+        return Err(metadata_error(format!(
+            "Box image metadata has {} entries, exceeding the portable {}-entry limit",
+            source.entries.len(),
+            PORTABLE_ROOTFS_METADATA_MAX_ENTRIES
+        )));
+    }
+
+    let mut unique = HashSet::with_capacity(source.entries.len());
+    let mut entries = Vec::with_capacity(source.entries.len());
+    for entry in source.entries {
+        if entry.uid > u32::MAX as u64 || entry.gid > u32::MAX as u64 {
+            return Err(metadata_error(
+                "Box image metadata uid/gid exceeds the portable Linux ID range".to_string(),
+            ));
+        }
+        let normalized = decode_normalized_path(&entry.path_base64)?;
+        if normalized
+            .first()
+            .is_some_and(|first| RUNTIME_INTERNAL_ROOT_ENTRIES.contains(&first.as_slice()))
+            || !unique.insert(normalized)
+        {
+            return Err(metadata_error(
+                "Box image metadata contains a duplicate or runtime-internal path".to_string(),
+            ));
+        }
+
+        let kind = match entry.kind {
+            RootfsEntryKind::Directory => PortableRootfsEntryKind::Directory,
+            RootfsEntryKind::Regular => PortableRootfsEntryKind::Regular,
+            RootfsEntryKind::Symlink => PortableRootfsEntryKind::Symlink,
+        };
+        validate_link_target(kind, entry.link_target_base64.as_deref())?;
+        entries.push(PortableRootfsMetadataEntry {
+            path_base64: entry.path_base64,
+            kind,
+            mode: entry.mode,
+            uid: entry.uid,
+            gid: entry.gid,
+            mtime: entry.mtime,
+            size: entry.size,
+            link_target_base64: entry.link_target_base64,
+        });
+    }
+
+    let manifest = PortableRootfsMetadataManifest::new(entries);
+    manifest.validate().map_err(metadata_error)?;
+    let encoded = serde_json::to_vec(&manifest)
+        .map_err(|error| metadata_error(format!("failed to encode portable metadata: {error}")))?;
+    if encoded.len() as u64 > PORTABLE_ROOTFS_METADATA_MAX_BYTES {
+        return Err(metadata_error(format!(
+            "portable rootfs metadata has {} bytes, exceeding the {}-byte limit",
+            encoded.len(),
+            PORTABLE_ROOTFS_METADATA_MAX_BYTES
+        )));
+    }
+    Ok(encoded)
+}
+
+fn decode_normalized_path(encoded: &str) -> Result<Vec<Vec<u8>>> {
+    if encoded.len() > MAX_ENCODED_PATH_BYTES {
+        return Err(metadata_error(
+            "Box image metadata path is too large".to_string(),
+        ));
+    }
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|error| metadata_error(format!("invalid Box image metadata path: {error}")))?;
+    if raw.is_empty() || raw.len() > MAX_DECODED_PATH_BYTES || raw.contains(&0) {
+        return Err(metadata_error(
+            "Box image metadata path is empty, too large, or contains NUL".to_string(),
+        ));
+    }
+    if raw.starts_with(b"/") {
+        return Err(metadata_error(
+            "Box image metadata path must be relative".to_string(),
+        ));
+    }
+
+    let mut normalized = Vec::new();
+    for component in raw.split(|byte| *byte == b'/') {
+        if component.is_empty() || component == b"." {
+            continue;
+        }
+        if component == b".." {
+            return Err(metadata_error(
+                "Box image metadata path contains a parent component".to_string(),
+            ));
+        }
+        normalized.push(component.to_vec());
+    }
+    Ok(normalized)
+}
+
+fn validate_link_target(kind: PortableRootfsEntryKind, encoded: Option<&str>) -> Result<()> {
+    if kind != PortableRootfsEntryKind::Symlink {
+        if encoded.is_some() {
+            return Err(metadata_error(
+                "non-symlink Box image metadata contains a link target".to_string(),
+            ));
+        }
+        return Ok(());
+    }
+    let encoded = encoded.ok_or_else(|| {
+        metadata_error("Box image symlink metadata is missing its target".to_string())
+    })?;
+    if encoded.len() > MAX_ENCODED_PATH_BYTES {
+        return Err(metadata_error(
+            "Box image symlink target is too large".to_string(),
+        ));
+    }
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|error| metadata_error(format!("invalid Box image symlink target: {error}")))?;
+    if raw.len() > MAX_DECODED_PATH_BYTES || raw.contains(&0) {
+        return Err(metadata_error(
+            "Box image symlink target is too large or contains NUL".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_plain_directory(path: &Path, label: &str) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
+    if !metadata.is_dir() || metadata_is_reparse_point(&metadata) {
+        return Err(metadata_error(format!(
+            "{label} is not a plain directory: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn open_plain_file(path: &Path, label: &str) -> Result<File> {
+    #[cfg(unix)]
+    let file = {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+            .open(path)
+    };
+    #[cfg(windows)]
+    let file = a3s_box_core::windows_file::open_regular_file(path, None).map(|opened| opened.0);
+    #[cfg(not(any(unix, windows)))]
+    let file = File::open(path);
+
+    let file = file.map_err(|error| {
+        metadata_error(format!(
+            "failed to open {label} {} without following links: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = file.metadata().map_err(BoxError::IoError)?;
+    if !metadata.is_file() || metadata_is_reparse_point(&metadata) {
+        return Err(metadata_error(format!(
+            "{label} is not a plain file: {}",
+            path.display()
+        )));
+    }
+    Ok(file)
+}
+
+fn remove_plain_file(path: &Path, label: &str) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
+    if !metadata.is_file() || metadata_is_reparse_point(&metadata) {
+        return Err(metadata_error(format!(
+            "{label} is not a plain file: {}",
+            path.display()
+        )));
+    }
+    std::fs::remove_file(path).map_err(BoxError::IoError)
+}
+
+fn ensure_absent(path: &Path, label: &str) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Err(metadata_error(format!(
+            "refusing to overwrite {label}: {}",
+            path.display()
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(BoxError::IoError(error)),
+    }
+}
+
+#[cfg(unix)]
+fn make_owner_writable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
+    std::fs::set_permissions(
+        path,
+        std::fs::Permissions::from_mode((metadata.mode() & 0o7777) | 0o200),
+    )
+    .map_err(BoxError::IoError)
+}
+
+#[cfg(not(unix))]
+fn make_owner_writable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn remove_plain_directory_tree(path: &Path, expected_parent: &Path) -> std::io::Result<()> {
+    if path.parent() != Some(expected_parent) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "refusing to remove unscoped OCI bundle temporary: {}",
+                path.display()
+            ),
+        ));
+    }
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if !metadata.is_dir() || metadata_is_reparse_point(&metadata) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "OCI bundle temporary is not a plain directory: {}",
+                path.display()
+            ),
+        ));
+    }
+    std::fs::remove_dir_all(path)
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> std::io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn remove_path_no_follow(path: &Path) -> std::io::Result<()> {
+    a3s_box_core::windows_file::remove_path_no_follow(path)
+}
+
+#[cfg(not(windows))]
+fn remove_path_no_follow(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(windows)]
+fn metadata_is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn metadata_is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
+}
+
+fn metadata_error(message: String) -> BoxError {
+    BoxError::OciImageError(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded(raw: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(raw)
+    }
+
+    fn entry(
+        path: &[u8],
+        kind: RootfsEntryKind,
+    ) -> a3s_box_core::rootfs_metadata::RootfsMetadataEntry {
+        a3s_box_core::rootfs_metadata::RootfsMetadataEntry {
+            path_base64: encoded(path),
+            kind,
+            mode: if kind == RootfsEntryKind::Directory {
+                0o755
+            } else {
+                0o644
+            },
+            uid: 12,
+            gid: 34,
+            mtime: 56,
+            size: 78,
+            link_target_base64: (kind == RootfsEntryKind::Symlink).then(|| encoded(b"tool")),
+        }
+    }
+
+    fn write_source(root: &Path, entries: Vec<a3s_box_core::rootfs_metadata::RootfsMetadataEntry>) {
+        let manifest = RootfsMetadataManifest::new(entries);
+        std::fs::write(
+            root.join(IMAGE_ROOTFS_METADATA_PATH.trim_start_matches('/')),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn publishes_exact_portable_contract_and_consumes_box_manifest() {
+        let temporary = tempfile::tempdir().unwrap();
+        write_source(
+            temporary.path(),
+            vec![
+                entry(b".", RootfsEntryKind::Directory),
+                entry(b"./bin/tool", RootfsEntryKind::Regular),
+                entry(b"./bin/link", RootfsEntryKind::Symlink),
+            ],
+        );
+
+        publish_portable_rootfs_metadata(temporary.path()).unwrap();
+
+        assert!(!temporary
+            .path()
+            .join(IMAGE_ROOTFS_METADATA_PATH.trim_start_matches('/'))
+            .exists());
+        let manifest: PortableRootfsMetadataManifest = serde_json::from_slice(
+            &std::fs::read(temporary.path().join(PORTABLE_ROOTFS_METADATA_FILE)).unwrap(),
+        )
+        .unwrap();
+        manifest.validate().unwrap();
+        assert_eq!(manifest.entries.len(), 3);
+        assert_eq!(manifest.entries[1].path_base64, encoded(b"./bin/tool"));
+        assert_eq!(manifest.entries[1].uid, 12);
+        assert_eq!(manifest.entries[1].gid, 34);
+        assert_eq!(manifest.entries[2].kind, PortableRootfsEntryKind::Symlink);
+        assert_eq!(
+            manifest.entries[2].link_target_base64,
+            Some(encoded(b"tool"))
+        );
+    }
+
+    #[test]
+    fn rejects_normalized_duplicates_without_publishing() {
+        let temporary = tempfile::tempdir().unwrap();
+        write_source(
+            temporary.path(),
+            vec![
+                entry(b"./bin/tool", RootfsEntryKind::Regular),
+                entry(b"bin//./tool", RootfsEntryKind::Regular),
+            ],
+        );
+
+        let error = publish_portable_rootfs_metadata(temporary.path()).unwrap_err();
+
+        assert!(error.to_string().contains("duplicate"));
+        assert!(!temporary
+            .path()
+            .join(PORTABLE_ROOTFS_METADATA_FILE)
+            .exists());
+        assert!(temporary
+            .path()
+            .join(IMAGE_ROOTFS_METADATA_PATH.trim_start_matches('/'))
+            .exists());
+    }
+
+    #[test]
+    fn rejects_runtime_internal_and_unsafe_paths_without_publishing() {
+        for path in [
+            b"./.a3s-box-env".as_slice(),
+            b"./.a3s-box-env/child".as_slice(),
+            b"../escape".as_slice(),
+            b"/absolute".as_slice(),
+        ] {
+            let temporary = tempfile::tempdir().unwrap();
+            write_source(
+                temporary.path(),
+                vec![entry(path, RootfsEntryKind::Regular)],
+            );
+
+            assert!(publish_portable_rootfs_metadata(temporary.path()).is_err());
+            assert!(!temporary
+                .path()
+                .join(PORTABLE_ROOTFS_METADATA_FILE)
+                .exists());
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_link_contract_without_publishing() {
+        let temporary = tempfile::tempdir().unwrap();
+        let mut invalid = entry(b"./bin/tool", RootfsEntryKind::Regular);
+        invalid.link_target_base64 = Some(encoded(b"target"));
+        write_source(temporary.path(), vec![invalid]);
+
+        assert!(publish_portable_rootfs_metadata(temporary.path()).is_err());
+        assert!(!temporary
+            .path()
+            .join(PORTABLE_ROOTFS_METADATA_FILE)
+            .exists());
+    }
+}

--- a/src/runtime/src/local_execution/oci_production.rs
+++ b/src/runtime/src/local_execution/oci_production.rs
@@ -2,10 +2,12 @@
 
 use std::path::{Path, PathBuf};
 
+use a3s_box_core::config::{ResourceConfig, TeeConfig};
 use a3s_box_core::{
     BoxError, ExecutionBackend, ExecutionIsolation, ExecutionManagerError, ExecutionManagerResult,
+    NetworkMode,
 };
-use a3s_oci_sdk::{CreateAttachments, IoMode, OciBundle, ProcessIo};
+use a3s_oci_sdk::{CreateAttachments, IoMode, IsolationRequest, OciBundle, ProcessIo};
 use async_trait::async_trait;
 
 use super::{
@@ -21,6 +23,31 @@ pub struct NativeLinuxOciBundleProvider {
     preparer: VmLocalExecutionBackend,
     runtime_path: PathBuf,
     agent_path: PathBuf,
+}
+
+/// Qualification-only producer for OCI Runtime's Windows dedicated-VM service.
+#[derive(Clone)]
+pub struct WindowsWhpxOciBundleProvider {
+    preparer: VmLocalExecutionBackend,
+    runtime_root: PathBuf,
+}
+
+impl WindowsWhpxOciBundleProvider {
+    pub fn new(home_dir: impl Into<PathBuf>, runtime_root: impl Into<PathBuf>) -> Self {
+        Self {
+            preparer: VmLocalExecutionBackend::new(home_dir),
+            runtime_root: runtime_root.into(),
+        }
+    }
+
+    pub fn runtime_root(&self) -> &Path {
+        &self.runtime_root
+    }
+
+    pub fn with_pull_progress_fn(mut self, pull_progress_fn: crate::PullProgressFn) -> Self {
+        self.preparer = self.preparer.with_pull_progress_fn(pull_progress_fn);
+        self
+    }
 }
 
 impl NativeLinuxOciBundleProvider {
@@ -151,6 +178,315 @@ impl OciBundleProvider for NativeLinuxOciBundleProvider {
             .cleanup_runtime_owned_sandbox_bundle()
             .map_err(|error| preparation_error("cleanup bundle", error))
     }
+}
+
+#[async_trait]
+impl OciBundleProvider for WindowsWhpxOciBundleProvider {
+    fn preflight(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<()> {
+        if !cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+            return Err(ExecutionManagerError::Unavailable(
+                "Box/WHPX OCI qualification requires Windows x86_64".to_string(),
+            ));
+        }
+        if record.isolation != ExecutionIsolation::Microvm
+            || !matches!(context.isolation(), IsolationRequest::DedicatedVm)
+        {
+            return Err(ExecutionManagerError::InvalidRequest(
+                "Box/WHPX OCI qualification requires dedicated MicroVM isolation".to_string(),
+            ));
+        }
+        let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "execution {} has no managed lifecycle metadata",
+                record.id
+            ))
+        })?;
+        metadata
+            .validate()
+            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
+        if metadata.plan.backend != ExecutionBackend::Krun {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "execution {} did not resolve to the MicroVM backend",
+                record.id
+            )));
+        }
+        validate_whpx_qualification(record)?;
+        context.runtime_bundle_handoff_directory(&self.runtime_root)?;
+        validate_runtime_root(&self.runtime_root)
+    }
+
+    async fn prepare(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<OciPreparedExecution> {
+        self.preflight(record, context)?;
+        let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+            ExecutionManagerError::Internal(format!(
+                "execution {} has no managed lifecycle metadata",
+                record.id
+            ))
+        })?;
+        let bundle_directory = context.runtime_bundle_handoff_directory(&self.runtime_root)?;
+        let mut manager = self.preparer.new_oci_preparation_manager(record)?;
+        let prepared = manager
+            .prepare_runtime_owned_microvm_bundle(&metadata.plan, &bundle_directory)
+            .await
+            .map_err(|error| whpx_preparation_error("prepare bundle", error))?;
+        let bundle = match OciBundle::load(&prepared.bundle_dir).await {
+            Ok(bundle) => bundle,
+            Err(error) => {
+                return Err(cleanup_after_whpx_prepare_failure(
+                    &manager,
+                    &bundle_directory,
+                    format!("failed to load the generated portable OCI bundle: {error}"),
+                ));
+            }
+        };
+        let io = ProcessIo {
+            stdin: if metadata.request.config.stdin_open {
+                IoMode::Pipe
+            } else {
+                IoMode::Null
+            },
+            stdout: IoMode::Capture,
+            stderr: IoMode::Capture,
+            terminal_size: None,
+        };
+        let attachments = match CreateAttachments::from_bundle(&bundle, io) {
+            Ok(attachments) => attachments,
+            Err(error) => {
+                return Err(cleanup_after_whpx_prepare_failure(
+                    &manager,
+                    &bundle_directory,
+                    format!("failed to derive portable OCI bundle attachments: {error}"),
+                ));
+            }
+        };
+        let mut result = match OciPreparedExecution::with_attachments(
+            bundle,
+            attachments,
+            prepared.console_output,
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                return Err(cleanup_after_whpx_prepare_failure(
+                    &manager,
+                    &bundle_directory,
+                    format!("failed to validate portable OCI bundle attachments: {error}"),
+                ));
+            }
+        };
+        result = match result.with_runtime_bundle_handoff(context, &self.runtime_root) {
+            Ok(result) => result,
+            Err(error) => {
+                return Err(cleanup_after_whpx_prepare_failure(
+                    &manager,
+                    &bundle_directory,
+                    format!("failed to bind portable OCI bundle handoff: {error}"),
+                ));
+            }
+        };
+        result.anonymous_volumes = prepared.anonymous_volumes;
+        Ok(result)
+    }
+
+    async fn cleanup(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {
+        let manager = self.preparer.new_oci_preparation_manager(record)?;
+        manager
+            .cleanup_runtime_owned_microvm_bundle()
+            .map_err(|error| whpx_preparation_error("cleanup bundle", error))
+    }
+}
+
+fn validate_whpx_qualification(record: &BoxRecord) -> ExecutionManagerResult<()> {
+    let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+        ExecutionManagerError::Internal(format!(
+            "execution {} has no managed lifecycle metadata",
+            record.id
+        ))
+    })?;
+    let config = &metadata.request.config;
+    let defaults = ResourceConfig::default();
+    if config.resources.vcpus != 1 || config.resources.memory_mb != 512 {
+        return Err(unqualified(
+            "the fixed WHPX profile requires exactly 1 vCPU and 512 MiB of memory",
+        ));
+    }
+    if config.resources.disk_mb != defaults.disk_mb || config.resources.timeout != defaults.timeout
+    {
+        return Err(unqualified(
+            "custom disk size or lifetime timeout is not qualified for the WHPX OCI profile",
+        ));
+    }
+    if config.tee != TeeConfig::None {
+        return Err(unqualified("TEE is not qualified for the WHPX OCI profile"));
+    }
+    if !config.workspace.as_os_str().is_empty()
+        || !config.volumes.is_empty()
+        || config.virtiofs_cache.is_some()
+        || !metadata.request.policy.volume_names.is_empty()
+        || metadata.request.policy.managed_secret_root.is_some()
+    {
+        return Err(unqualified(
+            "workspace, bind, named, and secret mounts are not qualified for the WHPX OCI profile",
+        ));
+    }
+    if !matches!(config.network, NetworkMode::None)
+        || !matches!(record.network_mode, NetworkMode::None)
+        || !config.port_map.is_empty()
+        || !config.dns.is_empty()
+        || !config.add_hosts.is_empty()
+    {
+        return Err(unqualified(
+            "the WHPX OCI profile requires network=none and no network customization",
+        ));
+    }
+    if config.pool.enabled
+        || config.pool.snapshot_fork
+        || config.deferred_main
+        || config.ksm
+        || config.snapshot_mem_file.is_some()
+        || config.snapshot_sock.is_some()
+        || config.restore_from.is_some()
+        || metadata.request.rootfs_snapshot_id.is_some()
+    {
+        return Err(unqualified(
+            "pool, deferred-main, KSM, and Snapshot modes are not qualified for the WHPX OCI profile",
+        ));
+    }
+    if !config.tmpfs.is_empty()
+        || config.resource_limits != Default::default()
+        || !config.cap_add.is_empty()
+        || !config.cap_drop.is_empty()
+        || !config.security_opt.is_empty()
+        || !config.sysctls.is_empty()
+        || config.privileged
+        || config.read_only
+        || config.sidecar.is_some()
+        || config.persistent
+    {
+        return Err(unqualified(
+            "custom mounts, controls, privileges, sidecars, and persistence are not qualified for the WHPX OCI profile",
+        ));
+    }
+    let policy = &metadata.request.policy;
+    if policy.init
+        || !policy.devices.is_empty()
+        || policy.gpus.is_some()
+        || policy.shm_size.is_some()
+        || policy.oom_kill_disable
+        || policy.oom_score_adj.is_some()
+    {
+        return Err(unqualified(
+            "init, device, GPU, shared-memory, and OOM overrides are not qualified for the WHPX OCI profile",
+        ));
+    }
+    if policy.platform.as_deref().is_some_and(|platform| {
+        !matches!(
+            platform.trim().to_ascii_lowercase().as_str(),
+            "linux/amd64" | "linux/x86_64"
+        )
+    }) {
+        return Err(unqualified(
+            "the WHPX OCI profile supports only Linux amd64 images",
+        ));
+    }
+    if record.cpus != 1 || record.memory_mb != 512 {
+        return Err(ExecutionManagerError::Internal(
+            "Box record resources drifted from the fixed WHPX qualification profile".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn unqualified(message: &str) -> ExecutionManagerError {
+    ExecutionManagerError::InvalidRequest(format!("Box/WHPX OCI qualification rejected: {message}"))
+}
+
+fn validate_runtime_root(path: &Path) -> ExecutionManagerResult<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        ExecutionManagerError::Unavailable(format!(
+            "failed to inspect WHPX runtime root {}: {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_dir() || metadata_is_reparse_point(&metadata) {
+        return Err(ExecutionManagerError::InvalidRequest(format!(
+            "WHPX runtime root is not a plain directory: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn metadata_is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn metadata_is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
+}
+
+fn whpx_preparation_error(action: &str, error: BoxError) -> ExecutionManagerError {
+    match error {
+        BoxError::ConfigError(message) => ExecutionManagerError::InvalidRequest(message),
+        error => {
+            ExecutionManagerError::Unavailable(format!("Box/WHPX OCI {action} failed: {error}"))
+        }
+    }
+}
+
+fn cleanup_after_whpx_prepare_failure(
+    manager: &crate::VmManager,
+    bundle_directory: &Path,
+    message: String,
+) -> ExecutionManagerError {
+    let bundle_cleanup = remove_scoped_bundle(bundle_directory);
+    let rootfs_cleanup = manager.cleanup_runtime_owned_microvm_bundle();
+    match (bundle_cleanup, rootfs_cleanup) {
+        (Ok(()), Ok(())) => ExecutionManagerError::Internal(message),
+        (bundle, rootfs) => ExecutionManagerError::Internal(format!(
+            "{message}; cleanup also failed: handoff={bundle:?}, rootfs={rootfs:?}"
+        )),
+    }
+}
+
+fn remove_scoped_bundle(bundle_directory: &Path) -> std::io::Result<()> {
+    if bundle_directory.file_name().and_then(|name| name.to_str()) != Some("bundle")
+        || bundle_directory.parent().and_then(Path::parent).is_none()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "refusing to remove an unscoped bundle: {}",
+                bundle_directory.display()
+            ),
+        ));
+    }
+    let metadata = match std::fs::symlink_metadata(bundle_directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if !metadata.is_dir() || metadata_is_reparse_point(&metadata) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "bundle is not a plain directory: {}",
+                bundle_directory.display()
+            ),
+        ));
+    }
+    std::fs::remove_dir_all(bundle_directory)
 }
 
 fn preparation_error(action: &str, error: BoxError) -> ExecutionManagerError {

--- a/src/runtime/src/sandbox/mod.rs
+++ b/src/runtime/src/sandbox/mod.rs
@@ -143,8 +143,9 @@ impl a3s_box_core::vmm::VmHandler for A3sOciHandler {
     }
 }
 pub use oci::{
-    compile_oci_spec, compile_runtime_owned_oci_spec, SandboxBundleSpec, SandboxMount,
-    SandboxResources, SandboxRuntimeProcess, SandboxTmpfs, DEFAULT_SANDBOX_PIDS_LIMIT,
+    compile_oci_spec, compile_portable_microvm_oci_spec, compile_runtime_owned_oci_spec,
+    SandboxBundleSpec, SandboxMount, SandboxResources, SandboxRuntimeProcess, SandboxTmpfs,
+    DEFAULT_SANDBOX_PIDS_LIMIT, PORTABLE_MICROVM_BUNDLE_SCHEMA,
 };
 pub use path_access::prepare_sandbox_path_access;
 pub use rootfs::{

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -10,7 +10,9 @@ use a3s_box_core::rootfs_metadata::RUNTIME_ENV_PATH;
 use a3s_oci_sdk::{
     CONTROL_CGROUP_CPU_HEADROOM_ANNOTATION, CONTROL_CGROUP_MEMORY_HEADROOM_ANNOTATION,
     CONTROL_CGROUP_PIDS_HEADROOM_ANNOTATION, CONTROL_WORKLOAD_CGROUP_LAYOUT_ANNOTATION,
-    CONTROL_WORKLOAD_CGROUP_LAYOUT_V1,
+    CONTROL_WORKLOAD_CGROUP_LAYOUT_V1, PORTABLE_ROOTFS_METADATA_ANNOTATION,
+    PORTABLE_ROOTFS_METADATA_SCHEMA_V1, RUNTIME_BUNDLE_HANDOFF_EXTENSION,
+    RUNTIME_BUNDLE_HANDOFF_MOVE_V1,
 };
 use oci_spec::runtime::{
     Arch, Capabilities, Capability, LinuxBuilder, LinuxCapabilitiesBuilder, LinuxCpuBuilder,
@@ -25,6 +27,8 @@ use super::capability::{IdMapping, SandboxIdMappingPlan};
 
 /// OCI annotation schema for generated A3S Sandbox bundles.
 pub const SANDBOX_BUNDLE_SCHEMA: &str = "a3s.box.sandbox-bundle.v1";
+/// Qualification schema for a portable one-VM-per-container bundle.
+pub const PORTABLE_MICROVM_BUNDLE_SCHEMA: &str = "a3s.box.portable-microvm-bundle.v1";
 /// Baseline process count enforced even when the caller omits `--pids-limit`.
 pub const DEFAULT_SANDBOX_PIDS_LIMIT: i64 = 4096;
 const DEFAULT_CPU_PERIOD_US: u64 = 100_000;
@@ -293,6 +297,85 @@ pub fn compile_runtime_owned_oci_spec(
     compile_spec(input, process, SandboxProcessOwner::RuntimeOwned)
 }
 
+/// Compile the bounded portable profile consumed by OCI Runtime's dedicated-VM driver.
+pub fn compile_portable_microvm_oci_spec(
+    box_id: &str,
+    hostname: &str,
+    runtime_process: &SandboxRuntimeProcess,
+) -> Result<Spec> {
+    validate_box_id(box_id)?;
+    validate_hostname(hostname)?;
+    validate_runtime_process_shape(runtime_process)?;
+
+    let user = UserBuilder::default()
+        .uid(runtime_process.uid)
+        .gid(runtime_process.gid)
+        .additional_gids(runtime_process.additional_gids.clone())
+        .build()
+        .map_err(oci_error)?;
+    let process = ProcessBuilder::default()
+        .terminal(false)
+        .user(user)
+        .args(runtime_process.args.clone())
+        .env(compile_runtime_environment(&runtime_process.environment)?)
+        .cwd(runtime_process.cwd.clone())
+        .capabilities(compile_workload_capabilities(
+            &[],
+            &runtime_process.dropped_capabilities,
+        )?)
+        .no_new_privileges(true)
+        .build()
+        .map_err(oci_error)?;
+    let linux = LinuxBuilder::default()
+        .namespaces(compile_portable_microvm_namespaces()?)
+        .cgroups_path(PathBuf::from(format!("a3s-box/{box_id}")))
+        .build()
+        .map_err(oci_error)?;
+    let mut annotations = HashMap::new();
+    annotations.insert(
+        "com.a3s.box.microvm.schema".to_string(),
+        PORTABLE_MICROVM_BUNDLE_SCHEMA.to_string(),
+    );
+    annotations.insert(
+        "com.a3s.box.isolation-class".to_string(),
+        "hardware-vm".to_string(),
+    );
+    annotations.insert(
+        "com.a3s.box.process-owner".to_string(),
+        "a3s-oci-runtime".to_string(),
+    );
+    annotations.insert(
+        RUNTIME_BUNDLE_HANDOFF_EXTENSION.to_string(),
+        RUNTIME_BUNDLE_HANDOFF_MOVE_V1.to_string(),
+    );
+    annotations.insert(
+        PORTABLE_ROOTFS_METADATA_ANNOTATION.to_string(),
+        PORTABLE_ROOTFS_METADATA_SCHEMA_V1.to_string(),
+    );
+
+    SpecBuilder::default()
+        .version("1.3.0".to_string())
+        .root(
+            RootBuilder::default()
+                .path(PathBuf::from("rootfs"))
+                .readonly(false)
+                .build()
+                .map_err(oci_error)?,
+        )
+        .mounts(vec![mount(
+            "/proc",
+            "proc",
+            "proc",
+            &["nosuid", "noexec", "nodev"],
+        )?])
+        .process(process)
+        .hostname(hostname.to_string())
+        .annotations(annotations)
+        .linux(linux)
+        .build()
+        .map_err(oci_error)
+}
+
 fn validate_bundle_input(input: &SandboxBundleSpec) -> Result<()> {
     validate_box_id(&input.box_id)?;
     validate_rootfs_path(&input.rootfs_path)?;
@@ -432,16 +515,7 @@ fn validate_runtime_process(
     process: &SandboxRuntimeProcess,
     id_mappings: &SandboxIdMappingPlan,
 ) -> Result<()> {
-    let executable = process.args.first().ok_or_else(|| {
-        BoxError::ConfigError("Sandbox runtime-owned process requires an executable".to_string())
-    })?;
-    validate_linux_absolute_normalized(Path::new(executable), "process executable")?;
-    if process.args.iter().any(|argument| argument.contains('\0')) {
-        return Err(BoxError::ConfigError(
-            "Sandbox process arguments must not contain NUL".to_string(),
-        ));
-    }
-    validate_linux_absolute_normalized(&process.cwd, "process working directory")?;
+    validate_runtime_process_shape(process)?;
     if process.uid > id_mappings.maximum_container_uid {
         return Err(BoxError::ConfigError(format!(
             "Sandbox process UID {} exceeds the mapped maximum {}",
@@ -456,6 +530,20 @@ fn validate_runtime_process(
             )));
         }
     }
+    Ok(())
+}
+
+fn validate_runtime_process_shape(process: &SandboxRuntimeProcess) -> Result<()> {
+    let executable = process.args.first().ok_or_else(|| {
+        BoxError::ConfigError("Sandbox runtime-owned process requires an executable".to_string())
+    })?;
+    validate_linux_absolute_normalized(Path::new(executable), "process executable")?;
+    if process.args.iter().any(|argument| argument.contains('\0')) {
+        return Err(BoxError::ConfigError(
+            "Sandbox process arguments must not contain NUL".to_string(),
+        ));
+    }
+    validate_linux_absolute_normalized(&process.cwd, "process working directory")?;
     Ok(())
 }
 
@@ -601,6 +689,25 @@ fn compile_namespaces() -> Result<Vec<oci_spec::runtime::LinuxNamespace>> {
         LinuxNamespaceType::Uts,
         LinuxNamespaceType::Network,
         LinuxNamespaceType::Cgroup,
+    ]
+    .into_iter()
+    .map(|typ| {
+        LinuxNamespaceBuilder::default()
+            .typ(typ)
+            .build()
+            .map_err(oci_error)
+    })
+    .collect()
+}
+
+fn compile_portable_microvm_namespaces() -> Result<Vec<oci_spec::runtime::LinuxNamespace>> {
+    [
+        LinuxNamespaceType::Uts,
+        LinuxNamespaceType::Mount,
+        LinuxNamespaceType::Ipc,
+        LinuxNamespaceType::Network,
+        LinuxNamespaceType::Cgroup,
+        LinuxNamespaceType::Pid,
     ]
     .into_iter()
     .map(|typ| {
@@ -1557,6 +1664,38 @@ mod tests {
             additional_gids: vec![789],
             dropped_capabilities: vec!["SETUID".to_string()],
         }
+    }
+
+    #[test]
+    fn portable_microvm_compiler_uses_relative_root_and_no_user_namespace() {
+        let value = as_json(
+            &compile_portable_microvm_oci_spec("box-123", "box-123", &sample_runtime_process())
+                .unwrap(),
+        );
+
+        assert_eq!(value["ociVersion"], "1.3.0");
+        assert_eq!(value["root"]["path"], "rootfs");
+        assert_eq!(value["root"]["readonly"], false);
+        assert_eq!(
+            value["annotations"][PORTABLE_ROOTFS_METADATA_ANNOTATION],
+            PORTABLE_ROOTFS_METADATA_SCHEMA_V1
+        );
+        assert_eq!(
+            value["annotations"][RUNTIME_BUNDLE_HANDOFF_EXTENSION],
+            RUNTIME_BUNDLE_HANDOFF_MOVE_V1
+        );
+        assert_eq!(
+            value["annotations"]["com.a3s.box.isolation-class"],
+            "hardware-vm"
+        );
+        let namespaces = value["linux"]["namespaces"].as_array().unwrap();
+        assert!(namespaces
+            .iter()
+            .any(|namespace| namespace["type"] == "mount"));
+        assert!(!namespaces
+            .iter()
+            .any(|namespace| namespace["type"] == "user"));
+        assert_eq!(value["mounts"][0]["destination"], "/proc");
     }
 
     #[test]

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -2,6 +2,7 @@
 
 mod layout;
 mod network;
+mod oci_microvm;
 mod ready;
 pub mod reap;
 mod sandbox;

--- a/src/runtime/src/vm/oci_microvm.rs
+++ b/src/runtime/src/vm/oci_microvm.rs
@@ -1,0 +1,99 @@
+//! Box-owned preparation for a portable dedicated-VM OCI bundle.
+
+use std::path::{Path, PathBuf};
+
+use a3s_box_core::{BoxError, ExecutionBackend, ResolvedExecutionPlan, Result};
+
+use super::VmManager;
+use crate::sandbox::{compile_portable_microvm_oci_spec, SandboxRuntimeProcess};
+
+/// Portable handoff produced without starting a Box-owned VM.
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeOwnedMicrovmBundle {
+    pub bundle_dir: PathBuf,
+    pub console_output: PathBuf,
+    pub anonymous_volumes: Vec<String>,
+}
+
+impl VmManager {
+    /// Resolve the image process, copy the fresh rootfs, and publish one exact handoff bundle.
+    pub(crate) async fn prepare_runtime_owned_microvm_bundle(
+        &mut self,
+        execution_plan: &ResolvedExecutionPlan,
+        bundle_directory: &Path,
+    ) -> Result<RuntimeOwnedMicrovmBundle> {
+        if execution_plan.backend != ExecutionBackend::Krun {
+            return Err(BoxError::BoxBootError {
+                message: "portable MicroVM OCI preparation requires the Krun execution plan"
+                    .to_string(),
+                hint: None,
+            });
+        }
+
+        let original_anonymous_volumes = self.anonymous_volumes.clone();
+        let box_dir = self.home_dir.join("boxes").join(&self.box_id);
+        let layout = match self.prepare_layout().await {
+            Ok(layout) => layout,
+            Err(error) => {
+                self.cleanup_boot_failure().await;
+                return Err(error);
+            }
+        };
+        self.image_config = layout.oci_config.clone();
+
+        let prepare = (|| -> Result<RuntimeOwnedMicrovmBundle> {
+            let instance_spec = self.build_runtime_owned_instance_spec(&layout)?;
+            if self.anonymous_volumes != original_anonymous_volumes {
+                return Err(BoxError::ConfigError(
+                    "portable MicroVM OCI qualification does not support image-declared volumes"
+                        .to_string(),
+                ));
+            }
+            let runtime_process: SandboxRuntimeProcess =
+                crate::vm::sandbox::resolve_runtime_owned_process(
+                    &layout.rootfs_path,
+                    &instance_spec,
+                    &self.config.cap_drop,
+                )?;
+            let hostname = self
+                .config
+                .hostname
+                .clone()
+                .unwrap_or_else(|| self.box_id.clone());
+            let spec =
+                compile_portable_microvm_oci_spec(&self.box_id, &hostname, &runtime_process)?;
+            crate::local_execution::oci_portable_rootfs::publish_portable_bundle(
+                &layout.rootfs_path,
+                &spec,
+                bundle_directory,
+            )?;
+
+            Ok(RuntimeOwnedMicrovmBundle {
+                bundle_dir: bundle_directory.to_path_buf(),
+                console_output: instance_spec
+                    .console_output
+                    .unwrap_or_else(|| box_dir.join("logs").join("console.log")),
+                anonymous_volumes: self.anonymous_volumes.clone(),
+            })
+        })();
+
+        match prepare {
+            Ok(prepared) => Ok(prepared),
+            Err(error) => {
+                self.cleanup_boot_failure().await;
+                Err(error)
+            }
+        }
+    }
+
+    /// Remove only Box-owned rootfs and socket preparation after runtime deletion.
+    pub(crate) fn cleanup_runtime_owned_microvm_bundle(&self) -> Result<()> {
+        let box_dir = self.home_dir.join("boxes").join(&self.box_id);
+        self.rootfs_provider.cleanup(&box_dir, false)?;
+        match std::fs::remove_dir_all(self.socket_dir()) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(BoxError::IoError(error)),
+        }
+    }
+}

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -910,7 +910,7 @@ struct RuntimeGroupEntry {
     members: Vec<String>,
 }
 
-fn resolve_runtime_owned_process(
+pub(crate) fn resolve_runtime_owned_process(
     rootfs: &Path,
     instance_spec: &crate::vmm::InstanceSpec,
     dropped_capabilities: &[String],


### PR DESCRIPTION
## Summary
- add a fail-closed Box producer for operation-scoped portable MicroVM OCI bundles
- convert Box rootfs metadata into the public `a3s.oci.rootfs-metadata.v1` replay contract
- add explicit Windows named-pipe qualification composition for the pinned WHPX service
- unify SDK, CI, release, roadmap, and documentation pins on OCI Runtime `6223f2b957f88d348a27b3542541261b1f0ffb55`

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- local `cargo check -p a3s-box-runtime --all-features` reached dependency compilation but could not link build scripts because this host lacks the Windows SDK import libraries; PR CI is the compile/test authority

## Scope
The Windows path remains explicit and qualification-only. The real WHPX Box lifecycle gate remains open in ROADMAP until blocking hardware evidence passes.