### PR TITLE
feat(runtime): persist OCI anonymous volume ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,11 @@ endpoint must be supplied explicitly so this experimental service can never
 activate by accident.
 
 Current Linux opt-in limits are intentional: only new Sandbox reservations are
-routed there; `all`/MicroVM migration is rejected on Linux; image-declared
-anonymous volumes must be replaced by explicit named or bind mounts. CLI
+routed there, and `all`/MicroVM migration is rejected on Linux. Image-declared
+anonymous volumes are planned from normalized image metadata after capability
+preflight, persisted in the initial Box reservation, and atomically claimed by
+the exact execution during bundle preparation. Recovery and removal therefore
+use durable ownership rather than scanning host directories. CLI
 `attach` now uses the persisted OCI route: read-only attach follows the
 generation-fenced Box console projection, while `attach -t` opens an exact
 managed PTY session; neither path falls back to a Box-owned runtime socket.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -432,11 +432,15 @@ owner replacement, and must publish final drain evidence before deletion.
   ownership, mode, symlink, or read-only semantics.
 - [ ] Add quiesce/resume integration for consistent stopped and online product
   snapshots.
+- [x] Persist normalized image-declared anonymous-volume identities before OCI
+  bundle preparation, enforce exact single-owner claims, and keep recovery and
+  removal driven by the durable Box record.
 
-The production provider currently accepts explicit bind/named/tmpfs mounts but
-rejects newly introduced image-declared anonymous volumes before Runtime
-mutation. That rejection remains until the complete B3 ownership and cleanup
-contract is qualified.
+The production provider accepts explicit bind/named/tmpfs mounts and now plans
+image-declared anonymous volumes without creating execution artifacts. Bundle
+preparation must reproduce the exact persisted plan before Runtime mutation;
+name collisions, ownership drift, duplicate destinations, and unsafe identities
+fail closed. The complete B3 storage/network qualification gate remains open.
 
 Exit gate: image, volume, snapshot, commit, copy, bridge/service networking,
 and cleanup suites pass without Box accessing a runtime-owned VM handle or

--- a/docs/host-sandbox-backend-design.md
+++ b/docs/host-sandbox-backend-design.md
@@ -266,6 +266,11 @@ The bundle compiler distinguishes:
 Mount destinations are normalized, traversal is rejected, and overlapping
 reserved paths fail validation. Volume ownership and UID/GID mapping are
 preserved across stop/restart and released exactly once at terminal cleanup.
+Image-declared anonymous volumes use a two-phase Box contract: immutable image
+metadata produces deterministic execution-bound identities before the initial
+record is reserved, then bundle preparation atomically claims only those exact
+identities. A named-volume collision or a different existing owner fails closed;
+no rootfs, mount, workspace, socket, or volume is created by the planning phase.
 
 Caller-owned read-only sources may live below a provider directory that is
 intentionally not searchable by the mapped container identity. Box opens the

--- a/src/cli/src/cleanup.rs
+++ b/src/cli/src/cleanup.rs
@@ -98,14 +98,14 @@ pub fn cleanup_stopped_box(record: &BoxRecord) -> a3s_box_core::error::Result<()
 }
 
 /// Remove anonymous volumes created from OCI `VOLUME` declarations.
