### PR TITLE
fix(runtime): preflight OCI isolation before image mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- **Fail-closed OCI isolation before CLI product mutation.** `run` and `create`
+  now ask the active migration router to preflight the selected isolation before
+  named-volume creation or image-cache access. OCI-routed MicroVM requests
+  require a launch-ready `DedicatedVm` driver without falling back to the legacy
+  backend, and record creation repeats the mutable capability check before
+  durable reservation.
 - MicroVM and Compose startup now preserve container-runtime invariants across
   arbitrary images: `--network none` disables networking, completed
   dependencies require an authoritative zero exit status, empty managed

--- a/README.md
+++ b/README.md
@@ -288,9 +288,11 @@ rootfs into the exact operation-scoped SDK handoff, converts its image metadata
 to `a3s.oci.rootfs-metadata.v1`, emits a relative `rootfs` OCI specification
 without a user namespace, and atomically publishes the bundle. OCI Runtime
 then moves that bundle into the exact WHPX generation share. Missing extension
-support or any unqualified option fails before image preparation. The endpoint
-must be supplied explicitly so this experimental service can never activate by
-accident.
+support or any unqualified option fails before image preparation. In addition,
+`run` and `create` require the migration router to observe a launch-ready
+`DedicatedVm` driver before named-volume creation or image-cache access. The
+endpoint must be supplied explicitly so this experimental service can never
+activate by accident.
 
 Current Linux opt-in limits are intentional: only new Sandbox reservations are
 routed there; `all`/MicroVM migration is rejected on Linux; image-declared

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,8 +118,11 @@ pass, and Box has not yet selected the unified backend for production MicroVM
 launches.
 
 Box now also contains an explicitly constructed `OciLocalExecutionBackend` and
-SDK-only lifecycle adapter. The opt-in path preflights launch-ready isolation
-and `a3s.oci.attachments.v1` support before reservation or bundle preparation,
+SDK-only lifecycle adapter. The CLI asks the active migration router to
+preflight the selected isolation before named-volume creation or image-cache
+access. An OCI route requires a launch-ready driver at that boundary, then
+repeats launch-readiness and `a3s.oci.attachments.v1` checks during record
+preflight before reservation or bundle preparation,
 keeps Box and runtime generations in separate durable fields, derives a
 versioned manifest for rootfs, mounts, networking, process I/O, secret
 classifications, and optional extensions, and persists exact
@@ -253,6 +256,14 @@ recovery remains a release gate rather than claimed evidence.
   process I/O, secrets, and optional runtime extensions.
 - [x] Reject an unavailable isolation class before image or product-state
   mutation.
+
+The early boundary is exercised through
+`selected_oci_isolation_preflight_fails_closed_without_fallback_or_state` at
+the migration router and
+`isolation_preflight_rejects_probe_only_driver_without_product_mutation`
+against the SDK-backed backend. The `run` and `create` CLI paths invoke that
+boundary before named-volume or image operations; record creation deliberately
+repeats the mutable capability check before durable reservation.
 
 Exit gate: the target architecture compiles behind an opt-in migration flag,
 and dependency checks prove that Box imports no OCI Runtime implementation

--- a/docs/windows-whpx.md
+++ b/docs/windows-whpx.md
@@ -110,7 +110,9 @@ the Cargo target directory.
 
 Requests such as `--cpus 2` or `--health-cmd ...` fail before image pull with
 an explicit WHPX diagnostic. `--no-healthcheck` remains available to disable an
-image-defined health check.
+image-defined health check. Qualification-mode `run` and `create` also require
+the configured OCI service to advertise one launch-ready `DedicatedVm` driver
+before named-volume creation or image-cache access.
 
 ## Smoke test
 

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -48,24 +48,6 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         ensure_network_exists(network)?;
     }
 
