### PR TITLE
Improve Windows symlink policy diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,6 +724,11 @@ jobs:
           Copy-Item `
             target/x86_64-pc-windows-msvc/release/examples/windows-whpx-oci-qualification.exe `
             target/x86_64-pc-windows-msvc/release/windows-whpx-oci-qualification.exe
+      - name: Test Windows symlink diagnostics
+        run: |
+          cd src
+          cargo test --locked -p a3s-box-core `
+            denial_diagnostic_distinguishes_endpoint_policy
       - name: Verify Windows artifact bundle
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -268,6 +268,13 @@ and deletion, complete lifecycle-directory cleanup, and zero residual A3S
 processes. This qualification-only composition remains explicit opt-in and is
 not enabled by default.
 
+The exact post-merge main artifact `aaf9e615ee8bb5e22a5214ca09d7e426701f2d58`
+from main CI run
+[`30898682738`](https://github.com/A3S-Lab/Box/actions/runs/30898682738)
+subsequently passed the same complete gate against the pinned OCI Runtime main
+artifacts. Its manifest-bound `a3s-box.exe` SHA-256 was
+`31e98e73b325825bf1c49798cc9f51d744bf2502785b6651978947e312b5fa6b`.
+
 This profile accepts only a fresh writable Linux amd64 rootfs, one vCPU,
 512 MiB, `network=none`, and no TEE, host mounts, volumes, devices, sidecars,
 Snapshot, custom security controls, or persistence. Box copies the prepared

--- a/README.md
+++ b/README.md
@@ -249,9 +249,11 @@ artifacts, preserving each artifact's `artifact-manifest.json`, then run:
 
 The runner accepts only artifacts whose source commits match this Box checkout
 and its exact OCI pin, requires both OCI bundles to come from one workflow run,
-and rechecks every size and SHA-256 digest. It then exercises replay-safe
-create, Box-manager reopen, start, wait, exact exit status, and delete through
-the named-pipe service on real WHPX. `summary.json` uses schema
+and rechecks every size and SHA-256 digest. It first requires the staged
+`a3s-box.exe` to report `OCI symlink support: available`, with separate logs for
+missing privilege and ACL or endpoint-protection denials. It then exercises
+replay-safe create, Box-manager reopen, start, wait, exact exit status, and
+delete through the named-pipe service on real WHPX. `summary.json` uses schema
 `a3s.box.windows-whpx-oci-qualification-run.v1` and records cleanup and process
 inventory together with both artifact manifests.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -298,7 +298,10 @@ Windows layer extraction and `a3s-box info` share one serialized privilege
 scope which temporarily enables only an already assigned
 `SeCreateSymbolicLinkPrivilege`, restores the token immediately, and otherwise
 retains the Developer Mode/fail-closed path so Linux OCI links are never
-flattened. Windows handoff validation treats only the
+flattened. The hardware runner now preflights that exact staged binary before
+starting the runtime and distinguishes a missing privilege from ACL or endpoint
+security denial in both CLI and extraction diagnostics. Windows handoff
+validation treats only the
 ordinary and verbatim namespace spellings of the exact same operation path as
 equivalent, and the hardware executable bounds preparation/start at 30 minutes.
 The first artifact-bound gate passed on real x86_64 Windows/WHPX on August 4,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -314,6 +314,14 @@ The report recorded exact create replay, manager-restart reconciliation,
 `libkrun-whpx`/`dedicated-vm`, observed running state, exit code 23, replay-safe
 deletion, complete lifecycle-directory cleanup, and zero residual A3S
 processes.
+
+The exact post-merge Box main artifact
+`aaf9e615ee8bb5e22a5214ca09d7e426701f2d58` from main CI run
+[`30898682738`](https://github.com/A3S-Lab/Box/actions/runs/30898682738)
+subsequently passed the same complete lifecycle gate against the pinned OCI
+Runtime main artifacts, binding final source, workflow, binary digests, and
+hardware evidence to main revisions.
+
 The deterministic live-session fixtures are
 still not proof that a real driver can transparently
 retain process or filesystem sessions after its owner dies.

--- a/docs/windows-whpx.md
+++ b/docs/windows-whpx.md
@@ -251,6 +251,14 @@ binding, running state, exit code 23, create and delete replay, manager-restart
 reconciliation, complete lifecycle-directory cleanup, and no residual A3S
 processes.
 
+The exact post-merge Box main artifact
+`aaf9e615ee8bb5e22a5214ca09d7e426701f2d58` from main CI run
+[`30898682738`](https://github.com/A3S-Lab/Box/actions/runs/30898682738)
+subsequently passed the same complete gate against the pinned OCI Runtime main
+artifacts. This verifies that the merge result, artifact manifest, and tested
+WHPX lifecycle all refer to published main revisions rather than only the PR
+head.
+
 ## Diagnostics and kernel override
 
 The default WHPX boot path automatically selects the current reliable

--- a/docs/windows-whpx.md
+++ b/docs/windows-whpx.md
@@ -27,6 +27,11 @@ Run `a3s-box info` before starting a workload. It should report both
 same scoped privilege implementation as layer extraction, so an assigned but
 initially disabled service-token privilege is reported accurately.
 
+If the probe reports that `SeCreateSymbolicLinkPrivilege` is enabled but link
+creation is still denied, check the A3S home ACL and endpoint-protection policy.
+Allow the approved `a3s-box.exe` binary and its A3S home directory according to
+the organization's security policy; do not flatten or replace OCI links.
+
 Linux OCI images commonly contain symbolic links for paths such as `/bin`,
 dynamic loaders, and shared libraries. The Windows rootfs is backed by NTFS and
 served to the guest through virtio-fs, so A3S Box must preserve those entries as
@@ -217,12 +222,16 @@ x86_64 minirootfs archive, whose SHA-256 is
 
 The runner verifies the checkout and pinned OCI source commits, requires the
 two OCI artifacts to share one workflow commit and run ID, and rehashes every
-input before staging it. It starts the protected named-pipe service, imports the
-rootfs into a dedicated Box home without registry access, and runs the public
-Box manager through idempotent create, manager reopen and reconcile, WHPX
-start/wait, exact exit code 23, and generation-fenced delete replay. Success
-also requires no Box execution directory, OCI generation share, bundle handoff,
-or A3S host process to remain. `report.json` and `summary.json` use the
+input before staging it. Before starting the service, it runs `a3s-box info`
+from the staged artifact and requires `OCI symlink support: available`; the
+captured `box-info.stdout.log` distinguishes missing Windows capability from an
+ACL or endpoint-protection denial. It then starts the protected named-pipe
+service, imports the rootfs into a dedicated Box home without registry access,
+and runs the public Box manager through idempotent create, manager reopen and
+reconcile, WHPX start/wait, exact exit code 23, and generation-fenced delete
+replay. Success also requires no Box execution directory, OCI generation share,
+bundle handoff, or A3S host process to remain. `report.json` and `summary.json`
+use the
 versioned `a3s.box.windows-whpx-oci-qualification.v1` and
 `a3s.box.windows-whpx-oci-qualification-run.v1` schemas respectively.
 Preparation and start have a 30-minute bound. On Windows, handoff validation

--- a/scripts/windows-whpx-oci-qualification.ps1
+++ b/scripts/windows-whpx-oci-qualification.ps1
@@ -54,6 +54,8 @@ $reportPath = Join-Path $outputRoot 'report.json'
 $summaryPath = Join-Path $outputRoot 'summary.json'
 $serviceStdoutPath = Join-Path $outputRoot 'oci-service.stdout.log'
 $serviceStderrPath = Join-Path $outputRoot 'oci-service.stderr.log'
+$infoStdoutPath = Join-Path $outputRoot 'box-info.stdout.log'
+$infoStderrPath = Join-Path $outputRoot 'box-info.stderr.log'
 $importStdoutPath = Join-Path $outputRoot 'box-import.stdout.log'
 $importStderrPath = Join-Path $outputRoot 'box-import.stderr.log'
 $qualificationStdoutPath = Join-Path $outputRoot 'qualification.stdout.log'
@@ -324,6 +326,7 @@ $serviceArguments = @(
 
 $service = $null
 $ready = $null
+$symlinkPreflight = $null
 $qualificationReport = $null
 $failure = $null
 $result = 'failed'
@@ -344,6 +347,42 @@ foreach ($name in @(
 }
 
 try {
+    $env:A3S_HOME = $boxHome
+    $infoProcess = Start-Process -FilePath $boxCli `
+        -ArgumentList 'info' `
+        -WorkingDirectory $boxBin `
+        -RedirectStandardOutput $infoStdoutPath `
+        -RedirectStandardError $infoStderrPath `
+        -WindowStyle Hidden -Wait -PassThru
+    $infoOutput = if (Test-Path -LiteralPath $infoStdoutPath -PathType Leaf) {
+        [string](Get-Content -LiteralPath $infoStdoutPath -Raw)
+    } else {
+        ''
+    }
+    $symlinkSupportLine = $infoOutput -split "`r?`n" |
+        Where-Object { $_ -like 'OCI symlink support:*' } |
+        Select-Object -First 1
+    if ($null -eq $symlinkSupportLine) {
+        $symlinkSupportLine = ''
+    }
+    $symlinkPreflight = [ordered]@{
+        exit_code = $infoProcess.ExitCode
+        status_line = $symlinkSupportLine
+        stdout = $infoStdoutPath
+        stderr = $infoStderrPath
+    }
+    if ($infoProcess.ExitCode -ne 0) {
+        throw "Staged Box capability preflight failed with exit code $($infoProcess.ExitCode); see $infoStdoutPath and $infoStderrPath"
+    }
+    if ($symlinkSupportLine -ne 'OCI symlink support: available') {
+        $diagnostic = if ([string]::IsNullOrWhiteSpace($symlinkSupportLine)) {
+            'the expected OCI symlink status was not emitted'
+        } else {
+            $symlinkSupportLine
+        }
+        throw "Staged Box binary cannot preserve Windows OCI symlinks: $diagnostic; see $infoStdoutPath and $infoStderrPath"
+    }
+
     $service = Start-Process -FilePath $ociCli `
         -ArgumentList (Join-QuotedNativeArguments -Arguments $serviceArguments) `
         -WorkingDirectory $ociBin `
@@ -374,7 +413,6 @@ try {
         throw 'OCI qualification readiness evidence does not match the launched owner.'
     }
 
-    $env:A3S_HOME = $boxHome
     $importProcess = Start-Process -FilePath $boxCli `
         -ArgumentList (Join-QuotedNativeArguments -Arguments @(
             'import', $rootfsArchive, $image
@@ -475,6 +513,7 @@ finally {
         box_artifact = $boxManifest
         oci_windows_artifact = $ociWindowsManifest
         oci_guest_artifact = $ociGuestManifest
+        symlink_preflight = $symlinkPreflight
         service_ready = $ready
         qualification = $qualificationReport
         residual_processes = $residual

--- a/src/cli/src/commands/info.rs
+++ b/src/cli/src/commands/info.rs
@@ -183,25 +183,53 @@ fn print_host_mount_info() {
 #[cfg(windows)]
 fn print_rootfs_symlink_info(home: &Path) {
     match probe_windows_symlink_support(home) {
-        Ok(()) => println!("OCI symlink support: available"),
-        Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => println!(
-            "OCI symlink support: unavailable (enable Windows Developer Mode or grant \
-             SeCreateSymbolicLinkPrivilege and allow the target directory; \
-             ERROR_ACCESS_DENIED (5) or ERROR_PRIVILEGE_NOT_HELD (1314))"
+        WindowsSymlinkProbe::Available => println!("OCI symlink support: available"),
+        WindowsSymlinkProbe::Denied {
+            assigned_privilege_enabled,
+        } => println!(
+            "OCI symlink support: unavailable ({})",
+            a3s_box_core::windows_symlink::denial_diagnostic(assigned_privilege_enabled)
         ),
-        Err(error) => println!("OCI symlink support: unavailable (probe failed: {error})"),
+        WindowsSymlinkProbe::Failed(error) => {
+            println!("OCI symlink support: unavailable (probe failed: {error})")
+        }
     }
 }
 
 #[cfg(windows)]
-fn probe_windows_symlink_support(home: &Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(home)?;
-    let directory = tempfile::Builder::new()
+enum WindowsSymlinkProbe {
+    Available,
+    Denied { assigned_privilege_enabled: bool },
+    Failed(std::io::Error),
+}
+
+#[cfg(windows)]
+fn probe_windows_symlink_support(home: &Path) -> WindowsSymlinkProbe {
+    if let Err(error) = std::fs::create_dir_all(home) {
+        return WindowsSymlinkProbe::Failed(error);
+    }
+    let directory = match tempfile::Builder::new()
         .prefix(".symlink-capability-")
-        .tempdir_in(home)?;
-    std::fs::write(directory.path().join("target"), b"probe")?;
-    let _guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
-    std::os::windows::fs::symlink_file("target", directory.path().join("link"))
+        .tempdir_in(home)
+    {
+        Ok(directory) => directory,
+        Err(error) => return WindowsSymlinkProbe::Failed(error),
+    };
+    if let Err(error) = std::fs::write(directory.path().join("target"), b"probe") {
+        return WindowsSymlinkProbe::Failed(error);
+    }
+
+    let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+    let assigned_privilege_enabled = guard.assigned_privilege_enabled();
+    match std::os::windows::fs::symlink_file("target", directory.path().join("link")) {
+        Ok(()) => WindowsSymlinkProbe::Available,
+        Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => {
+            WindowsSymlinkProbe::Denied {
+                assigned_privilege_enabled,
+            }
+        }
+        Err(error) => WindowsSymlinkProbe::Failed(error),
+    }
 }
 
 #[cfg(not(windows))]

--- a/src/core/src/windows_symlink.rs
+++ b/src/core/src/windows_symlink.rs
@@ -20,7 +20,7 @@ static WINDOWS_SYMLINK_PRIVILEGE_LOCK: Mutex<()> = Mutex::new(());
 pub struct WindowsSymlinkPrivilegeGuard {
     // Field order is intentional: restore the process privilege before
     // releasing the serialization lock.
-    _privilege: Option<WindowsTokenPrivilegeGuard>,
+    privilege: Option<WindowsTokenPrivilegeGuard>,
     _lock: MutexGuard<'static, ()>,
 }
 
@@ -41,9 +41,31 @@ impl WindowsSymlinkPrivilegeGuard {
             }
         };
         Self {
-            _privilege: privilege,
+            privilege,
             _lock: lock,
         }
+    }
+
+    /// Whether the process token's assigned privilege was enabled for this scope.
+    ///
+    /// A `false` result does not rule out Developer Mode as an alternate way to
+    /// authorize symbolic-link creation.
+    pub fn assigned_privilege_enabled(&self) -> bool {
+        self.privilege.is_some()
+    }
+}
+
+/// Explain a denied symlink operation using the effective privilege state.
+#[doc(hidden)]
+pub fn denial_diagnostic(assigned_privilege_enabled: bool) -> &'static str {
+    if assigned_privilege_enabled {
+        "SeCreateSymbolicLinkPrivilege was enabled, but the target directory ACL or endpoint \
+         security denied symbolic-link creation; verify the target ACL and allow the approved \
+         A3S Box executable and target directory in endpoint security; ERROR_ACCESS_DENIED (5) \
+         or ERROR_PRIVILEGE_NOT_HELD (1314)"
+    } else {
+        "enable Windows Developer Mode or grant SeCreateSymbolicLinkPrivilege and allow the \
+         target directory; ERROR_ACCESS_DENIED (5) or ERROR_PRIVILEGE_NOT_HELD (1314)"
     }
 }
 
@@ -169,6 +191,18 @@ impl Drop for WindowsTokenPrivilegeGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn denial_diagnostic_distinguishes_endpoint_policy() {
+        let enabled = denial_diagnostic(true);
+        assert!(enabled.contains("SeCreateSymbolicLinkPrivilege was enabled"));
+        assert!(enabled.contains("endpoint security"));
+        assert!(!enabled.contains("enable Windows Developer Mode"));
+
+        let unavailable = denial_diagnostic(false);
+        assert!(unavailable.contains("enable Windows Developer Mode"));
+        assert!(unavailable.contains("grant SeCreateSymbolicLinkPrivilege"));
+    }
 
     #[test]
     fn acquired_scope_preserves_a_real_link_when_the_identity_is_capable() {

--- a/src/runtime/src/oci/layers.rs
+++ b/src/runtime/src/oci/layers.rs
@@ -153,8 +153,10 @@ fn extract_layer_with_cap(
     // token mutation serialized and scoped to extraction; Developer Mode still
     // works when the token does not contain the privilege.
     #[cfg(windows)]
-    let _windows_symlink_guard =
+    let windows_symlink_guard =
         a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+    #[cfg(windows)]
+    let windows_symlink_privilege_enabled = windows_symlink_guard.assigned_privilege_enabled();
 
     let entries = archive
         .entries()
@@ -261,12 +263,12 @@ fn extract_layer_with_cap(
         let unpacked = entry.unpack_in(target_dir).map_err(|e| {
             #[cfg(windows)]
             if entry_is_symlink && windows_symlink_creation_was_denied(&e) {
+                let diagnostic = a3s_box_core::windows_symlink::denial_diagnostic(
+                    windows_symlink_privilege_enabled,
+                );
                 return BoxError::OciImageError(format!(
                     "Failed to extract layer to {}: Windows cannot preserve OCI symlink {}: \
-                     enable Developer Mode so a non-elevated process can create symbolic links, \
-                     or grant the service identity SeCreateSymbolicLinkPrivilege and allow the \
-                     target directory; flattening the link would corrupt the image \
-                     (ERROR_ACCESS_DENIED (5) or ERROR_PRIVILEGE_NOT_HELD (1314)). See \
+                     {diagnostic}; flattening the link would corrupt the image. See \
                      https://learn.microsoft.com/windows/advanced-settings/developer-mode",
                     target_dir.display(),
                     path.display(),


### PR DESCRIPTION
## Summary

- distinguish a missing Windows symlink capability from ACL or endpoint-security denial after `SeCreateSymbolicLinkPrivilege` is enabled
- preflight the exact staged `a3s-box.exe` before starting the WHPX qualification service and retain logs plus summary evidence
- document endpoint-protection remediation and the updated hardware-gate behavior

## Validation

- `cargo fmt --all --manifest-path src/Cargo.toml -- --check`
- `cargo metadata --manifest-path src/Cargo.toml --locked --no-deps --format-version 1`
- PowerShell AST parser for `scripts/windows-whpx-oci-qualification.ps1`
- `git diff --check`

Local `cargo check` cannot link build scripts because this host lacks the MSVC `link.exe`/Windows SDK; repository Windows CI is authoritative.