### PR TITLE
fix(runtime): recover Sandbox rootfs after provider death

### DIFF
--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -644,6 +644,7 @@ async fn service_failure_restarts_the_same_durable_execution() {
     let spec = runtime_spec("service-restart", 1, RuntimeUnitClass::Service);
     let running = driver.apply(&spec, &accepted(&spec)).await.unwrap();
     let provider_id = running.provider_resource_id.clone().unwrap();
+    let first_started_at_ms = running.started_at_ms.unwrap();
     backend.finish(&provider_id, 9);
 
     let inspection = driver.inspect(&unit(spec.clone(), running)).await.unwrap();
@@ -654,6 +655,10 @@ async fn service_failure_restarts_the_same_durable_execution() {
     assert_eq!(
         observation.provider_resource_id.as_deref(),
         Some(provider_id.as_str())
+    );
+    assert!(
+        observation.started_at_ms.unwrap() > first_started_at_ms,
+        "a restarted Service must publish a new process-incarnation timestamp"
     );
     assert_eq!(backend.starts(), 2);
     assert_eq!(driver.manager.managed_records().await.unwrap().len(), 1);

--- a/src/runtime/src/a3s_runtime_driver/test_support.rs
+++ b/src/runtime/src/a3s_runtime_driver/test_support.rs
@@ -92,8 +92,20 @@ impl DriverFakeBackend {
             })?;
         }
         let pid = std::process::id();
