### PR TITLE
feat(runtime): expose provider qualification seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- **Downstream real-process Runtime provider qualification seam.** The Linux
+  Box Runtime driver can be compiled with the explicit
+  `runtime-provider-qualification` feature to accept a caller-owned execution
+  backend, generation-fenced port connector, and immutable provider-build
+  identity. This keeps downstream Use/Gateway lifecycle tests on Box's
+  production mapping, durable state, health, endpoint, stop, and removal paths
+  without exposing the injection constructor in default release builds.
 - **Durable standalone Gateway scaling and live replica endpoints.** The
   machine-facing `scale-api` now journals revision-bound idempotent operations,
   reconciles deterministic stateless service slots through the canonical local

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -29,6 +29,9 @@ scale = ["dep:axum"]
 compose = ["vm"]
 operator = []
 build = ["dep:a3s-acl"]
+# Downstream product qualification may inject a real-process execution backend
+# and generation-fenced connector without enabling that seam in release builds.
+runtime-provider-qualification = ["vm"]
 
 [dependencies]
 a3s-box-core = { version = "3.2", path = "../core" }

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -31,6 +31,8 @@ use tokio::sync::OnceCell;
 
 use crate::local_execution::TransientRegistryAuthBroker;
 use crate::tee::AttestationPolicy;
+#[cfg(any(test, feature = "runtime-provider-qualification"))]
+use crate::LocalExecutionBackend;
 use crate::{ExecutionIsolation, LocalExecutionManager, VmLocalExecutionBackend};
 
 use self::artifact::ArtifactStorageOwner;
@@ -143,6 +145,51 @@ impl BoxRuntimeDriver {
             None,
             Some(broker),
         )
+    }
+
+    /// Construct the Box Runtime driver over a caller-owned qualification
+    /// backend and generation-fenced data-plane connector.
+    ///
+    /// This seam exists only for downstream product qualification. It lets a
+    /// host exercise the production Box Runtime mapping, durable lifecycle,
+    /// health, endpoint, stop, and removal code against real child processes
+    /// without requiring a nested hypervisor or privileged OCI runtime on a
+    /// general CI runner. Release builds do not expose this constructor unless
+    /// the explicit `runtime-provider-qualification` feature is enabled.
+    ///
+    /// The supplied provider build is immutable evidence for the complete
+    /// driver instance. Callers must not use this constructor as a production
+    /// capability-probe bypass.
+    #[cfg(any(test, feature = "runtime-provider-qualification"))]
+    pub fn new_for_runtime_provider_qualification(
+        config: BoxRuntimeDriverConfig,
+        backend: Arc<dyn LocalExecutionBackend>,
+        port_connector: Arc<dyn ExecutionPortConnector>,
+        execution_isolation: ExecutionIsolation,
+        provider_build: impl Into<String>,
+    ) -> RuntimeResult<Self> {
+        let provider_build = provider_build.into();
+        validate_qualification_provider_build(&provider_build)?;
+        let manager = LocalExecutionManager::new(
+            config.home_dir.join("boxes.json"),
+            &config.home_dir,
+            backend,
+        );
+        let driver = Self::with_manager_connector_and_materializer(
+            config,
+            manager,
+            port_connector,
+            execution_isolation,
+            None,
+            None,
+            Some(TransientRegistryAuthBroker::default()),
+        )?;
+        driver.provider_build.set(provider_build).map_err(|_| {
+            RuntimeError::Protocol(
+                "Box Runtime qualification provider build was initialized twice".into(),
+            )
+        })?;
+        Ok(driver)
     }
 
     /// Compose the shared Box driver with one caller-owned Secret resolver.
