### PR TITLE
fix(build): separate Debian and GNU architecture names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ All notable changes to A3S Box will be documented in this file.
   including SDK callers; only the CLI's explicit `snapshot rm --force` path can
   bypass that protection.
 
+### Fixed
+
+- Clean Apple Silicon release builds now keep Debian's `arm64` repository name
+  separate from clang's `aarch64-linux-gnu` target while preparing libkrun's
+  guest-init sysroot, avoiding a deterministic package-index 404 without
+  falling back to an older system libkrun.
+
 ## [3.2.0] — 2026-08-25
 
 ### Fixed

--- a/src/deps/libkrun-sys/build.rs
+++ b/src/deps/libkrun-sys/build.rs
@@ -487,12 +487,22 @@ fn make_command(
         .env("PREFIX", install_dir)
         .current_dir(source_dir);
 
-    // Darwin reports Apple Silicon as `arm64`, while the Debian sysroot used
-    // to build libkrun's Linux guest init stores its CRT and libgcc files under
-    // the GNU `aarch64-linux-gnu` tuple. Override the vendored Makefile's
-    // uname-derived value so clang searches the populated sysroot directory.
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    cmd.arg("ARCH=aarch64");
+    // The vendored Makefile overloads ARCH for both the Debian repository path
+    // and clang's GNU target. Debian calls AArch64 `arm64`, while the compiler
+    // and extracted sysroot use `aarch64-linux-gnu`. Supply each naming domain
+    // explicitly so a clean macOS build downloads and links the same sysroot.
+    #[cfg(target_os = "macos")]
+    {
+        let target_arch = env::var("CARGO_CFG_TARGET_ARCH")
+            .expect("CARGO_CFG_TARGET_ARCH is required for a macOS libkrun build");
+        let architecture = build_support::debian_cross_architecture(&target_arch)
+            .unwrap_or_else(|| panic!("unsupported macOS libkrun architecture: {target_arch}"));
+        cmd.arg(format!("ARCH={}", architecture.repository_arch));
+        cmd.arg(format!(
+            "CC_LINUX=/usr/bin/clang -target {} -fuse-ld=lld -Wl,-strip-debug --sysroot $(SYSROOT_LINUX) -Wno-c23-extensions",
+            architecture.gnu_target
+        ));
+    }
 
     for (key, value) in extra_env {
         cmd.env(key, value);

--- a/src/deps/libkrun-sys/build_support.rs
+++ b/src/deps/libkrun-sys/build_support.rs
@@ -3,6 +3,32 @@ use std::fs::File;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DebianCrossArchitecture {
+    pub(crate) repository_arch: &'static str,
+    pub(crate) gnu_target: &'static str,
+}
+
+/// Translate a Rust host architecture into the two names required by the
+/// vendored libkrun macOS cross-build.
+///
+/// Debian repository paths and GNU compiler targets intentionally use
+/// different architecture vocabularies. Keeping both values explicit avoids
+/// overloading libkrun's `ARCH` make variable for two incompatible domains.
+pub(crate) fn debian_cross_architecture(target_arch: &str) -> Option<DebianCrossArchitecture> {
+    match target_arch {
+        "aarch64" => Some(DebianCrossArchitecture {
+            repository_arch: "arm64",
+            gnu_target: "aarch64-linux-gnu",
+        }),
+        "x86_64" => Some(DebianCrossArchitecture {
+            repository_arch: "amd64",
+            gnu_target: "x86_64-linux-gnu",
+        }),
+        _ => None,
+    }
+}
+
 /// Calculate a lowercase SHA-256 digest without relying on platform commands.
 pub(crate) fn sha256_file(path: &Path) -> io::Result<String> {
     let mut file = File::open(path)?;

--- a/src/deps/libkrun-sys/tests/build_support.rs
+++ b/src/deps/libkrun-sys/tests/build_support.rs
@@ -4,6 +4,21 @@ mod build_support;
 use std::path::{Path, PathBuf};
 
 #[test]
+fn debian_repository_architectures_are_distinct_from_gnu_targets() {
+    let arm =
+        build_support::debian_cross_architecture("aarch64").expect("AArch64 should be supported");
+    assert_eq!(arm.repository_arch, "arm64");
+    assert_eq!(arm.gnu_target, "aarch64-linux-gnu");
+
+    let x86 =
+        build_support::debian_cross_architecture("x86_64").expect("x86_64 should be supported");
+    assert_eq!(x86.repository_arch, "amd64");
+    assert_eq!(x86.gnu_target, "x86_64-linux-gnu");
+
+    assert_eq!(build_support::debian_cross_architecture("riscv64"), None);
+}
+
+#[test]
 fn sha256_file_hashes_known_content() {
     let temp = tempfile::tempdir().expect("create temporary directory");
     let path = temp.path().join("payload.bin");


### PR DESCRIPTION
Summary:
- decouple Debian repository architecture names from GNU compiler targets in the macOS vendored libkrun build
- map Apple Silicon to Debian arm64 while preserving the aarch64-linux-gnu sysroot/compiler target
- reject unsupported mappings explicitly and document the clean-build fix

Validation:
- A3S_DEPS_STUB=1 cargo test --locked -p a3s-libkrun-sys --test build_support
- clean sysroot and a3s-libkrun-sys target, then build release CLI/shim plus aarch64 guest-init and verify shim signing
- ./scripts/host-integration-smoke.sh --pure