### PR TITLE
fix(ci): make the installed OCI product gate deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,6 +529,13 @@ jobs:
             "$RUNNER_TEMP" \
             "$install_dir"
 
+          sudo install -d -m 755 "$A3S_HOME/bin"
+          for artifact in a3s-box-shim a3s-box-guest-init a3s-oci a3s-oci-agent; do
+            sudo ln -s "$install_dir/$artifact" "$A3S_HOME/bin/$artifact"
+            test "$(realpath "$A3S_HOME/bin/$artifact")" = \
+              "$(realpath "$install_dir/$artifact")"
+          done
+
           {
             echo "A3S_BOX_INSTALL_DIR=$install_dir"
             echo "A3S_BOX_BINARY=$install_dir/a3s-box"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,11 +651,32 @@ jobs:
         if: always()
         run: |
           cleanup_status=0
-          if [ -f /tmp/a3s-box-ci-kvm-sentinel ]; then
-            if [ -c /dev/kvm ]; then
-              sudo rm -f /dev/kvm || cleanup_status=1
+          kvm_marker=/tmp/a3s-box-ci-kvm-sentinel
+          saved_kvm=/dev/a3s-box-ci-host-kvm
+          if [[ -e "$kvm_marker" || -L "$kvm_marker" ]]; then
+            if [[ -d /dev/kvm && ! -L /dev/kvm ]]; then
+              sudo rmdir /dev/kvm || cleanup_status=1
+            elif [[ -e /dev/kvm || -L /dev/kvm ]]; then
+              echo "::error::Refusing to remove an unexpected replacement at /dev/kvm"
+              cleanup_status=1
             fi
-            rm -f /tmp/a3s-box-ci-kvm-sentinel || cleanup_status=1
+            if [[ -e "$saved_kvm" || -L "$saved_kvm" ]]; then
+              if [[ ! -c "$saved_kvm" || -L "$saved_kvm" ]]; then
+                echo "::error::Saved host KVM device has the wrong type"
+                cleanup_status=1
+              elif [[ -e /dev/kvm || -L /dev/kvm ]]; then
+                echo "::error::Cannot restore the host KVM device because /dev/kvm is occupied"
+                cleanup_status=1
+              else
+                sudo mv -- "$saved_kvm" /dev/kvm || cleanup_status=1
+              fi
+            fi
+            if ((cleanup_status == 0)); then
+              rm -f -- "$kvm_marker" || cleanup_status=1
+            fi
+          elif [[ -e "$saved_kvm" || -L "$saved_kvm" ]]; then
+            echo "::error::Saved host KVM device exists without its ownership marker"
+            cleanup_status=1
           fi
           sudo python3 - "$A3S_BOX_OCI_HOST_ROOT/box-owner.json" <<'PY' || cleanup_status=1
           import json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 9c3be8e126dda7ff7add5e6e88c427f68c7d6629
+  A3S_OCI_RUNTIME_REV: 438e4b7936cd08d408160fe9341a21786f60cd26
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────
@@ -29,29 +29,9 @@ jobs:
         with:
           components: rustfmt
       - run: cd src && cargo fmt --all -- --check
-      - name: Verify CI and release OCI artifact pins agree
+      - name: Verify OCI SDK and artifact pins agree
         shell: bash
-        run: |
-          set -euo pipefail
-          read_pin() {
-            local workflow="$1"
-            local matches
-            mapfile -t matches < <(
-              sed -nE 's/^[[:space:]]*A3S_OCI_RUNTIME_REV:[[:space:]]*([0-9a-f]{40})[[:space:]]*$/\1/p' \
-                "$workflow"
-            )
-            if [ "${#matches[@]}" -ne 1 ]; then
-              echo "$workflow must contain exactly one 40-character OCI revision" >&2
-              exit 1
-            fi
-            printf '%s\n' "${matches[0]}"
-          }
-          ci_pin="$(read_pin .github/workflows/ci.yml)"
-          release_pin="$(read_pin .github/workflows/release.yml)"
-          if [ "$ci_pin" != "$release_pin" ]; then
-            echo "CI OCI revision $ci_pin differs from release revision $release_pin" >&2
-            exit 1
-          fi
+        run: bash scripts/check-oci-pins.sh
       - name: Reject removed Sandbox backend integrations
         run: |
           removed_patterns=(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,8 @@ jobs:
           repository: A3S-Lab/OCI-Runtime
           ref: ${{ env.A3S_OCI_RUNTIME_REV }}
           path: oci-runtime
+      - name: Verify pinned OCI contracts
+        run: bash scripts/check-oci-pins.sh oci-runtime
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,7 @@ jobs:
       - name: Package and install the no-KVM product
         run: |
           set -euo pipefail
-          install_dir="$RUNNER_TEMP/a3s-box-installed-${{ matrix.platform }}"
+          install_dir="$A3S_HOME/bin"
           bash scripts/package-no-kvm-product.sh \
             "${{ matrix.guest_target }}" \
             "${{ matrix.platform }}" \
@@ -509,12 +509,12 @@ jobs:
             "$RUNNER_TEMP" \
             "$install_dir"
 
-          sudo install -d -m 755 "$A3S_HOME/bin"
           for artifact in a3s-box-shim a3s-box-guest-init a3s-oci a3s-oci-agent; do
-            sudo ln -s "$install_dir/$artifact" "$A3S_HOME/bin/$artifact"
-            test "$(realpath "$A3S_HOME/bin/$artifact")" = \
-              "$(realpath "$install_dir/$artifact")"
+            test -x "$install_dir/$artifact"
+            test ! -L "$install_dir/$artifact"
           done
+          test -d "$install_dir/lib"
+          test ! -L "$install_dir/lib"
 
           {
             echo "A3S_BOX_INSTALL_DIR=$install_dir"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 9c3be8e126dda7ff7add5e6e88c427f68c7d6629
+  A3S_OCI_RUNTIME_REV: 438e4b7936cd08d408160fe9341a21786f60cd26
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,10 @@ jobs:
           ref: ${{ env.A3S_OCI_RUNTIME_REV }}
           path: oci-runtime
 
+      - name: Verify pinned OCI contracts
+        if: runner.os == 'Linux'
+        run: bash scripts/check-oci-pins.sh oci-runtime
+
       # dtolnay/rust-toolchain stable (2026-07-16)
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,12 +166,14 @@ later lifecycle, session, observability, filesystem, restart, and cleanup calls
 use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
-`9c3be8e126dda7ff7add5e6e88c427f68c7d6629` retains the matching long-lived,
-multi-container Native Linux host owner and adds the generation-safe bundle
-handoff used by the preparation context above, plus stable aggregate workload
-block-I/O metrics. Connection-local protocol or disconnect failures no longer
-terminate that shared owner or its unrelated containers. The same revision keeps durable
-Native Linux owner recovery out of the transient utility-VM guest executor, so
+`438e4b7936cd08d408160fe9341a21786f60cd26` is the exact source for the Rust
+SDK dependency, CI-built runtime and agent, and release artifacts. It retains
+the matching long-lived, multi-container Native Linux host owner, the
+generation-safe bundle handoff used by the preparation context above, and
+stable aggregate workload block-I/O metrics. Connection-local protocol or
+disconnect failures no longer terminate that shared owner or its unrelated
+containers. The same revision keeps durable Native Linux owner recovery out
+of the transient utility-VM guest executor, so
 WHPX reaches protocol negotiation without attempting host-only journal writes.
 Box now first validates the
 exact managed home and durably prepares snapshot-lower, named-volume, and

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -61,13 +61,15 @@ Box now:
 - rejects any reintroduction of the removed integration symbols in CI.
 
 The exact integration revision is
-`9c3be8e126dda7ff7add5e6e88c427f68c7d6629`, which retains the qualified
-control/workload cgroup and read-only bind behavior and adds deterministic
-multi-driver registration, isolation selection, and durable recorded-driver
-routing required by the unified execution migration. It also publishes stable
-aggregate workload block-I/O byte metrics consumed by Box statistics and
-isolates an aborted SDK connection from the shared host-service lifetime. Runtime service startup
-also fails closed when historical state references a missing driver or a
+`438e4b7936cd08d408160fe9341a21786f60cd26`. The Rust SDK dependency and the
+runtime and agent built by CI and release workflows all use this same source
+revision. It retains the qualified control/workload cgroup and read-only bind
+behavior, deterministic multi-driver registration, isolation selection, and
+durable recorded-driver routing required by the unified execution migration.
+It also publishes stable aggregate workload block-I/O byte metrics consumed by
+Box statistics and isolates an aborted SDK connection from the shared
+host-service lifetime. Runtime service startup also fails closed when
+historical state references a missing driver or a
 driver whose advertised isolation has drifted. Startup then calls only the
 exact recorded driver's idempotent recovery hook and commits any legal state
 observation before serving. Windows additionally has a protected, local-only
@@ -122,7 +124,8 @@ x86_64 and aarch64 hosts without KVM. Each must:
 4. assemble the supported Linux release layout, install it through `install.sh`,
    validate every executable dependency, require the shim to resolve libkrun
    from that layout, validate the install marker and OCI revision, and reject
-   any executable path outside that installation;
+   any executable path outside that installation; the R17 conformance home
+   binds its required binaries to that exact installation;
 5. require `/dev/kvm` to be absent, verify the installed product reports that
    exact condition, and execute the unchanged Rust, Python, TypeScript, and Go
    local SDK lifecycles;

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -124,8 +124,10 @@ x86_64 and aarch64 hosts without KVM. Each must:
 4. assemble the supported Linux release layout, install it through `install.sh`,
    validate every executable dependency, require the shim to resolve libkrun
    from that layout, validate the install marker and OCI revision, and reject
-   any executable path outside that installation; the R17 conformance home
-   binds its required binaries to that exact installation;
+   any executable path outside that installation; install the self-contained
+   distribution directly at the R17 conformance home's `bin` directory so the
+   required binaries and their `$ORIGIN/lib` dependencies retain one exact
+   installation identity without loader-breaking executable symlinks;
 5. require `/dev/kvm` to be absent, verify the installed product reports that
    exact condition, and execute the unchanged Rust, Python, TypeScript, and Go
    local SDK lifecycles;

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -118,30 +118,32 @@ The `SDK Local Sandbox (A3S OCI Runtime)` and
 x86_64 and aarch64 hosts without KVM. Each must:
 
 1. check out the exact pinned OCI Runtime revision;
-2. run its native Linux qualification script;
-3. build release Box binaries with the vendored libkrun and libkrunfw runtime,
+2. compare the Box recovery-evidence contract with the current recovery writer
+   schema in that exact OCI checkout before starting long builds or soak tests;
+3. run its native Linux qualification script;
+4. build release Box binaries with the vendored libkrun and libkrunfw runtime,
    plus guest init, the pinned OCI runtime, and the agent;
-4. assemble the supported Linux release layout, install it through `install.sh`,
+5. assemble the supported Linux release layout, install it through `install.sh`,
    validate every executable dependency, require the shim to resolve libkrun
    from that layout, validate the install marker and OCI revision, and reject
    any executable path outside that installation; install the self-contained
    distribution directly at the R17 conformance home's `bin` directory so the
    required binaries and their `$ORIGIN/lib` dependencies retain one exact
    installation identity without loader-breaking executable symlinks;
-5. require `/dev/kvm` to be absent, verify the installed product reports that
+6. require `/dev/kvm` to be absent, verify the installed product reports that
    exact condition, and execute the unchanged Rust, Python, TypeScript, and Go
    local SDK lifecycles;
-6. create a runner-local `/dev/kvm` path whose read/write open is rejected even
+7. create a runner-local `/dev/kvm` path whose read/write open is rejected even
    for the root test process, verify the installed product reports the access
    failure, and execute the same four-language lifecycle a second time;
-7. cover image management, named volumes, files, logs, metrics, pause/resume,
+8. cover image management, named volumes, files, logs, metrics, pause/resume,
    exact CPU/memory/PID enforcement, stop/restart, filesystem snapshots, and
    complete cleanup;
-8. kill the exact OCI owner under a running Sandbox, prove the launcher and init
+9. kill the exact OCI owner under a running Sandbox, prove the launcher and init
    terminate, then use distinct Box processes to rebind the endpoint, reconcile
    stopped-only state without a synthetic exit status, delete the old
    generation, and restart exactly the next Box and OCI generations;
-9. prove no Box shim, OCI owner, agent, runtime root, socket, or Box directory
+10. prove no Box shim, OCI owner, agent, runtime root, socket, or Box directory
    remains.
 
 If a hosted runner initially exposes a KVM character device, the gate moves it

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -120,15 +120,15 @@ x86_64 and aarch64 hosts without KVM. Each must:
 3. build release Box binaries with the vendored libkrun and libkrunfw runtime,
    plus guest init, the pinned OCI runtime, and the agent;
 4. assemble the supported Linux release layout, install it through `install.sh`,
-   validate the install marker and OCI revision, and reject any executable path
-   outside that installation;
+   validate every executable dependency, require the shim to resolve libkrun
+   from that layout, validate the install marker and OCI revision, and reject
+   any executable path outside that installation;
 5. require `/dev/kvm` to be absent, verify the installed product reports that
    exact condition, and execute the unchanged Rust, Python, TypeScript, and Go
    local SDK lifecycles;
-6. create a runner-local KVM character-device node whose read/write open is
-   rejected even for the root test process, verify the installed product
-   reports the access failure, and execute the same four-language lifecycle a
-   second time;
+6. create a runner-local `/dev/kvm` path whose read/write open is rejected even
+   for the root test process, verify the installed product reports the access
+   failure, and execute the same four-language lifecycle a second time;
 7. cover image management, named volumes, files, logs, metrics, pause/resume,
    exact CPU/memory/PID enforcement, stop/restart, filesystem snapshots, and
    complete cleanup;
@@ -138,6 +138,11 @@ x86_64 and aarch64 hosts without KVM. Each must:
    generation, and restart exactly the next Box and OCI generations;
 9. prove no Box shim, OCI owner, agent, runtime root, socket, or Box directory
    remains.
+
+If a hosted runner initially exposes a KVM character device, the gate moves it
+aside only after creating an exact ownership marker and restores it from both
+the script trap and the workflow's unconditional cleanup. Unexpected device
+types, replacement paths, stale markers, and backup collisions fail closed.
 
 ### Native configuration matrix
 

--- a/docs/host-sandbox-backend-design.md
+++ b/docs/host-sandbox-backend-design.md
@@ -370,10 +370,12 @@ libkrunfw, installs it through the user installer, certifies every advertised
 R17 provider profile, and runs the real Rust, Python, TypeScript, and Go SDK
 lifecycle exclusively through the installed Box, shim, guest init, runtime, and
 agent. The complete SDK lifecycle runs once with `/dev/kvm` absent and again
-with a present KVM character-device node that cannot be opened read/write;
+with a present `/dev/kvm` path that cannot be opened read/write;
 `a3s-box info` must report the matching host condition before each run. The
-resource profile observes exact CPU, memory, and PID limits, forces throttling,
-PID exhaustion, and a
+gate moves aside and later restores an initially present host KVM character
+device under an exact ownership marker, and fails closed on path or type drift.
+The resource profile observes exact CPU, memory, and PID limits, forces
+throttling, PID exhaustion, and a
 workload-only OOM, verifies the long-lived Service and exec transport remain
 available, and requires complete cgroup cleanup. The SDK matrix covers images,
 files, logs, metrics, named volumes, snapshots, pause/resume, filesystem-only

--- a/scripts/check-oci-pins.sh
+++ b/scripts/check-oci-pins.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+read_workflow_pin() {
+    local workflow="$1"
+    local matches
+    mapfile -t matches < <(
+        sed -nE \
+            's/^[[:space:]]*A3S_OCI_RUNTIME_REV:[[:space:]]*([0-9a-f]{40})[[:space:]]*$/\1/p' \
+            "$workflow"
+    )
+    if [[ "${#matches[@]}" -ne 1 ]]; then
+        echo "$workflow must contain exactly one 40-character OCI revision" >&2
+        return 1
+    fi
+    printf '%s\n' "${matches[0]}"
+}
+
+read_sdk_pin() {
+    local manifest="$1"
+    local matches
+    mapfile -t matches < <(
+        sed -nE \
+            's/^[[:space:]]*a3s-oci-sdk[[:space:]]*=.*rev[[:space:]]*=[[:space:]]*"([0-9a-f]{40})".*$/\1/p' \
+            "$manifest"
+    )
+    if [[ "${#matches[@]}" -ne 1 ]]; then
+        echo "$manifest must contain exactly one 40-character OCI SDK revision" >&2
+        return 1
+    fi
+    printf '%s\n' "${matches[0]}"
+}
+
+ci_pin="$(read_workflow_pin "$REPOSITORY_ROOT/.github/workflows/ci.yml")"
+release_pin="$(read_workflow_pin "$REPOSITORY_ROOT/.github/workflows/release.yml")"
+sdk_pin="$(read_sdk_pin "$REPOSITORY_ROOT/src/Cargo.toml")"
+
+if [[ "$ci_pin" != "$release_pin" || "$ci_pin" != "$sdk_pin" ]]; then
+    echo "OCI revisions differ: CI=$ci_pin release=$release_pin SDK=$sdk_pin" >&2
+    exit 1
+fi
+
+printf 'OCI SDK and artifact revision: %s\n' "$ci_pin"

--- a/scripts/check-oci-pins.sh
+++ b/scripts/check-oci-pins.sh
@@ -34,6 +34,41 @@ read_sdk_pin() {
     printf '%s\n' "$match"
 }
 
+read_box_recovery_schema() {
+    local smoke_script="$1"
+    local match
+    match="$(
+        sed -nE \
+            's/^[[:space:]]*assert recovery\["schemaVersion"\] == "(a3s\.oci\.native-linux-recovery\.v[0-9]+)"([[:space:]]*,.*)?$/\1/p' \
+            "$smoke_script"
+    )"
+    if [[ -z "$match" || "$match" == *$'\n'* ]]; then
+        echo "$smoke_script must assert exactly one native Linux recovery schema" >&2
+        return 1
+    fi
+    printf '%s\n' "$match"
+}
+
+read_runtime_recovery_schema() {
+    local runtime_root="$1"
+    local source="$runtime_root/crates/agent/src/executor/recovery.rs"
+    local match
+    if [[ ! -f "$source" ]]; then
+        echo "pinned OCI Runtime recovery source is missing: $source" >&2
+        return 1
+    fi
+    match="$(
+        sed -nE \
+            's/^const CONTAINER_SCHEMA_VERSION: &str = "(a3s\.oci\.native-linux-recovery\.v[0-9]+)";[[:space:]]*$/\1/p' \
+            "$source"
+    )"
+    if [[ -z "$match" || "$match" == *$'\n'* ]]; then
+        echo "$source must declare exactly one current recovery schema" >&2
+        return 1
+    fi
+    printf '%s\n' "$match"
+}
+
 ci_pin="$(read_workflow_pin "$REPOSITORY_ROOT/.github/workflows/ci.yml")"
 release_pin="$(read_workflow_pin "$REPOSITORY_ROOT/.github/workflows/release.yml")"
 sdk_pin="$(read_sdk_pin "$REPOSITORY_ROOT/src/Cargo.toml")"
@@ -44,3 +79,27 @@ if [[ "$ci_pin" != "$release_pin" || "$ci_pin" != "$sdk_pin" ]]; then
 fi
 
 printf 'OCI SDK and artifact revision: %s\n' "$ci_pin"
+
+if (($# > 1)); then
+    echo "usage: $0 [pinned-oci-runtime-checkout]" >&2
+    exit 2
+fi
+
+if (($# == 1)); then
+    runtime_root="$1"
+    runtime_revision="$(git -C "$runtime_root" rev-parse HEAD)"
+    if [[ "$runtime_revision" != "$ci_pin" ]]; then
+        echo "OCI checkout revision differs: expected=$ci_pin checkout=$runtime_revision" >&2
+        exit 1
+    fi
+
+    box_recovery_schema="$(
+        read_box_recovery_schema "$REPOSITORY_ROOT/scripts/local-sdk-smoke.sh"
+    )"
+    runtime_recovery_schema="$(read_runtime_recovery_schema "$runtime_root")"
+    if [[ "$box_recovery_schema" != "$runtime_recovery_schema" ]]; then
+        echo "OCI recovery schemas differ: Box=$box_recovery_schema Runtime=$runtime_recovery_schema" >&2
+        exit 1
+    fi
+    printf 'OCI native Linux recovery schema: %s\n' "$runtime_recovery_schema"
+fi

--- a/scripts/check-oci-pins.sh
+++ b/scripts/check-oci-pins.sh
@@ -6,32 +6,32 @@ REPOSITORY_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
 read_workflow_pin() {
     local workflow="$1"
-    local matches
-    mapfile -t matches < <(
+    local match
+    match="$(
         sed -nE \
             's/^[[:space:]]*A3S_OCI_RUNTIME_REV:[[:space:]]*([0-9a-f]{40})[[:space:]]*$/\1/p' \
             "$workflow"
-    )
-    if [[ "${#matches[@]}" -ne 1 ]]; then
+    )"
+    if [[ -z "$match" || "$match" == *$'\n'* ]]; then
         echo "$workflow must contain exactly one 40-character OCI revision" >&2
         return 1
     fi
-    printf '%s\n' "${matches[0]}"
+    printf '%s\n' "$match"
 }
 
 read_sdk_pin() {
     local manifest="$1"
-    local matches
-    mapfile -t matches < <(
+    local match
+    match="$(
         sed -nE \
             's/^[[:space:]]*a3s-oci-sdk[[:space:]]*=.*rev[[:space:]]*=[[:space:]]*"([0-9a-f]{40})".*$/\1/p' \
             "$manifest"
-    )
-    if [[ "${#matches[@]}" -ne 1 ]]; then
+    )"
+    if [[ -z "$match" || "$match" == *$'\n'* ]]; then
         echo "$manifest must contain exactly one 40-character OCI SDK revision" >&2
         return 1
     fi
-    printf '%s\n' "${matches[0]}"
+    printf '%s\n' "$match"
 }
 
 ci_pin="$(read_workflow_pin "$REPOSITORY_ROOT/.github/workflows/ci.yml")"

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -705,7 +705,7 @@ try {
       if (
         runtimeStats.executionId !== sandbox.id ||
         runtimeStats.generation !== sandbox.generation ||
-        runtimeStats.timestampUnixNs <= 0 ||
+        runtimeStats.timestampUnixNs <= 0n ||
         runtimeStats.processCount <= 0
       ) {
         throw new Error('runtime stats returned an invalid Sandbox snapshot')

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -81,9 +81,20 @@ if [ -z "${A3S_HOME:-}" ] ||
     exit 1
 fi
 
+install_runtime_asset() {
+    local source="$1"
+    local destination="$2"
+
+    if [[ -e "$destination" || -L "$destination" ]] &&
+        [[ "$source" -ef "$destination" ]]; then
+        return
+    fi
+    install -m 755 "$source" "$destination"
+}
+
 mkdir -p "$A3S_HOME/bin"
-install -m 755 "$A3S_BOX_SHIM_BINARY" "$A3S_HOME/bin/a3s-box-shim"
-install -m 755 "$guest_init" "$A3S_HOME/bin/a3s-box-guest-init"
+install_runtime_asset "$A3S_BOX_SHIM_BINARY" "$A3S_HOME/bin/a3s-box-shim"
+install_runtime_asset "$guest_init" "$A3S_HOME/bin/a3s-box-guest-init"
 
 echo "==> Rust SDK ($ISOLATION)"
 (

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -233,7 +233,29 @@ def load_recovery_record(host_root: Path, owner: dict, container_id: str) -> tup
     candidates = list(root.glob("c-*/recovery.json"))
     assert len(candidates) == 1, f"expected one live recovery record below {root}, found {len(candidates)}"
     recovery = read_private_json(candidates[0])
-    assert recovery["schemaVersion"] == "a3s.oci.native-linux-recovery.v1"
+    expected_fields = {
+        "schemaVersion",
+        "target",
+        "configDigest",
+        "owner",
+        "launcher",
+        "init",
+        "cgroup",
+        "intelRdt",
+    }
+    assert set(recovery) == expected_fields, (
+        f"unexpected native recovery fields: {sorted(recovery)}"
+    )
+    assert recovery["schemaVersion"] == "a3s.oci.native-linux-recovery.v3", (
+        f"unexpected native recovery schema: {recovery['schemaVersion']}"
+    )
+    config_digest = recovery["configDigest"]
+    assert config_digest.startswith("sha256:") and len(config_digest) == 71 and all(
+        character in "0123456789abcdef" for character in config_digest[7:]
+    ), "native recovery record has an invalid config digest"
+    assert recovery["intelRdt"] is None, (
+        "SDK smoke workload unexpectedly acquired Intel RDT recovery state"
+    )
     assert recovery["target"]["id"] == container_id
     assert int(recovery["owner"]["pid"]) == int(owner["pid"])
     assert int(recovery["owner"]["startTimeTicks"]) == int(owner["pid_start_time"])

--- a/scripts/no-kvm-packaged-sdk-smoke.sh
+++ b/scripts/no-kvm-packaged-sdk-smoke.sh
@@ -37,16 +37,88 @@ for artifact in \
     esac
 done
 
-sentinel_created=0
 sentinel_marker="/tmp/a3s-box-ci-kvm-sentinel"
-cleanup_kvm_sentinel() {
-    if ((sentinel_created)); then
-        sudo rm -f /dev/kvm
-        rm -f -- "$sentinel_marker"
-        sentinel_created=0
+saved_kvm="/dev/a3s-box-ci-host-kvm"
+kvm_state_owned=0
+kvm_original_moved=0
+kvm_test_directory_created=0
+
+cleanup_kvm_state() {
+    local cleanup_status=0
+
+    if ((kvm_test_directory_created)); then
+        if [[ -d /dev/kvm && ! -L /dev/kvm ]]; then
+            sudo rmdir /dev/kvm || cleanup_status=1
+        elif [[ -e /dev/kvm || -L /dev/kvm ]]; then
+            echo "refusing to remove an unexpected replacement at /dev/kvm" >&2
+            cleanup_status=1
+        fi
+    fi
+
+    if ((kvm_original_moved)); then
+        if [[ -e /dev/kvm || -L /dev/kvm ]]; then
+            echo "cannot restore the host KVM device because /dev/kvm is occupied" >&2
+            cleanup_status=1
+        elif [[ ! -c "$saved_kvm" || -L "$saved_kvm" ]]; then
+            echo "saved host KVM device is missing or has the wrong type" >&2
+            cleanup_status=1
+        else
+            sudo mv -- "$saved_kvm" /dev/kvm || cleanup_status=1
+        fi
+    fi
+
+    if ((cleanup_status == 0)); then
+        if rm -f -- "$sentinel_marker"; then
+            kvm_state_owned=0
+            kvm_original_moved=0
+            kvm_test_directory_created=0
+        else
+            cleanup_status=1
+        fi
+    fi
+
+    return "$cleanup_status"
+}
+
+handle_exit() {
+    local command_status=$?
+    trap - EXIT
+    if ((kvm_state_owned)) && ! cleanup_kvm_state; then
+        command_status=1
+    fi
+    exit "$command_status"
+}
+trap handle_exit EXIT
+
+prepare_kvm_states() {
+    if [[ -e "$sentinel_marker" || -L "$sentinel_marker" ]]; then
+        echo "refusing to replace an existing KVM ownership marker" >&2
+        exit 1
+    fi
+    if [[ -e "$saved_kvm" || -L "$saved_kvm" ]]; then
+        echo "refusing to replace a saved host KVM device" >&2
+        exit 1
+    fi
+    if [[ -e /dev/kvm || -L /dev/kvm ]]; then
+        if [[ ! -c /dev/kvm || -L /dev/kvm ]]; then
+            echo "host /dev/kvm exists but is not a character device" >&2
+            exit 1
+        fi
+    fi
+
+    printf '%s\n' 'owned by scripts/no-kvm-packaged-sdk-smoke.sh' \
+        > "$sentinel_marker"
+    kvm_state_owned=1
+
+    if [[ -e /dev/kvm || -L /dev/kvm ]]; then
+        sudo mv -- /dev/kvm "$saved_kvm"
+        kvm_original_moved=1
+    fi
+    if [[ -e /dev/kvm || -L /dev/kvm ]]; then
+        echo "failed to establish the KVM-absent test state" >&2
+        exit 1
     fi
 }
-trap cleanup_kvm_sentinel EXIT
 
 validate_recovery_report() {
     local report="$1"
@@ -76,34 +148,30 @@ run_sdk_phase() {
 
     case "$phase" in
         absent)
-            if [ -e /dev/kvm ]; then
-                echo "/dev/kvm unexpectedly exists on the no-KVM runner" >&2
+            if [[ -e /dev/kvm || -L /dev/kvm ]]; then
+                echo "/dev/kvm unexpectedly exists in the KVM-absent phase" >&2
                 exit 1
             fi
             expected_info_pattern='KVM is not available: /dev/kvm not found'
             ;;
         inaccessible)
-            test ! -e /dev/kvm
-            test ! -e "$sentinel_marker"
-            printf '%s\n' 'owned by scripts/no-kvm-packaged-sdk-smoke.sh' \
-                > "$sentinel_marker"
-            sentinel_created=1
-            sudo mknod -m 000 /dev/kvm c 10 232
+            [[ ! -e /dev/kvm && ! -L /dev/kvm ]]
+            kvm_test_directory_created=1
+            sudo install -d -m 000 /dev/kvm
             sudo python3 - <<'PY'
+import errno
 import os
 import stat
 
 metadata = os.lstat("/dev/kvm")
-assert stat.S_ISCHR(metadata.st_mode), "/dev/kvm sentinel is not a character device"
-assert os.major(metadata.st_rdev) == 10, "/dev/kvm sentinel has the wrong major number"
-assert os.minor(metadata.st_rdev) == 232, "/dev/kvm sentinel has the wrong minor number"
+assert stat.S_ISDIR(metadata.st_mode), "/dev/kvm test path is not a directory"
 try:
     descriptor = os.open("/dev/kvm", os.O_RDWR)
-except OSError:
-    pass
+except OSError as error:
+    assert error.errno == errno.EISDIR, error
 else:
     os.close(descriptor)
-    raise RuntimeError("/dev/kvm sentinel unexpectedly opened read/write")
+    raise RuntimeError("/dev/kvm test path unexpectedly opened read/write")
 PY
             expected_info_pattern='KVM access denied|Failed to access /dev/kvm'
             ;;
@@ -144,12 +212,13 @@ PY
     validate_recovery_report "$report"
 
     if [ "$phase" = inaccessible ]; then
-        test -c /dev/kvm
-        cleanup_kvm_sentinel
+        [[ -d /dev/kvm && ! -L /dev/kvm ]]
+        cleanup_kvm_state
     else
-        test ! -e /dev/kvm
+        [[ ! -e /dev/kvm && ! -L /dev/kvm ]]
     fi
 }
 
+prepare_kvm_states
 run_sdk_phase absent
 run_sdk_phase inaccessible

--- a/scripts/package-no-kvm-product.sh
+++ b/scripts/package-no-kvm-product.sh
@@ -141,5 +141,9 @@ jq --exit-status \
 for artifact in a3s-box a3s-box-shim a3s-box-guest-init a3s-oci a3s-oci-agent; do
     test -x "$INSTALL_DIR/$artifact"
 done
+installed_shim_ldd_output="$(LD_LIBRARY_PATH= ldd "$INSTALL_DIR/a3s-box-shim")"
+printf '%s\n' "$installed_shim_ldd_output"
+! grep -q 'not found' <<< "$installed_shim_ldd_output"
+grep -F "$INSTALL_DIR/lib/libkrun.so" <<< "$installed_shim_ldd_output"
 
 printf 'Installed %s from %s (sha256:%s)\n' "$PACKAGE_NAME" "$ARCHIVE" "$DIGEST"

--- a/scripts/package-no-kvm-product.sh
+++ b/scripts/package-no-kvm-product.sh
@@ -118,8 +118,9 @@ for binary in a3s-box a3s-box-shim; do
     ldd_output="$(LD_LIBRARY_PATH= ldd "$PACKAGE_ROOT/$binary")"
     printf '%s\n' "$ldd_output"
     ! grep -q 'not found' <<< "$ldd_output"
-    grep -F "$PACKAGE_ROOT/lib/libkrun.so" <<< "$ldd_output"
 done
+shim_ldd_output="$(LD_LIBRARY_PATH= ldd "$PACKAGE_ROOT/a3s-box-shim")"
+grep -F "$PACKAGE_ROOT/lib/libkrun.so" <<< "$shim_ldd_output"
 
 tar czf "$ARCHIVE" -C "$OUTPUT_ROOT" "$PACKAGE_NAME"
 DIGEST="$(sha256sum "$ARCHIVE" | awk '{ print $1 }')"

--- a/sdk/bridge-protocol.json
+++ b/sdk/bridge-protocol.json
@@ -1,3 +1,3 @@
 {
-  "version": 3
+  "version": 4
 }

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -198,7 +198,9 @@ idempotent after successful cleanup, and retryable after a cleanup failure.
 
 Runtime-native process inventory, normalized stats, ordered event polls and
 streams are exact-generation operations available for a running or paused
-Sandbox. Live resource updates require a running Sandbox:
+Sandbox. Live resource updates require a running Sandbox. Bridge protocol
+version 4 transports Unix-nanosecond timestamps as canonical decimal strings;
+the Go SDK decodes them to exact `uint64` values:
 
 ```go
 processes, err := sandbox.Processes(ctx)

--- a/sdk/go/internal/bridge/protocol.go
+++ b/sdk/go/internal/bridge/protocol.go
@@ -4,7 +4,7 @@ package bridge
 
 import "encoding/json"
 
-const ProtocolVersion = 3
+const ProtocolVersion = 4
 
 // RequiredOperations is the complete operation set used by this SDK version.
 // New clients verify this inventory before issuing a mutating request.

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -167,7 +167,7 @@ type ExecutionMemoryStats struct {
 type ExecutionStats struct {
 	ExecutionID     string               `json:"execution_id"`
 	Generation      uint64               `json:"generation"`
-	TimestampUnixNS uint64               `json:"timestamp_unix_ns"`
+	TimestampUnixNS uint64               `json:"timestamp_unix_ns,string"`
 	CPU             ExecutionCPUStats    `json:"cpu"`
 	Memory          ExecutionMemoryStats `json:"memory"`
 	ProcessCount    uint64               `json:"process_count"`
@@ -194,7 +194,7 @@ const (
 
 type ExecutionRuntimeEvent struct {
 	Sequence        uint64             `json:"sequence"`
-	TimestampUnixNS uint64             `json:"timestamp_unix_ns"`
+	TimestampUnixNS uint64             `json:"timestamp_unix_ns,string"`
 	ProcessID       *string            `json:"process_id"`
 	Kind            ExecutionEventKind `json:"kind"`
 	Attributes      map[string]string  `json:"attributes"`

--- a/sdk/go/sandbox_test.go
+++ b/sdk/go/sandbox_test.go
@@ -123,7 +123,7 @@ func TestSandboxRuntimeControlUsesExactGeneration(t *testing.T) {
 			return ExecutionStats{
 				ExecutionID:     "box-1",
 				Generation:      3,
-				TimestampUnixNS: 1_000_000,
+				TimestampUnixNS: 1_700_000_000_000_000_123,
 				CPU: ExecutionCPUStats{
 					UsageNS:     300,
 					UserNS:      200,
@@ -149,7 +149,7 @@ func TestSandboxRuntimeControlUsesExactGeneration(t *testing.T) {
 				Generation:  3,
 				Events: []ExecutionRuntimeEvent{{
 					Sequence:        8,
-					TimestampUnixNS: 1_000_001,
+					TimestampUnixNS: 1_700_000_000_000_000_124,
 					ProcessID:       &processID,
 					Kind:            EventProcessExited,
 					Attributes:      map[string]string{"exit_code": "0"},
@@ -181,11 +181,18 @@ func TestSandboxRuntimeControlUsesExactGeneration(t *testing.T) {
 		t.Fatalf("processes=%+v err=%v", processes, err)
 	}
 	stats, err := sandbox.RuntimeStats(ctx)
-	if err != nil || stats.CPU.UsageNS != 300 || stats.Metrics["io.read_bytes"] != 64 {
+	if err != nil ||
+		stats.TimestampUnixNS != 1_700_000_000_000_000_123 ||
+		stats.CPU.UsageNS != 300 ||
+		stats.Metrics["io.read_bytes"] != 64 {
 		t.Fatalf("stats=%+v err=%v", stats, err)
 	}
 	events, err := sandbox.Events(ctx, ExecutionEventsRequest{AfterSequence: 7, WaitTimeoutMS: &waitTimeoutMS})
-	if err != nil || len(events.Events) != 1 || events.Events[0].Kind != EventProcessExited || events.NextSequence != 8 {
+	if err != nil ||
+		len(events.Events) != 1 ||
+		events.Events[0].TimestampUnixNS != 1_700_000_000_000_000_124 ||
+		events.Events[0].Kind != EventProcessExited ||
+		events.NextSequence != 8 {
 		t.Fatalf("events=%+v err=%v", events, err)
 	}
 	cpuShares := uint64(512)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -146,7 +146,9 @@ default to 256 items and accept at most 4,096. A synchronous stream can use a
 an async iterator whose task cancellation kills the active local bridge
 process. Streams terminate on generation drift instead of following a restart.
 Reuse an explicit resource-update `operation_id` when retrying an outcome that
-is not yet known.
+is not yet known. Bridge protocol version 4 transports Unix-nanosecond
+timestamps as canonical decimal strings; the Python SDK decodes them to exact
+`int` values.
 
 ## Builder-style programmable CI/CD
 
@@ -243,6 +245,6 @@ client.prune_volumes()
 client.prune_networks()
 ```
 
-`client.capabilities()` returns bridge protocol version 3 and the exact 52
+`client.capabilities()` returns bridge protocol version 4 and the exact 52
 supported operation names. Registry passwords are passed only to the local
 runtime process.

--- a/sdk/python/src/a3s_box/_bridge_values.py
+++ b/sdk/python/src/a3s_box/_bridge_values.py
@@ -242,7 +242,7 @@ def execution_stats(result: Mapping[str, object]) -> ExecutionStats:
     return ExecutionStats(
         execution_id=string(result["execution_id"]),
         generation=integer(result["generation"]),
-        timestamp_unix_ns=unsigned_integer(result["timestamp_unix_ns"]),
+        timestamp_unix_ns=unsigned_decimal(result["timestamp_unix_ns"]),
         cpu=ExecutionCpuStats(
             usage_ns=unsigned_integer(cpu["usage_ns"]),
             user_ns=unsigned_integer(cpu["user_ns"]),
@@ -268,7 +268,7 @@ def execution_event_batch(
         events=tuple(
             ExecutionRuntimeEvent(
                 sequence=unsigned_integer(item["sequence"]),
-                timestamp_unix_ns=unsigned_integer(item["timestamp_unix_ns"]),
+                timestamp_unix_ns=unsigned_decimal(item["timestamp_unix_ns"]),
                 process_id=optional_string(item.get("process_id")),
                 kind=execution_event_kind(item["kind"]),
                 attributes=string_mapping(item["attributes"]),
@@ -473,6 +473,21 @@ def unsigned_integer(value: object) -> int:
     result = integer(value)
     if result < 0 or result > (1 << 64) - 1:
         protocol_error("an out-of-range unsigned integer")
+    return result
+
+
+def unsigned_decimal(value: object) -> int:
+    encoded = string(value)
+    if (
+        not encoded
+        or len(encoded) > 20
+        or (len(encoded) > 1 and encoded.startswith("0"))
+        or any(character not in "0123456789" for character in encoded)
+    ):
+        protocol_error("an invalid unsigned decimal string")
+    result = int(encoded)
+    if result > (1 << 64) - 1:
+        protocol_error("an out-of-range unsigned decimal string")
     return result
 
 

--- a/sdk/python/src/a3s_box/runtime.py
+++ b/sdk/python/src/a3s_box/runtime.py
@@ -14,7 +14,7 @@ from typing import Any, Protocol
 
 from .exceptions import A3SBoxError, A3SBoxNotInstalledError
 
-BRIDGE_PROTOCOL_VERSION = 3
+BRIDGE_PROTOCOL_VERSION = 4
 SUPPORTED_BRIDGE_OPERATIONS = (
     "sdk_capabilities",
     "runtime_diagnostics",

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -102,7 +102,7 @@ def event_stream_response(request: Mapping[str, object]) -> dict[str, Any]:
     events = [
         {
             "sequence": sequence,
-            "timestamp_unix_ns": 1_700_000_000_000_000_000 + sequence,
+            "timestamp_unix_ns": str(1_700_000_000_000_000_000 + sequence),
             "process_id": "init" if sequence == 5 else None,
             "kind": (
                 "container-started"
@@ -321,7 +321,7 @@ def response_for(request: Mapping[str, object]) -> dict[str, Any]:
         return {
             "execution_id": request["sandbox_id"],
             "generation": request["generation"],
-            "timestamp_unix_ns": 1_000_000,
+            "timestamp_unix_ns": "1700000000000000123",
             "cpu": {
                 "usage_ns": 300,
                 "user_ns": 200,
@@ -343,7 +343,7 @@ def response_for(request: Mapping[str, object]) -> dict[str, Any]:
             "events": [
                 {
                     "sequence": int(request["after_sequence"]) + 1,
-                    "timestamp_unix_ns": 1_000_001,
+                    "timestamp_unix_ns": "1700000000000000124",
                     "process_id": "exec-1",
                     "kind": "process-exited",
                     "attributes": {"exit_code": "0"},
@@ -902,7 +902,7 @@ class SdkTests(unittest.TestCase):
                 {
                     "execution_id": "sandbox-local-1",
                     "generation": 1,
-                    "timestamp_unix_ns": 0,
+                    "timestamp_unix_ns": "0",
                     "cpu": {
                         "usage_ns": 1,
                         "user_ns": 1,
@@ -927,7 +927,7 @@ class SdkTests(unittest.TestCase):
                     "events": [
                         {
                             "sequence": 7,
-                            "timestamp_unix_ns": 1,
+                            "timestamp_unix_ns": "1",
                             "process_id": None,
                             "kind": "runtime-warning",
                             "attributes": {},
@@ -1015,9 +1015,11 @@ class SdkTests(unittest.TestCase):
         self.assertEqual(logs[0].stream, "stdout")
         self.assertEqual(stats.memory_percent, 50.0)
         self.assertEqual(processes.processes[0].process_id, "init")
+        self.assertEqual(runtime_stats.timestamp_unix_ns, 1_700_000_000_000_000_123)
         self.assertEqual(runtime_stats.cpu.usage_ns, 300)
         self.assertEqual(runtime_stats.metrics["io.read_bytes"], 64)
         self.assertEqual(events.events[0].kind, "process-exited")
+        self.assertEqual(events.events[0].timestamp_unix_ns, 1_700_000_000_000_000_124)
         self.assertEqual(events.next_sequence, 8)
         self.assertEqual(sandbox.state, "removed")
         self.assertEqual(
@@ -1584,6 +1586,7 @@ class AsyncSdkTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(logs[0].message, "sdk-log\n")
         self.assertEqual(stats.block_write_bytes, 40)
         self.assertEqual(processes.processes[1].terminal, True)
+        self.assertEqual(runtime_stats.timestamp_unix_ns, 1_700_000_000_000_000_123)
         self.assertEqual(runtime_stats.memory.limit_bytes, 2048)
         self.assertEqual(events.next_sequence, 11)
         self.assertEqual(sandboxes[0].id, "sandbox-local-1")

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -139,9 +139,9 @@ default to 256 items and accept at most 4,096. `streamEvents()` is an
 `AsyncIterable`; pass an `AbortSignal` to cancel an active local bridge process.
 Streams terminate on generation drift instead of following a restart. Reuse an
 explicit resource-update `operationId` when retrying an outcome that is not yet
-known. Runtime and event timestamps are Unix epoch nanoseconds. They remain
-JavaScript `number` values for API compatibility, so current-epoch timestamps
-can round sub-microsecond digits; use event sequence values for exact ordering.
+known. Unix-nanosecond timestamps are `bigint` values; bridge protocol version
+4 transports them as canonical decimal strings so JavaScript never rounds the
+wire value through `number`.
 
 ## Builder-style programmable CI/CD
 
@@ -244,6 +244,6 @@ await client.pruneVolumes()
 await client.pruneNetworks()
 ```
 
-`client.capabilities()` returns bridge protocol version 3 and the exact 52
+`client.capabilities()` returns bridge protocol version 4 and the exact 52
 supported operation names. Registry passwords are passed only to the local
 runtime process.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -139,7 +139,9 @@ default to 256 items and accept at most 4,096. `streamEvents()` is an
 `AsyncIterable`; pass an `AbortSignal` to cancel an active local bridge process.
 Streams terminate on generation drift instead of following a restart. Reuse an
 explicit resource-update `operationId` when retrying an outcome that is not yet
-known.
+known. Runtime and event timestamps are Unix epoch nanoseconds. They remain
+JavaScript `number` values for API compatibility, so current-epoch timestamps
+can round sub-microsecond digits; use event sequence values for exact ordering.
 
 ## Builder-style programmable CI/CD
 

--- a/sdk/typescript/src/bridge-values.ts
+++ b/sdk/typescript/src/bridge-values.ts
@@ -227,7 +227,7 @@ export function executionStats(result: BridgeResult): ExecutionStats {
   return {
     executionId: requiredString(result, 'execution_id'),
     generation: requiredGeneration(result, 'generation'),
-    timestampUnixNs: requiredUnsignedInteger(result, 'timestamp_unix_ns'),
+    timestampUnixNs: requiredUnixNanoseconds(result, 'timestamp_unix_ns'),
     cpu: executionCpuStats(cpu),
     memory: executionMemoryStats(memory),
     processCount: requiredUnsignedInteger(result, 'process_count'),
@@ -266,7 +266,7 @@ export function executionEventBatch(
 function executionRuntimeEvent(result: BridgeResult): ExecutionRuntimeEvent {
   return {
     sequence: requiredUnsignedInteger(result, 'sequence'),
-    timestampUnixNs: requiredUnsignedInteger(result, 'timestamp_unix_ns'),
+    timestampUnixNs: requiredUnixNanoseconds(result, 'timestamp_unix_ns'),
     processId: optionalString(result, 'process_id'),
     kind: executionEventKind(result, 'kind'),
     attributes: stringRecord(result.attributes),
@@ -422,6 +422,23 @@ export function optionalUnsignedInteger(
   const value = result[key]
   if (value === null || value === undefined) return undefined
   return requiredUnsignedInteger(result, key)
+}
+
+function requiredUnixNanoseconds(
+  result: BridgeResult,
+  key: string
+): number {
+  const value = requiredNumber(result, key)
+  // Current epoch nanoseconds exceed MAX_SAFE_INTEGER. Protocol v3 uses JSON
+  // numbers, so retain the nearest JavaScript value while enforcing u64 bounds.
+  if (
+    !Number.isInteger(value) ||
+    value < 0 ||
+    value > Number((1n << 64n) - 1n)
+  ) {
+    bridgeTypeError(key)
+  }
+  return value
 }
 
 export function requiredGeneration(

--- a/sdk/typescript/src/bridge-values.ts
+++ b/sdk/typescript/src/bridge-values.ts
@@ -31,6 +31,8 @@ import type {
   FilesystemSnapshotInfo,
 } from './sandbox.js'
 
+const MAX_UNSIGNED_64 = (1n << 64n) - 1n
+
 export function buildImageInfo(result: BridgeResult): BuildImageInfo {
   return {
     reference: requiredString(result, 'reference'),
@@ -227,7 +229,7 @@ export function executionStats(result: BridgeResult): ExecutionStats {
   return {
     executionId: requiredString(result, 'execution_id'),
     generation: requiredGeneration(result, 'generation'),
-    timestampUnixNs: requiredUnixNanoseconds(result, 'timestamp_unix_ns'),
+    timestampUnixNs: requiredUnsignedBigInt(result, 'timestamp_unix_ns'),
     cpu: executionCpuStats(cpu),
     memory: executionMemoryStats(memory),
     processCount: requiredUnsignedInteger(result, 'process_count'),
@@ -266,7 +268,7 @@ export function executionEventBatch(
 function executionRuntimeEvent(result: BridgeResult): ExecutionRuntimeEvent {
   return {
     sequence: requiredUnsignedInteger(result, 'sequence'),
-    timestampUnixNs: requiredUnixNanoseconds(result, 'timestamp_unix_ns'),
+    timestampUnixNs: requiredUnsignedBigInt(result, 'timestamp_unix_ns'),
     processId: optionalString(result, 'process_id'),
     kind: executionEventKind(result, 'kind'),
     attributes: stringRecord(result.attributes),
@@ -415,6 +417,19 @@ export function requiredUnsignedInteger(
   return value
 }
 
+export function requiredUnsignedBigInt(
+  result: BridgeResult,
+  key: string
+): bigint {
+  const value = requiredString(result, key)
+  if (value.length > 20 || !/^(0|[1-9][0-9]*)$/.test(value)) {
+    bridgeTypeError(key)
+  }
+  const decoded = BigInt(value)
+  if (decoded > MAX_UNSIGNED_64) bridgeTypeError(key)
+  return decoded
+}
+
 export function optionalUnsignedInteger(
   result: BridgeResult,
   key: string
@@ -422,23 +437,6 @@ export function optionalUnsignedInteger(
   const value = result[key]
   if (value === null || value === undefined) return undefined
   return requiredUnsignedInteger(result, key)
-}
-
-function requiredUnixNanoseconds(
-  result: BridgeResult,
-  key: string
-): number {
-  const value = requiredNumber(result, key)
-  // Current epoch nanoseconds exceed MAX_SAFE_INTEGER. Protocol v3 uses JSON
-  // numbers, so retain the nearest JavaScript value while enforcing u64 bounds.
-  if (
-    !Number.isInteger(value) ||
-    value < 0 ||
-    value > Number((1n << 64n) - 1n)
-  ) {
-    bridgeTypeError(key)
-  }
-  return value
 }
 
 export function requiredGeneration(

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 
 import { A3SBoxError, A3SBoxNotInstalledError } from './errors.js'
 
-export const BRIDGE_PROTOCOL_VERSION = 3
+export const BRIDGE_PROTOCOL_VERSION = 4
 export const SUPPORTED_BRIDGE_OPERATIONS = [
   'sdk_capabilities',
   'runtime_diagnostics',

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -190,8 +190,8 @@ export interface ExecutionMemoryStats {
 export interface ExecutionStats {
   executionId: string
   generation: number
-  /** Unix epoch nanoseconds; JavaScript may round sub-microsecond digits. */
-  timestampUnixNs: number
+  /** Exact Unix epoch nanoseconds. */
+  timestampUnixNs: bigint
   cpu: ExecutionCpuStats
   memory: ExecutionMemoryStats
   processCount: number
@@ -215,8 +215,8 @@ export type ExecutionEventKind =
 
 export interface ExecutionRuntimeEvent {
   sequence: number
-  /** Unix epoch nanoseconds; JavaScript may round sub-microsecond digits. */
-  timestampUnixNs: number
+  /** Exact Unix epoch nanoseconds. */
+  timestampUnixNs: bigint
   processId?: string
   kind: ExecutionEventKind
   attributes: Readonly<Record<string, string>>
@@ -793,7 +793,7 @@ function validateProcessInventory(
 
 function validateExecutionStats(stats: ExecutionStats): void {
   if (
-    stats.timestampUnixNs <= 0 ||
+    stats.timestampUnixNs <= 0n ||
     stats.cpu.userNs + stats.cpu.systemNs > stats.cpu.usageNs ||
     (stats.memory.peakBytes !== undefined &&
       stats.memory.peakBytes < stats.memory.usageBytes) ||
@@ -817,7 +817,7 @@ function validateExecutionEventBatch(
 ): void {
   let previous = afterSequence
   for (const event of batch.events) {
-    if (event.sequence <= previous || event.timestampUnixNs <= 0) {
+    if (event.sequence <= previous || event.timestampUnixNs <= 0n) {
       throw new A3SBoxError(
         'Bridge returned an invalid runtime event order',
         'bridge_protocol_error'

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -190,6 +190,7 @@ export interface ExecutionMemoryStats {
 export interface ExecutionStats {
   executionId: string
   generation: number
+  /** Unix epoch nanoseconds; JavaScript may round sub-microsecond digits. */
   timestampUnixNs: number
   cpu: ExecutionCpuStats
   memory: ExecutionMemoryStats
@@ -214,6 +215,7 @@ export type ExecutionEventKind =
 
 export interface ExecutionRuntimeEvent {
   sequence: number
+  /** Unix epoch nanoseconds; JavaScript may round sub-microsecond digits. */
   timestampUnixNs: number
   processId?: string
   kind: ExecutionEventKind

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -208,7 +208,7 @@ class FakeRuntime {
         return {
           execution_id: request.sandbox_id,
           generation: request.generation,
-          timestamp_unix_ns: 1_700_000_000_000_000_000,
+          timestamp_unix_ns: '1700000000000000123',
           cpu: {
             usage_ns: 300,
             user_ns: 200,
@@ -230,7 +230,7 @@ class FakeRuntime {
           events: [
             {
               sequence: request.after_sequence + 1,
-              timestamp_unix_ns: 1_700_000_000_000_000_000,
+              timestamp_unix_ns: '1700000000000000124',
               process_id: 'exec-1',
               kind: 'process-exited',
               attributes: { exit_code: '0' },
@@ -856,7 +856,9 @@ function eventStreamResponse(request) {
     .slice(0, request.limit)
     .map((sequence) => ({
       sequence,
-      timestamp_unix_ns: 1_700_000_000_000_000_000 + sequence,
+      timestamp_unix_ns: (
+        1_700_000_000_000_000_000n + BigInt(sequence)
+      ).toString(),
       process_id: sequence === 5 ? 'init' : null,
       kind:
         sequence === 2
@@ -911,7 +913,7 @@ const malformedStatsSandbox = await Sandbox.create(undefined, {
   runtime: new MalformedSandboxRuntime('sandbox_runtime_stats', {
     execution_id: 'sandbox-local-1',
     generation: 1,
-    timestamp_unix_ns: 0,
+    timestamp_unix_ns: '0',
     cpu: { usage_ns: 1, user_ns: 1, system_ns: 0, throttled_ns: 0 },
     memory: { usage_bytes: 0, limit_bytes: null, peak_bytes: null },
     process_count: 1,
@@ -926,9 +928,13 @@ await assert.rejects(
 
 for (const timestampUnixNs of [
   -1,
-  1.5,
-  Number.POSITIVE_INFINITY,
-  Number.MAX_VALUE,
+  1_700_000_000_000_000_000,
+  '',
+  '-1',
+  '01',
+  '1.5',
+  '18446744073709551616',
+  '100000000000000000000',
 ]) {
   const invalidTimestampSandbox = await Sandbox.create(undefined, {
     runtime: new MalformedSandboxRuntime('sandbox_runtime_stats', {
@@ -955,7 +961,7 @@ const malformedEventsSandbox = await Sandbox.create(undefined, {
     events: [
       {
         sequence: 7,
-        timestamp_unix_ns: 1,
+        timestamp_unix_ns: '1',
         process_id: null,
         kind: 'runtime-warning',
         attributes: {},
@@ -1083,17 +1089,11 @@ assert.equal(lifecycleSandbox.state, 'removed')
 assert.equal(lifecycleLogs[0].message, 'sdk-log\n')
 assert.equal(lifecycleStats.memoryPercent, 50)
 assert.equal(lifecycleProcesses.processes[0].processId, 'init')
-assert.equal(
-  lifecycleRuntimeStats.timestampUnixNs,
-  1_700_000_000_000_000_000
-)
+assert.equal(lifecycleRuntimeStats.timestampUnixNs, 1_700_000_000_000_000_123n)
 assert.equal(lifecycleRuntimeStats.cpu.usageNs, 300)
 assert.equal(lifecycleRuntimeStats.metrics['io.read_bytes'], 64)
 assert.equal(lifecycleEvents.events[0].kind, 'process-exited')
-assert.equal(
-  lifecycleEvents.events[0].timestampUnixNs,
-  1_700_000_000_000_000_000
-)
+assert.equal(lifecycleEvents.events[0].timestampUnixNs, 1_700_000_000_000_000_124n)
 assert.equal(lifecycleEvents.nextSequence, 8)
 assert.deepEqual(
   lifecycleRuntime.requests.map((request) => request.operation),

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -208,7 +208,7 @@ class FakeRuntime {
         return {
           execution_id: request.sandbox_id,
           generation: request.generation,
-          timestamp_unix_ns: 1_000_000,
+          timestamp_unix_ns: 1_700_000_000_000_000_000,
           cpu: {
             usage_ns: 300,
             user_ns: 200,
@@ -230,7 +230,7 @@ class FakeRuntime {
           events: [
             {
               sequence: request.after_sequence + 1,
-              timestamp_unix_ns: 1_000_001,
+              timestamp_unix_ns: 1_700_000_000_000_000_000,
               process_id: 'exec-1',
               kind: 'process-exited',
               attributes: { exit_code: '0' },
@@ -856,7 +856,7 @@ function eventStreamResponse(request) {
     .slice(0, request.limit)
     .map((sequence) => ({
       sequence,
-      timestamp_unix_ns: 1_700_000_000_000_000 + sequence,
+      timestamp_unix_ns: 1_700_000_000_000_000_000 + sequence,
       process_id: sequence === 5 ? 'init' : null,
       kind:
         sequence === 2
@@ -923,6 +923,30 @@ await assert.rejects(
   (error) =>
     error instanceof A3SBoxError && error.code === 'bridge_protocol_error'
 )
+
+for (const timestampUnixNs of [
+  -1,
+  1.5,
+  Number.POSITIVE_INFINITY,
+  Number.MAX_VALUE,
+]) {
+  const invalidTimestampSandbox = await Sandbox.create(undefined, {
+    runtime: new MalformedSandboxRuntime('sandbox_runtime_stats', {
+      execution_id: 'sandbox-local-1',
+      generation: 1,
+      timestamp_unix_ns: timestampUnixNs,
+      cpu: { usage_ns: 1, user_ns: 1, system_ns: 0, throttled_ns: 0 },
+      memory: { usage_bytes: 0, limit_bytes: null, peak_bytes: null },
+      process_count: 1,
+      metrics: {},
+    }),
+  })
+  await assert.rejects(
+    invalidTimestampSandbox.runtimeStats(),
+    (error) =>
+      error instanceof A3SBoxError && error.code === 'bridge_protocol_error'
+  )
+}
 
 const malformedEventsSandbox = await Sandbox.create(undefined, {
   runtime: new MalformedSandboxRuntime('sandbox_events', {
@@ -1059,9 +1083,17 @@ assert.equal(lifecycleSandbox.state, 'removed')
 assert.equal(lifecycleLogs[0].message, 'sdk-log\n')
 assert.equal(lifecycleStats.memoryPercent, 50)
 assert.equal(lifecycleProcesses.processes[0].processId, 'init')
+assert.equal(
+  lifecycleRuntimeStats.timestampUnixNs,
+  1_700_000_000_000_000_000
+)
 assert.equal(lifecycleRuntimeStats.cpu.usageNs, 300)
 assert.equal(lifecycleRuntimeStats.metrics['io.read_bytes'], 64)
 assert.equal(lifecycleEvents.events[0].kind, 'process-exited')
+assert.equal(
+  lifecycleEvents.events[0].timestampUnixNs,
+  1_700_000_000_000_000_000
+)
 assert.equal(lifecycleEvents.nextSequence, 8)
 assert.deepEqual(
   lifecycleRuntime.requests.map((request) => request.operation),

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=82cbc663f0ab7a0a888defe71a5a7d257ae1f9de#82cbc663f0ab7a0a888defe71a5a7d257ae1f9de"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=438e4b7936cd08d408160fe9341a21786f60cd26#438e4b7936cd08d408160fe9341a21786f60cd26"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=82cbc663f0ab7a0a888defe71a5a7d257ae1f9de#82cbc663f0ab7a0a888defe71a5a7d257ae1f9de"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=438e4b7936cd08d408160fe9341a21786f60cd26#438e4b7936cd08d408160fe9341a21786f60cd26"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1810,7 +1810,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3723,7 +3723,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4750,7 +4750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "82cbc663f0ab7a0a888defe71a5a7d257ae1f9de" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "438e4b7936cd08d408160fe9341a21786f60cd26" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
@@ -1,5 +1,5 @@
 use std::path::{Component, Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use a3s_box_core::ExecutionIsolation;
 use a3s_oci_sdk::{CONTROL_CGROUP_NAME, WORKLOAD_CGROUP_NAME};
@@ -15,6 +15,8 @@ const CPU_PERIOD_US: u64 = 100_000;
 const CPU_QUOTA_US: u64 = CPU_MILLIS * (CPU_PERIOD_US / 1_000);
 const MEMORY_BYTES: u64 = 128 * 1024 * 1024;
 const PIDS: u32 = 32;
+const TASK_EXECUTION_TIMEOUT_MS: u64 = 400;
+const TASK_TIMEOUT_MAX_RUNTIME_MS: u64 = 5_000;
 
 pub(super) async fn run(
     fixture: &BoxRuntimeConformanceFixture,
@@ -296,19 +298,30 @@ pub(super) async fn run(
         ),
     )?;
 
-    let timeout = fixture
-        .cases
-        .task("resources-execution-timeout", "exec sleep 3600", 400);
-    let started = Instant::now();
+    let timeout = fixture.cases.task(
+        "resources-execution-timeout",
+        "exec sleep 3600",
+        TASK_EXECUTION_TIMEOUT_MS,
+    );
+    let applied_at = Instant::now();
     let timed_out = client.apply(&timeout).await?;
+    let wall_elapsed_ms = applied_at.elapsed().as_millis();
+    let provider_elapsed_ms = timed_out
+        .started_at_ms
+        .zip(timed_out.finished_at_ms)
+        .and_then(|(started, finished)| finished.checked_sub(started));
     require(
         timed_out.state == RuntimeUnitState::Failed
             && timed_out
                 .failure
                 .as_ref()
                 .is_some_and(|failure| failure.code == "execution_timeout" && !failure.retryable)
-            && started.elapsed() < Duration::from_secs(5),
-        "Task execution timeout was not behaviorally enforced",
+            && provider_elapsed_ms
+                .is_some_and(|elapsed| elapsed < TASK_TIMEOUT_MAX_RUNTIME_MS),
+        format!(
+            "Task execution timeout was not behaviorally enforced: state={:?} failure={:?} provider_elapsed_ms={provider_elapsed_ms:?} wall_elapsed_ms={wall_elapsed_ms}",
+            timed_out.state, timed_out.failure
+        ),
     )?;
     fixture
         .remove_unit(client, &timeout.spec, "resources-execution-timeout")

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -24,6 +24,7 @@ mod oci_production;
 mod oci_session;
 mod operations;
 mod port;
+mod prepared_rootfs;
 mod record;
 mod recovery;
 mod remove;

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -783,6 +783,7 @@ impl OciRuntimeService for FakeRuntimeService {
                 sequence,
                 timestamp_unix_ns: 1_700_000_000_000_000_000 + sequence,
                 container: target.clone(),
+                operation_id: None,
                 process_id: (sequence == 8).then(ProcessId::init),
                 kind: if sequence == 5 {
                     RuntimeEventKind::ContainerStarted
@@ -5032,6 +5033,8 @@ fn runtime_record(
         generation,
         driver,
         isolation,
+        guest_session: None,
+        network_enforcement: None,
         config_digest: config_digest.to_string(),
         attachments_digest: attachments_digest.map(str::to_string),
     })

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -2275,7 +2275,7 @@ async fn captured_exec_replays_after_lost_response_and_backend_reopen() {
 }
 
 #[tokio::test]
-async fn relative_exec_resolves_against_the_prepared_rootfs_path() {
+async fn relative_exec_tracks_the_prepared_rootfs_layout() {
     let directory = tempfile::tempdir().expect("temporary directory");
     let service = Arc::new(FakeRuntimeService::launch_ready());
     let manager = manager(
@@ -2291,21 +2291,25 @@ async fn relative_exec_resolves_against_the_prepared_rootfs_path() {
         )
         .await
         .expect("initial launch");
-    let rootfs = directory
+    let box_dir = directory
         .path()
         .join("home")
         .join("boxes")
-        .join(lease.execution_id.as_str())
-        .join("rootfs");
-    std::fs::create_dir_all(rootfs.join("usr/bin")).expect("create rootfs PATH directory");
-    let executable = rootfs.join("usr/bin/printf");
-    std::fs::write(&executable, b"fake executable").expect("create rootfs executable");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755))
-            .expect("mark rootfs command executable");
-    }
+        .join(lease.execution_id.as_str());
+    let prepare_executable = |rootfs: &std::path::Path, relative: &str| {
+        let executable = rootfs.join(relative);
+        std::fs::create_dir_all(executable.parent().expect("executable parent"))
+            .expect("create rootfs PATH directory");
+        std::fs::write(&executable, b"fake executable").expect("create rootfs executable");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755))
+                .expect("mark rootfs command executable");
+        }
+    };
+
+    prepare_executable(&box_dir.join("rootfs"), "usr/bin/printf");
 
     let mut exec = box_exec_request(Some("relative-path-command"));
     exec.cmd = vec!["printf".to_string(), "sdk-ok".to_string()];
@@ -2314,11 +2318,25 @@ async fn relative_exec_resolves_against_the_prepared_rootfs_path() {
         .await
         .expect("relative exec through OCI backend");
 
+    // A later generation of the same image uses the overlay cache-hit view.
+    // Keep the old rootfs populated to prove the resolver prefers `merged`.
+    prepare_executable(&box_dir.join("merged"), "usr/local/bin/printf");
+    let mut cached_exec = box_exec_request(Some("relative-path-cache-hit-command"));
+    cached_exec.cmd = vec!["printf".to_string(), "cache-hit".to_string()];
+    manager
+        .execute(&lease.execution_id, lease.generation, cached_exec)
+        .await
+        .expect("relative exec through cached overlay rootfs");
+
     let calls = service.exec_requests();
-    assert_eq!(calls.len(), 1);
+    assert_eq!(calls.len(), 2);
     assert_eq!(
         calls[0].process.args().as_ref().expect("process args"),
         &["/usr/bin/printf", "sdk-ok"]
+    );
+    assert_eq!(
+        calls[1].process.args().as_ref().expect("process args"),
+        &["/usr/local/bin/printf", "cache-hit"]
     );
 }
 

--- a/src/runtime/src/local_execution/oci_session.rs
+++ b/src/runtime/src/local_execution/oci_session.rs
@@ -394,8 +394,10 @@ fn resolve_exec_executable(
             })
         })
         .unwrap_or(DEFAULT_CONTAINER_PATH);
-    *command = resolve_runtime_executable(&record.box_dir.join("rootfs"), cwd, path, command)
-        .map_err(exec_path_request_error)?;
+    let rootfs = super::prepared_rootfs::resolve_prepared_rootfs(&record.box_dir)
+        .unwrap_or_else(|| record.box_dir.join("rootfs"));
+    *command =
+        resolve_runtime_executable(&rootfs, cwd, path, command).map_err(exec_path_request_error)?;
     Ok(())
 }
 

--- a/src/runtime/src/local_execution/prepared_rootfs.rs
+++ b/src/runtime/src/local_execution/prepared_rootfs.rs
@@ -1,0 +1,72 @@
+use std::path::{Path, PathBuf};
+
+/// Resolve the host-visible rootfs prepared for a managed execution.
+///
+/// Linux cache hits run through the overlay mount at `merged`, while cache
+/// misses and copy providers use `rootfs` directly. Legacy APFS providers
+/// expose their mounted data below `rootfs/.a3s-rootfs`. Keep this ordering in
+/// one place so lifecycle operations inspect the same filesystem view that was
+/// handed to the runtime.
+pub(super) fn resolve_prepared_rootfs(box_dir: &Path) -> Option<PathBuf> {
+    let populated = |path: &Path| {
+        path.is_dir()
+            && std::fs::read_dir(path)
+                .map(|mut entries| entries.next().is_some())
+                .unwrap_or(false)
+    };
+
+    let merged = box_dir.join("merged");
+    if crate::rootfs::is_mountpoint(&merged) || populated(&merged) {
+        return Some(merged);
+    }
+
+    let rootfs = box_dir.join("rootfs");
+    let apfs_data = rootfs.join(".a3s-rootfs");
+    if populated(&apfs_data) {
+        return Some(apfs_data);
+    }
+
+    populated(&rootfs).then_some(rootfs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_prepared_rootfs;
+
+    #[test]
+    fn prefers_the_overlay_runtime_view() {
+        let directory = tempfile::tempdir().unwrap();
+        let rootfs = directory.path().join("rootfs");
+        let merged = directory.path().join("merged");
+        std::fs::create_dir_all(&rootfs).unwrap();
+        std::fs::create_dir_all(&merged).unwrap();
+        std::fs::write(rootfs.join("lower"), b"lower").unwrap();
+        std::fs::write(merged.join("visible"), b"merged").unwrap();
+
+        assert_eq!(resolve_prepared_rootfs(directory.path()), Some(merged));
+    }
+
+    #[test]
+    fn resolves_copy_and_legacy_apfs_layouts() {
+        let copy = tempfile::tempdir().unwrap();
+        let copy_rootfs = copy.path().join("rootfs");
+        std::fs::create_dir_all(&copy_rootfs).unwrap();
+        std::fs::write(copy_rootfs.join("visible"), b"copy").unwrap();
+        assert_eq!(resolve_prepared_rootfs(copy.path()), Some(copy_rootfs));
+
+        let apfs = tempfile::tempdir().unwrap();
+        let apfs_rootfs = apfs.path().join("rootfs/.a3s-rootfs");
+        std::fs::create_dir_all(&apfs_rootfs).unwrap();
+        std::fs::write(apfs_rootfs.join("visible"), b"apfs").unwrap();
+        assert_eq!(resolve_prepared_rootfs(apfs.path()), Some(apfs_rootfs));
+    }
+
+    #[test]
+    fn rejects_absent_and_empty_layouts() {
+        let directory = tempfile::tempdir().unwrap();
+        assert_eq!(resolve_prepared_rootfs(directory.path()), None);
+        std::fs::create_dir_all(directory.path().join("merged")).unwrap();
+        std::fs::create_dir_all(directory.path().join("rootfs")).unwrap();
+        assert_eq!(resolve_prepared_rootfs(directory.path()), None);
+    }
+}

--- a/src/runtime/src/local_execution/snapshot.rs
+++ b/src/runtime/src/local_execution/snapshot.rs
@@ -1,6 +1,6 @@
 //! Crash-recoverable filesystem snapshots for managed executions.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use a3s_box_core::snapshot::SnapshotMetadata;
 use a3s_box_core::{
@@ -335,12 +335,13 @@ impl LocalExecutionManager {
                 }
                 return Ok(existing.size_bytes);
             }
-            let rootfs = resolve_managed_rootfs(&record.box_dir).ok_or_else(|| {
-                ExecutionManagerError::Unavailable(format!(
-                    "execution {} has no populated managed rootfs to snapshot",
-                    record.id
-                ))
-            })?;
+            let rootfs = super::prepared_rootfs::resolve_prepared_rootfs(&record.box_dir)
+                .ok_or_else(|| {
+                    ExecutionManagerError::Unavailable(format!(
+                        "execution {} has no populated managed rootfs to snapshot",
+                        record.id
+                    ))
+                })?;
             let metadata = build_snapshot_metadata(&record, &snapshot_id)?;
             #[cfg(target_os = "linux")]
             let rootfs_metadata = capture_sandbox_rootfs_metadata(&record, &rootfs)?;
@@ -509,25 +510,6 @@ fn execution_state(state: ManagedExecutionState) -> ExecutionManagerResult<Execu
             "invalid stable snapshot state {state}"
         ))),
     }
-}
-
-fn resolve_managed_rootfs(box_dir: &Path) -> Option<PathBuf> {
-    let populated = |path: &Path| {
-        path.is_dir()
-            && std::fs::read_dir(path)
-                .map(|mut entries| entries.next().is_some())
-                .unwrap_or(false)
-    };
-    let merged = box_dir.join("merged");
-    if populated(&merged) {
-        return Some(merged);
-    }
-    let rootfs = box_dir.join("rootfs");
-    let apfs_data = rootfs.join(".a3s-rootfs");
-    if populated(&apfs_data) {
-        return Some(apfs_data);
-    }
-    populated(&rootfs).then_some(rootfs)
 }
 
 #[cfg(target_os = "linux")]

--- a/src/sdk/src/bridge.rs
+++ b/src/sdk/src/bridge.rs
@@ -9,9 +9,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use a3s_box_core::{
-    error::BoxError, ExecutionEventsRequest, ExecutionGeneration, ExecutionId, ExecutionIsolation,
-    ExecutionSnapshot, ExecutionSnapshotId, ExecutionState, FilesystemEntry, FilesystemEntryKind,
-    OperationId, Platform, PortMapping,
+    error::BoxError, ExecutionEventBatch, ExecutionEventsRequest, ExecutionGeneration, ExecutionId,
+    ExecutionIsolation, ExecutionSnapshot, ExecutionSnapshotId, ExecutionState, ExecutionStats,
+    FilesystemEntry, FilesystemEntryKind, OperationId, Platform, PortMapping,
 };
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
@@ -32,7 +32,7 @@ pub use request::{
     BRIDGE_OPERATIONS,
 };
 
-pub const BRIDGE_PROTOCOL_VERSION: u8 = 3;
+pub const BRIDGE_PROTOCOL_VERSION: u8 = 4;
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 pub struct BridgeSandboxCreateRequest {
@@ -560,7 +560,7 @@ async fn execute_request(
             generation,
         } => {
             let sandbox = connected_sandbox(client, sandbox_id, generation).await?;
-            serialize_value(sandbox.runtime_stats().await?)
+            serialize_execution_stats(sandbox.runtime_stats().await?)
         }
         BridgeRequest::SandboxEvents {
             sandbox_id,
@@ -578,7 +578,7 @@ async fn execute_request(
                 .validate()
                 .map_err(|error| invalid(error.to_string()))?;
             let sandbox = connected_sandbox(client, sandbox_id, generation).await?;
-            serialize_value(sandbox.events(request).await?)
+            serialize_execution_event_batch(sandbox.events(request).await?)
         }
         BridgeRequest::SandboxUpdateResources {
             sandbox_id,
@@ -862,6 +862,59 @@ fn serialize_value(value: impl Serialize) -> Result<Value, BridgeFailure> {
         code: "runtime_error",
         message: format!("failed to encode SDK bridge result: {error}"),
     })
+}
+
+fn serialize_execution_stats(stats: ExecutionStats) -> Result<Value, BridgeFailure> {
+    let timestamp_unix_ns = stats.timestamp_unix_ns.to_string();
+    let mut value = serialize_value(stats)?;
+    replace_unsigned_decimal(&mut value, "timestamp_unix_ns", timestamp_unix_ns)?;
+    Ok(value)
+}
+
+fn serialize_execution_event_batch(batch: ExecutionEventBatch) -> Result<Value, BridgeFailure> {
+    let timestamps = batch
+        .events
+        .iter()
+        .map(|event| event.timestamp_unix_ns.to_string())
+        .collect::<Vec<_>>();
+    let mut value = serialize_value(batch)?;
+    let events = value
+        .get_mut("events")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| bridge_encoding_failure("runtime event batch has no event array"))?;
+    if events.len() != timestamps.len() {
+        return Err(bridge_encoding_failure(
+            "runtime event batch changed length during bridge encoding",
+        ));
+    }
+    for (event, timestamp_unix_ns) in events.iter_mut().zip(timestamps) {
+        replace_unsigned_decimal(event, "timestamp_unix_ns", timestamp_unix_ns)?;
+    }
+    Ok(value)
+}
+
+fn replace_unsigned_decimal(
+    value: &mut Value,
+    field: &str,
+    decimal: String,
+) -> Result<(), BridgeFailure> {
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| bridge_encoding_failure("runtime observation is not a JSON object"))?;
+    if !object.contains_key(field) {
+        return Err(bridge_encoding_failure(format!(
+            "runtime observation has no {field} field"
+        )));
+    }
+    object.insert(field.to_string(), Value::String(decimal));
+    Ok(())
+}
+
+fn bridge_encoding_failure(message: impl Into<String>) -> BridgeFailure {
+    BridgeFailure {
+        code: "runtime_error",
+        message: format!("failed to encode SDK bridge result: {}", message.into()),
+    }
 }
 
 fn serialize_field(name: &str, value: impl Serialize) -> Result<Value, BridgeFailure> {

--- a/src/sdk/src/bridge/tests.rs
+++ b/src/sdk/src/bridge/tests.rs
@@ -137,6 +137,54 @@ async fn malformed_json_returns_a_versioned_error_envelope() {
 }
 
 #[test]
+fn runtime_observation_timestamps_are_exact_decimal_strings() {
+    let timestamp_unix_ns = 1_700_000_000_000_000_123;
+    let stats = ExecutionStats {
+        execution_id: ExecutionId::new("box-1").unwrap(),
+        generation: ExecutionGeneration::INITIAL,
+        timestamp_unix_ns,
+        cpu: a3s_box_core::ExecutionCpuStats {
+            usage_ns: 300,
+            user_ns: 200,
+            system_ns: 100,
+            throttled_ns: 5,
+        },
+        memory: a3s_box_core::ExecutionMemoryStats {
+            usage_bytes: 1024,
+            limit_bytes: Some(2048),
+            peak_bytes: Some(1536),
+        },
+        process_count: 2,
+        metrics: BTreeMap::from([("io.read_bytes".to_string(), 64)]),
+    };
+    let stats_value = serialize_execution_stats(stats).unwrap();
+    assert_eq!(
+        stats_value["timestamp_unix_ns"],
+        timestamp_unix_ns.to_string()
+    );
+    assert_eq!(stats_value["cpu"]["usage_ns"], 300);
+
+    let batch = ExecutionEventBatch {
+        execution_id: ExecutionId::new("box-1").unwrap(),
+        generation: ExecutionGeneration::INITIAL,
+        events: vec![a3s_box_core::ExecutionRuntimeEvent {
+            sequence: 1,
+            timestamp_unix_ns,
+            process_id: None,
+            kind: a3s_box_core::ExecutionEventKind::ContainerStarted,
+            attributes: BTreeMap::new(),
+        }],
+        next_sequence: 1,
+    };
+    let batch_value = serialize_execution_event_batch(batch).unwrap();
+    assert_eq!(
+        batch_value["events"][0]["timestamp_unix_ns"],
+        timestamp_unix_ns.to_string()
+    );
+    assert_eq!(batch_value["events"][0]["sequence"], 1);
+}
+
+#[test]
 fn runtime_configuration_errors_are_invalid_requests() {
     let failure = BridgeFailure::from(ClientError::Runtime(
         a3s_box_core::error::BoxError::ConfigError("invalid CPU count".to_string()),


### PR DESCRIPTION
## Summary

- establish deterministic absent and inaccessible KVM states with fail-closed restoration
- validate packaged libkrun through its direct consumer, the Box shim
- activate the exact installed runtime assets in the R17 conformance home
- align the Rust OCI SDK, CI runtime and agent, and release artifacts to 438e4b7936cd08d408160fe9341a21786f60cd26
- enforce that the three OCI revisions cannot drift again
- document the installed-product gate and ownership contract

## Validation

- Git Bash syntax checks for all modified shell scripts
- executable OCI revision consistency check
- CI and release workflow YAML parsing
- cargo fmt --all -- --check
- cargo check --locked -p a3s-box-runtime --all-targets
- 58 OCI backend tests
- host virtualization check test
- authoritative x86_64 and aarch64 product gates running in GitHub Actions