### PR TITLE
fix(ci): check libkrun linkage on shim only

### DIFF
--- a/scripts/package-no-kvm-product.sh
+++ b/scripts/package-no-kvm-product.sh
@@ -118,7 +118,9 @@ for binary in a3s-box a3s-box-shim; do
     ldd_output="$(LD_LIBRARY_PATH= ldd "$PACKAGE_ROOT/$binary")"
     printf '%s\n' "$ldd_output"
     ! grep -q 'not found' <<< "$ldd_output"
-    grep -F "$PACKAGE_ROOT/lib/libkrun.so" <<< "$ldd_output"
+    if [ "$binary" = "a3s-box-shim" ]; then
+        grep -F "$PACKAGE_ROOT/lib/libkrun.so" <<< "$ldd_output"
+    fi
 done
 
 tar czf "$ARCHIVE" -C "$OUTPUT_ROOT" "$PACKAGE_NAME"


### PR DESCRIPTION
Summary:
- keep unresolved-library validation for both installed Box binaries
- require packaged libkrun linkage only for a3s-box-shim, which is the binary that owns the libkrun integration
- allow the a3s-box CLI to remain decoupled from libkrun

Root cause:
The no-KVM package gate introduced by #223 applied the shim-only linkage assertion to a3s-box first. Both x86_64 and aarch64 main CI exited immediately after printing the CLI ldd output.

Validation:
- bash -n scripts/package-no-kvm-product.sh
- shellcheck when available
- reproduces and explains main CI run 33476798204