+        let generation = record
+            .managed_execution
+            .as_ref()
+            .expect("fake managed execution metadata")
+            .generation
+            .get();
+        let generation_seconds = i64::try_from(generation).expect("fake execution generation");
+        let started_at = record.started_at.unwrap_or_else(|| {
+            chrono::DateTime::<chrono::Utc>::from_timestamp(1_784_031_000, 0)
+                .expect("fake start timestamp")
+                + chrono::Duration::seconds(generation_seconds)
+        });
         Ok(LocalExecutionHandle {
-            started_at: chrono::Utc::now(),
+            started_at,
             pid: Some(pid),
             pid_start_time: crate::process::pid_start_time(pid),
             exec_socket_path: record.box_dir.join("sockets/exec.sock"),

--- a/src/runtime/src/box_record.rs
+++ b/src/runtime/src/box_record.rs
@@ -75,7 +75,9 @@ pub struct BoxRecord {
     pub console_log: PathBuf,
     /// Creation timestamp.
     pub created_at: DateTime<Utc>,
-    /// Start timestamp.
+    /// Start timestamp for the current runtime incarnation.
+    ///
+    /// A managed restart advances this value while preserving the Box ID.
     pub started_at: Option<DateTime<Utc>>,
     /// Whether the execution is removed automatically after it stops.
     pub auto_remove: bool,

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -43,6 +43,7 @@ const CONFIG_DIGEST: &str =
     "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const ATTACHMENTS_DIGEST: &str =
     "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+const RUNTIME_RECORD_PID_ENV: &str = "A3S_BOX_TEST_RUNTIME_RECORD_PID";
 
 #[cfg(any(unix, windows))]
 #[path = "oci_backend_tests/process_restart.rs"]
@@ -4941,8 +4942,31 @@ fn runtime_record(
     attachments_digest: Option<&str>,
 ) -> OciResult<ContainerRecord> {
     let pid = if isolation == IsolationClass::SharedHostKernel {
-        i32::try_from(std::process::id())
-            .map_err(|error| Error::new(ErrorCode::Internal, error.to_string()))?
+        match std::env::var_os(RUNTIME_RECORD_PID_ENV) {
+            Some(pid) => {
+                let pid = pid.into_string().map_err(|_| {
+                    Error::new(
+                        ErrorCode::Internal,
+                        "configured test runtime PID is not UTF-8",
+                    )
+                })?;
+                let pid = pid.parse::<i32>().map_err(|error| {
+                    Error::new(
+                        ErrorCode::Internal,
+                        format!("configured test runtime PID is invalid: {error}"),
+                    )
+                })?;
+                if pid <= 1 {
+                    return Err(Error::new(
+                        ErrorCode::Internal,
+                        "configured test runtime PID is unsafe",
+                    ));
+                }
+                pid
+            }
+            None => i32::try_from(std::process::id())
+                .map_err(|error| Error::new(ErrorCode::Internal, error.to_string()))?,
+        }
     } else {
         4242
     };

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -30,7 +30,7 @@ use a3s_oci_sdk::{
     StartRequest, StateRequest, StatsRequest, TerminalSize, UpdateRequest, WaitProcessRequest,
     WaitRequest, WriteStdinRequest, PAUSED_STATE_ANNOTATION, RUNTIME_BUNDLE_HANDOFF_MOVE_V1,
 };
-use base64::{engine::general_purpose::STANDARD, Engine as _};
+use base64::engine::general_purpose::STANDARD;
 use chrono::Utc;
 use serde_json::json;
 

--- a/src/runtime/src/local_execution/oci_backend_tests/process_restart.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests/process_restart.rs
@@ -559,6 +559,11 @@ impl RuntimeOwnerChild {
             .env(ENDPOINT_ENV, endpoint)
             .env(READY_ENV, ready_path)
             .env(CALL_LOG_ENV, call_log)
+            // The runtime owner is deliberately killed and replaced. Model the
+            // independently living Sandbox init with the parent test process so
+            // PID identity validation proves owner recovery instead of observing
+            // the expected death of the transport process itself.
+            .env(RUNTIME_RECORD_PID_ENV, std::process::id().to_string())
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(stderr)

--- a/src/runtime/src/local_execution/record.rs
+++ b/src/runtime/src/local_execution/record.rs
@@ -210,6 +210,14 @@ pub(crate) fn clear_live_runtime(record: &mut BoxRecord, exit_code: Option<i32>)
     }
 }
 
+pub(crate) fn clear_live_runtime_for_restart(record: &mut BoxRecord) {
+    clear_live_runtime(record, None);
+    // `started_at` identifies the current runtime incarnation. Retaining the
+    // previous generation's timestamp makes a successful process replacement
+    // indistinguishable from a stale Running observation.
+    record.started_at = None;
+}
+
 pub(crate) fn clear_live_runtime_for_cold_pause(record: &mut BoxRecord) {
     record.pid = None;
     record.pid_start_time = None;

--- a/src/runtime/src/local_execution/snapshot.rs
+++ b/src/runtime/src/local_execution/snapshot.rs
@@ -537,12 +537,12 @@ fn capture_sandbox_rootfs_metadata(
 ) -> ExecutionManagerResult<a3s_box_core::rootfs_metadata::RootfsMetadataManifest> {
     let plan = if sandbox_bundle_config_present(record)? {
         let plan = sandbox_id_mapping_plan_from_bundle(record, Some(rootfs))?;
-        crate::sandbox::rootfs::persist_snapshot_id_mappings(&record.box_dir, &plan).map_err(
+        crate::sandbox::rootfs::persist_rootfs_id_mappings(&record.box_dir, &plan).map_err(
             |error| snapshot_error(record, "persist Sandbox snapshot ID mappings", error),
         )?;
         plan
     } else {
-        let plan = crate::sandbox::rootfs::load_snapshot_id_mappings(&record.box_dir)
+        let plan = crate::sandbox::rootfs::load_rootfs_id_mappings(&record.box_dir)
             .map_err(|error| snapshot_error(record, "load Sandbox snapshot ID mappings", error))?
             .ok_or_else(|| {
                 snapshot_error(
@@ -554,7 +554,7 @@ fn capture_sandbox_rootfs_metadata(
         validate_id_mapping_plan(record, &plan)?;
         plan
     };
-    crate::sandbox::rootfs::capture_snapshot_rootfs_metadata(rootfs, &plan)
+    crate::sandbox::rootfs::capture_rootfs_metadata(rootfs, &plan)
         .map_err(|error| snapshot_error(record, "capture Sandbox rootfs metadata", error))
 }
 
@@ -562,12 +562,11 @@ fn capture_sandbox_rootfs_metadata(
 pub(super) fn persist_sandbox_snapshot_mappings(record: &BoxRecord) -> ExecutionManagerResult<()> {
     if sandbox_bundle_config_present(record)? {
         let plan = sandbox_id_mapping_plan_from_bundle(record, None)?;
-        return crate::sandbox::rootfs::persist_snapshot_id_mappings(&record.box_dir, &plan)
-            .map_err(|error| {
-                snapshot_error(record, "persist Sandbox snapshot ID mappings", error)
-            });
+        return crate::sandbox::rootfs::persist_rootfs_id_mappings(&record.box_dir, &plan).map_err(
+            |error| snapshot_error(record, "persist Sandbox snapshot ID mappings", error),
+        );
     }
-    if let Some(plan) = crate::sandbox::rootfs::load_snapshot_id_mappings(&record.box_dir)
+    if let Some(plan) = crate::sandbox::rootfs::load_rootfs_id_mappings(&record.box_dir)
         .map_err(|error| snapshot_error(record, "load Sandbox snapshot ID mappings", error))?
     {
         return validate_id_mapping_plan(record, &plan);

--- a/src/runtime/src/local_execution/store.rs
+++ b/src/runtime/src/local_execution/store.rs
@@ -6,7 +6,7 @@ use a3s_box_core::{
 
 use super::record::{
     apply_handle, apply_restart_handle, apply_start_handle, clear_live_runtime,
-    clear_live_runtime_for_cold_pause, execution_id,
+    clear_live_runtime_for_cold_pause, clear_live_runtime_for_restart, execution_id,
 };
 use super::support::{generation, managed_state};
 use super::{LocalExecutionHandle, LocalExecutionManager};
@@ -204,7 +204,7 @@ impl LocalExecutionManager {
                         });
                     }
                 }
-                RuntimeUpdate::RestartAdvance => clear_live_runtime(record, None),
+                RuntimeUpdate::RestartAdvance => clear_live_runtime_for_restart(record),
                 RuntimeUpdate::RestartHandle(handle) => apply_restart_handle(record, &handle),
                 RuntimeUpdate::RestartTerminal(exit_code) => clear_live_runtime(record, exit_code),
             })

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -2160,6 +2160,10 @@ async fn restart_recovers_after_generation_advance_before_backend_start() {
         )
         .await
         .unwrap();
+    assert!(
+        restarting.started_at.is_none(),
+        "a new runtime generation must not retain the previous incarnation timestamp"
+    );
     assert_eq!(
         restarting.managed_execution.as_ref().unwrap().generation,
         ExecutionGeneration::new(2).unwrap()

--- a/src/runtime/src/sandbox/capability.rs
+++ b/src/runtime/src/sandbox/capability.rs
@@ -63,6 +63,69 @@ pub struct SandboxIdMappingPlan {
     pub maximum_container_gid: u32,
 }
 
+/// Validate one exact Box-produced user-namespace mapping plan.
+///
+/// Persisted plans are recovery authorities: accepting a gap, overlap, or a
+/// host-root mapping could translate a stopped rootfs to the wrong container
+/// identities. Keep this validation shared with OCI bundle compilation so the
+/// live and recovery paths enforce the same contract.
+pub(crate) fn validate_id_mapping_plan(plan: &SandboxIdMappingPlan) -> Result<()> {
+    validate_mapping_set(&plan.uid_mappings, plan.maximum_container_uid, "UID")?;
+    validate_mapping_set(&plan.gid_mappings, plan.maximum_container_gid, "GID")?;
+    if plan
+        .uid_mappings
+        .iter()
+        .any(|mapping| mapping.container_id == 0 && mapping.host_id == 0)
+        || plan
+            .gid_mappings
+            .iter()
+            .any(|mapping| mapping.container_id == 0 && mapping.host_id == 0)
+    {
+        return Err(BoxError::ConfigError(
+            "Sandbox container root must not map to host root".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_mapping_set(mappings: &[IdMapping], maximum: u32, kind: &str) -> Result<()> {
+    if mappings.is_empty() || mappings[0].container_id != 0 {
+        return Err(BoxError::ConfigError(format!(
+            "Sandbox {kind} mappings must start at container ID 0"
+        )));
+    }
+    let mut next = 0u32;
+    let mut host_ranges = Vec::new();
+    for mapping in mappings {
+        if mapping.size == 0 || mapping.container_id != next {
+            return Err(BoxError::ConfigError(format!(
+                "Sandbox {kind} mappings must be contiguous and non-empty"
+            )));
+        }
+        next = next.checked_add(mapping.size).ok_or_else(|| {
+            BoxError::ConfigError(format!("Sandbox {kind} container mapping overflows"))
+        })?;
+        let host_end = mapping.host_id.checked_add(mapping.size).ok_or_else(|| {
+            BoxError::ConfigError(format!("Sandbox {kind} host mapping overflows"))
+        })?;
+        if host_ranges
+            .iter()
+            .any(|(start, end)| mapping.host_id < *end && *start < host_end)
+        {
+            return Err(BoxError::ConfigError(format!(
+                "Sandbox {kind} host mappings overlap"
+            )));
+        }
+        host_ranges.push((mapping.host_id, host_end));
+    }
+    if next <= maximum {
+        return Err(BoxError::ConfigError(format!(
+            "Sandbox {kind} mappings do not cover container ID {maximum}"
+        )));
+    }
+    Ok(())
+}
+
 /// cgroup v2 delegation evidence for the current service process.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CgroupV2Evidence {

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -23,7 +23,7 @@ use oci_spec::runtime::{
     Spec, SpecBuilder, UserBuilder,
 };
 
-use super::capability::{IdMapping, SandboxIdMappingPlan};
+use super::capability::{validate_id_mapping_plan, IdMapping, SandboxIdMappingPlan};
 
 /// OCI annotation schema for generated A3S Sandbox bundles.
 pub const SANDBOX_BUNDLE_SCHEMA: &str = "a3s.box.sandbox-bundle.v1";
@@ -1051,63 +1051,6 @@ fn certified_seccomp_architecture() -> Result<Arch> {
             "Sandbox seccomp is not certified for architecture {architecture}"
         ))),
     }
-}
-
-fn validate_id_mapping_plan(plan: &SandboxIdMappingPlan) -> Result<()> {
-    validate_mapping_set(&plan.uid_mappings, plan.maximum_container_uid, "UID")?;
-    validate_mapping_set(&plan.gid_mappings, plan.maximum_container_gid, "GID")?;
-    if plan
-        .uid_mappings
-        .iter()
-        .any(|mapping| mapping.container_id == 0 && mapping.host_id == 0)
-        || plan
-            .gid_mappings
-            .iter()
-            .any(|mapping| mapping.container_id == 0 && mapping.host_id == 0)
-    {
-        return Err(BoxError::ConfigError(
-            "Sandbox container root must not map to host root".to_string(),
-        ));
-    }
-    Ok(())
-}
-
-fn validate_mapping_set(mappings: &[IdMapping], maximum: u32, kind: &str) -> Result<()> {
-    if mappings.is_empty() || mappings[0].container_id != 0 {
-        return Err(BoxError::ConfigError(format!(
-            "Sandbox {kind} mappings must start at container ID 0"
-        )));
-    }
-    let mut next = 0u32;
-    let mut host_ranges = Vec::new();
-    for mapping in mappings {
-        if mapping.size == 0 || mapping.container_id != next {
-            return Err(BoxError::ConfigError(format!(
-                "Sandbox {kind} mappings must be contiguous and non-empty"
-            )));
-        }
-        next = next.checked_add(mapping.size).ok_or_else(|| {
-            BoxError::ConfigError(format!("Sandbox {kind} container mapping overflows"))
-        })?;
-        let host_end = mapping.host_id.checked_add(mapping.size).ok_or_else(|| {
-            BoxError::ConfigError(format!("Sandbox {kind} host mapping overflows"))
-        })?;
-        if host_ranges
-            .iter()
-            .any(|(start, end)| mapping.host_id < *end && *start < host_end)
-        {
-            return Err(BoxError::ConfigError(format!(
-                "Sandbox {kind} host mappings overlap"
-            )));
-        }
-        host_ranges.push((mapping.host_id, host_end));
-    }
-    if next <= maximum {
-        return Err(BoxError::ConfigError(format!(
-            "Sandbox {kind} mappings do not cover container ID {maximum}"
-        )));
-    }
-    Ok(())
 }
 
 fn validate_user_mount(mount: &SandboxMount) -> Result<()> {

--- a/src/runtime/src/sandbox/rootfs.rs
+++ b/src/runtime/src/sandbox/rootfs.rs
@@ -652,6 +652,20 @@ fn unmap_host_id(mappings: &[IdMapping], id: u32, kind: &str, path: &Path) -> Re
                 });
         }
     }
+
+    // Layout preparation can refresh Box-owned guest files before an
+    // interrupted generation has published its terminal manifest. Those
+    // writes run as host root, so they legitimately carry raw ID zero rather
+    // than the previous generation's subordinate ID. Accept that identity
+    // only for the exact runtime-managed paths; every guest-controlled path
+    // remains fail-closed below.
+    if id == 0 {
+        let relative = safe_relative_path(path)?;
+        if runtime_managed_rootfs_mode(&relative).is_some() {
+            return Ok(0);
+        }
+    }
+
     Err(BoxError::ConfigError(format!(
         "Sandbox rootfs capture host {kind} {id} at {} is outside the OCI mappings",
         path.display()
@@ -1222,8 +1236,29 @@ mod tests {
             host_id: 100_000,
             size: 1,
         }];
-        let error = unmap_host_id(&mappings, 0, "UID", Path::new("etc/hostname")).unwrap_err();
-        assert!(error.to_string().contains("etc/hostname"));
+        let error = unmap_host_id(&mappings, 0, "UID", Path::new("etc/passwd")).unwrap_err();
+        assert!(error.to_string().contains("etc/passwd"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn reverse_mapping_accepts_only_host_root_runtime_managed_writes() {
+        let mappings = vec![IdMapping {
+            container_id: 0,
+            host_id: 100_000,
+            size: 1,
+        }];
+
+        assert_eq!(
+            unmap_host_id(&mappings, 0, "UID", Path::new("./usr/sbin/init")).unwrap(),
+            0
+        );
+        assert_eq!(
+            unmap_host_id(&mappings, 0, "GID", Path::new("etc/hostname")).unwrap(),
+            0
+        );
+        assert!(unmap_host_id(&mappings, 1, "UID", Path::new("usr/sbin/init")).is_err());
+        assert!(unmap_host_id(&mappings, 0, "UID", Path::new("usr/bin/unmanaged")).is_err());
     }
 
     #[cfg(unix)]

--- a/src/runtime/src/sandbox/rootfs.rs
+++ b/src/runtime/src/sandbox/rootfs.rs
@@ -21,13 +21,13 @@ use a3s_box_core::rootfs_metadata::{
 #[cfg(any(target_os = "linux", test))]
 use base64::Engine;
 
-use super::capability::{IdMapping, SandboxIdMappingPlan};
+use super::capability::{validate_id_mapping_plan, IdMapping, SandboxIdMappingPlan};
 
 const MAX_ROOTFS_METADATA_BYTES: u64 = 64 * 1024 * 1024;
 #[cfg(target_os = "linux")]
-const SNAPSHOT_ID_MAPPING_FILE: &str = "sandbox/rootfs-id-mappings.json";
+const ROOTFS_ID_MAPPING_FILE: &str = "sandbox/rootfs-id-mappings.json";
 #[cfg(target_os = "linux")]
-const MAX_SNAPSHOT_ID_MAPPING_BYTES: u64 = 64 * 1024;
+const MAX_ROOTFS_ID_MAPPING_BYTES: u64 = 64 * 1024;
 
 /// Container IDs discovered in the authoritative rootfs metadata manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,23 +38,25 @@ pub struct RootfsIdentityRequirements {
 }
 
 /// Persist the exact user-namespace mapping needed to translate a stopped
-/// Sandbox rootfs back to container ownership during filesystem snapshots.
+/// Sandbox rootfs back to container ownership after an interruption or during
+/// a filesystem Snapshot.
 #[cfg(target_os = "linux")]
-pub(crate) fn persist_snapshot_id_mappings(
+pub(crate) fn persist_rootfs_id_mappings(
     box_dir: &Path,
     plan: &SandboxIdMappingPlan,
 ) -> Result<()> {
-    let destination = box_dir.join(SNAPSHOT_ID_MAPPING_FILE);
+    validate_id_mapping_plan(plan)?;
+    let destination = box_dir.join(ROOTFS_ID_MAPPING_FILE);
     let parent = destination.parent().ok_or_else(|| {
         BoxError::ConfigError(format!(
-            "Sandbox snapshot mapping path has no parent: {}",
+            "Sandbox rootfs mapping path has no parent: {}",
             destination.display()
         ))
     })?;
     std::fs::create_dir_all(parent).map_err(BoxError::IoError)?;
     let mut encoded = serde_json::to_vec_pretty(plan).map_err(|error| {
         BoxError::SerializationError(format!(
-            "Failed to encode Sandbox snapshot ID mappings: {error}"
+            "Failed to encode Sandbox rootfs ID mappings: {error}"
         ))
     })?;
     encoded.push(b'\n');
@@ -70,41 +72,99 @@ pub(crate) fn persist_snapshot_id_mappings(
     Ok(())
 }
 
-/// Load a persisted snapshot mapping, rejecting links, oversized artifacts,
-/// and malformed JSON before it can influence host ownership translation.
+/// Load a persisted rootfs mapping, rejecting links, oversized artifacts,
+/// malformed JSON, and invalid ranges before it can influence host ownership
+/// translation.
 #[cfg(target_os = "linux")]
-pub(crate) fn load_snapshot_id_mappings(box_dir: &Path) -> Result<Option<SandboxIdMappingPlan>> {
-    let path = box_dir.join(SNAPSHOT_ID_MAPPING_FILE);
+pub(crate) fn load_rootfs_id_mappings(box_dir: &Path) -> Result<Option<SandboxIdMappingPlan>> {
+    let path = box_dir.join(ROOTFS_ID_MAPPING_FILE);
     let metadata = match std::fs::symlink_metadata(&path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(BoxError::IoError(error)),
     };
-    if !metadata.file_type().is_file() || metadata.len() > MAX_SNAPSHOT_ID_MAPPING_BYTES {
+    if !metadata.file_type().is_file() || metadata.len() > MAX_ROOTFS_ID_MAPPING_BYTES {
         return Err(BoxError::ConfigError(format!(
-            "Sandbox snapshot ID mapping artifact is not a bounded regular file: {}",
+            "Sandbox rootfs ID mapping artifact is not a bounded regular file: {}",
             path.display()
         )));
     }
     let mut encoded = Vec::with_capacity(metadata.len() as usize);
     std::fs::File::open(&path)
         .map_err(BoxError::IoError)?
-        .take(MAX_SNAPSHOT_ID_MAPPING_BYTES + 1)
+        .take(MAX_ROOTFS_ID_MAPPING_BYTES + 1)
         .read_to_end(&mut encoded)
         .map_err(BoxError::IoError)?;
-    if encoded.len() as u64 > MAX_SNAPSHOT_ID_MAPPING_BYTES {
+    if encoded.len() as u64 > MAX_ROOTFS_ID_MAPPING_BYTES {
         return Err(BoxError::ConfigError(format!(
-            "Sandbox snapshot ID mapping artifact exceeds {} bytes: {}",
-            MAX_SNAPSHOT_ID_MAPPING_BYTES,
+            "Sandbox rootfs ID mapping artifact exceeds {} bytes: {}",
+            MAX_ROOTFS_ID_MAPPING_BYTES,
             path.display()
         )));
     }
-    serde_json::from_slice(&encoded).map(Some).map_err(|error| {
+    let plan: SandboxIdMappingPlan = serde_json::from_slice(&encoded).map_err(|error| {
         BoxError::SerializationError(format!(
-            "Failed to decode Sandbox snapshot ID mappings {}: {error}",
+            "Failed to decode Sandbox rootfs ID mappings {}: {error}",
             path.display()
         ))
-    })
+    })?;
+    validate_id_mapping_plan(&plan)?;
+    Ok(Some(plan))
+}
+
+/// Rebuild one replay manifest from a stopped Sandbox generation.
+///
+/// guest-init consumes the image or previous-generation manifest before it
+/// executes the workload. If the provider is then killed, no terminal manifest
+/// can be published. The persisted mapping remains outside the guest rootfs and
+/// lets Box reverse the stopped host IDs into their exact container identities,
+/// including files and ownership changes created during the interrupted run.
+#[cfg(target_os = "linux")]
+pub(crate) fn recover_interrupted_rootfs_metadata(box_dir: &Path, root: &Path) -> Result<bool> {
+    for path in [
+        root.join(ROOTFS_METADATA_PATH.trim_start_matches('/')),
+        root.join(PREVIOUS_ROOTFS_METADATA_PATH.trim_start_matches('/')),
+        root.join(IMAGE_ROOTFS_METADATA_PATH.trim_start_matches('/')),
+    ] {
+        if load_manifest_if_present(&path)?.is_some() {
+            return Ok(false);
+        }
+    }
+
+    let Some(plan) = load_rootfs_id_mappings(box_dir)? else {
+        return Ok(false);
+    };
+    let manifest = capture_rootfs_metadata(root, &plan)?;
+    publish_replay_rootfs_metadata(root, &manifest)?;
+    Ok(true)
+}
+
+#[cfg(target_os = "linux")]
+fn publish_replay_rootfs_metadata(root: &Path, manifest: &RootfsMetadataManifest) -> Result<()> {
+    manifest.validate().map_err(BoxError::OciImageError)?;
+    let encoded = serde_json::to_vec(manifest).map_err(|error| {
+        BoxError::SerializationError(format!(
+            "Failed to encode recovered Sandbox rootfs metadata: {error}"
+        ))
+    })?;
+    if encoded.len() as u64 > MAX_ROOTFS_METADATA_BYTES {
+        return Err(BoxError::OciImageError(format!(
+            "Recovered Sandbox rootfs metadata exceeds the {} byte limit",
+            MAX_ROOTFS_METADATA_BYTES
+        )));
+    }
+
+    let destination = root.join(PREVIOUS_ROOTFS_METADATA_PATH.trim_start_matches('/'));
+    let mut temporary = tempfile::NamedTempFile::new_in(root).map_err(BoxError::IoError)?;
+    temporary.write_all(&encoded).map_err(BoxError::IoError)?;
+    temporary.as_file().sync_all().map_err(BoxError::IoError)?;
+    temporary
+        .persist_noclobber(&destination)
+        .map_err(|error| BoxError::IoError(error.error))?;
+    std::fs::File::open(root)
+        .and_then(|directory| directory.sync_all())
+        .map_err(BoxError::IoError)?;
+    Ok(())
 }
 
 /// Host IDs representing container root for one mapping plan.
@@ -477,14 +537,15 @@ pub(crate) fn prepare_rootfs_ownership_with_preference(
     Ok(())
 }
 
-/// Capture authoritative guest-visible metadata for a quiesced Sandbox rootfs.
+/// Capture authoritative guest-visible metadata for a stopped or quiesced
+/// Sandbox rootfs.
 ///
 /// The host sees user-namespace IDs, so every UID/GID is translated back
 /// through the exact OCI mappings before the manifest is stored in a
 /// filesystem Snapshot. The walk never follows symlinks and rejects special
 /// files, preventing a FIFO or device node from entering the copy path.
 #[cfg(target_os = "linux")]
-pub(crate) fn capture_snapshot_rootfs_metadata(
+pub(crate) fn capture_rootfs_metadata(
     root: &Path,
     plan: &SandboxIdMappingPlan,
 ) -> Result<RootfsMetadataManifest> {
@@ -1053,6 +1114,83 @@ mod tests {
                 link_target_base64: None,
             }],
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn interrupted_generation_recovers_exact_replay_metadata_from_persisted_mappings() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let home = tempfile::tempdir().unwrap();
+        let box_dir = home.path().join("boxes/interrupted");
+        let root = box_dir.join("merged");
+        std::fs::create_dir_all(&root).unwrap();
+        let state = root.join("state.txt");
+        std::fs::write(&state, "changed while running\n").unwrap();
+        std::fs::set_permissions(&state, std::fs::Permissions::from_mode(0o620)).unwrap();
+
+        let effective_uid = unsafe { libc::geteuid() };
+        let effective_gid = unsafe { libc::getegid() };
+        let (host_uid, host_gid, mapping_size, state_container_id) = if effective_uid == 0
+            && effective_gid == 0
+        {
+            let host_uid = 100_000;
+            let host_gid = 100_000;
+            for (path, offset) in [(&root, 0), (&state, 7)] {
+                let path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+                assert_eq!(
+                    unsafe { libc::lchown(path.as_ptr(), host_uid + offset, host_gid + offset) },
+                    0,
+                    "failed to prepare mapped rootfs ownership: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+            (host_uid, host_gid, 8, 7)
+        } else {
+            (effective_uid, effective_gid, 1, 0)
+        };
+        let plan = SandboxIdMappingPlan {
+            uid_mappings: vec![IdMapping {
+                container_id: 0,
+                host_id: host_uid,
+                size: mapping_size,
+            }],
+            gid_mappings: vec![IdMapping {
+                container_id: 0,
+                host_id: host_gid,
+                size: mapping_size,
+            }],
+            maximum_container_uid: mapping_size - 1,
+            maximum_container_gid: mapping_size - 1,
+        };
+        persist_rootfs_id_mappings(&box_dir, &plan).unwrap();
+
+        assert!(recover_interrupted_rootfs_metadata(&box_dir, &root).unwrap());
+        let previous = root.join(PREVIOUS_ROOTFS_METADATA_PATH.trim_start_matches('/'));
+        let recovered: RootfsMetadataManifest =
+            serde_json::from_slice(&std::fs::read(&previous).unwrap()).unwrap();
+        let state_entry = recovered
+            .entries
+            .iter()
+            .find(|entry| entry.kind == RootfsEntryKind::Regular)
+            .unwrap();
+        assert_eq!(state_entry.uid, u64::from(state_container_id));
+        assert_eq!(state_entry.gid, u64::from(state_container_id));
+        assert_eq!(state_entry.mode & 0o7777, 0o620);
+        assert_eq!(state_entry.size, 22);
+
+        let requirements = inspect_rootfs_identity_requirements(&root).unwrap();
+        assert_eq!(requirements.maximum_uid, state_container_id);
+        assert_eq!(requirements.maximum_gid, state_container_id);
+        assert_eq!(requirements.manifest_path, previous);
+        assert!(!recover_interrupted_rootfs_metadata(&box_dir, &root).unwrap());
+
+        prepare_rootfs_ownership(&root, &plan, 0, false).unwrap();
+        let state_metadata = std::fs::symlink_metadata(&state).unwrap();
+        assert_eq!(state_metadata.uid(), host_uid + state_container_id);
+        assert_eq!(state_metadata.gid(), host_gid + state_container_id);
+        assert_eq!(state_metadata.permissions().mode() & 0o7777, 0o620);
     }
 
     #[test]

--- a/src/runtime/src/sandbox/rootfs.rs
+++ b/src/runtime/src/sandbox/rootfs.rs
@@ -608,8 +608,8 @@ fn collect_snapshot_rootfs_metadata(
             .encode(manifest_path.as_os_str().as_bytes()),
         kind,
         mode: metadata.mode(),
-        uid: unmap_host_id(&plan.uid_mappings, metadata.uid(), "UID")? as u64,
-        gid: unmap_host_id(&plan.gid_mappings, metadata.gid(), "GID")? as u64,
+        uid: unmap_host_id(&plan.uid_mappings, metadata.uid(), "UID", manifest_path)? as u64,
+        gid: unmap_host_id(&plan.gid_mappings, metadata.gid(), "GID", manifest_path)? as u64,
         mtime: metadata.mtime().max(0) as u64,
         size: metadata.size(),
         link_target_base64,
@@ -635,7 +635,7 @@ fn collect_snapshot_rootfs_metadata(
 }
 
 #[cfg(target_os = "linux")]
-fn unmap_host_id(mappings: &[IdMapping], id: u32, kind: &str) -> Result<u32> {
+fn unmap_host_id(mappings: &[IdMapping], id: u32, kind: &str, path: &Path) -> Result<u32> {
     for mapping in mappings {
         let Some(end) = mapping.host_id.checked_add(mapping.size) else {
             continue;
@@ -646,13 +646,15 @@ fn unmap_host_id(mappings: &[IdMapping], id: u32, kind: &str) -> Result<u32> {
                 .checked_add(id - mapping.host_id)
                 .ok_or_else(|| {
                     BoxError::ConfigError(format!(
-                        "Sandbox Snapshot {kind} reverse mapping overflows u32"
+                        "Sandbox rootfs capture {kind} reverse mapping overflows u32 at {}",
+                        path.display()
                     ))
                 });
         }
     }
     Err(BoxError::ConfigError(format!(
-        "Sandbox Snapshot host {kind} {id} is outside the OCI mappings"
+        "Sandbox rootfs capture host {kind} {id} at {} is outside the OCI mappings",
+        path.display()
     )))
 }
 
@@ -1210,6 +1212,18 @@ mod tests {
         assert_eq!(map_container_id(&mappings, 0, "UID").unwrap(), 100_000);
         assert_eq!(map_container_id(&mappings, 12, "UID").unwrap(), 200_002);
         assert!(map_container_id(&mappings, 16, "UID").is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn reverse_mapping_failure_names_the_exact_rootfs_path() {
+        let mappings = vec![IdMapping {
+            container_id: 0,
+            host_id: 100_000,
+            size: 1,
+        }];
+        let error = unmap_host_id(&mappings, 0, "UID", Path::new("etc/hostname")).unwrap_err();
+        assert!(error.to_string().contains("etc/hostname"));
     }
 
     #[cfg(unix)]

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -18,6 +18,8 @@ use crate::process_path::{
 use crate::sandbox::rootfs::{
     inspect_rootfs_identity_requirements_with_preference, prepare_rootfs_ownership_with_preference,
 };
+#[cfg(target_os = "linux")]
+use crate::sandbox::rootfs::{persist_rootfs_id_mappings, recover_interrupted_rootfs_metadata};
 use crate::sandbox::A3sOciController;
 use crate::sandbox::{
     compile_oci_spec, compile_runtime_owned_oci_spec, plan_id_mappings,
@@ -119,6 +121,16 @@ impl VmManager {
             a3s_box_core::rootfs_metadata::stage_terminal_rootfs_metadata_for_boot(
                 &layout.rootfs_path,
             )?;
+            #[cfg(target_os = "linux")]
+            if !layout.prefer_image_rootfs_metadata
+                && recover_interrupted_rootfs_metadata(&box_dir, &layout.rootfs_path)?
+            {
+                tracing::info!(
+                    box_id = %self.box_id,
+                    rootfs = %layout.rootfs_path.display(),
+                    "Recovered interrupted Sandbox rootfs metadata"
+                );
+            }
             let instance_prepare_start = std::time::Instant::now();
             let resolv_content = a3s_box_core::dns::generate_resolv_conf(&self.config.dns);
             crate::oci::rootfs::write_guest_file(
@@ -213,6 +225,8 @@ impl VmManager {
                 &bundle_spec.mounts,
                 &bundle_spec.id_mappings,
             )?;
+            #[cfg(target_os = "linux")]
+            persist_rootfs_id_mappings(&box_dir, &bundle_spec.id_mappings)?;
             a3s_box_core::lifecycle_profile::record_lifecycle_phase(
                 "sandbox.bundle",
                 bundle_start.elapsed(),
@@ -365,6 +379,16 @@ impl VmManager {
             a3s_box_core::rootfs_metadata::stage_terminal_rootfs_metadata_for_boot(
                 &layout.rootfs_path,
             )?;
+            #[cfg(target_os = "linux")]
+            if !layout.prefer_image_rootfs_metadata
+                && recover_interrupted_rootfs_metadata(&box_dir, &layout.rootfs_path)?
+            {
+                tracing::info!(
+                    box_id = %self.box_id,
+                    rootfs = %layout.rootfs_path.display(),
+                    "Recovered interrupted Sandbox rootfs metadata"
+                );
+            }
             let resolv_content = a3s_box_core::dns::generate_resolv_conf(&self.config.dns);
             crate::oci::rootfs::write_guest_file(
                 &layout.rootfs_path,
@@ -444,6 +468,8 @@ impl VmManager {
                 &bundle_spec.mounts,
                 &bundle_spec.id_mappings,
             )?;
+            #[cfg(target_os = "linux")]
+            persist_rootfs_id_mappings(&box_dir, &bundle_spec.id_mappings)?;
             self.create_diff_baseline(&layout);
 
             Ok(RuntimeOwnedSandboxBundle {


### PR DESCRIPTION
## Summary

- persist the exact Sandbox UID/GID mapping before every provider launch
- reconstruct a one-shot replay manifest from a stopped mapped rootfs after abrupt provider death
- preserve files and mode/ownership changes made during the interrupted generation
- share mapping validation between OCI compilation and recovery and keep malformed state fail-closed
- add a Linux regression test for interrupted-generation metadata recovery

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`

Heavy compilation and Linux integration gates are intentionally delegated to GitHub Actions.