### PR TITLE
fix(runtime): finalize exited OCI providers

### DIFF
--- a/src/cli/src/commands/diff.rs
+++ b/src/cli/src/commands/diff.rs
@@ -187,6 +187,12 @@ fn walk_tar_archive(
 ) -> Result<HashMap<String, RootfsFileInfo>, Box<dyn std::error::Error>> {
     use std::os::unix::ffi::OsStrExt;
 
+    // POSIX/ustar file type bits are part of the archive mode contract and do
+    // not depend on the host's `libc::mode_t` width.
+    const DIRECTORY_MODE: u32 = 0o040000;
+    const REGULAR_FILE_MODE: u32 = 0o100000;
+    const SYMBOLIC_LINK_MODE: u32 = 0o120000;
+
     let mut archive = tar::Archive::new(std::fs::File::open(archive_path)?);
     let mut entries = HashMap::new();
     let mut hard_links = Vec::new();
@@ -213,19 +219,15 @@ fn walk_tar_archive(
             continue;
         }
         let (size, mode, is_dir) = if entry_type.is_dir() {
-            (0, u32::from(libc::S_IFDIR) | permissions, true)
+            (0, DIRECTORY_MODE | permissions, true)
         } else if entry_type.is_symlink() {
             let size = item
                 .link_name()?
                 .map(|target| target.as_os_str().as_bytes().len() as u64)
                 .unwrap_or(0);
-            (size, u32::from(libc::S_IFLNK) | permissions, false)
+            (size, SYMBOLIC_LINK_MODE | permissions, false)
         } else if entry_type.is_file() {
-            (
-                header.size()?,
-                u32::from(libc::S_IFREG) | permissions,
-                false,
-            )
+            (header.size()?, REGULAR_FILE_MODE | permissions, false)
         } else {
             continue;
         };

--- a/src/runtime/src/rootfs/ext4.rs
+++ b/src/runtime/src/rootfs/ext4.rs
@@ -7,7 +7,9 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::Read;
+#[cfg(any(target_os = "macos", all(unix, test)))]
+use std::io::{Seek, SeekFrom};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
@@ -39,6 +41,7 @@ const MAX_CAPACITY_BYTES: u64 = 64 * 1024 * 1024 * 1024;
 const MAX_IMAGE_METADATA_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Validation result for a mutable guest-owned generation selected for boot.
+#[cfg(any(target_os = "macos", all(unix, test)))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Ext4ResumeValidation {
     /// The filesystem was cleanly unmounted and passed full structural checks.
@@ -718,6 +721,7 @@ pub(super) fn validate_ext4_image(path: &Path, expected_length: u64) -> Result<(
 /// journal, so a host-side tree reader is the wrong recovery mechanism. We
 /// instead validate the exact A3S superblock envelope and let the isolated
 /// guest kernel replay its own journal on the next read-write mount.
+#[cfg(any(target_os = "macos", all(unix, test)))]
 pub(super) fn validate_ext4_image_for_resume(
     path: &Path,
     expected_length: u64,
@@ -761,6 +765,7 @@ pub(super) fn validate_ext4_image_for_resume(
     Ok(Ext4ResumeValidation::JournalRecoveryRequired)
 }
 
+#[cfg(any(target_os = "macos", all(unix, test)))]
 fn validate_recovery_superblock(
     superblock: &mkext4::spec::Superblock,
     bytes: &[u8; mkext4::spec::Superblock::LEN],

--- a/src/runtime/src/rootfs/ext4_artifact.rs
+++ b/src/runtime/src/rootfs/ext4_artifact.rs
@@ -29,6 +29,7 @@ pub(super) fn open_ext4_artifact(directory: &Path) -> Result<Ext4Artifact> {
 /// mounted by a host crash is accepted only when its primary superblock still
 /// matches the exact A3S artifact contract; the guest kernel then owns journal
 /// replay inside the VM.
+#[cfg(target_os = "macos")]
 pub(super) fn open_ext4_artifact_for_resume(
     directory: &Path,
 ) -> Result<(Ext4Artifact, Ext4ResumeValidation)> {

--- a/src/runtime/src/rootfs/mod.rs
+++ b/src/runtime/src/rootfs/mod.rs
@@ -17,9 +17,9 @@ mod baseline;
 mod builder;
 #[cfg(unix)]
 mod ext4;
-#[cfg(unix)]
+#[cfg(any(target_os = "macos", all(unix, test)))]
 mod ext4_artifact;
-#[cfg(unix)]
+#[cfg(any(target_os = "macos", all(unix, test)))]
 mod ext4_cache;
 #[cfg(target_os = "macos")]
 mod guest_native_ext4;
@@ -39,7 +39,7 @@ pub use ext4::{
     publish_ext4_artifact, Ext4Artifact, Ext4ArtifactManifest, Ext4ArtifactOptions,
     EXT4_ARTIFACT_SCHEMA, EXT4_BUILDER_ID,
 };
-#[cfg(unix)]
+#[cfg(target_os = "macos")]
 pub(crate) use ext4_cache::{Ext4ArtifactCache, Ext4CacheIdentity};
 #[cfg(target_os = "macos")]
 pub use guest_native_ext4::GuestNativeExt4Provider;

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -114,6 +114,7 @@ impl VmManager {
                     workspace_path,
                     console_output: Some(logs_dir.join("console.log")),
                     oci_config,
+                    #[cfg(target_os = "macos")]
                     oci_manifest_digest: None,
                     prefer_image_rootfs_metadata: false,
                     tee_instance_config,
@@ -170,6 +171,7 @@ impl VmManager {
                     workspace_path,
                     console_output: Some(logs_dir.join("console.log")),
                     oci_config,
+                    #[cfg(target_os = "macos")]
                     oci_manifest_digest: None,
                     prefer_image_rootfs_metadata: false,
                     tee_instance_config,
@@ -231,6 +233,7 @@ impl VmManager {
                 workspace_path,
                 console_output: Some(logs_dir.join("console.log")),
                 oci_config,
+                #[cfg(target_os = "macos")]
                 oci_manifest_digest: None,
                 prefer_image_rootfs_metadata: false,
                 tee_instance_config,
@@ -271,6 +274,7 @@ impl VmManager {
                 workspace_path,
                 console_output: Some(logs_dir.join("console.log")),
                 oci_config: None,
+                #[cfg(target_os = "macos")]
                 oci_manifest_digest: None,
                 prefer_image_rootfs_metadata: !has_persistent_rootfs_generation,
                 tee_instance_config,
@@ -412,6 +416,7 @@ impl VmManager {
             workspace_path,
             console_output: Some(logs_dir.join("console.log")),
             oci_config,
+            #[cfg(target_os = "macos")]
             oci_manifest_digest: Some(manifest_digest),
             prefer_image_rootfs_metadata,
             tee_instance_config,

--- a/src/runtime/src/vm/lifecycle.rs
+++ b/src/runtime/src/vm/lifecycle.rs
@@ -95,6 +95,7 @@ impl VmManager {
         // best-effort and would otherwise leak on every wedged stop. Capture the
         // error and surface it after teardown instead of returning early.
         let mut stop_error = None;
+        #[cfg(unix)]
         let requires_guest_rootfs_handoff =
             if preserve_rootfs && self.boot_mode != VmBootMode::RootfsMaintenance {
                 match crate::rootfs::guest_native_ext4_generation_exists(&box_dir) {
@@ -186,7 +187,7 @@ impl VmManager {
                 self.deliver_guest_stop_signal(signal).await
             };
             #[cfg(unix)]
-            let provider_exited = if guest_stop_delivered {
+            let _provider_exited = if guest_stop_delivered {
                 let graceful_wait = if signal == libc::SIGKILL {
                     std::time::Duration::ZERO
                 } else {
@@ -239,8 +240,6 @@ impl VmManager {
                 false
             };
 
-            #[cfg(windows)]
-            let provider_exited = false;
             #[cfg(unix)]
             let handler_signal = if guest_stop_delivered {
                 libc::SIGKILL
@@ -252,18 +251,20 @@ impl VmManager {
             #[cfg(unix)]
             let handler_timeout_ms = if guest_stop_delivered { 0 } else { timeout_ms };
 
-            let _handler_stopped = if provider_exited {
-                true
-            } else {
-                match handler.stop(handler_signal, handler_timeout_ms) {
-                    Ok(()) => true,
-                    Err(e) => {
-                        tracing::error!(box_id = %self.box_id, error = %e, "Failed to stop VM handler; continuing teardown");
-                        if stop_error.is_none() {
-                            stop_error = Some(e);
-                        }
-                        false
+            // Observing provider exit proves that the workload stopped, but it
+            // does not finalize the backend. In particular, A3S OCI owns its
+            // terminal generation and private endpoint until `stop` performs
+            // the authoritative delete. Every handler implementation treats an
+            // already-exited process idempotently, so always run this finalizer;
+            // the zero timeout prevents a second graceful-wait interval.
+            let _handler_stopped = match handler.stop(handler_signal, handler_timeout_ms) {
+                Ok(()) => true,
+                Err(e) => {
+                    tracing::error!(box_id = %self.box_id, error = %e, "Failed to stop VM handler; continuing teardown");
+                    if stop_error.is_none() {
+                        stop_error = Some(e);
                     }
+                    false
                 }
             };
             #[cfg(not(windows))]

--- a/src/runtime/src/vm/maintenance.rs
+++ b/src/runtime/src/vm/maintenance.rs
@@ -19,7 +19,7 @@ use a3s_box_core::vmm::{
 /// the archive implementation come from the current A3S installation, not from
 /// the mutable filesystem being inspected.
 pub async fn archive_stopped_guest_native_rootfs<W>(
-    mut config: BoxConfig,
+    config: BoxConfig,
     box_id: String,
     output: &mut W,
 ) -> Result<u64>
@@ -29,13 +29,14 @@ where
     #[cfg(not(target_os = "macos"))]
     {
         let _ = (config, box_id, output);
-        return Err(BoxError::StateError(
+        Err(BoxError::StateError(
             "Guest-native rootfs maintenance is currently available only on macOS".to_string(),
-        ));
+        ))
     }
 
     #[cfg(target_os = "macos")]
     {
+        let mut config = config;
         sanitize_maintenance_config(&mut config);
         let mut vm = VmManager::with_box_id(config, EventEmitter::new(16), box_id);
         let maintenance_dir = vm.socket_dir().join("rootfs-maintenance");

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -97,6 +97,7 @@ pub(crate) struct BoxLayout {
     /// Exact resolved OCI manifest behind a fresh image-derived generation.
     /// Snapshot and externally prebuilt roots intentionally have no reusable
     /// base identity until their own generation protocol is implemented.
+    #[cfg(target_os = "macos")]
     pub(crate) oci_manifest_digest: Option<String>,
     /// Fresh image/cache rootfs generations must ignore any terminal manifest
     /// baked into an older malicious image. Persistent and Snapshot generations

--- a/src/runtime/src/vm/network.rs
+++ b/src/runtime/src/vm/network.rs
@@ -388,6 +388,7 @@ mod tests {
             workspace_path: std::path::PathBuf::new(),
             console_output: None,
             oci_config: None,
+            #[cfg(target_os = "macos")]
             oci_manifest_digest: None,
             prefer_image_rootfs_metadata: false,
             tee_instance_config: None,

--- a/src/runtime/src/vm/spec/tests.rs
+++ b/src/runtime/src/vm/spec/tests.rs
@@ -87,6 +87,7 @@ fn test_layout(
         workspace_path: base.join("workspace"),
         console_output: None,
         oci_config,
+        #[cfg(target_os = "macos")]
         oci_manifest_digest: None,
         prefer_image_rootfs_metadata: false,
         tee_instance_config: None,

--- a/src/runtime/src/vm/tests.rs
+++ b/src/runtime/src/vm/tests.rs
@@ -35,13 +35,13 @@ impl VmHandler for RecordingHandler {
 #[cfg(unix)]
 struct GuestStopHandler {
     exited: Arc<AtomicBool>,
-    host_stop_called: Arc<AtomicBool>,
+    backend_finalized: Arc<AtomicBool>,
 }
 
 #[cfg(unix)]
 impl VmHandler for GuestStopHandler {
     fn stop(&mut self, _signal: i32, _timeout_ms: u64) -> Result<()> {
-        self.host_stop_called.store(true, Ordering::SeqCst);
+        self.backend_finalized.store(true, Ordering::SeqCst);
         Ok(())
     }
 

--- a/src/runtime/src/vm/tests/lifecycle.rs
+++ b/src/runtime/src/vm/tests/lifecycle.rs
@@ -58,10 +58,10 @@ async fn destroy_uses_guest_stop_and_verifies_raw_rootfs_handoff() {
     vm.exec_socket_path = Some(exec_socket);
 
     let exited = Arc::new(AtomicBool::new(false));
-    let host_stop_called = Arc::new(AtomicBool::new(false));
+    let backend_finalized = Arc::new(AtomicBool::new(false));
     *vm.handler.write().await = Some(Box::new(GuestStopHandler {
         exited: Arc::clone(&exited),
-        host_stop_called: Arc::clone(&host_stop_called),
+        backend_finalized: Arc::clone(&backend_finalized),
     }));
 
     let server_exited = Arc::clone(&exited);
@@ -83,7 +83,7 @@ async fn destroy_uses_guest_stop_and_verifies_raw_rootfs_handoff() {
     vm.destroy_with_options(libc::SIGTERM, 1_000).await.unwrap();
     server.await.unwrap();
 
-    assert!(!host_stop_called.load(Ordering::SeqCst));
+    assert!(backend_finalized.load(Ordering::SeqCst));
     assert_eq!(vm.exit_code(), Some(143));
     assert!(box_dir.exists());
 }


### PR DESCRIPTION
## Summary
- always finalize an exited VM handler so A3S OCI deletes its terminal generation and private endpoint
- compile macOS guest-native ext4 cache/recovery code only where production uses it while retaining Linux unit coverage
- use host-independent POSIX archive type bits in CLI diff

## Why
The guest-first shutdown path skipped the handler finalizer after observing provider exit. For A3S OCI this left runtime.json behind after runtime.sock disappeared, so managed removal correctly refused to touch the rootfs. The concurrent guest-native rootfs change also exposed macOS-only code to Linux production builds, causing 44 Clippy errors.

## Validation
- cargo fmt --all -- --check
- cargo clippy --locked --workspace --all-targets -- -D warnings (Linux/WSL)
- cargo test --locked --workspace --lib (Linux/WSL; all passed)
- focused lifecycle regression: 1 passed
- ext4/cache tests: 12 passed
- CLI diff tests: 8 passed