### PR TITLE
Align Runtime provider dependency with 0.3.0

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -293,8 +293,8 @@ dependencies = [
 
 [[package]]
 name = "a3s-runtime"
-version = "0.2.0"
-source = "git+https://github.com/A3S-Lab/Runtime.git?rev=061cde95e16eb4cbd9f58724e6cbb60de6ace77e#061cde95e16eb4cbd9f58724e6cbb60de6ace77e"
+version = "0.3.0"
+source = "git+https://github.com/A3S-Lab/Runtime.git?rev=6a5546145a74c9f380a0d86c2490a144a22883f8#6a5546145a74c9f380a0d86c2490a144a22883f8"
 dependencies = [
  "async-trait",
  "fs2",
@@ -2264,7 +2264,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3067,7 +3067,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -124,7 +124,7 @@ ring = "0.17"
 # Shared types (transport protocol, privacy, tools)
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
-a3s-runtime = { version = "0.2.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "061cde95e16eb4cbd9f58724e6cbb60de6ace77e" }
+a3s-runtime = { version = "0.3.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "6a5546145a74c9f380a0d86c2490a144a22883f8" }
 a3s-oci-sdk = { version = "0.2.0", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "9c3be8e126dda7ff7add5e6e88c427f68c7d6629" }
 
 # Metrics


### PR DESCRIPTION
## Summary

- pin `a3s-runtime` to the exact released `0.3.0` revision used by Use and CLI
- regenerate the locked dependency graph
- align the shared Runtime provider type graph required by #172

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p a3s-box-runtime --all-targets --locked` on macOS arm64
- `cargo check -p a3s-box-runtime --all-targets --locked` in Linux arm64 Docker with `A3S_DEPS_STUB=1`
- native library suite: 1625 passed, 1 ignored; the sole failing macOS `/var` versus `/private/var` path-alias test reproduces unchanged on `main`