-pub fn cleanup_anonymous_volumes(anonymous_volumes: &[String]) {
+pub fn cleanup_anonymous_volumes(box_id: &str, anonymous_volumes: &[String]) {
     if anonymous_volumes.is_empty() {
         return;
     }
 
     if let Ok(vol_store) = a3s_box_runtime::VolumeStore::default_path() {
         for volume_name in anonymous_volumes {
-            if let Err(err) = vol_store.remove(volume_name, true) {
+            if let Err(err) = vol_store.remove_anonymous(volume_name, box_id) {
                 tracing::debug!(
                     volume = volume_name,
                     error = %err,
@@ -176,7 +176,7 @@ pub fn cleanup_removed_box(record: &BoxRecord) -> a3s_box_core::error::Result<()
             .map(String::as_str),
     )?;
     cleanup_record_resources(record);
-    cleanup_anonymous_volumes(&record.anonymous_volumes);
+    cleanup_anonymous_volumes(&record.id, &record.anonymous_volumes);
     remove_host_cgroup(record);
 
     if record.box_dir.exists() {

--- a/src/cli/src/commands/compose/lifecycle.rs
+++ b/src/cli/src/commands/compose/lifecycle.rs
@@ -80,7 +80,7 @@ pub(super) fn cleanup_partial_service_box(
     anonymous_volumes: &[String],
 ) {
     crate::cleanup::cleanup_box_resources(box_id, volume_names, network_name);
-    crate::cleanup::cleanup_anonymous_volumes(anonymous_volumes);
+    crate::cleanup::cleanup_anonymous_volumes(box_id, anonymous_volumes);
     // Release every directory-rootfs compatibility provider before deleting
     // the box dir. Linux may use overlayfs and snapshot/legacy macOS boxes may
     // use APFS; guest-native ext4 has no host mount. Resource cleanup above

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -640,7 +640,7 @@ async fn cleanup_managed_execution(
         if natural_exit {
             // Explicit managed kills remove auto-remove anonymous volumes in the
             // backend. Natural exit has no kill path, so the CLI owns cleanup.
-            crate::cleanup::cleanup_anonymous_volumes(&ctx.anonymous_volumes);
+            crate::cleanup::cleanup_anonymous_volumes(&ctx.box_id, &ctx.anonymous_volumes);
         }
         if let Err(error) = std::fs::remove_dir_all(&ctx.box_dir) {
             if error.kind() != std::io::ErrorKind::NotFound {

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -83,10 +83,10 @@ pub use box_state::BoxStateStore;
 pub use local_execution::{
     acquire_execution_lifecycle_lock, ExecutionLifecycleLock, LocalExecutionBackend,
     LocalExecutionBackendRouter, LocalExecutionHandle, LocalExecutionManager,
-    LocalExecutionObservation, LocalExecutionTermination, OciBundlePreparationContext,
-    OciBundleProvider, OciLifecycleAdapter, OciLocalExecutionBackend, OciMigrationPolicy,
-    OciPreparedExecution, OciRuntimeBinding, OciRuntimeEndpoint, OciRuntimeLaunch,
-    OCI_RUNTIME_BINDING_SCHEMA_VERSION,
+    LocalExecutionObservation, LocalExecutionResourcePlan, LocalExecutionTermination,
+    OciBundlePreparationContext, OciBundleProvider, OciLifecycleAdapter, OciLocalExecutionBackend,
+    OciMigrationPolicy, OciPreparedExecution, OciRuntimeBinding, OciRuntimeEndpoint,
+    OciRuntimeLaunch, OCI_RUNTIME_BINDING_SCHEMA_VERSION,
 };
 #[cfg(feature = "vm")]
 pub use local_execution::{

--- a/src/runtime/src/local_execution/api.rs
+++ b/src/runtime/src/local_execution/api.rs
@@ -39,6 +39,10 @@ impl ExecutionManager for LocalExecutionManager {
             })?
             .runtime_route = route;
         self.backend.preflight(&record).await?;
+        self.backend
+            .plan_create_resources(&record)
+            .await?
+            .apply_to(&mut record)?;
         let reservation = self.reserve(record).await?;
         super::record::reservation_from_record(reservation.record())
     }

--- a/src/runtime/src/local_execution/backend.rs
+++ b/src/runtime/src/local_execution/backend.rs
@@ -11,9 +11,59 @@ use a3s_box_core::{
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use std::collections::HashSet;
 
 use crate::local_execution::OciRuntimeBinding;
 use crate::{BoxRecord, ManagedRuntimeRoute};
+
+/// Product resources derived by a backend before a new execution is reserved.
+///
+/// Planning may resolve immutable image metadata, but it must not create any
+/// execution-owned resource. The manager validates and persists this plan in
+/// the [`BoxRecord`] before `start` may materialize it, so restart recovery and
+/// removal never have to infer ownership from host artifacts.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LocalExecutionResourcePlan {
+    /// Exact Box-owned anonymous volume identities required by the image.
+    pub anonymous_volumes: Vec<String>,
+}
+
+impl LocalExecutionResourcePlan {
+    pub(crate) fn apply_to(self, record: &mut BoxRecord) -> ExecutionManagerResult<()> {
+        if !record.anonymous_volumes.is_empty() {
+            return Err(ExecutionManagerError::Internal(format!(
+                "new execution {} already contains anonymous-volume ownership",
+                record.id
+            )));
+        }
+
+        let mut seen = HashSet::with_capacity(self.anonymous_volumes.len());
+        for name in &self.anonymous_volumes {
+            if !valid_planned_volume_name(name) {
+                return Err(ExecutionManagerError::Internal(format!(
+                    "backend planned an invalid anonymous-volume identity for {}: {name:?}",
+                    record.id
+                )));
+            }
+            if !seen.insert(name) {
+                return Err(ExecutionManagerError::Internal(format!(
+                    "backend planned duplicate anonymous-volume identity {name:?} for {}",
+                    record.id
+                )));
+            }
+        }
+        record.anonymous_volumes = self.anonymous_volumes;
+        Ok(())
+    }
+}
+
+fn valid_planned_volume_name(name: &str) -> bool {
+    name.starts_with("anon_")
+        && name.len() <= 128
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
 
 /// Runtime evidence persisted after an execution becomes ready.
 #[derive(Debug, Clone)]
@@ -121,6 +171,17 @@ pub trait LocalExecutionBackend: Send + Sync {
     /// published. Backends must repeat mutable capability checks at launch.
     async fn preflight(&self, _record: &BoxRecord) -> ExecutionManagerResult<()> {
         Ok(())
+    }
+
+    /// Derive execution-owned resource identities without materializing them.
+    ///
+    /// The manager invokes this only after backend preflight and publishes the
+    /// returned identities as part of the initial durable reservation.
+    async fn plan_create_resources(
+        &self,
+        _record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionResourcePlan> {
+        Ok(LocalExecutionResourcePlan::default())
     }
 
     async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle>;

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -58,7 +58,7 @@ use a3s_box_core::{
 
 pub use backend::{
     LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation,
-    LocalExecutionTermination,
+    LocalExecutionResourcePlan, LocalExecutionTermination,
 };
 pub use oci_backend::{
     oci_isolation_request, OciBundlePreparationContext, OciBundleProvider, OciLifecycleAdapter,

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -45,7 +45,7 @@ use sha2::{Digest, Sha256};
 use super::resources::ExecutionResourceGuard;
 use super::{
     LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation,
-    LocalExecutionTermination,
+    LocalExecutionResourcePlan, LocalExecutionTermination,
 };
 use crate::{BoxRecord, ManagedExecutionState};
 
@@ -419,7 +419,7 @@ impl OciPreparedExecution {
         }
         if self.anonymous_volumes != record.anonymous_volumes {
             return Err(ExecutionManagerError::InvalidRequest(format!(
-                "A3S OCI preparation introduced uncommitted anonymous-volume state for {}",
+                "A3S OCI preparation drifted from the durable anonymous-volume plan for {}",
                 record.id
             )));
         }
@@ -523,6 +523,15 @@ pub trait OciBundleProvider: Send + Sync {
         _context: &OciBundlePreparationContext,
     ) -> ExecutionManagerResult<()> {
         Ok(())
+    }
+
+    /// Derive Box-owned identities from immutable image metadata without
+    /// creating the bundle, rootfs, mounts, or volumes they will later name.
+    async fn plan_create_resources(
+        &self,
+        _record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionResourcePlan> {
+        Ok(LocalExecutionResourcePlan::default())
     }
 
     /// Prepare one immutable OCI bundle after runtime capability preflight.
@@ -1545,6 +1554,14 @@ impl LocalExecutionBackend for OciLocalExecutionBackend {
         let info = self.adapter.require_isolation(record.isolation).await?;
         let context = self.preparation_context(record, &info)?;
         self.provider.preflight(record, &context)
+    }
+
+    async fn plan_create_resources(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionResourcePlan> {
+        self.metadata(record)?;
+        self.provider.plan_create_resources(record).await
     }
 
     async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -1268,6 +1268,7 @@ impl OciRuntimeService for FakeRuntimeService {
 
 #[derive(Default)]
 struct FakeBundleProvider {
+    resource_plans: AtomicUsize,
     prepares: AtomicUsize,
     cleanups: AtomicUsize,
     projection_ensures: AtomicUsize,
@@ -1278,10 +1279,25 @@ struct FakeBundleProvider {
     expected_snapshot_lower: Mutex<Option<std::path::PathBuf>>,
     snapshot_lower_observed: AtomicBool,
     last_box_dir: Mutex<Option<std::path::PathBuf>>,
+    planned_anonymous_volumes: Mutex<Vec<String>>,
 }
 
 #[async_trait]
 impl OciBundleProvider for FakeBundleProvider {
+    async fn plan_create_resources(
+        &self,
+        _record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionResourcePlan> {
+        self.resource_plans.fetch_add(1, Ordering::SeqCst);
+        Ok(LocalExecutionResourcePlan {
+            anonymous_volumes: self
+                .planned_anonymous_volumes
+                .lock()
+                .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?
+                .clone(),
+        })
+    }
+
     async fn prepare(
         &self,
         record: &BoxRecord,
@@ -1714,6 +1730,39 @@ async fn isolation_preflight_rejects_probe_only_driver_without_product_mutation(
     assert!(!manager.state_path().exists());
     assert_eq!(provider.prepares.load(Ordering::SeqCst), 0);
     assert!(service.create_requests().is_empty());
+}
+
+#[tokio::test]
+async fn create_persists_provider_resource_plan_before_any_runtime_preparation() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let provider = Arc::new(FakeBundleProvider::default());
+    *provider.planned_anonymous_volumes.lock().unwrap() =
+        vec!["anon_12345678_0123456789abcdef0123456789abcdef".to_string()];
+    let manager = manager(
+        &directory,
+        test_endpoint(),
+        service.clone(),
+        provider.clone(),
+    );
+
+    let reservation = manager
+        .create(
+            request("planned-resources", ExecutionIsolation::Sandbox),
+            &box_operation("planned-resources-create"),
+        )
+        .await
+        .expect("reserve the provider resource plan");
+    let record = persisted(&manager, &reservation.execution_id);
+
+    assert_eq!(
+        record.anonymous_volumes,
+        vec!["anon_12345678_0123456789abcdef0123456789abcdef"]
+    );
+    assert_eq!(provider.resource_plans.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.prepares.load(Ordering::SeqCst), 0);
+    assert!(service.create_requests().is_empty());
+    assert!(!record.box_dir.exists());
 }
 
 #[tokio::test]

--- a/src/runtime/src/local_execution/oci_production.rs
+++ b/src/runtime/src/local_execution/oci_production.rs
@@ -11,10 +11,11 @@ use a3s_oci_sdk::{CreateAttachments, IoMode, IsolationRequest, OciBundle, Proces
 use async_trait::async_trait;
 
 use super::{
-    OciBundlePreparationContext, OciBundleProvider, OciPreparedExecution, VmLocalExecutionBackend,
+    LocalExecutionResourcePlan, OciBundlePreparationContext, OciBundleProvider,
+    OciPreparedExecution, VmLocalExecutionBackend,
 };
 use crate::sandbox::probe_sandbox_capabilities_for;
-use crate::BoxRecord;
+use crate::{BoxRecord, ManagedExecutionMetadata};
 
 /// Prepares immutable bundles from Box image/rootfs policy while the separate
 /// A3S OCI Runtime service owns container lifecycle and I/O.
@@ -79,32 +80,49 @@ impl NativeLinuxOciBundleProvider {
 
 #[async_trait]
 impl OciBundleProvider for NativeLinuxOciBundleProvider {
+    async fn plan_create_resources(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionResourcePlan> {
+        let metadata = native_linux_metadata(record)?;
+        let mut manager = self.preparer.new_oci_preparation_manager(record)?;
+        let anonymous_volumes =
+            if let Some(snapshot_id) = metadata.request.rootfs_snapshot_id.as_ref() {
+                let home_dir = self.preparer.home_dir().to_path_buf();
+                let snapshot_id = snapshot_id.to_string();
+                let expected_image = metadata.request.config.image.clone();
+                let config = tokio::task::spawn_blocking(move || {
+                    let store = crate::SnapshotStore::new(&home_dir.join("snapshots"))?;
+                    let _snapshot_lock = store.acquire_exclusive_lock()?;
+                    let rootfs = store.rootfs_path(&snapshot_id);
+                    crate::resolved_image::load_snapshot_oci_config(&rootfs, &expected_image)
+                })
+                .await
+                .map_err(|error| {
+                    ExecutionManagerError::Internal(format!(
+                        "native Linux OCI snapshot resource planning task failed: {error}"
+                    ))
+                })?
+                .map_err(|error| preparation_error("plan snapshot-owned resources", error))?;
+                manager
+                    .plan_anonymous_volumes(&config)
+                    .map(|plans| plans.into_iter().map(|plan| plan.name).collect())
+                    .map_err(|error| preparation_error("plan snapshot-owned resources", error))?
+            } else {
+                manager
+                    .plan_image_anonymous_volumes()
+                    .await
+                    .map_err(|error| preparation_error("plan image-owned resources", error))?
+            };
+        Ok(LocalExecutionResourcePlan { anonymous_volumes })
+    }
+
     async fn prepare(
         &self,
         record: &BoxRecord,
         _context: &OciBundlePreparationContext,
     ) -> ExecutionManagerResult<OciPreparedExecution> {
-        if record.isolation != ExecutionIsolation::Sandbox {
-            return Err(ExecutionManagerError::InvalidRequest(format!(
-                "native Linux OCI migration only prepares Sandbox executions, got {:?}",
-                record.isolation
-            )));
-        }
-        let metadata = record.managed_execution.as_ref().ok_or_else(|| {
-            ExecutionManagerError::Internal(format!(
-                "execution {} has no managed lifecycle metadata",
-                record.id
-            ))
-        })?;
-        metadata
-            .validate()
-            .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
-        if metadata.plan.backend != ExecutionBackend::A3sOci {
-            return Err(ExecutionManagerError::InvalidRequest(format!(
-                "execution {} did not resolve to the A3S OCI Sandbox backend",
-                record.id
-            )));
-        }
+        let metadata = native_linux_metadata(record)?;
 
         // Re-hash the exact configured artifacts immediately before rootfs or
         // bundle mutations. Owner startup and bundle evidence use this same pair.
@@ -546,6 +564,31 @@ fn preparation_error(action: &str, error: BoxError) -> ExecutionManagerError {
     }
 }
 
+fn native_linux_metadata(record: &BoxRecord) -> ExecutionManagerResult<&ManagedExecutionMetadata> {
+    if record.isolation != ExecutionIsolation::Sandbox {
+        return Err(ExecutionManagerError::InvalidRequest(format!(
+            "native Linux OCI migration only prepares Sandbox executions, got {:?}",
+            record.isolation
+        )));
+    }
+    let metadata = record.managed_execution.as_ref().ok_or_else(|| {
+        ExecutionManagerError::Internal(format!(
+            "execution {} has no managed lifecycle metadata",
+            record.id
+        ))
+    })?;
+    metadata
+        .validate()
+        .map_err(|error| ExecutionManagerError::Internal(error.to_string()))?;
+    if metadata.plan.backend != ExecutionBackend::A3sOci {
+        return Err(ExecutionManagerError::InvalidRequest(format!(
+            "execution {} did not resolve to the A3S OCI Sandbox backend",
+            record.id
+        )));
+    }
+    Ok(metadata)
+}
+
 fn cleanup_after_prepare_failure(
     manager: &crate::VmManager,
     message: String,
@@ -555,5 +598,75 @@ fn cleanup_after_prepare_failure(
         Err(cleanup) => {
             ExecutionManagerError::Internal(format!("{message}; cleanup also failed: {cleanup}"))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use a3s_box_core::{
+        BoxConfig, CreateExecutionRequest, ExecutionId, ExecutionIsolation, ExecutionSnapshotId,
+        NetworkMode, OperationId, SnapshotImageConfig, SnapshotMetadata,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn native_resource_plan_uses_snapshot_metadata_without_resolving_a_moved_tag() {
+        let temporary = tempfile::tempdir().unwrap();
+        let home = temporary.path().join("home");
+        let snapshot_id = "anonymous-volume-snapshot";
+        let image = "example.invalid/moved:latest";
+        let source = temporary.path().join("snapshot-rootfs");
+        std::fs::create_dir_all(&source).unwrap();
+        let mut snapshot = SnapshotMetadata::new(
+            snapshot_id.to_string(),
+            snapshot_id.to_string(),
+            "source-execution".to_string(),
+            image.to_string(),
+        );
+        snapshot.image_config = Some(SnapshotImageConfig {
+            volumes: vec!["/snapshot-data".to_string()],
+            ..Default::default()
+        });
+        crate::SnapshotStore::new(&home.join("snapshots"))
+            .unwrap()
+            .save(snapshot, &source)
+            .unwrap();
+
+        let execution_id =
+            ExecutionId::new("12345678-0000-0000-0000-000000000001".to_string()).unwrap();
+        let request = CreateExecutionRequest {
+            external_sandbox_id: "snapshot-plan".to_string(),
+            config: BoxConfig {
+                image: image.to_string(),
+                isolation: ExecutionIsolation::Sandbox,
+                network: NetworkMode::None,
+                ..Default::default()
+            },
+            labels: BTreeMap::new(),
+            policy: Default::default(),
+            rootfs_snapshot_id: Some(ExecutionSnapshotId::new(snapshot_id).unwrap()),
+        };
+        let mut record = crate::local_execution::record::build_managed_record(
+            &home,
+            &execution_id,
+            OperationId::new("snapshot-resource-plan").unwrap(),
+            request,
+            chrono::Utc::now(),
+        )
+        .unwrap();
+        record.managed_execution.as_mut().unwrap().runtime_route =
+            crate::ManagedRuntimeRoute::OciSdk;
+        let provider = NativeLinuxOciBundleProvider::new(&home, "/runtime", "/agent");
+
+        let plan = provider.plan_create_resources(&record).await.unwrap();
+
+        assert_eq!(plan.anonymous_volumes.len(), 1);
+        assert!(plan.anonymous_volumes[0].starts_with("anon_12345678_"));
+        assert!(!home.join("images").exists());
+        assert!(!record.box_dir.exists());
+        assert!(!home.join("volumes").exists());
     }
 }

--- a/src/runtime/src/local_execution/remove.rs
+++ b/src/runtime/src/local_execution/remove.rs
@@ -153,15 +153,9 @@ fn remove_anonymous_volumes(home_dir: &Path, record: &BoxRecord) -> ExecutionMan
     }
     let store = crate::VolumeStore::new(home_dir.join("volumes.json"), home_dir.join("volumes"));
     for name in &record.anonymous_volumes {
-        if store
-            .get(name)
-            .map_err(|error| cleanup_error(record, "inspect an anonymous volume", error))?
-            .is_some()
-        {
-            store
-                .remove(name, true)
-                .map_err(|error| cleanup_error(record, "remove an anonymous volume", error))?;
-        }
+        store
+            .remove_anonymous(name, &record.id)
+            .map_err(|error| cleanup_error(record, "remove an anonymous volume", error))?;
     }
     Ok(())
 }

--- a/src/runtime/src/local_execution/router.rs
+++ b/src/runtime/src/local_execution/router.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 
 use super::{
     LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation,
-    LocalExecutionTermination,
+    LocalExecutionResourcePlan, LocalExecutionTermination,
 };
 use crate::{BoxRecord, ManagedRuntimeRoute};
 
@@ -157,6 +157,15 @@ impl LocalExecutionBackend for LocalExecutionBackendRouter {
 
     async fn preflight(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {
         self.backend_for_record(record)?.preflight(record).await
+    }
+
+    async fn plan_create_resources(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionResourcePlan> {
+        self.backend_for_record(record)?
+            .plan_create_resources(record)
+            .await
     }
 
     async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {

--- a/src/runtime/src/local_execution/router_tests.rs
+++ b/src/runtime/src/local_execution/router_tests.rs
@@ -11,7 +11,8 @@ use async_trait::async_trait;
 use super::record::build_managed_record;
 use super::{
     LocalExecutionBackend, LocalExecutionBackendRouter, LocalExecutionHandle,
-    LocalExecutionManager, LocalExecutionObservation, OciMigrationPolicy,
+    LocalExecutionManager, LocalExecutionObservation, LocalExecutionResourcePlan,
+    OciMigrationPolicy,
 };
 use crate::{BoxRecord, ManagedRuntimeRoute};
 
@@ -24,6 +25,7 @@ struct RoutedProbeBackend {
     kills: AtomicUsize,
     observed_isolations: Mutex<Vec<ExecutionIsolation>>,
     observed_routes: Mutex<Vec<ManagedRuntimeRoute>>,
+    planned_anonymous_volumes: Mutex<Vec<String>>,
 }
 
 impl RoutedProbeBackend {
@@ -53,6 +55,11 @@ impl RoutedProbeBackend {
 
     fn observed_isolations(&self) -> Vec<ExecutionIsolation> {
         self.observed_isolations.lock().unwrap().clone()
+    }
+
+    fn plan_anonymous_volumes(&self, names: &[&str]) {
+        *self.planned_anonymous_volumes.lock().unwrap() =
+            names.iter().map(|name| (*name).to_string()).collect();
     }
 }
 
@@ -89,6 +96,15 @@ impl LocalExecutionBackend for RoutedProbeBackend {
         } else {
             Ok(())
         }
+    }
+
+    async fn plan_create_resources(
+        &self,
+        _record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionResourcePlan> {
+        Ok(LocalExecutionResourcePlan {
+            anonymous_volumes: self.planned_anonymous_volumes.lock().unwrap().clone(),
+        })
     }
 
     async fn start(&self, _record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {
@@ -164,6 +180,7 @@ async fn sandbox_policy_stamps_oci_route_before_preflight_and_reservation() {
     let temporary = tempfile::tempdir().unwrap();
     let legacy = Arc::new(RoutedProbeBackend::default());
     let oci = Arc::new(RoutedProbeBackend::default());
+    oci.plan_anonymous_volumes(&["anon_planned_one", "anon_planned_two"]);
     let router = LocalExecutionBackendRouter::new(
         legacy.clone(),
         oci.clone(),
@@ -189,12 +206,45 @@ async fn sandbox_policy_stamps_oci_route_before_preflight_and_reservation() {
         .expect("reserved record");
 
     assert_eq!(
-        record.managed_execution.unwrap().runtime_route,
+        record.managed_execution.as_ref().unwrap().runtime_route,
         ManagedRuntimeRoute::OciSdk
     );
     assert_eq!(legacy.preflights(), 0);
     assert_eq!(oci.preflights(), 1);
     assert_eq!(oci.observed_routes(), vec![ManagedRuntimeRoute::OciSdk]);
+    assert_eq!(
+        record.anonymous_volumes,
+        vec!["anon_planned_one", "anon_planned_two"]
+    );
+}
+
+#[tokio::test]
+async fn invalid_backend_resource_plan_is_never_reserved() {
+    let temporary = tempfile::tempdir().unwrap();
+    let state_path = temporary.path().join("boxes.json");
+    let legacy = Arc::new(RoutedProbeBackend::default());
+    let oci = Arc::new(RoutedProbeBackend::default());
+    oci.plan_anonymous_volumes(&["../escaped"]);
+    let manager = LocalExecutionManager::new(
+        &state_path,
+        temporary.path(),
+        Arc::new(LocalExecutionBackendRouter::new(
+            legacy,
+            oci,
+            OciMigrationPolicy::AllViaOci,
+        )),
+    );
+
+    let error = manager
+        .create(
+            request(ExecutionIsolation::Sandbox),
+            &OperationId::new("invalid-resource-plan").unwrap(),
+        )
+        .await
+        .expect_err("unsafe planned identities must fail before reservation");
+
+    assert!(matches!(error, ExecutionManagerError::Internal(_)));
+    assert!(!state_path.exists());
 }
 
 #[tokio::test]

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -473,7 +473,8 @@ impl VmLocalExecutionBackend {
             if anonymous_volumes.is_empty() {
                 anonymous_volumes = self.anonymous_volumes_for_record(record).await;
             }
-            self.cleanup_anonymous_volumes(anonymous_volumes).await;
+            self.cleanup_anonymous_volumes(&record.id, anonymous_volumes)
+                .await;
         }
         Ok(LocalExecutionTermination {
             outcome: KillOutcome::Killed,
@@ -530,18 +531,19 @@ impl VmLocalExecutionBackend {
         }
     }
 
-    async fn cleanup_anonymous_volumes(&self, names: Vec<String>) {
+    async fn cleanup_anonymous_volumes(&self, owner: &str, names: Vec<String>) {
         if names.is_empty() {
             return;
         }
         let home_dir = self.home_dir.clone();
+        let owner = owner.to_string();
         let task = tokio::task::spawn_blocking(move || {
             let store = crate::VolumeStore::new(
                 home_dir.join("volumes.json"),
                 home_dir.join("volumes"),
             );
             for name in names {
-                if let Err(error) = store.remove(&name, true) {
+                if let Err(error) = store.remove_anonymous(&name, &owner) {
                     tracing::warn!(volume = %name, %error, "Failed to remove managed anonymous volume");
                 }
             }

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use a3s_box_core::{
-    volume::VolumeConfig, BoxConfig, CreateExecutionRequest, ExecutionGeneration,
-    ExecutionIsolation, NetworkMode, OperationId, VmHandler, VmMetrics,
+    BoxConfig, CreateExecutionRequest, ExecutionGeneration, ExecutionIsolation, NetworkMode,
+    OperationId, VmHandler, VmMetrics,
 };
 
 use super::*;
@@ -489,12 +489,12 @@ async fn retained_stops_preserve_anonymous_volumes_but_auto_remove_kill_removes_
     let temporary = tempfile::tempdir().unwrap();
     let backend = VmLocalExecutionBackend::new(temporary.path());
     let mut record = record(temporary.path(), ExecutionIsolation::Microvm);
-    let volume_name = "anonymous-restart-volume";
+    let volume_name = "anon_restart_volume";
     let volumes = crate::VolumeStore::new(
         temporary.path().join("volumes.json"),
         temporary.path().join("volumes"),
     );
-    volumes.create(VolumeConfig::new(volume_name, "")).unwrap();
+    volumes.claim_anonymous(volume_name, &record.id).unwrap();
     record.anonymous_volumes = vec![volume_name.to_string()];
     let sentinel = record.box_dir.join("rootfs/workspace/cold-pause.txt");
     std::fs::create_dir_all(sentinel.parent().unwrap()).unwrap();

--- a/src/runtime/src/local_execution/vm_sandbox.rs
+++ b/src/runtime/src/local_execution/vm_sandbox.rs
@@ -293,7 +293,8 @@ impl VmLocalExecutionBackend {
         }
         if remove_anonymous_volumes {
             let anonymous_volumes = self.anonymous_volumes_for_record(record).await;
-            self.cleanup_anonymous_volumes(anonymous_volumes).await;
+            self.cleanup_anonymous_volumes(&record.id, anonymous_volumes)
+                .await;
         }
         Ok(LocalExecutionTermination {
             outcome: KillOutcome::Killed,

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -18,6 +18,41 @@ mod image;
 pub(crate) use image::persistent_rootfs_generation_exists;
 use image::{registry_auth_for_image, validate_image_health_support};
 impl VmManager {
+    /// Resolve only immutable image metadata needed to reserve Box-owned
+    /// resources. This deliberately does not prepare a rootfs, workspace,
+    /// socket, mount, or volume directory.
+    pub(crate) async fn plan_image_anonymous_volumes(&mut self) -> Result<Vec<String>> {
+        let box_dir = self.home_dir.join("boxes").join(&self.box_id);
+        let image_config = match crate::resolved_image::load_resolved_image_config(&box_dir)? {
+            Some(persisted) => crate::oci::OciImageConfig::from(persisted),
+            None => {
+                let reference = self.config.image.clone();
+                let images_dir = self.home_dir.join("images");
+                let store =
+                    crate::oci::ImageStore::new(&images_dir, crate::DEFAULT_IMAGE_CACHE_SIZE)?;
+                let auth = registry_auth_for_image(
+                    &self.home_dir,
+                    &reference,
+                    self.transient_registry_auth.take(),
+                )?;
+                let mut puller = crate::oci::ImagePuller::new(std::sync::Arc::new(store), auth);
+                if let Some(ref metrics) = self.prom {
+                    puller = puller.set_metrics(metrics.clone());
+                }
+                if let Some(ref progress) = self.pull_progress_fn {
+                    puller = puller.with_progress_fn(progress.clone());
+                }
+                let image = puller.pull(&reference).await?;
+                let config = image.config().clone();
+                drop(puller);
+                config
+            }
+        };
+
+        self.plan_anonymous_volumes(&image_config)
+            .map(|plans| plans.into_iter().map(|plan| plan.name).collect())
+    }
+
     pub(crate) async fn prepare_layout(&mut self) -> Result<BoxLayout> {
         let transient_registry_auth = self.transient_registry_auth.take();
         // Create box-specific directories

--- a/src/runtime/src/vm/layout/tests.rs
+++ b/src/runtime/src/vm/layout/tests.rs
@@ -97,6 +97,40 @@ fn write_static_test_elf(path: &Path) {
     std::fs::write(path, elf).unwrap();
 }
 
+#[tokio::test]
+async fn image_resource_planning_reads_metadata_without_preparing_runtime_artifacts() {
+    let home = TempDir::new().unwrap();
+    let mut vm = make_vm_manager_with_home(home.path());
+    vm.box_id = "12345678-0000-0000-0000-000000000001".to_string();
+    vm.config.image = "example.invalid/must-not-pull:latest".to_string();
+    let box_dir = home.path().join("boxes").join(&vm.box_id);
+    std::fs::create_dir_all(&box_dir).unwrap();
+    let config = crate::oci::OciImageConfig {
+        entrypoint: None,
+        cmd: None,
+        env: Vec::new(),
+        working_dir: None,
+        user: None,
+        exposed_ports: Vec::new(),
+        labels: std::collections::HashMap::new(),
+        volumes: vec!["/data".to_string(), "/data/./".to_string()],
+        stop_signal: None,
+        health_check: None,
+        onbuild: Vec::new(),
+    };
+    crate::resolved_image::persist_resolved_image_config(&box_dir, &config).unwrap();
+
+    let planned = vm.plan_image_anonymous_volumes().await.unwrap();
+
+    assert_eq!(planned.len(), 1);
+    assert!(planned[0].starts_with("anon_12345678_"));
+    assert!(!home.path().join("images").exists());
+    assert!(!home.path().join("volumes").exists());
+    assert!(!box_dir.join("rootfs").exists());
+    assert!(!box_dir.join("workspace").exists());
+    assert!(!box_dir.join("sockets").exists());
+}
+
 #[test]
 fn installed_guest_init_cannot_be_shadowed_by_a_stale_development_build() {
     let temporary = TempDir::new().unwrap();

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -620,7 +620,7 @@ impl VmManager {
         );
 
         for volume_name in &created {
-            if let Err(error) = store.remove(volume_name, true) {
+            if let Err(error) = store.remove_anonymous(volume_name, &self.box_id) {
                 tracing::debug!(
                     box_id = %self.box_id,
                     volume = volume_name,

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -402,7 +402,7 @@ impl VmManager {
             let instance_spec = self.build_runtime_owned_instance_spec(&layout)?;
             if self.anonymous_volumes != original_anonymous_volumes {
                 return Err(BoxError::ConfigError(
-                    "OCI migration does not yet introduce image-declared anonymous volumes; create an explicit named or bind mount before enabling migration"
+                    "OCI image-declared anonymous volumes drifted from the durable Box ownership plan"
                         .to_string(),
                 ));
             }
@@ -531,12 +531,9 @@ impl VmManager {
         }
 
         if let Some(image) = layout.oci_config.as_ref() {
-            let mut anonymous_index = self.config.volumes.len();
-            for destination in &image.volumes {
-                let destination = normalized_container_path(destination, "volume destination")?;
-                if user_destinations.contains(&destination) {
-                    continue;
-                }
+            for (offset, planned) in self.plan_anonymous_volumes(image)?.into_iter().enumerate() {
+                let anonymous_index = self.config.volumes.len() + offset;
+                let destination = PathBuf::from(planned.guest_path);
                 let tag = format!("vol{anonymous_index}");
                 let source = instance_spec
                     .fs_mounts
@@ -556,7 +553,6 @@ impl VmManager {
                     destination,
                     read_only: false,
                 });
-                anonymous_index += 1;
             }
         }
 

--- a/src/runtime/src/vm/spec.rs
+++ b/src/runtime/src/vm/spec.rs
@@ -15,7 +15,7 @@ use a3s_box_core::guest_exec::{
 };
 use a3s_box_core::rootfs_metadata::RUNTIME_ENV_PATH;
 
-use super::{fnv1a_hash, BoxLayout, VmManager};
+use super::{BoxLayout, VmManager};
 
 const SBIN_INIT: &str = "/sbin/init";
 const USR_SBIN_INIT: &str = "/usr/sbin/init";
@@ -129,71 +129,97 @@ impl VmManager {
             fs_mounts.push(mount);
         }
 
-        // Auto-create anonymous volumes for OCI VOLUME directives
-        let user_guest_paths: std::collections::HashSet<String> = parsed_volumes
-            .iter()
-            .map(|volume| volume.guest_path.clone())
-            .collect();
-        let mut anon_vol_offset = self.config.volumes.len();
+        // Materialize the identities that were deterministically planned from
+        // image metadata. Legacy names remain reusable for existing records,
+        // but every newly derived identity is bound to the full Box ID.
+        let anonymous_volume_plan = layout
+            .oci_config
+            .as_ref()
+            .map(|config| self.plan_anonymous_volumes(config))
+            .transpose()?
+            .unwrap_or_default();
+        let durable_anonymous_volumes = self.anonymous_volumes.clone();
         let mut seen_anonymous_volumes = std::collections::HashSet::new();
+        let mut materialized_anonymous_destinations = Vec::new();
         self.anonymous_volumes
             .retain(|name| seen_anonymous_volumes.insert(name.clone()));
+        let materialization_plan = anonymous_volume_plan
+            .iter()
+            .map(|planned| {
+                let name = if seen_anonymous_volumes.contains(&planned.name) {
+                    planned.name.clone()
+                } else if seen_anonymous_volumes.contains(&planned.legacy_name) {
+                    planned.legacy_name.clone()
+                } else {
+                    planned.name.clone()
+                };
+                (planned, name)
+            })
+            .collect::<Vec<_>>();
 
-        if let Some(ref oci_config) = layout.oci_config {
-            for vol_path in &oci_config.volumes {
-                Self::validate_guest_mount_path(vol_path)?;
-                // Skip if the user already mounted something at this path
-                if user_guest_paths.contains(vol_path) {
-                    tracing::debug!(
-                        path = vol_path,
-                        "Skipping anonymous volume — user volume already covers this path"
+        if self.config.isolation.is_sandbox() {
+            let planned_names = materialization_plan
+                .iter()
+                .map(|(_, name)| name.as_str())
+                .collect::<std::collections::HashSet<_>>();
+            let durable_names = durable_anonymous_volumes
+                .iter()
+                .map(String::as_str)
+                .collect::<std::collections::HashSet<_>>();
+            if planned_names.len() != materialization_plan.len()
+                || durable_names.len() != durable_anonymous_volumes.len()
+                || planned_names != durable_names
+            {
+                return Err(BoxError::ConfigError(
+                    "OCI image-declared anonymous volumes drifted from the durable Box ownership plan"
+                        .to_string(),
+                ));
+            }
+        }
+
+        for (planned, anon_name) in materialization_plan {
+            // Create the volume via VolumeStore (best-effort)
+            match self.create_anonymous_volume(&anon_name) {
+                Ok((host_path, created)) => {
+                    // `workspace` is the only non-volume mount before this
+                    // sequence, so the next fs-mount position is the exact
+                    // contiguous volume tag even when a MicroVM best-effort
+                    // anonymous claim was skipped.
+                    let tag = format!("vol{}", fs_mounts.len().saturating_sub(1));
+                    fs_mounts.push(FsMount {
+                        tag: tag.clone(),
+                        host_path: PathBuf::from(&host_path),
+                        read_only: false,
+                    });
+                    materialized_anonymous_destinations.push(planned.guest_path.clone());
+                    if seen_anonymous_volumes.insert(anon_name.clone()) {
+                        self.anonymous_volumes.push(anon_name.clone());
+                    }
+                    if created {
+                        self.created_anonymous_volumes.push(anon_name);
+                    }
+                    tracing::info!(
+                        volume = %tag,
+                        guest_path = %planned.guest_path,
+                        host_path = %host_path,
+                        "Created anonymous volume for OCI VOLUME directive"
                     );
-                    continue;
                 }
-
-                // Generate a deterministic anonymous volume name
-                let path_hash = &format!("{:x}", fnv1a_hash(vol_path))[..8];
-                let short_box_id = &self.box_id[..8.min(self.box_id.len())];
-                let anon_name = format!("anon_{}_{}", short_box_id, path_hash);
-
-                // Create the volume via VolumeStore (best-effort)
-                match self.create_anonymous_volume(&anon_name) {
-                    Ok((host_path, created)) => {
-                        let tag = format!("vol{}", anon_vol_offset);
-                        fs_mounts.push(FsMount {
-                            tag: tag.clone(),
-                            host_path: PathBuf::from(&host_path),
-                            read_only: false,
+                Err(e) => {
+                    if self.config.isolation.is_sandbox() {
+                        return Err(BoxError::BoxBootError {
+                            message: format!(
+                                "Failed to create required Sandbox anonymous volume for {}: {e}",
+                                planned.guest_path
+                            ),
+                            hint: None,
                         });
-                        if seen_anonymous_volumes.insert(anon_name.clone()) {
-                            self.anonymous_volumes.push(anon_name.clone());
-                        }
-                        if created {
-                            self.created_anonymous_volumes.push(anon_name);
-                        }
-                        anon_vol_offset += 1;
-                        tracing::info!(
-                            volume = %tag,
-                            guest_path = vol_path,
-                            host_path = %host_path,
-                            "Created anonymous volume for OCI VOLUME directive"
-                        );
                     }
-                    Err(e) => {
-                        if self.config.isolation.is_sandbox() {
-                            return Err(BoxError::BoxBootError {
-                                message: format!(
-                                    "Failed to create required Sandbox anonymous volume for {vol_path}: {e}"
-                                ),
-                                hint: None,
-                            });
-                        }
-                        tracing::warn!(
-                            path = vol_path,
-                            error = %e,
-                            "Failed to create anonymous volume, skipping"
-                        );
-                    }
+                    tracing::warn!(
+                        path = %planned.guest_path,
+                        error = %e,
+                        "Failed to create anonymous volume, skipping"
+                    );
                 }
             }
         }
@@ -385,18 +411,12 @@ impl VmManager {
             }
 
             // Pass anonymous volume mounts (from OCI VOLUME directives) to guest init
-            if let Some(ref oci_config) = layout.oci_config {
-                let mut anon_idx = self.config.volumes.len();
-                for vol_path in &oci_config.volumes {
-                    if user_guest_paths.contains(vol_path) {
-                        continue;
-                    }
-                    env.push((
-                        format!("BOX_VOL_{}", anon_idx),
-                        format!("vol{}:{}:copy", anon_idx, vol_path),
-                    ));
-                    anon_idx += 1;
-                }
+            for (offset, guest_path) in materialized_anonymous_destinations.iter().enumerate() {
+                let index = self.config.volumes.len() + offset;
+                env.push((
+                    format!("BOX_VOL_{}", index),
+                    format!("vol{}:{}:copy", index, guest_path),
+                ));
             }
 
             // Pass tmpfs mounts to guest init.

--- a/src/runtime/src/vm/spec/tests/boot.rs
+++ b/src/runtime/src/vm/spec/tests/boot.rs
@@ -578,6 +578,31 @@ fn test_build_instance_spec_tracks_new_anonymous_volumes_only() {
 }
 
 #[test]
+fn sandbox_rejects_anonymous_plan_drift_before_volume_materialization() {
+    let home = tempdir().unwrap();
+    let layout_dir = tempdir().unwrap();
+    let mut oci_config = test_oci_config(None, None);
+    oci_config.volumes = vec!["/data".to_string()];
+    let layout = test_layout(layout_dir.path(), Some(oci_config), true);
+    let mut vm = test_vm_manager(BoxConfig {
+        isolation: a3s_box_core::ExecutionIsolation::Sandbox,
+        ..Default::default()
+    });
+    vm.home_dir = home.path().to_path_buf();
+
+    let error = vm
+        .build_runtime_owned_instance_spec(&layout)
+        .expect_err("Sandbox may only materialize its durable ownership plan");
+
+    assert!(error
+        .to_string()
+        .contains("drifted from the durable Box ownership plan"));
+    assert!(!home.path().join("volumes").exists());
+    assert!(vm.anonymous_volumes.is_empty());
+    assert!(vm.created_anonymous_volumes.is_empty());
+}
+
+#[test]
 fn test_guest_init_exec_path_supports_usr_sbin_without_sbin() {
     let dir = tempdir().unwrap();
     let rootfs = dir.path();

--- a/src/runtime/src/vm/spec/tests/general.rs
+++ b/src/runtime/src/vm/spec/tests/general.rs
@@ -1,6 +1,57 @@
 use super::*;
 
 #[test]
+fn anonymous_volume_plan_normalizes_deduplicates_and_honors_explicit_mounts() {
+    let explicit = tempfile::tempdir().unwrap();
+    let vm = test_vm_manager(BoxConfig {
+        volumes: vec![format!("{}:/data/./", explicit.path().display())],
+        ..Default::default()
+    });
+    let mut image = test_oci_config(None, None);
+    image.volumes = vec![
+        "/data".to_string(),
+        "/data/".to_string(),
+        "/cache/./".to_string(),
+        "/cache".to_string(),
+    ];
+
+    let plan = vm.plan_anonymous_volumes(&image).unwrap();
+
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].guest_path, "/cache");
+}
+
+#[test]
+fn anonymous_volume_identity_is_deterministic_and_bound_to_the_full_execution_id() {
+    let image = OciImageConfig {
+        volumes: vec!["/var/cache".to_string(), "/data".to_string()],
+        ..test_oci_config(None, None)
+    };
+    let reordered_image = OciImageConfig {
+        volumes: vec!["/data".to_string(), "/var/cache".to_string()],
+        ..test_oci_config(None, None)
+    };
+    let first = VmManager::with_box_id(
+        BoxConfig::default(),
+        EventEmitter::new(1),
+        "12345678-0000-0000-0000-000000000001".to_string(),
+    );
+    let second = VmManager::with_box_id(
+        BoxConfig::default(),
+        EventEmitter::new(1),
+        "12345678-0000-0000-0000-000000000002".to_string(),
+    );
+
+    let first_plan = first.plan_anonymous_volumes(&image).unwrap();
+    let replay = first.plan_anonymous_volumes(&reordered_image).unwrap();
+    let second_plan = second.plan_anonymous_volumes(&image).unwrap();
+
+    assert_eq!(first_plan, replay);
+    assert_ne!(first_plan[0].name, second_plan[0].name);
+    assert!(first_plan[0].name.starts_with("anon_12345678_"));
+}
+
+#[test]
 fn test_build_instance_spec_passes_configured_virtiofs_cache_mode() {
     let dir = tempdir().unwrap();
     let layout = test_layout(dir.path(), Some(test_oci_config(None, None)), true);

--- a/src/runtime/src/vm/spec/volumes.rs
+++ b/src/runtime/src/vm/spec/volumes.rs
@@ -5,6 +5,13 @@ use sha2::{Digest, Sha256};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlannedAnonymousVolume {
+    pub(crate) name: String,
+    pub(crate) legacy_name: String,
+    pub(crate) guest_path: String,
+}
+
 impl VmManager {
     /// Parse a volume mount string from the right so colons in a host path do
     /// not consume the host/guest separator. The guest always uses an absolute
@@ -44,7 +51,7 @@ impl VmManager {
         })
     }
 
-    pub(super) fn validate_guest_mount_path(guest_path: &str) -> Result<()> {
+    pub(super) fn normalize_guest_mount_path(guest_path: &str) -> Result<String> {
         if !guest_path.starts_with('/')
             || guest_path.contains('\0')
             || guest_path.split('/').any(|component| component == "..")
@@ -71,7 +78,82 @@ impl VmManager {
                 "Guest volume path {guest_path:?} overlaps reserved runtime state /run/a3s-box"
             )));
         }
-        Ok(())
+        Ok(normalized)
+    }
+
+    pub(super) fn validate_guest_mount_path(guest_path: &str) -> Result<()> {
+        Self::normalize_guest_mount_path(guest_path).map(|_| ())
+    }
+
+    /// Derive stable anonymous-volume identities from immutable image metadata.
+    ///
+    /// The result is pure: no directory or store entry is created. Equivalent
+    /// guest paths are normalized and deduplicated, and an explicit user mount
+    /// always overrides an image `VOLUME` declaration.
+    pub(crate) fn plan_anonymous_volumes(
+        &self,
+        oci_config: &crate::oci::OciImageConfig,
+    ) -> Result<Vec<PlannedAnonymousVolume>> {
+        let explicit_destinations = self
+            .config
+            .volumes
+            .iter()
+            .map(|volume| {
+                let parsed = Self::parse_volume_spec(volume)?;
+                Self::normalize_guest_mount_path(&parsed.guest_path)
+            })
+            .collect::<Result<std::collections::HashSet<_>>>()?;
+        let mut declared_destinations = oci_config
+            .volumes
+            .iter()
+            .map(|raw_path| {
+                Self::normalize_guest_mount_path(raw_path)
+                    .map(|guest_path| (guest_path, raw_path.as_str()))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        declared_destinations.sort_unstable();
+        let mut planned_destinations = std::collections::HashSet::new();
+        let short_box_id = self
+            .box_id
+            .chars()
+            .filter(|character| character.is_ascii_alphanumeric())
+            .take(8)
+            .collect::<String>();
+
+        let mut plans = Vec::new();
+        for (guest_path, raw_path) in declared_destinations {
+            if explicit_destinations.contains(&guest_path)
+                || !planned_destinations.insert(guest_path.clone())
+            {
+                continue;
+            }
+
+            let mut identity = Sha256::new();
+            identity.update(b"a3s-box-anonymous-volume-v1\0");
+            identity.update(self.box_id.as_bytes());
+            identity.update(b"\0");
+            identity.update(guest_path.as_bytes());
+            let digest = identity.finalize();
+            let name = format!(
+                "anon_{}_{}",
+                if short_box_id.is_empty() {
+                    "box"
+                } else {
+                    short_box_id.as_str()
+                },
+                hex::encode(&digest[..16])
+            );
+
+            let legacy_path_hash = format!("{:016x}", crate::vm::fnv1a_hash(raw_path));
+            let legacy_short_box_id = self.box_id.chars().take(8).collect::<String>();
+            let legacy_name = format!("anon_{}_{}", legacy_short_box_id, &legacy_path_hash[..8]);
+            plans.push(PlannedAnonymousVolume {
+                name,
+                legacy_name,
+                guest_path,
+            });
+        }
+        Ok(plans)
     }
 
     pub(super) fn prepare_volume_mount(
@@ -289,17 +371,7 @@ impl VmManager {
             self.home_dir.join("volumes"),
         );
 
-        // If the volume already exists (e.g., from a previous run), reuse it
-        if let Some(existing) = store.get(name)? {
-            return Ok((existing.mount_point, false));
-        }
-
-        let mut config = a3s_box_core::volume::VolumeConfig::new(name, "");
-        config
-            .labels
-            .insert("anonymous".to_string(), "true".to_string());
-        config.attach(&self.box_id);
-        let created = store.create(config)?;
-        Ok((created.mount_point, true))
+        let (volume, created) = store.claim_anonymous(name, &self.box_id)?;
+        Ok((volume.mount_point, created))
     }
 }

--- a/src/runtime/src/vm/tests/lifecycle.rs
+++ b/src/runtime/src/vm/tests/lifecycle.rs
@@ -95,8 +95,8 @@ async fn test_cleanup_boot_failure_stops_handler_and_removes_created_volumes() {
     let mut vm =
         VmManager::with_box_id(BoxConfig::default(), EventEmitter::new(16), box_id.clone());
     vm.home_dir = tmp.path().to_path_buf();
-    vm.anonymous_volumes = vec!["created-volume".to_string(), "reused-volume".to_string()];
-    vm.created_anonymous_volumes = vec!["created-volume".to_string()];
+    vm.anonymous_volumes = vec!["anon_created".to_string(), "anon_reused".to_string()];
+    vm.created_anonymous_volumes = vec!["anon_created".to_string()];
 
     let stopped = Arc::new(AtomicBool::new(false));
     *vm.handler.write().await = Some(Box::new(RecordingHandler {
@@ -110,24 +110,17 @@ async fn test_cleanup_boot_failure_stops_handler_and_removes_created_volumes() {
         tmp.path().join("volumes.json"),
         tmp.path().join("volumes"),
     );
-    store
-        .create(a3s_box_core::volume::VolumeConfig::new(
-            "created-volume",
-            "",
-        ))
-        .unwrap();
-    store
-        .create(a3s_box_core::volume::VolumeConfig::new("reused-volume", ""))
-        .unwrap();
+    store.claim_anonymous("anon_created", &box_id).unwrap();
+    store.claim_anonymous("anon_reused", &box_id).unwrap();
 
     vm.cleanup_boot_failure().await;
 
     assert!(stopped.load(Ordering::SeqCst));
     assert!(vm.handler.read().await.is_none());
     assert!(vm.created_anonymous_volumes.is_empty());
-    assert_eq!(vm.anonymous_volumes, vec!["reused-volume".to_string()]);
-    assert!(store.get("created-volume").unwrap().is_none());
-    assert!(store.get("reused-volume").unwrap().is_some());
+    assert_eq!(vm.anonymous_volumes, vec!["anon_reused".to_string()]);
+    assert!(store.get("anon_created").unwrap().is_none());
+    assert!(store.get("anon_reused").unwrap().is_some());
     assert!(!box_dir.exists());
 }
 

--- a/src/runtime/src/volume/store.rs
+++ b/src/runtime/src/volume/store.rs
@@ -24,6 +24,11 @@ struct VolumesFile {
     volumes: HashMap<String, VolumeConfig>,
 }
 
+const ANONYMOUS_LABEL: &str = "anonymous";
+const ANONYMOUS_KIND_LABEL: &str = "a3s.box.volume.kind";
+const ANONYMOUS_KIND: &str = "anonymous-v1";
+const ANONYMOUS_OWNER_LABEL: &str = "a3s.box.volume.owner";
+
 impl VolumeStore {
     /// Create a new store at the given path.
     pub fn new(path: impl Into<PathBuf>, volumes_dir: impl Into<PathBuf>) -> Self {
@@ -175,6 +180,70 @@ impl VolumeStore {
         })
     }
 
+    /// Atomically create or reclaim one Box-owned anonymous volume.
+    ///
+    /// Anonymous identities are single-owner capabilities. An existing named
+    /// volume, a volume owned by another execution, or metadata pointing away
+    /// from the canonical managed directory all fail closed without mutation.
+    pub(crate) fn claim_anonymous(&self, name: &str, owner: &str) -> Result<(VolumeConfig, bool)> {
+        validate_anonymous_identity(name, owner)?;
+
+        let expected_mount_point = self.volumes_dir.join(name).to_string_lossy().into_owned();
+        self.with_write_lock(|volumes| {
+            if let Some(existing) = volumes.get_mut(name) {
+                validate_anonymous_config(existing, name, owner, &expected_mount_point)?;
+                ensure_managed_volume_directory(Path::new(&expected_mount_point))?;
+                existing.attach(owner);
+                existing
+                    .labels
+                    .insert(ANONYMOUS_KIND_LABEL.to_string(), ANONYMOUS_KIND.to_string());
+                existing
+                    .labels
+                    .insert(ANONYMOUS_OWNER_LABEL.to_string(), owner.to_string());
+                return Ok((existing.clone(), false));
+            }
+
+            let mut config = VolumeConfig::new(name, "");
+            config
+                .labels
+                .insert(ANONYMOUS_LABEL.to_string(), "true".to_string());
+            config
+                .labels
+                .insert(ANONYMOUS_KIND_LABEL.to_string(), ANONYMOUS_KIND.to_string());
+            config
+                .labels
+                .insert(ANONYMOUS_OWNER_LABEL.to_string(), owner.to_string());
+            config.attach(owner);
+            self.materialize(config, volumes)
+                .map(|created| (created, true))
+        })
+    }
+
+    /// Remove only the anonymous volume capability owned by `owner`.
+    ///
+    /// The directory is removed while the metadata lock is held, before the
+    /// atomic metadata update. If a previous claim created the deterministic
+    /// directory but crashed before publishing metadata, the durable Box
+    /// record can use this operation to remove that orphan safely.
+    pub fn remove_anonymous(&self, name: &str, owner: &str) -> Result<bool> {
+        validate_anonymous_identity(name, owner)?;
+        let expected_mount_point = self.volumes_dir.join(name).to_string_lossy().into_owned();
+        self.with_write_lock(|volumes| {
+            let existed = if let Some(existing) = volumes.get(name) {
+                validate_anonymous_config(existing, name, owner, &expected_mount_point)?;
+                true
+            } else {
+                false
+            };
+
+            remove_managed_volume_path(Path::new(&expected_mount_point))?;
+            if existed {
+                volumes.remove(name);
+            }
+            Ok(existed)
+        })
+    }
+
     /// Create the volume's data directory, set its mount point, and insert it
     /// into `volumes`. Caller must already hold the write lock.
     fn materialize(
@@ -183,13 +252,7 @@ impl VolumeStore {
         volumes: &mut HashMap<String, VolumeConfig>,
     ) -> Result<VolumeConfig> {
         let vol_dir = self.volumes_dir.join(&config.name);
-        std::fs::create_dir_all(&vol_dir).map_err(|e| {
-            BoxError::ConfigError(format!(
-                "failed to create volume directory {}: {}",
-                vol_dir.display(),
-                e
-            ))
-        })?;
+        ensure_managed_volume_directory(&vol_dir)?;
         config.mount_point = vol_dir.to_string_lossy().into_owned();
         volumes.insert(config.name.clone(), config.clone());
         Ok(config)
@@ -293,6 +356,127 @@ impl VolumeStore {
     /// Get the store file path.
     pub fn path(&self) -> &Path {
         &self.path
+    }
+}
+
+fn valid_anonymous_volume_name(name: &str) -> bool {
+    name.starts_with("anon_")
+        && name.len() <= 128
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn validate_anonymous_identity(name: &str, owner: &str) -> Result<()> {
+    if !valid_anonymous_volume_name(name) {
+        return Err(BoxError::ConfigError(format!(
+            "invalid anonymous volume name {name:?}"
+        )));
+    }
+    if owner.is_empty() || owner.contains('\0') {
+        return Err(BoxError::ConfigError(
+            "anonymous volume owner must be a non-empty execution identity".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_anonymous_config(
+    config: &VolumeConfig,
+    name: &str,
+    owner: &str,
+    expected_mount_point: &str,
+) -> Result<()> {
+    if config.labels.get(ANONYMOUS_LABEL).map(String::as_str) != Some("true") {
+        return Err(BoxError::ConfigError(format!(
+            "volume {name:?} is not an anonymous volume"
+        )));
+    }
+    if config.driver != "local" {
+        return Err(BoxError::ConfigError(format!(
+            "anonymous volume {name:?} does not use the local driver"
+        )));
+    }
+    if config.mount_point != expected_mount_point {
+        return Err(BoxError::ConfigError(format!(
+            "anonymous volume {name:?} does not use its canonical managed directory"
+        )));
+    }
+    let exact_owner = config.in_use_by.len() == 1
+        && config
+            .in_use_by
+            .first()
+            .is_some_and(|current| current == owner);
+    if config.in_use_by.iter().any(|current| current != owner) {
+        return Err(BoxError::ConfigError(format!(
+            "anonymous volume {name:?} is owned by another execution"
+        )));
+    }
+    match config.labels.get(ANONYMOUS_KIND_LABEL).map(String::as_str) {
+        Some(ANONYMOUS_KIND)
+            if exact_owner
+                && config
+                    .labels
+                    .get(ANONYMOUS_OWNER_LABEL)
+                    .is_some_and(|current| current == owner) =>
+        {
+            Ok(())
+        }
+        None if exact_owner => Ok(()),
+        _ => Err(BoxError::ConfigError(format!(
+            "anonymous volume {name:?} has no compatible ownership contract"
+        ))),
+    }
+}
+
+fn ensure_managed_volume_directory(path: &Path) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(BoxError::ConfigError(format!(
+                "managed volume path {} is not a directory",
+                path.display()
+            )))
+        }
+        Ok(_) => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(BoxError::ConfigError(format!(
+                "failed to inspect volume directory {}: {error}",
+                path.display()
+            )))
+        }
+    }
+    std::fs::create_dir_all(path).map_err(|error| {
+        BoxError::ConfigError(format!(
+            "failed to create volume directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        BoxError::ConfigError(format!(
+            "failed to verify volume directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(BoxError::ConfigError(format!(
+            "managed volume path {} is not a directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn remove_managed_volume_path(path: &Path) -> Result<()> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(BoxError::IoError(error)),
+    };
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        std::fs::remove_dir_all(path).map_err(BoxError::IoError)
+    } else {
+        std::fs::remove_file(path).map_err(BoxError::IoError)
     }
 }
 
@@ -548,6 +732,198 @@ mod tests {
         assert_eq!(reused.size_limit, 4096);
         assert_eq!(reused.in_use_by, vec!["box-1"]);
         assert!(PathBuf::from(&reused.mount_point).exists());
+    }
+
+    #[test]
+    fn claim_anonymous_is_idempotent_for_the_exact_owner() {
+        let (_dir, store) = temp_store();
+
+        let (first, first_created) = store.claim_anonymous("anon_owned", "box-owner").unwrap();
+        let (second, second_created) = store.claim_anonymous("anon_owned", "box-owner").unwrap();
+
+        assert!(first_created);
+        assert!(!second_created);
+        assert_eq!(first.mount_point, second.mount_point);
+        assert_eq!(second.in_use_by, vec!["box-owner"]);
+        assert_eq!(
+            second.labels.get(ANONYMOUS_LABEL).map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            second.labels.get(ANONYMOUS_KIND_LABEL).map(String::as_str),
+            Some(ANONYMOUS_KIND)
+        );
+        assert_eq!(
+            second.labels.get(ANONYMOUS_OWNER_LABEL).map(String::as_str),
+            Some("box-owner")
+        );
+    }
+
+    #[test]
+    fn claim_anonymous_upgrades_an_exact_owner_legacy_volume() {
+        let (_dir, store) = temp_store();
+        let mut legacy = VolumeConfig::new("anon_legacy", "");
+        legacy
+            .labels
+            .insert(ANONYMOUS_LABEL.to_string(), "true".to_string());
+        legacy.attach("box-owner");
+        store.create(legacy).unwrap();
+
+        let (claimed, created) = store.claim_anonymous("anon_legacy", "box-owner").unwrap();
+
+        assert!(!created);
+        assert_eq!(
+            claimed.labels.get(ANONYMOUS_KIND_LABEL).map(String::as_str),
+            Some(ANONYMOUS_KIND)
+        );
+        assert_eq!(
+            claimed
+                .labels
+                .get(ANONYMOUS_OWNER_LABEL)
+                .map(String::as_str),
+            Some("box-owner")
+        );
+    }
+
+    #[test]
+    fn claim_anonymous_rejects_named_volume_collision_without_mutation() {
+        let (_dir, store) = temp_store();
+        let named = store
+            .create(VolumeConfig::new("anon_collision", ""))
+            .unwrap();
+
+        let error = store
+            .claim_anonymous("anon_collision", "box-owner")
+            .expect_err("a named volume must never become anonymously owned");
+
+        assert!(error.to_string().contains("not an anonymous volume"));
+        assert_eq!(
+            store.get("anon_collision").unwrap().unwrap().in_use_by,
+            named.in_use_by
+        );
+    }
+
+    #[test]
+    fn claim_anonymous_rejects_a_different_owner_without_mutation() {
+        let (_dir, store) = temp_store();
+        store.claim_anonymous("anon_owned", "box-one").unwrap();
+
+        let error = store
+            .claim_anonymous("anon_owned", "box-two")
+            .expect_err("anonymous volumes have exactly one Box owner");
+
+        assert!(error.to_string().contains("owned by another execution"));
+        assert_eq!(
+            store.get("anon_owned").unwrap().unwrap().in_use_by,
+            vec!["box-one"]
+        );
+    }
+
+    #[test]
+    fn claim_anonymous_rejects_unsafe_identity_before_creating_a_directory() {
+        let (dir, store) = temp_store();
+
+        let error = store
+            .claim_anonymous("../escaped", "box-owner")
+            .expect_err("managed identities may not escape the volume root");
+
+        assert!(error.to_string().contains("invalid anonymous volume name"));
+        assert!(!dir.path().join("escaped").exists());
+        assert!(store.load().unwrap().is_empty());
+    }
+
+    #[test]
+    fn concurrent_anonymous_claims_publish_one_exact_owner() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(VolumeStore::new(
+            dir.path().join("volumes.json"),
+            dir.path().join("volumes"),
+        ));
+        let handles = (0..16)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                thread::spawn(move || {
+                    store
+                        .claim_anonymous("anon_concurrent", "box-owner")
+                        .unwrap()
+                        .1
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let created = handles
+            .into_iter()
+            .map(|handle| usize::from(handle.join().unwrap()))
+            .sum::<usize>();
+        let claimed = store.get("anon_concurrent").unwrap().unwrap();
+
+        assert_eq!(created, 1);
+        assert_eq!(claimed.in_use_by, vec!["box-owner"]);
+        assert_eq!(store.list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn remove_anonymous_requires_and_removes_the_exact_owner() {
+        let (_dir, store) = temp_store();
+        let (claimed, _) = store.claim_anonymous("anon_owned", "box-owner").unwrap();
+
+        let removed = store.remove_anonymous("anon_owned", "box-owner").unwrap();
+
+        assert!(removed);
+        assert!(store.get("anon_owned").unwrap().is_none());
+        assert!(!PathBuf::from(claimed.mount_point).exists());
+    }
+
+    #[test]
+    fn remove_anonymous_rejects_named_and_different_owner_collisions() {
+        let (_dir, store) = temp_store();
+        let named = store.create(VolumeConfig::new("anon_named", "")).unwrap();
+        store.claim_anonymous("anon_owned", "box-one").unwrap();
+
+        let named_error = store
+            .remove_anonymous("anon_named", "box-one")
+            .expect_err("named volume metadata must fail closed");
+        let owner_error = store
+            .remove_anonymous("anon_owned", "box-two")
+            .expect_err("another owner must fail closed");
+
+        assert!(named_error.to_string().contains("not an anonymous volume"));
+        assert!(owner_error
+            .to_string()
+            .contains("owned by another execution"));
+        assert!(PathBuf::from(named.mount_point).exists());
+        assert!(store.get("anon_owned").unwrap().is_some());
+    }
+
+    #[test]
+    fn remove_anonymous_cleans_an_unpublished_deterministic_directory() {
+        let (_dir, store) = temp_store();
+        let orphan = store.volume_dir("anon_unpublished");
+        std::fs::create_dir_all(&orphan).unwrap();
+        std::fs::write(orphan.join("partial"), b"partial").unwrap();
+
+        let removed = store
+            .remove_anonymous("anon_unpublished", "box-owner")
+            .unwrap();
+
+        assert!(!removed);
+        assert!(!orphan.exists());
+        assert!(store.get("anon_unpublished").unwrap().is_none());
+    }
+
+    #[test]
+    fn reclaim_anonymous_recreates_a_missing_owned_directory() {
+        let (_dir, store) = temp_store();
+        let (claimed, _) = store.claim_anonymous("anon_owned", "box-owner").unwrap();
+        std::fs::remove_dir_all(&claimed.mount_point).unwrap();
+
+        let (reclaimed, created) = store.claim_anonymous("anon_owned", "box-owner").unwrap();
+
+        assert!(!created);
+        assert!(PathBuf::from(reclaimed.mount_point).is_dir());
     }
 
     #[test]

--- a/src/sdk/src/client/support.rs
+++ b/src/sdk/src/client/support.rs
@@ -515,7 +515,7 @@ fn cleanup_stopped_box(paths: &A3sBoxPaths, record: &BoxRecord) {
 fn cleanup_removed_box(paths: &A3sBoxPaths, record: &BoxRecord) {
     detach_volumes(paths, &record.volume_names, &record.id);
     cleanup_network_endpoint(paths, record);
-    cleanup_anonymous_volumes(paths, &record.anonymous_volumes);
+    cleanup_anonymous_volumes(paths, &record.id, &record.anonymous_volumes);
     remove_host_cgroup(record);
     if record.box_dir.exists() {
         a3s_box_runtime::rootfs::unmount_box_overlay(&record.box_dir.join("merged"));
@@ -538,10 +538,10 @@ fn detach_volumes(paths: &A3sBoxPaths, volume_names: &[String], box_id: &str) {
     }
 }
 
-fn cleanup_anonymous_volumes(paths: &A3sBoxPaths, volume_names: &[String]) {
+fn cleanup_anonymous_volumes(paths: &A3sBoxPaths, owner: &str, volume_names: &[String]) {
     let store = VolumeStore::new(&paths.volumes_file, &paths.volumes_dir);
     for volume_name in volume_names {
-        let _ = store.remove(volume_name, true);
+        let _ = store.remove_anonymous(volume_name, owner);
     }
 }
 

--- a/src/sdk/src/client/tests/state.rs
+++ b/src/sdk/src/client/tests/state.rs
@@ -232,13 +232,16 @@
         record.box_dir = dir.path().join("boxes").join(&record.id);
         record.exec_socket_path = dir.path().join("external-sockets").join("exec.sock");
         record.volume_names = vec!["data".to_string()];
-        record.anonymous_volumes = vec!["anon".to_string()];
+        let anonymous_volume = "anon_sdk_removal";
+        record.anonymous_volumes = vec![anonymous_volume.to_string()];
         std::fs::create_dir_all(record.box_dir.join("merged")).unwrap();
         std::fs::create_dir_all(record.exec_socket_path.parent().unwrap()).unwrap();
         write_boxes(&client, &[record.clone()]);
 
         client.create_volume(CreateVolume::new("data")).unwrap();
-        client.create_volume(CreateVolume::new("anon")).unwrap();
+        client
+            .create_volume(CreateVolume::new(anonymous_volume))
+            .unwrap();
         client
             .volume_store()
             .modify("data", |volume| {
@@ -247,8 +250,19 @@
             .unwrap();
         client
             .volume_store()
-            .modify("anon", |volume| {
+            .modify(anonymous_volume, |volume| {
                 volume.in_use_by = vec![record.id.clone()];
+                volume
+                    .labels
+                    .insert("anonymous".to_string(), "true".to_string());
+                volume.labels.insert(
+                    "a3s.box.volume.kind".to_string(),
+                    "anonymous-v1".to_string(),
+                );
+                volume.labels.insert(
+                    "a3s.box.volume.owner".to_string(),
+                    record.id.clone(),
+                );
             })
             .unwrap();
         client
@@ -269,7 +283,7 @@
             .unwrap()
             .in_use_by
             .is_empty());
-        assert!(client.get_volume("anon").unwrap().is_none());
+        assert!(client.get_volume(anonymous_volume).unwrap().is_none());
         assert_eq!(
             client.get_network("dev").unwrap().unwrap().endpoint_count,
             0


### PR DESCRIPTION
Summary:
- plan normalized image-declared anonymous volume identities after backend preflight and persist them in the initial Box reservation
- materialize only the durable plan through exact-owner, cross-process atomic claims and fail closed on drift or collisions
- use frozen snapshot image metadata, preserve legacy identities, and make recovery, rollback, SDK, CLI, and removal share the same ownership-safe cleanup path
- document the completed Sandbox storage contract and roadmap status

Validation:
- ./scripts/host-integration-smoke.sh --pure
- 1745+ runtime library tests, complete workspace library and integration suites
- workspace all-targets all-features Clippy with warnings denied
- cargo fmt and diff checks