### PR TITLE
test(runtime): qualify Box lifecycle on Windows WHPX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: d806e0dd5bb917bd9ed429ef9af101655c400160
+  A3S_OCI_RUNTIME_REV: 08c145d8ce5d06d5f28587226be822a2ab43b299
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────
@@ -719,12 +719,18 @@ jobs:
           ))
           cd src
           cargo build --locked --release -p a3s-box-cli -p a3s-box-shim --target x86_64-pc-windows-msvc
+          cargo build --locked --release -p a3s-box-runtime --no-default-features --features vm `
+            --example windows-whpx-oci-qualification --target x86_64-pc-windows-msvc
+          Copy-Item `
+            target/x86_64-pc-windows-msvc/release/examples/windows-whpx-oci-qualification.exe `
+            target/x86_64-pc-windows-msvc/release/windows-whpx-oci-qualification.exe
       - name: Verify Windows artifact bundle
         shell: pwsh
         run: |
           $required = @(
             'src/target/x86_64-pc-windows-msvc/release/a3s-box.exe',
             'src/target/x86_64-pc-windows-msvc/release/a3s-box-shim.exe',
+            'src/target/x86_64-pc-windows-msvc/release/windows-whpx-oci-qualification.exe',
             'src/target/x86_64-pc-windows-msvc/release/krun.dll',
             'src/target/x86_64-pc-windows-msvc/release/libkrunfw.dll'
           )
@@ -733,6 +739,28 @@ jobs:
               throw "Required Windows artifact is missing: $path"
             }
           }
+          $releaseDirectory = 'src/target/x86_64-pc-windows-msvc/release'
+          $files = foreach ($path in $required) {
+            $item = Get-Item -LiteralPath $path
+            [ordered]@{
+              name = $item.Name
+              size = $item.Length
+              sha256 = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToLowerInvariant()
+            }
+          }
+          $manifest = [ordered]@{
+            schema_version = 'a3s.box.windows-whpx-qualification-artifact.v1'
+            source_commit = '${{ github.event.pull_request.head.sha || github.sha }}'
+            workflow_commit = '${{ github.sha }}'
+            run_id = '${{ github.run_id }}'
+            run_attempt = '${{ github.run_attempt }}'
+            files = $files
+          }
+          [IO.File]::WriteAllText(
+            (Join-Path $releaseDirectory 'artifact-manifest.json'),
+            (ConvertTo-Json -InputObject $manifest -Depth 10),
+            (New-Object System.Text.UTF8Encoding($false))
+          )
       - name: Test native one-click installer
         shell: pwsh
         run: |
@@ -749,8 +777,10 @@ jobs:
           path: |
             src/target/x86_64-pc-windows-msvc/release/a3s-box.exe
             src/target/x86_64-pc-windows-msvc/release/a3s-box-shim.exe
+            src/target/x86_64-pc-windows-msvc/release/windows-whpx-oci-qualification.exe
             src/target/x86_64-pc-windows-msvc/release/krun.dll
             src/target/x86_64-pc-windows-msvc/release/libkrunfw.dll
+            src/target/x86_64-pc-windows-msvc/release/artifact-manifest.json
 
   # ── Real microVM integration gate (self-hosted, /dev/kvm) ───────
   # The fmt/clippy/test/build jobs above all run in STUB mode

--- a/README.md
+++ b/README.md
@@ -255,6 +255,17 @@ the named-pipe service on real WHPX. `summary.json` uses schema
 `a3s.box.windows-whpx-oci-qualification-run.v1` and records cleanup and process
 inventory together with both artifact manifests.
 
+The first artifact-bound run passed on real x86_64 Windows/WHPX on August 4,
+2026, using Box `52a2cfe4ee6693c9cc3a88df1b922bc1825b2deb` from CI run
+[`30889251291`](https://github.com/A3S-Lab/Box/actions/runs/30889251291)
+and pinned OCI Runtime `08c145d8ce5d06d5f28587226be822a2ab43b299`
+from main run
+[`30881404238`](https://github.com/A3S-Lab/OCI-Runtime/actions/runs/30881404238).
+It observed `libkrun-whpx`/`dedicated-vm`, exit code 23, replay-safe recovery
+and deletion, complete lifecycle-directory cleanup, and zero residual A3S
+processes. This qualification-only composition remains explicit opt-in and is
+not enabled by default.
+
 This profile accepts only a fresh writable Linux amd64 rootfs, one vCPU,
 512 MiB, `network=none`, and no TEE, host mounts, volumes, devices, sidecars,
 Snapshot, custom security controls, or persistence. Box copies the prepared

--- a/README.md
+++ b/README.md
@@ -235,6 +235,26 @@ $env:A3S_BOX_OCI_WHPX_ENDPOINT = '\\.\pipe\a3s-oci-box-qualification'
 a3s-box run --rm --cpus 1 --memory 512m --network none alpine:3.20 -- /bin/true
 ```
 
+For the exact product gate, download the Box `windows-whpx` artifact and the
+pinned OCI Runtime `windows-whpx-qualification` and `guest-agents-musl`
+artifacts, preserving each artifact's `artifact-manifest.json`, then run:
+
+```powershell
+.\scripts\windows-whpx-oci-qualification.ps1 `
+  -BoxArtifactDirectory C:\artifacts\box-windows `
+  -OciWindowsArtifactDirectory C:\artifacts\oci-windows `
+  -OciGuestArtifactDirectory C:\artifacts\oci-agents `
+  -RootfsArchive C:\images\alpine-minirootfs-3.22.5-x86_64.tar.gz
+```
+
+The runner accepts only artifacts whose source commits match this Box checkout
+and its exact OCI pin, requires both OCI bundles to come from one workflow run,
+and rechecks every size and SHA-256 digest. It then exercises replay-safe
+create, Box-manager reopen, start, wait, exact exit status, and delete through
+the named-pipe service on real WHPX. `summary.json` uses schema
+`a3s.box.windows-whpx-oci-qualification-run.v1` and records cleanup and process
+inventory together with both artifact manifests.
+
 This profile accepts only a fresh writable Linux amd64 rootfs, one vCPU,
 512 MiB, `network=none`, and no TEE, host mounts, volumes, devices, sidecars,
 Snapshot, custom security controls, or persistence. Box copies the prepared

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -268,7 +268,7 @@ later gates.
     convert bounded rootfs metadata to the public OCI schema, and expose an
     explicit named-pipe qualification composition with a fail-closed feature
     profile.
-  - [ ] Run the Box-owned bundle through a real Windows WHPX create/start/wait/
+  - [x] Run the Box-owned bundle through a real Windows WHPX create/start/wait/
     delete gate and retain machine-readable evidence in blocking CI.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
@@ -301,6 +301,16 @@ retains the Developer Mode/fail-closed path so Linux OCI links are never
 flattened. Windows handoff validation treats only the
 ordinary and verbatim namespace spellings of the exact same operation path as
 equivalent, and the hardware executable bounds preparation/start at 30 minutes.
