### PR TITLE
chore(runtime): pin OCI qualification artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 6223f2b957f88d348a27b3542541261b1f0ffb55
+  A3S_OCI_RUNTIME_REV: d806e0dd5bb917bd9ed429ef9af101655c400160
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 6223f2b957f88d348a27b3542541261b1f0ffb55
+  A3S_OCI_RUNTIME_REV: d806e0dd5bb917bd9ed429ef9af101655c400160
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,7 +143,7 @@ later lifecycle, session, observability, filesystem, restart, and cleanup calls
 use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
-`6223f2b957f88d348a27b3542541261b1f0ffb55` retains the matching long-lived,
+`d806e0dd5bb917bd9ed429ef9af101655c400160` retains the matching long-lived,
 multi-container Native Linux host owner and adds the generation-safe bundle
 handoff used by the preparation context above. Box now first validates the
 exact managed home and durably prepares snapshot-lower, named-volume, and

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -61,7 +61,7 @@ Box now:
 - rejects any reintroduction of the removed integration symbols in CI.
 
 The exact integration revision is
-`6223f2b957f88d348a27b3542541261b1f0ffb55`, which retains the qualified
+`d806e0dd5bb917bd9ed429ef9af101655c400160`, which retains the qualified
 control/workload cgroup and read-only bind behavior and adds deterministic
 multi-driver registration, isolation selection, and durable recorded-driver
 routing required by the unified execution migration. Runtime service startup

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=6223f2b957f88d348a27b3542541261b1f0ffb55#6223f2b957f88d348a27b3542541261b1f0ffb55"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=d806e0dd5bb917bd9ed429ef9af101655c400160#d806e0dd5bb917bd9ed429ef9af101655c400160"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=6223f2b957f88d348a27b3542541261b1f0ffb55#6223f2b957f88d348a27b3542541261b1f0ffb55"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=d806e0dd5bb917bd9ed429ef9af101655c400160#d806e0dd5bb917bd9ed429ef9af101655c400160"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,7 +125,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "061cde95e16eb4cbd9f58724e6cbb60de6ace77e" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "6223f2b957f88d348a27b3542541261b1f0ffb55" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "d806e0dd5bb917bd9ed429ef9af101655c400160" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- advance every exact OCI Runtime pin to d806e0dd5bb917bd9ed429ef9af101655c400160
- keep Cargo.lock, CI, release, roadmap, and integration plan on one revision
- consume the revision whose CI retains commit-bound Windows/guest qualification artifacts

## Validation
- cargo fmt --all -- --check
- cargo metadata --locked --no-deps --format-version 1
- git diff --check
- no stale 6223f2b revision remains