@@ -372,6 +419,21 @@ fn validate_config(config: &BoxRuntimeDriverConfig) -> RuntimeResult<()> {
     {
         return Err(RuntimeError::InvalidRequest(
             "Box Runtime Secret root must be an encodable absolute normalized non-root Linux path"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(any(test, feature = "runtime-provider-qualification"))]
+fn validate_qualification_provider_build(provider_build: &str) -> RuntimeResult<()> {
+    if provider_build.is_empty()
+        || provider_build.len() > 255
+        || provider_build.trim() != provider_build
+        || provider_build.bytes().any(|byte| byte.is_ascii_control())
+    {
+        return Err(RuntimeError::InvalidRequest(
+            "Box Runtime qualification provider build must be a trimmed non-empty string of at most 255 bytes"
                 .into(),
         ));
     }

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -14,6 +14,7 @@ use a3s_runtime::RuntimeDriver;
 
 use super::mapping::{creation_request, creation_request_with_sev_snp, operation};
 use super::metadata::validate_record_for_spec;
+use super::test_support::DriverFakeBackend;
 use super::*;
 
 const TEST_EXECUTION_ISOLATION: ExecutionIsolation = ExecutionIsolation::Microvm;
@@ -108,6 +109,67 @@ fn driver_allows_explicit_shared_kernel_selection() {
     .unwrap();
 
     assert_eq!(driver.execution_isolation(), ExecutionIsolation::Sandbox);
+}
+
+#[tokio::test]
+async fn qualification_constructor_freezes_explicit_provider_build() {
+    let directory = tempfile::tempdir().unwrap();
+    let home_dir = directory.path().join("home");
+    let backend = std::sync::Arc::new(DriverFakeBackend::default());
+    let connector = std::sync::Arc::new(LocalExecutionManager::new(
+        home_dir.join("connector-boxes.json"),
+        &home_dir,
+        backend.clone(),
+    ));
+    let driver = BoxRuntimeDriver::new_for_runtime_provider_qualification(
+        BoxRuntimeDriverConfig {
+            home_dir,
+            secret_root: directory.path().join("runtime-secrets"),
+            control_timeout: Duration::from_secs(2),
+            task_poll_interval: Duration::from_millis(5),
+        },
+        backend,
+        connector,
+        ExecutionIsolation::Sandbox,
+        "a3s-box/qualification real-process/v1",
+    )
+    .unwrap();
+
+    let capabilities = driver.capabilities().await.unwrap();
+    assert_eq!(
+        capabilities.provider_build,
+        "a3s-box/qualification real-process/v1"
+    );
+    assert_eq!(driver.execution_isolation(), ExecutionIsolation::Sandbox);
+}
+
+#[test]
+fn qualification_constructor_rejects_unbounded_provider_build() {
+    let directory = tempfile::tempdir().unwrap();
+    let home_dir = directory.path().join("home");
+    let backend = std::sync::Arc::new(DriverFakeBackend::default());
+    let connector = std::sync::Arc::new(LocalExecutionManager::new(
+        home_dir.join("connector-boxes.json"),
+        &home_dir,
+        backend.clone(),
+    ));
+    let error = match BoxRuntimeDriver::new_for_runtime_provider_qualification(
+        BoxRuntimeDriverConfig {
+            home_dir,
+            secret_root: directory.path().join("runtime-secrets"),
+            control_timeout: Duration::from_secs(2),
+            task_poll_interval: Duration::from_millis(5),
+        },
+        backend,
+        connector,
+        ExecutionIsolation::Sandbox,
+        " qualification\n",
+    ) {
+        Ok(_) => panic!("invalid qualification provider build was accepted"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, RuntimeError::InvalidRequest(_)));
 }
 
 fn mutate_record(

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -10,6 +10,9 @@
 //! - `compose` — Multi-container compose orchestration (enabled by default)
 //! - `operator` — Kubernetes CRD autoscaler controller (enabled by default)
 //! - `build` — Dockerfile/Containerfile build engine (enabled by default)
+//! - `runtime-provider-qualification` — Explicit downstream real-process
+//!   qualification seam for the Linux A3S Runtime provider (disabled by
+//!   default; never a production capability-probe fallback)
 
 #![allow(clippy::result_large_err)]
 

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -2241,6 +2241,10 @@ mod tests {
             true
         }
 
+        fn has_exited(&self) -> bool {
+            false
+        }
+
         fn pid(&self) -> u32 {
             42
         }


### PR DESCRIPTION
## Summary

- add an explicit opt-in Runtime provider qualification feature
- let downstream product tests inject a real-process execution backend and generation-fenced connector while retaining production Box mapping and lifecycle logic
- validate and freeze the provider build identity
- make the Linux running-handler test deterministic instead of depending on whether PID 42 exists

## Validation

- cargo fmt --all -- --check
- git diff --check
- Linux a3s-box-runtime library tests with runtime-provider-qualification: 1754 passed, 0 failed, 5 ignored
- focused qualification constructor tests: 2 passed

Local Clippy was not available in the minimal Linux image; repository CI is the authoritative Clippy gate.