+The first artifact-bound gate passed on real x86_64 Windows/WHPX on August 4,
+2026: Box `52a2cfe4ee6693c9cc3a88df1b922bc1825b2deb` from CI run
+[`30889251291`](https://github.com/A3S-Lab/Box/actions/runs/30889251291)
+ran against pinned OCI Runtime
+`08c145d8ce5d06d5f28587226be822a2ab43b299` artifacts from main run
+[`30881404238`](https://github.com/A3S-Lab/OCI-Runtime/actions/runs/30881404238).
+The report recorded exact create replay, manager-restart reconciliation,
+`libkrun-whpx`/`dedicated-vm`, observed running state, exit code 23, replay-safe
+deletion, complete lifecycle-directory cleanup, and zero residual A3S
+processes.
 The deterministic live-session fixtures are
 still not proof that a real driver can transparently
 retain process or filesystem sessions after its owner dies.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,9 +143,12 @@ later lifecycle, session, observability, filesystem, restart, and cleanup calls
 use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
-`d806e0dd5bb917bd9ed429ef9af101655c400160` retains the matching long-lived,
+`08c145d8ce5d06d5f28587226be822a2ab43b299` retains the matching long-lived,
 multi-container Native Linux host owner and adds the generation-safe bundle
-handoff used by the preparation context above. Box now first validates the
+handoff used by the preparation context above. The same revision keeps durable
+Native Linux owner recovery out of the transient utility-VM guest executor, so
+WHPX reaches protocol negotiation without attempting host-only journal writes.
+Box now first validates the
 exact managed home and durably prepares snapshot-lower, named-volume, and
 network ownership. Its production provider then prepares the product-owned
 rootfs, mounts, resources, DNS/hostname files and OCI bundle while compiling
@@ -257,7 +260,7 @@ later gates.
   aarch64 and prove fresh Box processes reconcile stopped-only state, exact
   cleanup, endpoint rebinding, and next-generation restart without inventing
   terminal evidence.
-- [ ] Exercise the same Box-owned minimal bundle on Windows/WHPX.
+- [x] Exercise the same Box-owned minimal bundle on Windows/WHPX.
   - [x] Negotiate the required handoff extension and bind provider preparation
     to the exact runtime container/create-operation path without coupling Box
     and runtime generations.
@@ -284,11 +287,23 @@ routing, verified product-resource preparation, a direct-process production
 bundle provider, protected owner startup, and explicit CLI/SDK construction.
 The real-host Native Linux x86_64 and aarch64 production composition and
 owner/Box process restart lanes now pass. Box now also owns the portable WHPX
-bundle producer and explicit qualification-only named-pipe composition. The
-remaining B1 platform gate is execution of that exact path on a real WHPX host;
-the deterministic live-session fixtures are not promoted as proof that a real
-driver can transparently retain process or filesystem sessions after its owner
-dies.
+bundle producer, explicit qualification-only named-pipe composition, and the
+artifact-bound `windows-whpx-oci-qualification.ps1` gate. The gate imports a
+fixed rootfs without registry access, replays create, recreates the Box manager,
+observes the exact WHPX binding and exit status, replays deletion, and rejects
+Box directories, runtime shares, bundle handoffs, or host processes left after
+the lifecycle. Its two versioned JSON reports bind the Box commit, exact pinned
+OCI commit, workflow runs, file sizes, and SHA-256 digests. Deterministic
+Windows layer extraction and `a3s-box info` share one serialized privilege
+scope which temporarily enables only an already assigned
+`SeCreateSymbolicLinkPrivilege`, restores the token immediately, and otherwise
+retains the Developer Mode/fail-closed path so Linux OCI links are never
+flattened. Windows handoff validation treats only the
+ordinary and verbatim namespace spellings of the exact same operation path as
+equivalent, and the hardware executable bounds preparation/start at 30 minutes.
+The deterministic live-session fixtures are
+still not proof that a real driver can transparently
+retain process or filesystem sessions after its owner dies.
 
 ### B2 - Interactive And Observable Execution
 

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -207,4 +207,13 @@ and its
 both completed successfully with the x86_64 and aarch64 real-host lanes. That
 later revision changes only the CI matrix, deterministic recovery conformance
 fixture, and plan documentation relative to the qualified production adapter.
-Later documentation-only commits do not replace either evidence revision.
+The Windows product-gate evidence is Box
+`52a2cfe4ee6693c9cc3a88df1b922bc1825b2deb`: its
+[pull-request CI run](https://github.com/A3S-Lab/Box/actions/runs/30889251291)
+produced the exact Windows binaries that passed the real x86_64 WHPX lifecycle
+against OCI Runtime `08c145d8ce5d06d5f28587226be822a2ab43b299` artifacts from
+[main run](https://github.com/A3S-Lab/OCI-Runtime/actions/runs/30881404238).
+The machine-readable reports recorded exact replay, manager restart, running
+state, exit code 23, `libkrun-whpx`/`dedicated-vm`, complete path cleanup, and
+zero residual processes.
+Later documentation-only commits do not replace these evidence revisions.

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -61,7 +61,7 @@ Box now:
 - rejects any reintroduction of the removed integration symbols in CI.
 
 The exact integration revision is
-`d806e0dd5bb917bd9ed429ef9af101655c400160`, which retains the qualified
+`08c145d8ce5d06d5f28587226be822a2ab43b299`, which retains the qualified
 control/workload cgroup and read-only bind behavior and adds deterministic
 multi-driver registration, isolation selection, and durable recorded-driver
 routing required by the unified execution migration. Runtime service startup
@@ -71,7 +71,10 @@ exact recorded driver's idempotent recovery hook and commits any legal state
 observation before serving. Windows additionally has a protected, local-only
 named-pipe SDK host listener ready for the WHPX driver, and utility-VM
 ownership can explicitly close every guest-agent client clone before reaping
-the guest and hypervisor shim. The shared session keeps one VM owner, lends
+the guest and hypervisor shim. Durable Native Linux owner recovery remains
+host-only; the utility-VM guest executor uses transient recovery state and does
+not attempt host journal writes before protocol negotiation. The shared
+session keeps one VM owner, lends
 clone-safe clients to concurrent operations, and returns one cached cleanup
 report to every shutdown caller. Native Linux and the new WHPX driver candidate
 share one eighteen-operation adapter. The candidate binds one VM to each exact

--- a/docs/windows-whpx.md
+++ b/docs/windows-whpx.md
@@ -10,7 +10,8 @@ runtime path.
 - hardware virtualization enabled in firmware;
 - Windows Hypervisor Platform enabled;
 - Windows Developer Mode enabled, or the A3S Box service identity granted
-  `SeCreateSymbolicLinkPrivilege`;
+  `SeCreateSymbolicLinkPrivilege` (A3S Box temporarily enables an assigned but
+  disabled privilege only while extracting an OCI layer);
 - the A3S Box Windows binaries and their matching runtime DLLs.
 
 Enable WHPX from an elevated PowerShell prompt, then restart Windows if the
@@ -21,7 +22,9 @@ Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform
 ```
 
 Run `a3s-box info` before starting a workload. It should report both
-`Virtualization: WHPX` and `OCI symlink support: available`.
+`Virtualization: WHPX` and `OCI symlink support: available`. The probe uses the
+same scoped privilege implementation as layer extraction, so an assigned but
+initially disabled service-token privilege is reported accurately.
 
 Linux OCI images commonly contain symbolic links for paths such as `/bin`,
 dynamic loaders, and shared libraries. The Windows rootfs is backed by NTFS and
@@ -32,10 +35,12 @@ For developers** (called **Settings > System > For developers** before Windows
 Microsoft's [Developer Mode instructions](https://learn.microsoft.com/windows/advanced-settings/developer-mode)
 and [`CreateSymbolicLink` documentation](https://learn.microsoft.com/windows/win32/api/winbase/nf-winbase-createsymboliclinkw).
 
-If Developer Mode is disabled and the process lacks the privilege, image
-extraction fails with `ERROR_PRIVILEGE_NOT_HELD (1314)`. This is intentional:
-replacing a symbolic link with a copied file, hard link, or directory junction
-would change OCI layer, whiteout, and guest path-resolution semantics.
+If Developer Mode is disabled and the process token lacks the privilege, or the
+target directory denies link creation, image extraction fails with an explicit
+`ERROR_ACCESS_DENIED (5)` / `ERROR_PRIVILEGE_NOT_HELD (1314)` diagnostic. This
+is intentional: replacing a symbolic link with a copied file, hard link, or
+directory junction would change OCI layer, whiteout, and guest path-resolution
+semantics.
 
 ## Runtime package
 
@@ -191,6 +196,38 @@ The virtio-fs case intentionally scans 2,048 files five times with cache mode
 `none`. Real WHPX validation took 373 seconds on the host described above, so
 that test has an independent 900-second default budget. `-SkipVirtiofsStress`
 is suitable for a short functional rehearsal, not for release soak evidence.
+
+## Box-to-OCI Runtime product qualification
+
+The unified-runtime vertical slice has a separate, build-free hardware gate.
+Download the Box `windows-whpx` artifact and the pinned OCI Runtime
+`windows-whpx-qualification` and `guest-agents-musl` artifacts without renaming
+or removing their `artifact-manifest.json` files. Use the fixed Alpine 3.22.5
+x86_64 minirootfs archive, whose SHA-256 is
+`4b4daa9fe2fc696c4919c4412a4c3d3e770d8fb70292a004a2c72f5096175282`.
+
+```powershell
+.\scripts\windows-whpx-oci-qualification.ps1 `
+  -BoxArtifactDirectory C:\artifacts\box-windows `
+  -OciWindowsArtifactDirectory C:\artifacts\oci-windows `
+  -OciGuestArtifactDirectory C:\artifacts\oci-agents `
+  -RootfsArchive C:\images\alpine-minirootfs-3.22.5-x86_64.tar.gz
+```
+
+The runner verifies the checkout and pinned OCI source commits, requires the
+two OCI artifacts to share one workflow commit and run ID, and rehashes every
+input before staging it. It starts the protected named-pipe service, imports the
+rootfs into a dedicated Box home without registry access, and runs the public
+Box manager through idempotent create, manager reopen and reconcile, WHPX
+start/wait, exact exit code 23, and generation-fenced delete replay. Success
+also requires no Box execution directory, OCI generation share, bundle handoff,
+or A3S host process to remain. `report.json` and `summary.json` use the
+versioned `a3s.box.windows-whpx-oci-qualification.v1` and
+`a3s.box.windows-whpx-oci-qualification-run.v1` schemas respectively.
+Preparation and start have a 30-minute bound. On Windows, handoff validation
+accepts the ordinary and `\\?\` namespace spellings only when they name the
+same exact container/create-operation path; a different operation suffix or a
+filesystem alias remains invalid.
 
 ## Diagnostics and kernel override
 

--- a/docs/windows-whpx.md
+++ b/docs/windows-whpx.md
@@ -11,7 +11,8 @@ runtime path.
 - Windows Hypervisor Platform enabled;
 - Windows Developer Mode enabled, or the A3S Box service identity granted
   `SeCreateSymbolicLinkPrivilege` (A3S Box temporarily enables an assigned but
-  disabled privilege only while extracting an OCI layer);
+  disabled privilege only while probing the capability or extracting an OCI
+  layer);
 - the A3S Box Windows binaries and their matching runtime DLLs.
 
 Enable WHPX from an elevated PowerShell prompt, then restart Windows if the
@@ -228,6 +229,18 @@ Preparation and start have a 30-minute bound. On Windows, handoff validation
 accepts the ordinary and `\\?\` namespace spellings only when they name the
 same exact container/create-operation path; a different operation suffix or a
 filesystem alias remains invalid.
+
+The first artifact-bound product gate passed on real x86_64 Windows/WHPX on
+August 4, 2026. It used Box
+`52a2cfe4ee6693c9cc3a88df1b922bc1825b2deb` from CI run
+[`30889251291`](https://github.com/A3S-Lab/Box/actions/runs/30889251291)
+and pinned OCI Runtime `08c145d8ce5d06d5f28587226be822a2ab43b299`
+from main run
+[`30881404238`](https://github.com/A3S-Lab/OCI-Runtime/actions/runs/30881404238).
+The twelve-minute run observed the exact `libkrun-whpx`/`dedicated-vm`
+binding, running state, exit code 23, create and delete replay, manager-restart
+reconciliation, complete lifecycle-directory cleanup, and no residual A3S
+processes.
 
 ## Diagnostics and kernel override
 

--- a/scripts/windows-whpx-oci-qualification.ps1
+++ b/scripts/windows-whpx-oci-qualification.ps1
@@ -1,0 +1,489 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$BoxArtifactDirectory,
+    [Parameter(Mandatory)]
+    [string]$OciWindowsArtifactDirectory,
+    [Parameter(Mandatory)]
+    [string]$OciGuestArtifactDirectory,
+    [Parameter(Mandatory)]
+    [string]$RootfsArchive,
+    [string]$OutputDirectory = ''
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
+    throw 'The Box/WHPX OCI qualification must run on Windows.'
+}
+
+$expectedRootfsSha256 = '4b4daa9fe2fc696c4919c4412a4c3d3e770d8fb70292a004a2c72f5096175282'
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$boxArtifacts = (Resolve-Path -LiteralPath $BoxArtifactDirectory -ErrorAction Stop).Path
+$ociWindowsArtifacts = (
+    Resolve-Path -LiteralPath $OciWindowsArtifactDirectory -ErrorAction Stop
+).Path
+$ociGuestArtifacts = (
+    Resolve-Path -LiteralPath $OciGuestArtifactDirectory -ErrorAction Stop
+).Path
+$rootfsArchive = (Resolve-Path -LiteralPath $RootfsArchive -ErrorAction Stop).Path
+$tar = (Get-Command tar.exe -ErrorAction Stop).Source
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+$runId = '{0}-{1}' -f (
+    Get-Date
+).ToUniversalTime().ToString('yyyyMMddTHHmmssZ'), $PID
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    $OutputDirectory = Join-Path $repositoryRoot `
+        "target\windows-whpx-oci-qualification\$runId"
+}
+$outputRoot = [IO.Path]::GetFullPath($OutputDirectory)
+if (Test-Path -LiteralPath $outputRoot) {
+    throw "Refusing to reuse a qualification directory: $outputRoot"
+}
+
+$boxHome = Join-Path $outputRoot 'box-whpx-oci-qualification-home'
+$runtimeRoot = Join-Path $boxHome 'oci-runtime'
+$systemRoot = Join-Path $runtimeRoot 'system'
+$stateRoot = Join-Path $runtimeRoot 'state'
+$readyPath = Join-Path $runtimeRoot 'service-ready.json'
+$boxBin = Join-Path $outputRoot 'box-bin'
+$ociBin = Join-Path $outputRoot 'oci-bin'
+$reportPath = Join-Path $outputRoot 'report.json'
+$summaryPath = Join-Path $outputRoot 'summary.json'
+$serviceStdoutPath = Join-Path $outputRoot 'oci-service.stdout.log'
+$serviceStderrPath = Join-Path $outputRoot 'oci-service.stderr.log'
+$importStdoutPath = Join-Path $outputRoot 'box-import.stdout.log'
+$importStderrPath = Join-Path $outputRoot 'box-import.stderr.log'
+$qualificationStdoutPath = Join-Path $outputRoot 'qualification.stdout.log'
+$qualificationStderrPath = Join-Path $outputRoot 'qualification.stderr.log'
+$pipeName = '\\.\pipe\a3s-oci-box-qualification-{0}-{1}' -f $PID, (
+    [Guid]::NewGuid().ToString('N')
+)
+$image = 'a3s-box-whpx-oci-qualification:local'
+$startedAt = [DateTime]::UtcNow
+
+function Write-Utf8Text {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [AllowEmptyString()]
+        [Parameter(Mandatory)]
+        [string]$Text
+    )
+
+    [IO.File]::WriteAllText($Path, $Text, $script:utf8NoBom)
+}
+
+function Write-JsonFile {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [object]$Value
+    )
+
+    Write-Utf8Text -Path $Path -Text (
+        ConvertTo-Json -InputObject $Value -Depth 30
+    )
+}
+
+function Resolve-RegularFile {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $resolved = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+    $item = Get-Item -LiteralPath $resolved -Force
+    if ($item.PSIsContainer -or $item.Length -le 0) {
+        throw "Expected a non-empty regular file: $resolved"
+    }
+    if ($item.PSObject.Properties.Name -contains 'LinkType' -and $item.LinkType) {
+        throw "Qualification inputs must not be links: $resolved"
+    }
+    $resolved
+}
+
+function Read-VerifiedArtifactManifest {
+    param(
+        [Parameter(Mandatory)][string]$Directory,
+        [Parameter(Mandatory)][string]$Schema,
+        [Parameter(Mandatory)][string]$ExpectedSourceCommit
+    )
+
+    $manifestPath = Resolve-RegularFile (
+        Join-Path $Directory 'artifact-manifest.json'
+    )
+    $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+    if ($manifest.schema_version -ne $Schema) {
+        throw "Unexpected artifact schema in ${manifestPath}: $($manifest.schema_version)"
+    }
+    if ($manifest.source_commit -ne $ExpectedSourceCommit) {
+        throw "Artifact source commit mismatch in ${manifestPath}: expected $ExpectedSourceCommit, found $($manifest.source_commit)"
+    }
+    if ($manifest.workflow_commit -notmatch '^[0-9a-f]{40}$') {
+        throw "Artifact workflow commit is invalid in $manifestPath"
+    }
+    foreach ($record in @($manifest.files)) {
+        $name = [string]$record.name
+        if ([string]::IsNullOrWhiteSpace($name) -or
+            [IO.Path]::GetFileName($name) -cne $name) {
+            throw "Artifact manifest contains an unsafe file name: $name"
+        }
+        $path = Resolve-RegularFile (Join-Path $Directory $name)
+        $item = Get-Item -LiteralPath $path
+        $sha256 = (
+            Get-FileHash -LiteralPath $path -Algorithm SHA256
+        ).Hash.ToLowerInvariant()
+        if ($item.Length -ne [long]($record.size) -or $sha256 -ne $record.sha256) {
+            throw "Artifact file does not match its manifest: $path"
+        }
+    }
+    $manifest
+}
+
+function Require-ManifestFile {
+    param(
+        [Parameter(Mandatory)][object]$Manifest,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    $matches = @($Manifest.files | Where-Object { $_.name -eq $Name })
+    if ($matches.Count -ne 1) {
+        throw "Artifact manifest must contain exactly one $Name entry"
+    }
+}
+
+function Join-QuotedNativeArguments {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+
+    @($Arguments | ForEach-Object {
+        if ($_.Contains('"')) {
+            throw "Native argument contains an unsupported quote: $_"
+        }
+        '"{0}"' -f $_
+    }) -join ' '
+}
+
+function Get-A3sProcesses {
+    @(
+        Get-Process -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.ProcessName -in @(
+                    'a3s-box',
+                    'a3s-box-shim',
+                    'a3s-oci',
+                    'a3s-oci-krun-shim',
+                    'windows-whpx-oci-qualification'
+                )
+            } |
+            Select-Object ProcessName, Id, StartTime, Path
+    )
+}
+
+function Wait-ForNoA3sProcesses {
+    for ($attempt = 0; $attempt -lt 150; $attempt++) {
+        $processes = @(Get-A3sProcesses)
+        if ($processes.Count -eq 0) {
+            return @()
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    @(Get-A3sProcesses)
+}
+
+function Directory-IsAbsentOrEmpty {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $true
+    }
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return $false
+    }
+    $null -eq (Get-ChildItem -LiteralPath $Path -Force | Select-Object -First 1)
+}
+
+$commit = (& git -C $repositoryRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or $commit -notmatch '^[0-9a-f]{40}$') {
+    throw 'Unable to resolve the Box source commit.'
+}
+$worktreeStatus = @(& git -C $repositoryRoot status --porcelain)
+if ($LASTEXITCODE -ne 0) {
+    throw 'Unable to inspect the Box worktree.'
+}
+$ciWorkflow = Get-Content -LiteralPath (
+    Join-Path $repositoryRoot '.github\workflows\ci.yml'
+) -Raw
+$pinnedMatch = [regex]::Match(
+    $ciWorkflow,
+    '(?m)^\s*A3S_OCI_RUNTIME_REV:\s*([0-9a-f]{40})\s*$'
+)
+if (-not $pinnedMatch.Success) {
+    throw 'Unable to resolve the exact OCI Runtime revision from CI.'
+}
+$pinnedOciCommit = $pinnedMatch.Groups[1].Value
+
+$boxManifest = Read-VerifiedArtifactManifest `
+    -Directory $boxArtifacts `
+    -Schema 'a3s.box.windows-whpx-qualification-artifact.v1' `
+    -ExpectedSourceCommit $commit
+$ociWindowsManifest = Read-VerifiedArtifactManifest `
+    -Directory $ociWindowsArtifacts `
+    -Schema 'a3s.oci.windows-whpx-qualification-artifact.v1' `
+    -ExpectedSourceCommit $pinnedOciCommit
+$ociGuestManifest = Read-VerifiedArtifactManifest `
+    -Directory $ociGuestArtifacts `
+    -Schema 'a3s.oci.guest-agent-qualification-artifact.v1' `
+    -ExpectedSourceCommit $pinnedOciCommit
+
+foreach ($name in @(
+    'a3s-box.exe',
+    'a3s-box-shim.exe',
+    'windows-whpx-oci-qualification.exe',
+    'krun.dll',
+    'libkrunfw.dll'
+)) {
+    Require-ManifestFile -Manifest $boxManifest -Name $name
+}
+foreach ($name in @(
+    'a3s-oci.exe',
+    'a3s-oci-krun-shim.exe',
+    'krun.dll',
+    'libkrunfw.dll'
+)) {
+    Require-ManifestFile -Manifest $ociWindowsManifest -Name $name
+}
+Require-ManifestFile -Manifest $ociGuestManifest -Name 'a3s-oci-agent-x86_64'
+if ($ociWindowsManifest.run_id -ne $ociGuestManifest.run_id -or
+    $ociWindowsManifest.workflow_commit -ne $ociGuestManifest.workflow_commit) {
+    throw 'OCI Windows and guest artifacts must come from the same workflow run.'
+}
+
+$rootfsArchive = Resolve-RegularFile $rootfsArchive
+$rootfsSha256 = (
+    Get-FileHash -LiteralPath $rootfsArchive -Algorithm SHA256
+).Hash.ToLowerInvariant()
+if ($rootfsSha256 -ne $expectedRootfsSha256) {
+    throw "Rootfs SHA-256 mismatch: expected $expectedRootfsSha256, found $rootfsSha256"
+}
+
+$preexisting = @(Get-A3sProcesses)
+if ($preexisting.Count -gt 0) {
+    $description = ($preexisting | ForEach-Object {
+        '{0}:{1}' -f $_.ProcessName, $_.Id
+    }) -join ', '
+    throw "Refusing to start with active A3S runtime processes: $description"
+}
+
+New-Item -ItemType Directory -Path `
+    $outputRoot, $boxHome, $systemRoot, $stateRoot, $boxBin, $ociBin | Out-Null
+foreach ($name in @(
+    'a3s-box.exe',
+    'a3s-box-shim.exe',
+    'windows-whpx-oci-qualification.exe',
+    'krun.dll',
+    'libkrunfw.dll'
+)) {
+    Copy-Item -LiteralPath (Join-Path $boxArtifacts $name) `
+        -Destination (Join-Path $boxBin $name)
+}
+foreach ($name in @(
+    'a3s-oci.exe',
+    'a3s-oci-krun-shim.exe',
+    'krun.dll',
+    'libkrunfw.dll'
+)) {
+    Copy-Item -LiteralPath (Join-Path $ociWindowsArtifacts $name) `
+        -Destination (Join-Path $ociBin $name)
+}
+
+& $tar -xf $rootfsArchive -C $systemRoot
+if ($LASTEXITCODE -ne 0) {
+    throw 'Failed to extract the WHPX utility-VM system root.'
+}
+New-Item -ItemType Directory -Path `
+    (Join-Path $systemRoot 'run\a3s-oci-runtime'), `
+    (Join-Path $systemRoot 'usr\bin') -Force | Out-Null
+Copy-Item -LiteralPath (
+    Join-Path $ociGuestArtifacts 'a3s-oci-agent-x86_64'
+) -Destination (Join-Path $systemRoot 'usr\bin\a3s-oci-agent')
+
+$boxCli = Join-Path $boxBin 'a3s-box.exe'
+$qualification = Join-Path $boxBin 'windows-whpx-oci-qualification.exe'
+$ociCli = Join-Path $ociBin 'a3s-oci.exe'
+$ociShim = Join-Path $ociBin 'a3s-oci-krun-shim.exe'
+$serviceArguments = @(
+    'box-whpx-qualification-service',
+    '--shim', $ociShim,
+    '--runtime-root', $runtimeRoot,
+    '--vm-rootfs', $systemRoot,
+    '--state-root', $stateRoot,
+    '--pipe', $pipeName,
+    '--ready-file', $readyPath
+)
+
+$service = $null
+$ready = $null
+$qualificationReport = $null
+$failure = $null
+$result = 'failed'
+$residual = @()
+$previousEnvironment = [ordered]@{}
+foreach ($name in @(
+    'A3S_HOME',
+    'A3S_BOX_WHPX_OCI_QUALIFICATION',
+    'A3S_BOX_OCI_HOST_ROOT',
+    'A3S_BOX_OCI_WHPX_ENDPOINT',
+    'A3S_BOX_WHPX_OCI_IMAGE',
+    'A3S_BOX_WHPX_OCI_REPORT'
+)) {
+    $previousEnvironment[$name] = [Environment]::GetEnvironmentVariable(
+        $name,
+        [EnvironmentVariableTarget]::Process
+    )
+}
+
+try {
+    $service = Start-Process -FilePath $ociCli `
+        -ArgumentList (Join-QuotedNativeArguments -Arguments $serviceArguments) `
+        -WorkingDirectory $ociBin `
+        -RedirectStandardOutput $serviceStdoutPath `
+        -RedirectStandardError $serviceStderrPath `
+        -WindowStyle Hidden -PassThru
+
+    for ($attempt = 0; $attempt -lt 300; $attempt++) {
+        if ($service.HasExited) {
+            throw "OCI qualification service exited with code $($service.ExitCode) before readiness"
+        }
+        if (Test-Path -LiteralPath $readyPath -PathType Leaf) {
+            $candidate = Get-Content -LiteralPath $readyPath -Raw | ConvertFrom-Json
+            if ($candidate.schema_version -eq 'a3s.oci.box-whpx-service-ready.v1') {
+                $ready = $candidate
+                break
+            }
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    if ($null -eq $ready) {
+        throw 'Timed out waiting for the OCI qualification service.'
+    }
+    if ($ready.owner_pid -ne $service.Id -or
+        $ready.endpoint -ne $pipeName -or
+        [IO.Path]::GetFullPath($ready.runtime_root) -ne $runtimeRoot -or
+        [IO.Path]::GetFullPath($ready.state_root) -ne $stateRoot) {
+        throw 'OCI qualification readiness evidence does not match the launched owner.'
+    }
+
+    $env:A3S_HOME = $boxHome
+    $importProcess = Start-Process -FilePath $boxCli `
+        -ArgumentList (Join-QuotedNativeArguments -Arguments @(
+            'import', $rootfsArchive, $image
+        )) `
+        -WorkingDirectory $boxBin `
+        -RedirectStandardOutput $importStdoutPath `
+        -RedirectStandardError $importStderrPath `
+        -WindowStyle Hidden -Wait -PassThru
+    if ($importProcess.ExitCode -ne 0) {
+        throw "Box image import failed with exit code $($importProcess.ExitCode)"
+    }
+
+    $env:A3S_BOX_WHPX_OCI_QUALIFICATION = '1'
+    $env:A3S_BOX_OCI_HOST_ROOT = $runtimeRoot
+    $env:A3S_BOX_OCI_WHPX_ENDPOINT = $pipeName
+    $env:A3S_BOX_WHPX_OCI_IMAGE = $image
+    $env:A3S_BOX_WHPX_OCI_REPORT = $reportPath
+    $qualificationProcess = Start-Process -FilePath $qualification `
+        -WorkingDirectory $boxBin `
+        -RedirectStandardOutput $qualificationStdoutPath `
+        -RedirectStandardError $qualificationStderrPath `
+        -WindowStyle Hidden -Wait -PassThru
+    if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
+        throw 'Box qualification executable did not emit its report.'
+    }
+    $qualificationReport = Get-Content -LiteralPath $reportPath -Raw |
+        ConvertFrom-Json
+    if ($qualificationProcess.ExitCode -ne 0 -or
+        $qualificationReport.schema_version -ne 'a3s.box.windows-whpx-oci-qualification.v1' -or
+        $qualificationReport.status -ne 'passed') {
+        throw "Box qualification failed with exit code $($qualificationProcess.ExitCode)"
+    }
+    if (-not $qualificationReport.create_replay_exact -or
+        -not $qualificationReport.manager_restart_reconciled -or
+        -not $qualificationReport.observed_running -or
+        $qualificationReport.terminal_state -ne 'stopped' -or
+        $qualificationReport.exit_code -ne 23 -or
+        $qualificationReport.runtime_binding.driver -ne 'libkrun-whpx' -or
+        $qualificationReport.runtime_binding.isolation -ne 'dedicated-vm' -or
+        -not $qualificationReport.removed -or
+        -not $qualificationReport.remove_replay_absent -or
+        -not $qualificationReport.reconcile_absent -or
+        -not $qualificationReport.box_directory_absent -or
+        -not $qualificationReport.runtime_shares_absent -or
+        -not $qualificationReport.bundle_handoffs_absent) {
+        throw 'Box qualification report does not satisfy the complete lifecycle contract.'
+    }
+    if (-not (Directory-IsAbsentOrEmpty (Join-Path $runtimeRoot 'shares')) -or
+        -not (Directory-IsAbsentOrEmpty (Join-Path $runtimeRoot 'bundle-handoffs'))) {
+        throw 'OCI runtime shares or Box bundle handoffs remain after qualification.'
+    }
+    $result = 'passed'
+}
+catch {
+    $failure = $_.Exception.Message
+}
+finally {
+    foreach ($name in $previousEnvironment.Keys) {
+        [Environment]::SetEnvironmentVariable(
+            $name,
+            $previousEnvironment[$name],
+            [EnvironmentVariableTarget]::Process
+        )
+    }
+    if ($null -ne $service -and -not $service.HasExited) {
+        Stop-Process -Id $service.Id -Force -ErrorAction SilentlyContinue
+        $service.WaitForExit(15000) | Out-Null
+    }
+    $residual = @(Wait-ForNoA3sProcesses)
+    if ($residual.Count -gt 0) {
+        foreach ($process in $residual) {
+            if ($null -ne $process.Path -and
+                [IO.Path]::GetFullPath($process.Path).StartsWith(
+                    $outputRoot,
+                    [StringComparison]::OrdinalIgnoreCase
+                )) {
+                Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            }
+        }
+        if ($null -eq $failure) {
+            $failure = 'Qualification leaked one or more staged A3S processes.'
+        }
+        $result = 'failed'
+    }
+
+    $summary = [ordered]@{
+        schema_version = 'a3s.box.windows-whpx-oci-qualification-run.v1'
+        status = $result
+        started_at_utc = $startedAt.ToString('o')
+        completed_at_utc = [DateTime]::UtcNow.ToString('o')
+        error = $failure
+        box_commit = $commit
+        box_worktree_status = $worktreeStatus
+        pinned_oci_commit = $pinnedOciCommit
+        rootfs_archive = $rootfsArchive
+        rootfs_sha256 = $rootfsSha256
+        endpoint = $pipeName
+        box_artifact = $boxManifest
+        oci_windows_artifact = $ociWindowsManifest
+        oci_guest_artifact = $ociGuestManifest
+        service_ready = $ready
+        qualification = $qualificationReport
+        residual_processes = $residual
+    }
+    Write-JsonFile -Path $summaryPath -Value $summary
+}
+
+if ($null -ne $failure) {
+    throw "$failure; see $summaryPath"
+}
+Write-Output "Box/WHPX OCI qualification passed: $summaryPath"
+Get-Content -LiteralPath $summaryPath

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=d806e0dd5bb917bd9ed429ef9af101655c400160#d806e0dd5bb917bd9ed429ef9af101655c400160"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=08c145d8ce5d06d5f28587226be822a2ab43b299#08c145d8ce5d06d5f28587226be822a2ab43b299"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=d806e0dd5bb917bd9ed429ef9af101655c400160#d806e0dd5bb917bd9ed429ef9af101655c400160"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=08c145d8ce5d06d5f28587226be822a2ab43b299#08c145d8ce5d06d5f28587226be822a2ab43b299"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -125,7 +125,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "061cde95e16eb4cbd9f58724e6cbb60de6ace77e" }
-a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "d806e0dd5bb917bd9ed429ef9af101655c400160" }
+a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "08c145d8ce5d06d5f28587226be822a2ab43b299" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/cli/src/commands/info.rs
+++ b/src/cli/src/commands/info.rs
@@ -184,9 +184,10 @@ fn print_host_mount_info() {
 fn print_rootfs_symlink_info(home: &Path) {
     match probe_windows_symlink_support(home) {
         Ok(()) => println!("OCI symlink support: available"),
-        Err(error) if error.raw_os_error() == Some(1314) => println!(
+        Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => println!(
             "OCI symlink support: unavailable (enable Windows Developer Mode or grant \
-             SeCreateSymbolicLinkPrivilege; ERROR_PRIVILEGE_NOT_HELD (1314))"
+             SeCreateSymbolicLinkPrivilege and allow the target directory; \
+             ERROR_ACCESS_DENIED (5) or ERROR_PRIVILEGE_NOT_HELD (1314))"
         ),
         Err(error) => println!("OCI symlink support: unavailable (probe failed: {error})"),
     }
@@ -199,6 +200,7 @@ fn probe_windows_symlink_support(home: &Path) -> std::io::Result<()> {
         .prefix(".symlink-capability-")
         .tempdir_in(home)?;
     std::fs::write(directory.path().join("target"), b"probe")?;
+    let _guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
     std::os::windows::fs::symlink_file("target", directory.path().join("link"))
 }
 

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -25,7 +25,9 @@ base64 = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48", features = [
     "Win32_Foundation",
+    "Win32_Security",
     "Win32_Storage_FileSystem",
+    "Win32_System_Threading",
 ] }
 
 [lib]

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -32,6 +32,8 @@ pub mod vmm;
 pub mod volume;
 #[cfg(windows)]
 pub mod windows_file;