-    let image_config = common::cached_image_config(&args.common.image).await?;
-    let health_check = common::effective_health_check(
-        &args.common,
-        image_config
-            .as_ref()
-            .and_then(|config| config.health_check.as_ref()),
-    );
-    common::validate_health_check_support(health_check.as_ref())
-        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    let effective_stop_signal = common::effective_stop_signal(
-        args.common.stop_signal.as_deref(),
-        image_config
-            .as_ref()
-            .and_then(|config| config.stop_signal.as_deref()),
-    );
-    let isolation = common::execution_isolation(&args.common);
-    let name = args.common.name.unwrap_or_else(generate_name);
-
     // Parse --shm-size
     let shm_size = match &args.common.shm_size {
         Some(s) => {
@@ -74,19 +56,7 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         None => None,
     };
 
-    let home = a3s_box_core::dirs_home();
-
-    // Resolve named volumes
-    let mut resolved_volumes = Vec::new();
-    let mut volume_names = Vec::new();
-    for vol_spec in &args.common.volumes {
-        let (resolved, vol_name) = super::volume::resolve_named_volume(vol_spec)?;
-        if let Some(name) = vol_name {
-            volume_names.push(name);
-        }
-        resolved_volumes.push(resolved);
-    }
-
+    let isolation = common::execution_isolation(&args.common);
     let entrypoint = args
         .common
         .entrypoint
@@ -96,7 +66,7 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
     let mut extra_env = env.into_iter().collect::<Vec<_>>();
     extra_env.sort_by(|left, right| left.0.cmp(&right.0));
 
-    let config = BoxConfig {
+    let mut config = BoxConfig {
         isolation,
         image: args.common.image.clone(),
         resources: ResourceConfig {
@@ -109,7 +79,7 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         user: args.common.user.clone(),
         workdir: args.common.workdir.clone(),
         hostname: args.common.hostname.clone(),
-        volumes: resolved_volumes,
+        volumes: args.common.volumes.clone(),
         virtiofs_cache: args
             .common
             .virtiofs_cache
@@ -131,6 +101,44 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         persistent: true,
         ..Default::default()
     };
+    a3s_box_core::resolve_execution(&config)?;
+
+    let home = a3s_box_core::dirs_home();
+    let manager = super::configured_local_execution_manager(&home).await?;
+    manager.preflight_isolation(isolation).await?;
+
+    // Resolve named volumes only after the selected route is launch-ready.
+    let mut resolved_volumes = Vec::new();
+    let mut volume_names = Vec::new();
+    for vol_spec in &args.common.volumes {
+        let (resolved, vol_name) = super::volume::resolve_named_volume(vol_spec)?;
+        if let Some(name) = vol_name {
+            volume_names.push(name);
+        }
+        resolved_volumes.push(resolved);
+    }
+    config.volumes = resolved_volumes;
+
+    // Image-defined lifecycle defaults are read only after the selected
+    // backend proves that this isolation currently has a launch-ready route.
+    // Record creation repeats mutable capability checks before reservation.
+    let image_config = common::cached_image_config(&args.common.image).await?;
+    let health_check = common::effective_health_check(
+        &args.common,
+        image_config
+            .as_ref()
+            .and_then(|config| config.health_check.as_ref()),
+    );
+    common::validate_health_check_support(health_check.as_ref())
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let effective_stop_signal = common::effective_stop_signal(
+        args.common.stop_signal.as_deref(),
+        image_config
+            .as_ref()
+            .and_then(|config| config.stop_signal.as_deref()),
+    );
+    let name = args.common.name.unwrap_or_else(generate_name);
+
     let policy = ExecutionRecordPolicy {
         name: Some(name.clone()),
         auto_remove: false,
@@ -159,7 +167,6 @@ pub async fn execute(args: CreateArgs) -> Result<(), Box<dyn std::error::Error>>
         policy,
         rootfs_snapshot_id: None,
     };
-    let manager = super::configured_local_execution_manager(&home).await?;
     let reservation = manager.create(request, &operation_id).await?;
     let box_id = reservation.execution_id.to_string();
 

--- a/src/cli/src/commands/run/setup.rs
+++ b/src/cli/src/commands/run/setup.rs
@@ -55,9 +55,9 @@ pub(super) async fn setup_and_boot(
         .entrypoint
         .as_ref()
         .map(|ep| ep.split_whitespace().map(String::from).collect::<Vec<_>>());
+
     let mut volume_specs = args.common.volumes.clone();
     apply_package_caches(&args.package_cache, &mut volume_specs, &mut env);
-    let (resolved_volumes, volume_names) = resolve_volumes(&volume_specs)?;
 
     // Parse --shm-size once; reuse for both tmpfs entry and the box record.
     let shm_size = match &args.common.shm_size {
@@ -87,12 +87,12 @@ pub(super) async fn setup_and_boot(
 
     let tee = build_tee_config(args);
 
-    let config = build_box_config(
+    let mut config = build_box_config(
         args,
         memory_mb,
         resource_limits.clone(),
         entrypoint_override.clone(),
-        resolved_volumes.clone(),
+        volume_specs.clone(),
         env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
         port_map.clone(),
         network_mode.clone(),
@@ -102,11 +102,26 @@ pub(super) async fn setup_and_boot(
     .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
     a3s_box_core::resolve_execution(&config)?;
 
-    // Freeze image-defined lifecycle defaults into the managed creation
-    // request. Pulling is cache-first, and happens only after the pure backend
-    // compatibility check above, so an invalid Sandbox request has no registry
-    // or runtime side effects.
+    // Probe the route selected by the active migration policy after complete,
+    // side-effect-free configuration validation but before named-volume
+    // creation or image-cache access. Record creation repeats mutable checks.
     let pull_progress_fn = pull_progress_callback(args.common.image.clone());
+    let home = a3s_box_core::dirs_home();
+    let manager = LocalExecutionManager::with_configured_backend_and_pull_progress(
+        home.join("boxes.json"),
+        &home,
+        Some(std::sync::Arc::clone(&pull_progress_fn)),
+    )
+    .await?;
+    manager.preflight_isolation(config.isolation).await?;
+
+    let (resolved_volumes, volume_names) = resolve_volumes(&volume_specs)?;
+    config.volumes = resolved_volumes;
+
+    // Freeze image-defined lifecycle defaults into the managed creation
+    // request. Pulling is cache-first and happens only after both the pure
+    // configuration check and the selected backend's launch-readiness probe.
+    // Record creation repeats mutable capability checks before reservation.
     let image_config_start = std::time::Instant::now();
     let image_config = pull_image_config(args, std::sync::Arc::clone(&pull_progress_fn)).await?;
     a3s_box_core::lifecycle_profile::record_lifecycle_phase(
@@ -139,13 +154,6 @@ pub(super) async fn setup_and_boot(
             stop_signal: effective_stop_signal,
         },
     );
-    let home = a3s_box_core::dirs_home();
-    let manager = LocalExecutionManager::with_configured_backend_and_pull_progress(
-        home.join("boxes.json"),
-        &home,
-        Some(pull_progress_fn),
-    )
-    .await?;
     let reserve_start = std::time::Instant::now();
     let reservation = manager.create(request, &operation_id).await?;
     a3s_box_core::lifecycle_profile::record_lifecycle_phase("cli.reserve", reserve_start.elapsed());

--- a/src/runtime/src/local_execution/backend.rs
+++ b/src/runtime/src/local_execution/backend.rs
@@ -4,9 +4,10 @@ use std::path::PathBuf;
 
 use a3s_box_core::{
     pty::PtyRequest, ExecOutput, ExecRequest, ExecutionEventBatch, ExecutionEventsRequest,
-    ExecutionId, ExecutionManagerError, ExecutionManagerResult, ExecutionProcess,
-    ExecutionProcessInventory, ExecutionResourceUpdate, ExecutionState, ExecutionStats,
-    FileRequest, FileResponse, FilesystemRequest, FilesystemResponse, KillOutcome, OperationId,
+    ExecutionId, ExecutionIsolation, ExecutionManagerError, ExecutionManagerResult,
+    ExecutionProcess, ExecutionProcessInventory, ExecutionResourceUpdate, ExecutionState,
+    ExecutionStats, FileRequest, FileResponse, FilesystemRequest, FilesystemResponse, KillOutcome,
+    OperationId,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -97,6 +98,16 @@ impl LocalExecutionObservation {
 /// external sandbox ID in managed metadata is an untrusted diagnostic label.
 #[async_trait]
 pub trait LocalExecutionBackend: Send + Sync {
+    /// Perform any backend-only launch-readiness probe available before callers
+    /// execute external image operations. Backends without a context-free probe
+    /// may defer to record preflight. Mutable checks must be repeated there.
+    async fn preflight_isolation(
+        &self,
+        _isolation: ExecutionIsolation,
+    ) -> ExecutionManagerResult<()> {
+        Ok(())
+    }
+
     /// Select the durable route for a new record before capability preflight.
     ///
     /// Custom test or embedding backends may leave the route unspecified. Box

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -51,7 +51,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use a3s_box_core::{
-    ExecutionGeneration, ExecutionId, ExecutionManagerError, ExecutionManagerResult,
+    ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionManagerError,
+    ExecutionManagerResult,
 };
 
 pub use backend::{
@@ -100,6 +101,16 @@ impl LocalExecutionManager {
 
     pub fn state_path(&self) -> &std::path::Path {
         self.store.path()
+    }
+
+    /// Probe the backend selected by the current creation policy before an
+    /// image pull or other product preparation. Record creation repeats all
+    /// mutable capability checks before publishing durable state.
+    pub async fn preflight_isolation(
+        &self,
+        isolation: ExecutionIsolation,
+    ) -> ExecutionManagerResult<()> {
+        self.backend.preflight_isolation(isolation).await
     }
 
     pub(super) async fn require_running_record(

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -1526,6 +1526,13 @@ async fn rollback_execution_resources(resources: ExecutionResourceGuard, record:
 
 #[async_trait]
 impl LocalExecutionBackend for OciLocalExecutionBackend {
+    async fn preflight_isolation(
+        &self,
+        isolation: ExecutionIsolation,
+    ) -> ExecutionManagerResult<()> {
+        self.adapter.require_isolation(isolation).await.map(|_| ())
+    }
+
     fn route_for_create(
         &self,
         _record: &BoxRecord,

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -1690,6 +1690,32 @@ fn durable_state_rejects_a_runtime_binding_owned_by_another_product_execution() 
 }
 
 #[tokio::test]
+async fn isolation_preflight_rejects_probe_only_driver_without_product_mutation() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::probe_only());
+    let provider = Arc::new(FakeBundleProvider::default());
+    let manager = manager(
+        &directory,
+        test_endpoint(),
+        service.clone(),
+        provider.clone(),
+    );
+
+    let error = manager
+        .preflight_isolation(ExecutionIsolation::Microvm)
+        .await
+        .expect_err("probe-only driver must fail the early isolation preflight");
+
+    assert!(matches!(
+        error,
+        ExecutionManagerError::Unavailable(message) if message.contains("launch-ready")
+    ));
+    assert!(!manager.state_path().exists());
+    assert_eq!(provider.prepares.load(Ordering::SeqCst), 0);
+    assert!(service.create_requests().is_empty());
+}
+
+#[tokio::test]
 async fn preflight_rejects_probe_only_isolation_before_store_or_preparation() {
     let directory = tempfile::tempdir().expect("temporary directory");
     let service = Arc::new(FakeRuntimeService::probe_only());

--- a/src/runtime/src/local_execution/router.rs
+++ b/src/runtime/src/local_execution/router.rs
@@ -75,6 +75,19 @@ impl LocalExecutionBackendRouter {
         self.policy
     }
 
+    fn backend_for_isolation(
+        &self,
+        isolation: ExecutionIsolation,
+    ) -> &Arc<dyn LocalExecutionBackend> {
+        match self.policy.route(isolation) {
+            ManagedRuntimeRoute::BoxVm => &self.legacy,
+            ManagedRuntimeRoute::OciSdk => &self.oci,
+            ManagedRuntimeRoute::Unspecified => {
+                unreachable!("creation policy always selects a route")
+            }
+        }
+    }
+
     fn route_for_record(&self, record: &BoxRecord) -> ExecutionManagerResult<ManagedRuntimeRoute> {
         resolved_runtime_route(record)
     }
@@ -123,6 +136,15 @@ pub(super) fn resolved_runtime_route(
 
 #[async_trait]
 impl LocalExecutionBackend for LocalExecutionBackendRouter {
+    async fn preflight_isolation(
+        &self,
+        isolation: ExecutionIsolation,
+    ) -> ExecutionManagerResult<()> {
+        self.backend_for_isolation(isolation)
+            .preflight_isolation(isolation)
+            .await
+    }
+
     fn route_for_create(&self, record: &BoxRecord) -> ExecutionManagerResult<ManagedRuntimeRoute> {
         if record.managed_execution.is_none() {
             return Err(ExecutionManagerError::Internal(format!(

--- a/src/runtime/src/local_execution/router_tests.rs
+++ b/src/runtime/src/local_execution/router_tests.rs
@@ -17,19 +17,30 @@ use crate::{BoxRecord, ManagedRuntimeRoute};
 
 #[derive(Default)]
 struct RoutedProbeBackend {
+    fail_isolation_preflight: AtomicBool,
     fail_preflight: AtomicBool,
+    isolation_preflights: AtomicUsize,
     preflights: AtomicUsize,
     kills: AtomicUsize,
+    observed_isolations: Mutex<Vec<ExecutionIsolation>>,
     observed_routes: Mutex<Vec<ManagedRuntimeRoute>>,
 }
 
 impl RoutedProbeBackend {
+    fn reject_isolation_preflight(&self) {
+        self.fail_isolation_preflight.store(true, Ordering::Relaxed);
+    }
+
     fn reject_preflight(&self) {
         self.fail_preflight.store(true, Ordering::Relaxed);
     }
 
     fn preflights(&self) -> usize {
         self.preflights.load(Ordering::Relaxed)
+    }
+
+    fn isolation_preflights(&self) -> usize {
+        self.isolation_preflights.load(Ordering::Relaxed)
     }
 
     fn kills(&self) -> usize {
@@ -39,10 +50,29 @@ impl RoutedProbeBackend {
     fn observed_routes(&self) -> Vec<ManagedRuntimeRoute> {
         self.observed_routes.lock().unwrap().clone()
     }
+
+    fn observed_isolations(&self) -> Vec<ExecutionIsolation> {
+        self.observed_isolations.lock().unwrap().clone()
+    }
 }
 
 #[async_trait]
 impl LocalExecutionBackend for RoutedProbeBackend {
+    async fn preflight_isolation(
+        &self,
+        isolation: ExecutionIsolation,
+    ) -> ExecutionManagerResult<()> {
+        self.isolation_preflights.fetch_add(1, Ordering::Relaxed);
+        self.observed_isolations.lock().unwrap().push(isolation);
+        if self.fail_isolation_preflight.load(Ordering::Relaxed) {
+            Err(ExecutionManagerError::Unavailable(
+                "selected isolation is unavailable".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     async fn preflight(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {
         self.preflights.fetch_add(1, Ordering::Relaxed);
         self.observed_routes.lock().unwrap().push(
@@ -98,6 +128,35 @@ impl LocalExecutionBackend for RoutedProbeBackend {
         self.kills.fetch_add(1, Ordering::Relaxed);
         Ok(KillOutcome::Killed)
     }
+}
+
+#[tokio::test]
+async fn selected_oci_isolation_preflight_fails_closed_without_fallback_or_state() {
+    let temporary = tempfile::tempdir().unwrap();
+    let state_path = temporary.path().join("boxes.json");
+    let legacy = Arc::new(RoutedProbeBackend::default());
+    let oci = Arc::new(RoutedProbeBackend::default());
+    oci.reject_isolation_preflight();
+    let manager = LocalExecutionManager::new(
+        &state_path,
+        temporary.path(),
+        Arc::new(LocalExecutionBackendRouter::new(
+            legacy.clone(),
+            oci.clone(),
+            OciMigrationPolicy::AllViaOci,
+        )),
+    );
+
+    let error = manager
+        .preflight_isolation(ExecutionIsolation::Microvm)
+        .await
+        .expect_err("selected OCI isolation must fail closed");
+
+    assert!(matches!(error, ExecutionManagerError::Unavailable(_)));
+    assert_eq!(legacy.isolation_preflights(), 0);
+    assert_eq!(oci.isolation_preflights(), 1);
+    assert_eq!(oci.observed_isolations(), vec![ExecutionIsolation::Microvm]);
+    assert!(!state_path.exists());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add a backend-neutral early isolation preflight and route it through the active OCI migration policy
- require an OCI launch-ready driver before run/create can create named volumes or access the image cache
- retain the record-level capability preflight so mutable host state is checked again before reservation
- document and regress the fail-closed no-fallback boundary

## Validation
- cargo fmt --all -- --check
- cargo test -p a3s-box-runtime isolation_preflight -- --nocapture (2 passed)
- cargo test -p a3s-box-cli --no-run
- cargo clippy -p a3s-box-runtime -p a3s-box-cli --all-targets
- full local runtime/CLI suites: 2,146 tests passed; Windows symlink-only cases could not create test symlinks because this host lacks SeCreateSymbolicLinkPrivilege, and two concurrent tar cases passed when rerun alone