+#[cfg(windows)]
+pub mod windows_symlink;
 
 // Re-export commonly used types
 pub use audit::{AuditAction, AuditConfig, AuditEvent, AuditOutcome};

--- a/src/core/src/windows_symlink.rs
+++ b/src/core/src/windows_symlink.rs
@@ -1,0 +1,203 @@
+//! Scoped Windows capability for preserving OCI symbolic links.
+//!
+//! Windows administrator and service tokens may contain
+//! `SeCreateSymbolicLinkPrivilege` in a disabled state. OCI extraction and
+//! rootfs diagnostics must observe the same effective capability, so this
+//! module owns the single process-token implementation used by both paths.
+
+use std::sync::{Mutex, MutexGuard};
+
+static WINDOWS_SYMLINK_PRIVILEGE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Serialized scope which enables an already assigned symbolic-link privilege.
+///
+/// The scope does not grant a privilege absent from the process token. In that
+/// case it leaves the token unchanged so Windows Developer Mode can still
+/// authorize `CreateSymbolicLinkW`. The previous token state is restored before
+/// the process-wide serialization lock is released.
+#[must_use]
+#[doc(hidden)]
+pub struct WindowsSymlinkPrivilegeGuard {
+    // Field order is intentional: restore the process privilege before
+    // releasing the serialization lock.
+    _privilege: Option<WindowsTokenPrivilegeGuard>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl WindowsSymlinkPrivilegeGuard {
+    /// Acquire the process-wide scope used around a bounded symlink operation.
+    pub fn acquire() -> Self {
+        let lock = WINDOWS_SYMLINK_PRIVILEGE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let privilege = match WindowsTokenPrivilegeGuard::enable_symlink_creation() {
+            Ok(privilege) => privilege,
+            Err(error) => {
+                tracing::debug!(
+                    error = %error,
+                    "Could not enable the optional Windows symlink privilege"
+                );
+                None
+            }
+        };
+        Self {
+            _privilege: privilege,
+            _lock: lock,
+        }
+    }
+}
+
+struct WindowsTokenPrivilegeGuard {
+    token: windows_sys::Win32::Foundation::HANDLE,
+    previous: windows_sys::Win32::Security::TOKEN_PRIVILEGES,
+}
+
+impl WindowsTokenPrivilegeGuard {
+    fn enable_symlink_creation() -> std::io::Result<Option<Self>> {
+        use std::mem::size_of;
+        use std::ptr::null;
+        use windows_sys::Win32::Foundation::{
+            CloseHandle, GetLastError, SetLastError, ERROR_NOT_ALL_ASSIGNED, ERROR_SUCCESS, LUID,
+        };
+        use windows_sys::Win32::Security::{
+            AdjustTokenPrivileges, LookupPrivilegeValueW, LUID_AND_ATTRIBUTES,
+            SE_CREATE_SYMBOLIC_LINK_NAME, SE_PRIVILEGE_ENABLED, TOKEN_ADJUST_PRIVILEGES,
+            TOKEN_PRIVILEGES, TOKEN_QUERY,
+        };
+        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+        let mut token = 0;
+        // SAFETY: `token` is a valid output pointer and the pseudo process
+        // handle remains valid for the duration of this call.
+        if unsafe {
+            OpenProcessToken(
+                GetCurrentProcess(),
+                TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+                &mut token,
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let mut luid = LUID {
+            LowPart: 0,
+            HighPart: 0,
+        };
+        // SAFETY: the privilege name is a static NUL-terminated Windows string,
+        // `luid` is writable, and the local-system name is intentionally null.
+        if unsafe { LookupPrivilegeValueW(null(), SE_CREATE_SYMBOLIC_LINK_NAME, &mut luid) } == 0 {
+            let error = std::io::Error::last_os_error();
+            // SAFETY: `token` was returned by OpenProcessToken above.
+            unsafe { CloseHandle(token) };
+            return Err(error);
+        }
+
+        let requested = TOKEN_PRIVILEGES {
+            PrivilegeCount: 1,
+            Privileges: [LUID_AND_ATTRIBUTES {
+                Luid: luid,
+                Attributes: SE_PRIVILEGE_ENABLED,
+            }],
+        };
+        let mut previous = TOKEN_PRIVILEGES {
+            PrivilegeCount: 0,
+            Privileges: [LUID_AND_ATTRIBUTES {
+                Luid: LUID {
+                    LowPart: 0,
+                    HighPart: 0,
+                },
+                Attributes: 0,
+            }],
+        };
+        let mut previous_length = 0;
+        // AdjustTokenPrivileges can return success while reporting
+        // ERROR_NOT_ALL_ASSIGNED through GetLastError.
+        // SAFETY: both TOKEN_PRIVILEGES buffers are initialized and sized for
+        // the single privilege requested here.
+        unsafe { SetLastError(ERROR_SUCCESS) };
+        let adjusted = unsafe {
+            AdjustTokenPrivileges(
+                token,
+                0,
+                &requested,
+                size_of::<TOKEN_PRIVILEGES>() as u32,
+                &mut previous,
+                &mut previous_length,
+            )
+        };
+        let adjustment_error = unsafe { GetLastError() };
+        if adjusted == 0 {
+            // SAFETY: `token` was returned by OpenProcessToken above.
+            unsafe { CloseHandle(token) };
+            return if adjustment_error == ERROR_SUCCESS {
+                Err(std::io::Error::other(
+                    "AdjustTokenPrivileges failed without a Windows error code",
+                ))
+            } else {
+                Err(std::io::Error::from_raw_os_error(adjustment_error as i32))
+            };
+        }
+        if adjustment_error != ERROR_SUCCESS {
+            // SAFETY: `token` was returned by OpenProcessToken above.
+            unsafe { CloseHandle(token) };
+            if adjustment_error == ERROR_NOT_ALL_ASSIGNED {
+                return Ok(None);
+            }
+            return Err(std::io::Error::from_raw_os_error(adjustment_error as i32));
+        }
+
+        Ok(Some(Self { token, previous }))
+    }
+}
+
+impl Drop for WindowsTokenPrivilegeGuard {
+    fn drop(&mut self) {
+        use std::ptr::null_mut;
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::Security::AdjustTokenPrivileges;
+
+        // SAFETY: this restores the exact privilege state captured from the
+        // same open token, then closes that owned handle.
+        unsafe {
+            AdjustTokenPrivileges(self.token, 0, &self.previous, 0, null_mut(), null_mut());
+            CloseHandle(self.token);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acquired_scope_preserves_a_real_link_when_the_identity_is_capable() {
+        let temporary = tempfile::tempdir().unwrap();
+        std::fs::write(temporary.path().join("target"), b"probe").unwrap();
+
+        let result = {
+            let _guard = WindowsSymlinkPrivilegeGuard::acquire();
+            std::os::windows::fs::symlink_file("target", temporary.path().join("link"))
+        };
+        match result {
+            Ok(()) => {
+                let link = temporary.path().join("link");
+                assert!(std::fs::symlink_metadata(&link)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink());
+                assert_eq!(
+                    std::fs::read_link(link).unwrap(),
+                    std::path::Path::new("target")
+                );
+            }
+            Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => {
+                eprintln!("skipping Windows symlink privilege test: {error}");
+            }
+            Err(error) => panic!("Windows symlink privilege scope failed unexpectedly: {error}"),
+        }
+
+        // Dropping the first scope must release the process-wide lock.
+        let _second = WindowsSymlinkPrivilegeGuard::acquire();
+    }
+}

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -16,6 +16,11 @@ name = "managed-sandbox-smoke"
 path = "examples/managed_sandbox_smoke.rs"
 required-features = ["vm"]
 
+[[example]]
+name = "windows-whpx-oci-qualification"
+path = "examples/windows_whpx_oci_qualification.rs"
+required-features = ["vm"]
+
 [features]
 default = ["vm", "pool", "scale", "compose", "operator", "build"]
 vm = []

--- a/src/runtime/examples/windows_whpx_oci_qualification.rs
+++ b/src/runtime/examples/windows_whpx_oci_qualification.rs
@@ -1,0 +1,543 @@
+//! Destructive product-lifecycle qualification for Box over A3S OCI Runtime/WHPX.
+//!
+//! The PowerShell qualification runner owns the isolated home, runtime service,
+//! image import, artifact verification, and process-leak checks. This executable
+//! exercises only the public Box lifecycle boundary and always emits a versioned
+//! JSON report when `A3S_BOX_WHPX_OCI_REPORT` names an absolute output path.
+
+#[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+fn main() {
+    eprintln!("windows-whpx-oci-qualification requires Windows x86_64");
+    std::process::exit(2);
+}
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+#[tokio::main]
+async fn main() {
+    qualification::main().await;
+}
+
+#[cfg_attr(
+    not(all(target_os = "windows", target_arch = "x86_64")),
+    allow(dead_code)
+)]
+mod qualification {
+    use std::collections::BTreeMap;
+    use std::error::Error;
+    use std::fs::OpenOptions;
+    use std::io::{self, Write};
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    use a3s_box_core::{
+        BoxConfig, CreateExecutionRequest, ExecutionBackend, ExecutionGeneration, ExecutionId,
+        ExecutionIsolation, ExecutionManager, ExecutionState, IsolationClass as BoxIsolationClass,
+        NetworkMode, OperationId, ReconcileOutcome, ResourceConfig,
+    };
+    use a3s_box_runtime::{
+        LocalExecutionManager, ManagedExecutionStore, ManagedRuntimeRoute, OciRuntimeBinding,
+        WindowsWhpxOciMigrationConfig,
+    };
+    use a3s_oci_sdk::{DriverKind, IsolationClass as OciIsolationClass};
+    use serde::Serialize;
+
+    const ENABLE_ENV: &str = "A3S_BOX_WHPX_OCI_QUALIFICATION";
+    const HOME_ENV: &str = "A3S_HOME";
+    const RUNTIME_ROOT_ENV: &str = "A3S_BOX_OCI_HOST_ROOT";
+    const ENDPOINT_ENV: &str = "A3S_BOX_OCI_WHPX_ENDPOINT";
+    const IMAGE_ENV: &str = "A3S_BOX_WHPX_OCI_IMAGE";
+    const REPORT_ENV: &str = "A3S_BOX_WHPX_OCI_REPORT";
+    const SCHEMA_VERSION: &str = "a3s.box.windows-whpx-oci-qualification.v1";
+    const STDOUT_MARKER: &str = "a3s-box-whpx-oci-stdout";
+    const STDERR_MARKER: &str = "a3s-box-whpx-oci-stderr";
+    const EXPECTED_EXIT_CODE: i32 = 23;
+
+    type AnyError = Box<dyn Error + Send + Sync>;
+
+    #[derive(Debug, Clone)]
+    struct Inputs {
+        home_dir: PathBuf,
+        state_path: PathBuf,
+        runtime_root: PathBuf,
+        endpoint: String,
+        image: String,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct QualificationReport {
+        schema_version: &'static str,
+        status: &'static str,
+        started_at_utc: String,
+        completed_at_utc: String,
+        error: Option<String>,
+        cleanup_error: Option<String>,
+        home_dir: Option<PathBuf>,
+        state_path: Option<PathBuf>,
+        runtime_root: Option<PathBuf>,
+        endpoint: Option<String>,
+        image: Option<String>,
+        operation_id: Option<String>,
+        execution_id: Option<String>,
+        box_generation: Option<ExecutionGeneration>,
+        create_replay_exact: bool,
+        manager_restart_reconciled: bool,
+        observed_running: bool,
+        terminal_state: Option<ExecutionState>,
+        exit_code: Option<i32>,
+        runtime_binding: Option<OciRuntimeBinding>,
+        removed: bool,
+        remove_replay_absent: bool,
+        reconcile_absent: bool,
+        box_directory_absent: bool,
+        runtime_shares_absent: bool,
+        bundle_handoffs_absent: bool,
+    }
+
+    impl QualificationReport {
+        fn new() -> Self {
+            Self {
+                schema_version: SCHEMA_VERSION,
+                status: "failed",
+                started_at_utc: chrono::Utc::now().to_rfc3339(),
+                completed_at_utc: String::new(),
+                error: None,
+                cleanup_error: None,
+                home_dir: None,
+                state_path: None,
+                runtime_root: None,
+                endpoint: None,
+                image: None,
+                operation_id: None,
+                execution_id: None,
+                box_generation: None,
+                create_replay_exact: false,
+                manager_restart_reconciled: false,
+                observed_running: false,
+                terminal_state: None,
+                exit_code: None,
+                runtime_binding: None,
+                removed: false,
+                remove_replay_absent: false,
+                reconcile_absent: false,
+                box_directory_absent: false,
+                runtime_shares_absent: false,
+                bundle_handoffs_absent: false,
+            }
+        }
+    }
+
+    pub(super) async fn main() {
+        let report_path = match absolute_environment_path(REPORT_ENV) {
+            Ok(path) => path,
+            Err(error) => {
+                eprintln!("WHPX OCI qualification cannot select its report: {error}");
+                std::process::exit(2);
+            }
+        };
+        let mut report = QualificationReport::new();
+
+        let inputs = load_inputs(&mut report);
+        let outcome = match inputs {
+            Ok(inputs) => {
+                let operation_id = OperationId::new(format!(
+                    "windows-whpx-oci-qualification-{}",
+                    uuid::Uuid::new_v4()
+                ));
+                match operation_id {
+                    Ok(operation_id) => {
+                        report.operation_id = Some(operation_id.to_string());
+                        let outcome = exercise(&inputs, &operation_id, &mut report).await;
+                        if outcome.is_err() {
+                            if let Err(error) = cleanup(&inputs, &operation_id).await {
+                                report.cleanup_error = Some(error.to_string());
+                            }
+                        }
+                        outcome
+                    }
+                    Err(error) => Err(error.into()),
+                }
+            }
+            Err(error) => Err(error),
+        };
+
+        match outcome {
+            Ok(()) => report.status = "passed",
+            Err(error) => report.error = Some(error.to_string()),
+        }
+        report.completed_at_utc = chrono::Utc::now().to_rfc3339();
+
+        if let Err(error) = write_report(&report_path, &report) {
+            eprintln!(
+                "WHPX OCI qualification could not write {}: {error}",
+                report_path.display()
+            );
+            std::process::exit(1);
+        }
+        if report.status != "passed" {
+            eprintln!(
+                "WHPX OCI qualification failed: {}",
+                report.error.as_deref().unwrap_or("unknown failure")
+            );
+            std::process::exit(1);
+        }
+        println!("WHPX OCI qualification passed: {}", report_path.display());
+    }
+
+    fn load_inputs(report: &mut QualificationReport) -> Result<Inputs, AnyError> {
+        require(
+            std::env::var(ENABLE_ENV).as_deref() == Ok("1"),
+            format!("set {ENABLE_ENV}=1 to acknowledge the destructive qualification"),
+        )?;
+        let home_dir = absolute_environment_path(HOME_ENV)?;
+        require(
+            home_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("whpx-oci-qualification")),
+            "A3S_HOME must name a dedicated whpx-oci-qualification directory",
+        )?;
+        let runtime_root = absolute_environment_path(RUNTIME_ROOT_ENV)?;
+        require(
+            runtime_root.starts_with(&home_dir),
+            "A3S_BOX_OCI_HOST_ROOT must be inside the dedicated A3S_HOME",
+        )?;
+        let endpoint = required_environment_string(ENDPOINT_ENV)?;
+        let image = required_environment_string(IMAGE_ENV)?;
+        let state_path = home_dir.join("managed-executions.json");
+
+        report.home_dir = Some(home_dir.clone());
+        report.state_path = Some(state_path.clone());
+        report.runtime_root = Some(runtime_root.clone());
+        report.endpoint = Some(endpoint.clone());
+        report.image = Some(image.clone());
+        Ok(Inputs {
+            home_dir,
+            state_path,
+            runtime_root,
+            endpoint,
+            image,
+        })
+    }
+
+    async fn exercise(
+        inputs: &Inputs,
+        operation_id: &OperationId,
+        report: &mut QualificationReport,
+    ) -> Result<(), AnyError> {
+        let request = qualification_request(&inputs.image);
+        let manager = connect(inputs).await?;
+        let reservation = manager.create(request.clone(), operation_id).await?;
+        report.execution_id = Some(reservation.execution_id.to_string());
+        report.box_generation = Some(reservation.generation);
+
+        require(
+            reservation.plan.backend == ExecutionBackend::Krun
+                && reservation.plan.isolation_class == BoxIsolationClass::HardwareVm,
+            "the Box request did not retain its dedicated MicroVM product plan",
+        )?;
+        let replay = manager.create(request, operation_id).await?;
+        require(
+            replay.execution_id == reservation.execution_id
+                && replay.generation == reservation.generation
+                && replay.plan == reservation.plan
+                && same_resources(&replay.resources, &reservation.resources),
+            "idempotent Box create replay changed its reservation",
+        )?;
+        report.create_replay_exact = true;
+
+        let store = ManagedExecutionStore::new(&inputs.state_path);
+        let created = store
+            .get(&reservation.execution_id)?
+            .ok_or_else(|| failure("created Box record is missing"))?;
+        let metadata = created
+            .managed_execution
+            .as_ref()
+            .ok_or_else(|| failure("created Box record has no managed metadata"))?;
+        require(
+            metadata.runtime_route == ManagedRuntimeRoute::OciSdk,
+            "created Box record is not durably routed through the OCI SDK",
+        )?;
+        require(
+            metadata.oci_runtime.is_none(),
+            "unstarted Box record unexpectedly contains a runtime generation",
+        )?;
+
+        drop(manager);
+        let restarted = connect(inputs).await?;
+        let recovered = match restarted.reconcile(operation_id).await? {
+            ReconcileOutcome::Created(reservation) => reservation,
+            _ => {
+                return Err(failure(
+                    "restarted Box manager did not recover created state",
+                ))
+            }
+        };
+        require(
+            recovered.execution_id == reservation.execution_id
+                && recovered.generation == reservation.generation
+                && recovered.plan == reservation.plan
+                && same_resources(&recovered.resources, &reservation.resources),
+            "restarted Box manager recovered different reservation evidence",
+        )?;
+        report.manager_restart_reconciled = true;
+
+        let lease = tokio::time::timeout(
+            Duration::from_secs(30 * 60),
+            restarted.start(&recovered.execution_id, recovered.generation),
+        )
+        .await
+        .map_err(|_| failure("timed out preparing or starting the WHPX execution"))??;
+        require(
+            lease.execution_id == recovered.execution_id
+                && lease.generation == recovered.generation
+                && lease.plan == recovered.plan
+                && same_resources(&lease.resources, &recovered.resources),
+            "started Box lease differs from its durable reservation",
+        )?;
+        let running = store
+            .get(&recovered.execution_id)?
+            .ok_or_else(|| failure("started Box record is missing"))?;
+        let binding = running
+            .managed_execution
+            .as_ref()
+            .and_then(|metadata| metadata.oci_runtime.clone())
+            .ok_or_else(|| failure("started Box record has no exact OCI runtime binding"))?;
+        require(
+            binding.driver == DriverKind::LibkrunWhpx
+                && binding.isolation == OciIsolationClass::DedicatedVm,
+            "runtime did not return the dedicated-VM libkrun/WHPX binding",
+        )?;
+        report.runtime_binding = Some(binding);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(180);
+        loop {
+            let status = restarted.inspect(&recovered.execution_id).await?;
+            match status.state {
+                ExecutionState::Running => report.observed_running = true,
+                ExecutionState::Stopped => {
+                    report.terminal_state = Some(status.state);
+                    break;
+                }
+                ExecutionState::Failed => {
+                    return Err(failure("WHPX execution entered failed state"));
+                }
+                ExecutionState::Created | ExecutionState::Creating => {}
+                ExecutionState::Paused => {
+                    return Err(failure("WHPX execution unexpectedly entered paused state"));
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(failure("timed out waiting for the WHPX execution to stop"));
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        require(
+            report.observed_running,
+            "Box never observed the WHPX execution in running state",
+        )?;
+
+        let stopped = store
+            .get(&recovered.execution_id)?
+            .ok_or_else(|| failure("terminal Box record is missing"))?;
+        report.exit_code = stopped.exit_code;
+        require(
+            stopped.exit_code == Some(EXPECTED_EXIT_CODE),
+            format!(
+                "expected exact exit code {EXPECTED_EXIT_CODE}, found {:?}",
+                stopped.exit_code
+            ),
+        )?;
+        let stopped_metadata = stopped
+            .managed_execution
+            .as_ref()
+            .ok_or_else(|| failure("terminal Box record lost managed metadata"))?;
+        require(
+            stopped_metadata.oci_runtime.is_none() && stopped_metadata.finished_at.is_some(),
+            "terminal Box record retained live runtime state or lost its completion time",
+        )?;
+
+        report.removed = restarted
+            .remove(&recovered.execution_id, recovered.generation)
+            .await?;
+        require(report.removed, "terminal Box generation was not removed")?;
+        report.remove_replay_absent = !restarted
+            .remove(&recovered.execution_id, recovered.generation)
+            .await?;
+        require(
+            report.remove_replay_absent,
+            "remove replay did not report the generation as absent",
+        )?;
+        report.reconcile_absent = matches!(
+            restarted.reconcile(operation_id).await?,
+            ReconcileOutcome::Absent
+        );
+        require(
+            report.reconcile_absent,
+            "removed Box operation remained reconcilable",
+        )?;
+
+        report.box_directory_absent = !inputs
+            .home_dir
+            .join("boxes")
+            .join(recovered.execution_id.as_str())
+            .exists();
+        report.runtime_shares_absent =
+            directory_absent_or_empty(&inputs.runtime_root.join("shares"))?;
+        report.bundle_handoffs_absent =
+            directory_absent_or_empty(&inputs.runtime_root.join("bundle-handoffs"))?;
+        require(
+            report.box_directory_absent
+                && report.runtime_shares_absent
+                && report.bundle_handoffs_absent,
+            "Box or OCI runtime-owned lifecycle paths remained after deletion",
+        )?;
+        Ok(())
+    }
+
+    async fn connect(inputs: &Inputs) -> Result<LocalExecutionManager, AnyError> {
+        let config = WindowsWhpxOciMigrationConfig::new(
+            inputs.runtime_root.clone(),
+            inputs.endpoint.clone(),
+        )?;
+        Ok(LocalExecutionManager::with_windows_whpx_oci_qualification(
+            &inputs.state_path,
+            &inputs.home_dir,
+            config,
+        )
+        .await?)
+    }
+
+    fn qualification_request(image: &str) -> CreateExecutionRequest {
+        CreateExecutionRequest {
+            external_sandbox_id: "windows-whpx-oci-qualification".to_string(),
+            config: BoxConfig {
+                isolation: ExecutionIsolation::Microvm,
+                image: image.to_string(),
+                resources: ResourceConfig {
+                    vcpus: 1,
+                    memory_mb: 512,
+                    ..Default::default()
+                },
+                cmd: vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    format!(
+                        "printf '{STDOUT_MARKER}\\n'; printf '{STDERR_MARKER}\\n' >&2; sleep 10; exit {EXPECTED_EXIT_CODE}"
+                    ),
+                ],
+                network: NetworkMode::None,
+                persistent: false,
+                ..Default::default()
+            },
+            labels: BTreeMap::from([(
+                "purpose".to_string(),
+                "windows-whpx-oci-qualification".to_string(),
+            )]),
+            policy: Default::default(),
+            rootfs_snapshot_id: None,
+        }
+    }
+
+    async fn cleanup(inputs: &Inputs, operation_id: &OperationId) -> Result<(), AnyError> {
+        if !inputs.state_path.exists() {
+            return Ok(());
+        }
+        let store = ManagedExecutionStore::new(&inputs.state_path);
+        let Some(record) = store.get_by_operation_id(operation_id)? else {
+            return Ok(());
+        };
+        let generation = record
+            .managed_execution
+            .as_ref()
+            .ok_or_else(|| failure("qualification cleanup lost managed metadata"))?
+            .generation;
+        let execution_id = ExecutionId::new(record.id)?;
+        let manager = connect(inputs).await?;
+        let state = manager.inspect(&execution_id).await?.state;
+        if matches!(state, ExecutionState::Running | ExecutionState::Paused) {
+            manager.kill(&execution_id, generation).await?;
+        }
+        manager.remove(&execution_id, generation).await?;
+        Ok(())
+    }
+
+    fn absolute_environment_path(name: &str) -> Result<PathBuf, AnyError> {
+        let path = std::env::var_os(name)
+            .map(PathBuf::from)
+            .ok_or_else(|| failure(format!("{name} must be set")))?;
+        require(path.is_absolute(), format!("{name} must be absolute"))?;
+        require(
+            !path.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::CurDir | std::path::Component::ParentDir
+                )
+            }),
+            format!("{name} must be normalized"),
+        )?;
+        Ok(path)
+    }
+
+    fn required_environment_string(name: &str) -> Result<String, AnyError> {
+        let value = std::env::var(name).map_err(|_| failure(format!("{name} must be set")))?;
+        require(
+            !value.trim().is_empty(),
+            format!("{name} must not be empty"),
+        )?;
+        Ok(value)
+    }
+
+    fn same_resources(left: &ResourceConfig, right: &ResourceConfig) -> bool {
+        left.vcpus == right.vcpus
+            && left.memory_mb == right.memory_mb
+            && left.disk_mb == right.disk_mb
+            && left.timeout == right.timeout
+    }
+
+    fn directory_absent_or_empty(path: &Path) -> Result<bool, AnyError> {
+        if !path.exists() {
+            return Ok(true);
+        }
+        require(
+            path.is_dir(),
+            format!("{} is not a directory", path.display()),
+        )?;
+        Ok(std::fs::read_dir(path)?.next().is_none())
+    }
+
+    fn write_report(path: &Path, report: &QualificationReport) -> io::Result<()> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| io::Error::other("report path has no parent"))?;
+        std::fs::create_dir_all(parent)?;
+        if path.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("refusing to overwrite {}", path.display()),
+            ));
+        }
+        let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
+        let contents = serde_json::to_vec_pretty(report).map_err(io::Error::other)?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        file.write_all(&contents)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(temporary, path)
+    }
+
+    fn require(condition: bool, message: impl Into<String>) -> Result<(), AnyError> {
+        if condition {
+            Ok(())
+        } else {
+            Err(failure(message))
+        }
+    }
+
+    fn failure(message: impl Into<String>) -> AnyError {
+        Box::new(io::Error::other(message.into()))
+    }
+}

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -378,7 +378,7 @@ impl OciPreparedExecution {
         runtime_root: impl AsRef<Path>,
     ) -> ExecutionManagerResult<Self> {
         let expected = context.runtime_bundle_handoff_directory(runtime_root)?;
-        if self.bundle.directory() != expected {
+        if !exact_handoff_directory_matches(self.bundle.directory(), &expected) {
             return Err(ExecutionManagerError::InvalidRequest(format!(
                 "A3S OCI bundle handoff must use exact operation path {}: {}",
                 expected.display(),
@@ -421,6 +421,53 @@ impl OciPreparedExecution {
         }
         Ok(())
     }
+}
+
+#[cfg(not(windows))]
+fn exact_handoff_directory_matches(directory: &Path, expected: &Path) -> bool {
+    directory == expected
+}
+
+#[cfg(windows)]
+fn exact_handoff_directory_matches(directory: &Path, expected: &Path) -> bool {
+    // `OciBundle::load` resolves an existing directory with
+    // `std::fs::canonicalize`. Windows returns that same directory in the
+    // verbatim `\\?\C:\...` namespace, while the operation-scoped SDK path is
+    // intentionally constructed before publication as `C:\...`. Strip only
+    // that namespace spelling (including its UNC form); do not resolve either
+    // input here, because accepting a symlink alias would weaken the exact
+    // container/operation ownership boundary.
+    windows_path_without_verbatim_prefix(directory)
+        == windows_path_without_verbatim_prefix(expected)
+}
+
+#[cfg(windows)]
+fn windows_path_without_verbatim_prefix(path: &Path) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt as _;
+
+    const BACKSLASH: u16 = b'\\' as u16;
+    const QUESTION_MARK: u16 = b'?' as u16;
+    const COLON: u16 = b':' as u16;
+    const UNC: [u16; 4] = [b'U' as u16, b'N' as u16, b'C' as u16, BACKSLASH];
+
+    let encoded = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    let Some(rest) = encoded.strip_prefix(&[BACKSLASH, BACKSLASH, QUESTION_MARK, BACKSLASH]) else {
+        return encoded;
+    };
+    let has_drive_prefix = rest.len() >= 3
+        && ((b'A' as u16..=b'Z' as u16).contains(&rest[0])
+            || (b'a' as u16..=b'z' as u16).contains(&rest[0]))
+        && rest[1] == COLON;
+    if has_drive_prefix {
+        return rest.to_vec();
+    }
+    if let Some(unc_rest) = rest.strip_prefix(&UNC) {
+        let mut normalized = Vec::with_capacity(unc_rest.len() + 2);
+        normalized.extend([BACKSLASH, BACKSLASH]);
+        normalized.extend_from_slice(unc_rest);
+        return normalized;
+    }
+    encoded
 }
 
 /// Product-owned preparation boundary consumed by the OCI lifecycle backend.

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -1402,7 +1402,8 @@ impl OciBundleProvider for RuntimeBundleHandoffProvider {
                 "failed to write portable bundle handoff: {error}"
             ))
         })?;
-        let bundle = OciBundle::from_json(directory, config)
+        let bundle = OciBundle::load(&directory)
+            .await
             .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
         let mut prepared = OciPreparedExecution::new(bundle, record.console_log.clone())?
             .with_runtime_bundle_handoff(context, &self.runtime_root)?;
@@ -1709,7 +1710,9 @@ async fn bundle_handoff_uses_the_exact_context_sent_to_runtime_create() {
         &create.id,
         &create.context.operation_id,
     )
-    .expect("exact handoff path");
+    .expect("exact handoff path")
+    .canonicalize()
+    .expect("canonical handoff path");
     assert_eq!(create.bundle.directory(), expected_directory);
     assert!(create.attachments.uses_runtime_bundle_handoff());
     assert_eq!(
@@ -1719,6 +1722,25 @@ async fn bundle_handoff_uses_the_exact_context_sent_to_runtime_create() {
     assert_ne!(lease.generation.get(), RUNTIME_GENERATION.0);
     assert!(provider.preflights.load(Ordering::SeqCst) >= 2);
     assert_eq!(provider.prepares.load(Ordering::SeqCst), 1);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_handoff_comparison_accepts_only_the_verbatim_namespace_spelling() {
+    use std::path::Path;
+
+    assert!(exact_handoff_directory_matches(
+        Path::new(r"\\?\C:\runtime\bundle-handoffs\box-1\create-1\bundle"),
+        Path::new(r"C:\runtime\bundle-handoffs\box-1\create-1\bundle"),
+    ));
+    assert!(exact_handoff_directory_matches(
+        Path::new(r"\\?\UNC\server\share\runtime\bundle-handoffs\box-1\create-1\bundle"),
+        Path::new(r"\\server\share\runtime\bundle-handoffs\box-1\create-1\bundle"),
+    ));
+    assert!(!exact_handoff_directory_matches(
+        Path::new(r"\\?\C:\runtime\bundle-handoffs\box-1\create-2\bundle"),
+        Path::new(r"C:\runtime\bundle-handoffs\box-1\create-1\bundle"),
+    ));
 }
 
 #[tokio::test]

--- a/src/runtime/src/oci/layers.rs
+++ b/src/runtime/src/oci/layers.rs
@@ -146,6 +146,16 @@ fn extract_layer_with_cap(
         BTreeMap::new()
     };
 
+    // Windows grants administrators SeCreateSymbolicLinkPrivilege but normally
+    // leaves it disabled in the process token. `tar` creates OCI links through
+    // `std::os::windows::fs::symlink_file`, which otherwise fails even though
+    // the service identity already owns the privilege. Keep the process-wide
+    // token mutation serialized and scoped to extraction; Developer Mode still
+    // works when the token does not contain the privilege.
+    #[cfg(windows)]
+    let _windows_symlink_guard =
+        a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+
     let entries = archive
         .entries()
         .map_err(|e| BoxError::OciImageError(format!("Failed to read layer entries: {e}")))?;
@@ -246,14 +256,17 @@ fn extract_layer_with_cap(
         } else {
             None
         };
+        #[cfg(windows)]
+        let entry_is_symlink = entry.header().entry_type().is_symlink();
         let unpacked = entry.unpack_in(target_dir).map_err(|e| {
             #[cfg(windows)]
-            if error_chain_has_raw_os_error(&e, WINDOWS_SYMLINK_PRIVILEGE_ERROR) {
+            if entry_is_symlink && windows_symlink_creation_was_denied(&e) {
                 return BoxError::OciImageError(format!(
                     "Failed to extract layer to {}: Windows cannot preserve OCI symlink {}: \
                      enable Developer Mode so a non-elevated process can create symbolic links, \
-                     or grant the service identity SeCreateSymbolicLinkPrivilege; flattening the \
-                     link would corrupt the image (ERROR_PRIVILEGE_NOT_HELD (1314)). See \
+                     or grant the service identity SeCreateSymbolicLinkPrivilege and allow the \
+                     target directory; flattening the link would corrupt the image \
+                     (ERROR_ACCESS_DENIED (5) or ERROR_PRIVILEGE_NOT_HELD (1314)). See \
                      https://learn.microsoft.com/windows/advanced-settings/developer-mode",
                     target_dir.display(),
                     path.display(),
@@ -717,7 +730,20 @@ fn collect_final_metadata(
 }
 
 #[cfg(windows)]
+const WINDOWS_SYMLINK_ACCESS_DENIED_ERROR: i32 = 5;
+
+#[cfg(windows)]
 const WINDOWS_SYMLINK_PRIVILEGE_ERROR: i32 = 1314;
+
+#[cfg(windows)]
+fn windows_symlink_creation_was_denied(error: &std::io::Error) -> bool {
+    [
+        WINDOWS_SYMLINK_ACCESS_DENIED_ERROR,
+        WINDOWS_SYMLINK_PRIVILEGE_ERROR,
+    ]
+    .into_iter()
+    .any(|code| error_chain_has_raw_os_error(error, code))
+}
 
 #[cfg(windows)]
 fn error_chain_has_raw_os_error(error: &std::io::Error, code: i32) -> bool {
@@ -843,6 +869,81 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_symlink_denial_classifies_access_and_privilege_errors() {
+        for code in [
+            WINDOWS_SYMLINK_ACCESS_DENIED_ERROR,
+            WINDOWS_SYMLINK_PRIVILEGE_ERROR,
+        ] {
+            assert!(windows_symlink_creation_was_denied(
+                &std::io::Error::from_raw_os_error(code)
+            ));
+            assert!(windows_symlink_creation_was_denied(&std::io::Error::other(
+                format!("wrapped Windows symlink failure (os error {code})")
+            )));
+        }
+        assert!(!windows_symlink_creation_was_denied(
+            &std::io::Error::from_raw_os_error(206)
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_layer_extraction_temporarily_enables_an_assigned_symlink_privilege() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use tar::Builder;
+
+        let temp_dir = TempDir::new().unwrap();
+        let layer = temp_dir.path().join("symlink.tar.gz");
+        let target = temp_dir.path().join("rootfs");
+        let file = File::create(&layer).unwrap();
+        let mut builder = Builder::new(GzEncoder::new(file, Compression::default()));
+        let mut target_header = tar::Header::new_gnu();
+        target_header.set_size(7);
+        target_header.set_mode(0o644);
+        target_header.set_uid(0);
+        target_header.set_gid(0);
+        target_header.set_cksum();
+        builder
+            .append_data(&mut target_header, "target", b"payload".as_slice())
+            .unwrap();
+        let mut link_header = tar::Header::new_gnu();
+        link_header.set_entry_type(tar::EntryType::Symlink);
+        link_header.set_size(0);
+        link_header.set_mode(0o777);
+        link_header.set_uid(0);
+        link_header.set_gid(0);
+        builder
+            .append_link(&mut link_header, "link", "target")
+            .unwrap();
+        builder.finish().unwrap();
+        drop(builder);
+
+        match extract_layer_with_metadata(&layer, &target) {
+            Ok(()) => {
+                let link = target.join("link");
+                assert!(fs::symlink_metadata(&link)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink());
+                assert_eq!(fs::read_link(link).unwrap(), PathBuf::from("target"));
+            }
+            Err(error)
+                if error.to_string().contains("ERROR_ACCESS_DENIED (5)")
+                    || error
+                        .to_string()
+                        .contains("ERROR_PRIVILEGE_NOT_HELD (1314)") =>
+            {
+                eprintln!(
+                    "skipping Windows symlink extraction test: the test identity has no symlink capability"
+                );
+            }
+            Err(error) => panic!("Windows layer extraction failed unexpectedly: {error}"),
+        }
+    }
 
     #[test]
     fn test_extract_layer_creates_target_directory() {


### PR DESCRIPTION
## Summary
- pin the public OCI SDK and CI qualification checkout to `08c145d8ce5d06d5f28587226be822a2ab43b299`
- add an artifact-bound Windows x86_64 example for replay-safe Box create, manager reopen, WHPX start/wait, exact exit status, and generation-fenced delete
- add a build-free PowerShell runner that verifies Box and OCI artifact manifests, imports the fixed Alpine rootfs offline, starts the protected named-pipe service, and rejects process/path leaks
- publish the qualification executable and versioned artifact manifest from Windows CI, and document the completed B1 hardware gate

## Validation
- OCI Runtime run `30879920895`: all Linux, macOS, Windows, lifecycle, clippy, test, and artifact jobs passed
- real local WHPX direct-driver gate passed from the same OCI run (`a3s.oci.whpx-driver-smoke.v1`, all lifecycle and cleanup fields true)
- `cargo fmt --all --check`
- `cargo metadata --locked --no-deps`
- PowerShell parser validation for `scripts/windows-whpx-oci-qualification.ps1`
- `git diff --check`

The full Box-owned hardware run will use this PR's `windows-whpx` artifact together with both artifacts from the successful OCI main run for the exact pinned commit before merge.