### PR TITLE
fix(build): preserve guest device and OCI identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Warm-pool Dockerfile `RUN` now mounts an ephemeral guest-native `/dev` and
+  binds the guest's standard devices before chroot. Character device numbers
+  are no longer persisted through macOS VirtioFS as unusable `0:0` nodes, so
+  tools can reliably open `/dev/null`, `/dev/urandom`, and their peers without
+  committing runtime devices to image layers.
+- Registry push now uploads the exact verified manifest bytes from the local
+  OCI layout through the authenticated raw-manifest API. Pretty-printed local
+  manifests retain their content digest instead of being silently
+  canonicalized to a second digest before post-push verification.
 - macOS VirtioFS directory iteration now snapshots entries per open or rewound
   handle, returns synthetic FUSE resume cookies, and gives `fdopendir` its own
   descriptor. Paginated, mutating tree deletion no longer skips unrelated

--- a/src/cli/tests/host_smoke.rs
+++ b/src/cli/tests/host_smoke.rs
@@ -977,6 +977,7 @@ fn test_real_build_run_pool_smoke() {
         format!(
             r#"FROM {image}
 WORKDIR /work
+RUN test -c /dev/null && test -c /dev/urandom && printf 'discarded\n' > /dev/null
 RUN printf 'shell-ok\n' > /shell.txt
 RUN ["/bin/sh", "-c", "printf 'exec-ok\n' > exec.txt"]
 RUN --mount=type=cache,id=warm-smoke,sharing=locked,mode=0750,target=/root/.cache printf 'cache-only\n' > /root/.cache/cache.txt

--- a/src/cli/tests/support/mod.rs
+++ b/src/cli/tests/support/mod.rs
@@ -757,7 +757,9 @@ pub fn create_minimal_oci_tar(path: &Path, reference: &str) {
             "size": layer.len()
         }]
     });
-    let manifest_bytes = serde_json::to_vec(&manifest).expect("serialize manifest");
+    // Keep this non-canonical on purpose: registry push must preserve the exact
+    // content-addressed bytes instead of reserializing the typed manifest.
+    let manifest_bytes = serde_json::to_vec_pretty(&manifest).expect("serialize manifest");
     let manifest_digest = sha256_hex(&manifest_bytes);
     std::fs::write(blobs.join(&manifest_digest), &manifest_bytes).expect("write manifest blob");
 

--- a/src/guest/init/src/container_devices.rs
+++ b/src/guest/init/src/container_devices.rs
@@ -1,0 +1,198 @@
+//! Ephemeral container `/dev` setup inside the guest mount namespace.
+
+use nix::mount::{mount, MsFlags};
+use std::fs::{File, OpenOptions};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+const STANDARD_DEVICES: [&str; 6] = ["null", "zero", "full", "random", "urandom", "tty"];
+
+/// Populate a container rootfs with guest-native standard devices.
+///
+/// Image rootfs directories can be transported over VirtioFS. Character device
+/// numbers are host-ABI metadata and cannot be persisted safely through a macOS
+/// host filesystem: a Linux `mknod(1, 3)` otherwise reappears as `0:0` in the
+/// guest and opening `/dev/null` fails with `ENXIO`. Mount an ephemeral `/dev`
+/// in the guest namespace and bind the guest's real devices instead. Nothing is
+/// written into the image layer, and repeated execs reuse the existing mount.
+pub(crate) fn ensure_container_dev_nodes(rootfs: &str) {
+    let rootfs = Path::new(rootfs);
+    let dev = rootfs.join("dev");
+    if let Err(error) = ensure_dev_directory(&dev) {
+        warn!(path = %dev.display(), %error, "Failed to prepare container /dev");
+        return;
+    }
+
+    if !mount_ephemeral_dev_if_needed(rootfs, &dev) {
+        return;
+    }
+
+    for directory in ["pts", "shm"] {
+        let path = dev.join(directory);
+        if let Err(error) = std::fs::create_dir_all(&path) {
+            warn!(path = %path.display(), %error, "Failed to create container device directory");
+        }
+    }
+
+    for name in STANDARD_DEVICES {
+        bind_standard_device(&dev, name);
+    }
+
+    for (link, target) in [
+        ("stdin", "/proc/self/fd/0"),
+        ("stdout", "/proc/self/fd/1"),
+        ("stderr", "/proc/self/fd/2"),
+        ("fd", "/proc/self/fd"),
+    ] {
+        let path = dev.join(link);
+        if std::fs::symlink_metadata(&path).is_ok() {
+            continue;
+        }
+        if let Err(error) = std::os::unix::fs::symlink(target, &path) {
+            warn!(path = %path.display(), %error, "Failed to create container device symlink");
+        }
+    }
+}
+
+fn ensure_dev_directory(dev: &Path) -> std::io::Result<()> {
+    match std::fs::symlink_metadata(dev) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
+        Ok(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "container /dev is not a directory",
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => std::fs::create_dir_all(dev),
+        Err(error) => Err(error),
+    }
+}
+
+fn mount_ephemeral_dev_if_needed(rootfs: &Path, dev: &Path) -> bool {
+    let root_device = match std::fs::metadata(rootfs).map(|metadata| metadata.dev()) {
+        Ok(device) => device,
+        Err(error) => {
+            warn!(path = %rootfs.display(), %error, "Failed to inspect container rootfs device");
+            return false;
+        }
+    };
+    let dev_device = match std::fs::metadata(dev).map(|metadata| metadata.dev()) {
+        Ok(device) => device,
+        Err(error) => {
+            warn!(path = %dev.display(), %error, "Failed to inspect container /dev device");
+            return false;
+        }
+    };
+    if root_device != dev_device {
+        return true;
+    }
+
+    match mount(
+        Some("tmpfs"),
+        dev,
+        Some("tmpfs"),
+        MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC,
+        Some("mode=755,size=65536k"),
+    ) {
+        Ok(()) => true,
+        Err(error) => {
+            warn!(path = %dev.display(), %error, "Failed to mount ephemeral container /dev");
+            false
+        }
+    }
+}
+
+fn bind_standard_device(dev: &Path, name: &str) {
+    let source = PathBuf::from("/dev").join(name);
+    let target = dev.join(name);
+    if devices_match(&source, &target) {
+        return;
+    }
+
+    let target_file = match prepare_bind_target(&target) {
+        Ok(file) => file,
+        Err(error) => {
+            warn!(path = %target.display(), %error, "Failed to prepare container device target");
+            return;
+        }
+    };
+    let target_fd_path = format!("/proc/self/fd/{}", target_file.as_raw_fd());
+    if let Err(error) = mount(
+        Some(source.as_path()),
+        target_fd_path.as_str(),
+        None::<&str>,
+        MsFlags::MS_BIND,
+        None::<&str>,
+    ) {
+        warn!(source = %source.display(), path = %target.display(), %error, "Failed to bind container device");
+        return;
+    }
+
+    if !devices_match(&source, &target) {
+        warn!(source = %source.display(), path = %target.display(), "Container device bind did not expose the expected device");
+    }
+}
+
+fn prepare_bind_target(target: &Path) -> std::io::Result<File> {
+    match std::fs::symlink_metadata(target) {
+        Ok(_) => std::fs::remove_file(target)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o666)
+        .open(target)
+}
+
+fn devices_match(source: &Path, target: &Path) -> bool {
+    let Ok(source) = std::fs::metadata(source) else {
+        return false;
+    };
+    let Ok(target) = std::fs::metadata(target) else {
+        return false;
+    };
+    source.file_type().is_char_device()
+        && target.file_type().is_char_device()
+        && source.rdev() == target.rdev()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_a_non_directory_dev_without_following_it() {
+        let root = tempfile::tempdir().unwrap();
+        let dev = root.path().join("dev");
+        std::fs::write(&dev, "not a directory").unwrap();
+
+        let error = ensure_dev_directory(&dev).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn rejects_a_symlinked_dev() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let dev = root.path().join("dev");
+        std::os::unix::fs::symlink(outside.path(), &dev).unwrap();
+
+        let error = ensure_dev_directory(&dev).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn creates_a_missing_dev_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let dev = root.path().join("dev");
+
+        ensure_dev_directory(&dev).unwrap();
+
+        assert!(dev.is_dir());
+    }
+}

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -1960,7 +1960,7 @@ fn build_command(
                 // Populate the standard /dev device nodes (urandom, null, ...);
                 // many workloads (e.g. Apache httpd seeding its RNG from
                 // /dev/urandom) fail to start without them.
-                ensure_container_dev_nodes(rootfs);
+                crate::container_devices::ensure_container_dev_nodes(rootfs);
                 // CRI MaskedPaths/ReadonlyPaths arrive as ':'-separated absolute
                 // paths over A3S_SEC_MASKED_PATHS / A3S_SEC_READONLY_PATHS.
                 let masked = parse_sec_path_list(spec.env, "A3S_SEC_MASKED_PATHS=");
@@ -2853,69 +2853,6 @@ pub(crate) fn ensure_container_pseudo_filesystems(rootfs: &str) {
             None::<&str>,
         ) {
             warn!("Failed to mount {fstype} at {target}: {e}");
-        }
-    }
-}
-
-/// Create the standard character device nodes in a container `rootfs`.
-///
-/// A minimal image rootfs has an empty `/dev`, but many workloads need the
-/// usual nodes — e.g. Apache httpd reads `/dev/urandom` to seed its RNG and
-/// aborts with `AH00141` if it is absent. Created with `mknod` while guest-init
-/// still holds `CAP_MKNOD` (before the privilege drop and chroot). Best-effort
-/// and idempotent: an existing node is left as-is.
-#[cfg(target_os = "linux")]
-pub(crate) fn ensure_container_dev_nodes(rootfs: &str) {
-    let dev = format!("{rootfs}/dev");
-    if let Err(e) = std::fs::create_dir_all(&dev) {
-        warn!("Failed to create container /dev {dev}: {e}");
-        return;
-    }
-    // (name, major, minor) — the fixed Linux char-device numbers.
-    for (name, major, minor) in [
-        ("null", 1u32, 3u32),
-        ("zero", 1, 5),
-        ("full", 1, 7),
-        ("random", 1, 8),
-        ("urandom", 1, 9),
-        ("tty", 5, 0),
-    ] {
-        let path = format!("{dev}/{name}");
-        if std::path::Path::new(&path).exists() {
-            continue;
-        }
-        let Ok(cpath) = std::ffi::CString::new(path.as_str()) else {
-            continue;
-        };
-        let mode: libc::mode_t = libc::S_IFCHR | 0o666;
-        // SAFETY: mknod with a valid CString path + fixed device numbers.
-        let ret = unsafe { libc::mknod(cpath.as_ptr(), mode, libc::makedev(major, minor)) };
-        if ret != 0 {
-            warn!(
-                "Failed to mknod {path}: {}",
-                std::io::Error::last_os_error()
-            );
-        }
-    }
-
-    // Standard /dev/std{in,out,err} + /dev/fd symlinks into the process's own fds.
-    // Apps that log to /dev/stdout or /dev/stderr (official nginx, and many others)
-    // then resolve to their own stdio — which is re-openable now that the main
-    // process's stdout/stderr are pipes (see setup_main_stdio_pipes in main.rs).
-    for (link, target) in [
-        ("stdin", "/proc/self/fd/0"),
-        ("stdout", "/proc/self/fd/1"),
-        ("stderr", "/proc/self/fd/2"),
-        ("fd", "/proc/self/fd"),
-    ] {
-        let path = format!("{dev}/{link}");
-        // symlink_metadata does not follow the link, so an existing symlink whose
-        // target is not yet resolvable still counts as present (idempotent).
-        if std::fs::symlink_metadata(&path).is_ok() {
-            continue;
-        }
-        if let Err(e) = std::os::unix::fs::symlink(target, &path) {
-            warn!("Failed to symlink /dev/{link} -> {target}: {e}");
         }
     }
 }

--- a/src/guest/init/src/lib.rs
+++ b/src/guest/init/src/lib.rs
@@ -13,6 +13,8 @@
 pub mod attest_server;
 #[cfg(target_os = "linux")]
 pub mod cgroup;
+#[cfg(target_os = "linux")]
+mod container_devices;
 #[cfg(any(target_os = "linux", all(test, unix)))]
 pub mod diff_baseline;
 pub mod exec_server;

--- a/src/guest/init/src/pty_server.rs
+++ b/src/guest/init/src/pty_server.rs
@@ -300,7 +300,7 @@ fn handle_pty_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::er
         // /proc + /sys, then the standard /dev nodes — many workloads read
         // /proc/self/* or /dev/urandom and won't start without them. Idempotent.
         crate::exec_server::ensure_container_pseudo_filesystems(rootfs);
-        crate::exec_server::ensure_container_dev_nodes(rootfs);
+        crate::container_devices::ensure_container_dev_nodes(rootfs);
         // CRI MaskedPaths / ReadonlyPaths (best-effort; a path that doesn't exist
         // is skipped) — these need /proc + /sys mounted above.
         let masked = crate::exec_server::parse_sec_path_list(&request.env, "A3S_SEC_MASKED_PATHS=");

--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -7,13 +7,16 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use a3s_box_core::error::{BoxError, Result};
-use oci_distribution::client::{ClientConfig, ClientProtocol, Config, ImageLayer, PushResponse};
+use futures::{stream, StreamExt, TryStreamExt};
+use oci_distribution::client::{
+    ClientConfig, ClientProtocol, Config, ImageLayer, PushResponse, DEFAULT_MAX_CONCURRENT_UPLOAD,
+};
 use oci_distribution::errors::{OciDistributionError, OciErrorCode};
 use oci_distribution::manifest::{
     ImageIndexEntry, OciImageManifest, IMAGE_MANIFEST_MEDIA_TYPE, OCI_IMAGE_MEDIA_TYPE,
 };
 use oci_distribution::secrets::RegistryAuth as OciRegistryAuth;
-use oci_distribution::{Client, Reference};
+use oci_distribution::{Client, Reference, RegistryOperation};
 use oci_reqwest::header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, LOCATION};
 use zeroize::Zeroize;
 
@@ -848,17 +851,54 @@ impl RegistryPusher {
         manifest_data: &[u8],
     ) -> std::result::Result<PushResponse, OciDistributionError> {
         let auth = self.auth.to_oci_auth();
-        match self
-            .client
-            .push(
-                oci_ref,
-                layers,
-                config.clone(),
-                &auth,
-                Some(manifest.clone()),
-            )
-            .await
-        {
+        let push = async {
+            self.client
+                .auth(oci_ref, &auth, RegistryOperation::Push)
+                .await?;
+
+            stream::iter(layers.iter().zip(&manifest.layers))
+                .map(|(layer, descriptor)| async move {
+                    self.client
+                        .push_blob(oci_ref, &layer.data, &descriptor.digest)
+                        .await?;
+                    Ok::<(), OciDistributionError>(())
+                })
+                .buffer_unordered(DEFAULT_MAX_CONCURRENT_UPLOAD)
+                .try_collect::<Vec<_>>()
+                .await?;
+            let config_url = self
+                .client
+                .push_blob(oci_ref, &config.data, &manifest.config.digest)
+                .await?;
+
+            // `Client::push` canonicalizes a typed manifest before uploading it.
+            // That is semantically equivalent JSON but has a different OCI
+            // content digest when the local layout stores pretty-printed bytes.
+            // Preserve the layout's content-addressed identity by uploading the
+            // already verified bytes through the client's authenticated raw API.
+            let media_type = manifest
+                .media_type
+                .as_deref()
+                .unwrap_or(OCI_IMAGE_MEDIA_TYPE);
+            let content_type = oci_reqwest::header::HeaderValue::from_bytes(media_type.as_bytes())
+                .map_err(|error| {
+                    OciDistributionError::GenericError(Some(format!(
+                        "invalid manifest media type {media_type:?}: {error}"
+                    )))
+                })?;
+            let manifest_url = self
+                .client
+                .push_manifest_raw(oci_ref, manifest_data.to_vec(), content_type)
+                .await?;
+
+            Ok(PushResponse {
+                config_url,
+                manifest_url,
+            })
+        }
+        .await;
+
+        match push {
             Err(first_error)
                 if is_unauthorized_registry_error(&first_error)
                     && self.auth.basic_credentials().is_some() =>
@@ -2202,5 +2242,7 @@ mod tests {
 
 #[cfg(test)]
 mod basic_pull_tests;
+#[cfg(test)]
+mod push_tests;
 #[cfg(test)]
 mod resilient_pull_tests;

--- a/src/runtime/src/oci/registry/push_tests.rs
+++ b/src/runtime/src/oci/registry/push_tests.rs
@@ -1,0 +1,225 @@
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use axum::body::{Body, HttpBody};
+use axum::extract::State;
+use axum::http::{Method, Request, Response, StatusCode};
+use axum::routing::any;
+use axum::Router;
+use sha2::{Digest, Sha256};
+
+use super::{ImageReference, RegistryAuth, RegistryProtocol, RegistryPusher};
+
+const REPOSITORY: &str = "a3s/app";
+
+#[derive(Clone)]
+struct PushRegistryState {
+    base_url: String,
+    manifest_bytes: Arc<Mutex<Option<Vec<u8>>>>,
+}
+
+struct PushRegistryFixture {
+    reference: ImageReference,
+    manifest_bytes: Arc<Mutex<Option<Vec<u8>>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl PushRegistryFixture {
+    async fn start() -> Self {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let manifest_bytes = Arc::new(Mutex::new(None));
+        let state = PushRegistryState {
+            base_url: format!("http://{address}"),
+            manifest_bytes: Arc::clone(&manifest_bytes),
+        };
+        let app = Router::new()
+            .route("/*path", any(push_registry_handler))
+            .with_state(state);
+        let task = tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .unwrap()
+                .serve(app.into_make_service())
+                .await
+                .unwrap();
+        });
+
+        Self {
+            reference: ImageReference {
+                registry: address.to_string(),
+                repository: REPOSITORY.to_string(),
+                tag: Some("latest".to_string()),
+                digest: None,
+            },
+            manifest_bytes,
+            task,
+        }
+    }
+
+    fn pushed_manifest(&self) -> Vec<u8> {
+        self.manifest_bytes
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("manifest was not pushed")
+    }
+}
+
+impl Drop for PushRegistryFixture {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn push_registry_handler(
+    State(state): State<PushRegistryState>,
+    request: Request<Body>,
+) -> Response<Body> {
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    let upload_path = format!("/v2/{REPOSITORY}/blobs/uploads/");
+    let manifest_path = format!("/v2/{REPOSITORY}/manifests/latest");
+
+    if method == Method::GET && path == "/v2/" {
+        return response(StatusCode::OK, None, None, Body::empty());
+    }
+    if method == Method::POST && path == upload_path {
+        let location = format!("{}{upload_path}fixture", state.base_url);
+        return response(StatusCode::ACCEPTED, Some(&location), None, Body::empty());
+    }
+    if method == Method::PATCH && path == format!("{upload_path}fixture") {
+        let _ = body_bytes(request.into_body()).await;
+        let location = format!("{}{upload_path}fixture", state.base_url);
+        return response(StatusCode::ACCEPTED, Some(&location), None, Body::empty());
+    }
+    if method == Method::PUT && path == format!("{upload_path}fixture") {
+        let _ = body_bytes(request.into_body()).await;
+        let location = format!("{}/v2/{REPOSITORY}/blobs/fixture", state.base_url);
+        return response(StatusCode::CREATED, Some(&location), None, Body::empty());
+    }
+    if method == Method::PUT && path == manifest_path {
+        let bytes = body_bytes(request.into_body()).await;
+        let digest = digest(&bytes);
+        *state.manifest_bytes.lock().unwrap() = Some(bytes);
+        let location = format!("{}/v2/{REPOSITORY}/manifests/{digest}", state.base_url);
+        return response(
+            StatusCode::CREATED,
+            Some(&location),
+            Some(&digest),
+            Body::empty(),
+        );
+    }
+    if method == Method::GET && path == manifest_path {
+        let bytes = state
+            .manifest_bytes
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or_default();
+        let digest = digest(&bytes);
+        return Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "application/vnd.oci.image.manifest.v1+json")
+            .header("docker-content-digest", digest)
+            .body(Body::from(bytes))
+            .unwrap();
+    }
+
+    response(StatusCode::NOT_FOUND, None, None, Body::empty())
+}
+
+fn response(
+    status: StatusCode,
+    location: Option<&str>,
+    digest: Option<&str>,
+    body: Body,
+) -> Response<Body> {
+    let mut builder = Response::builder().status(status);
+    if let Some(location) = location {
+        builder = builder.header("location", location);
+    }
+    if let Some(digest) = digest {
+        builder = builder.header("docker-content-digest", digest);
+    }
+    builder.body(body).unwrap()
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+async fn body_bytes(mut body: Body) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    while let Some(chunk) = body.data().await {
+        bytes.extend_from_slice(&chunk.unwrap());
+    }
+    bytes
+}
+
+fn write_blob(layout: &Path, bytes: &[u8]) -> String {
+    let digest = digest(bytes);
+    let hex = digest.strip_prefix("sha256:").unwrap();
+    let blobs = layout.join("blobs/sha256");
+    std::fs::create_dir_all(&blobs).unwrap();
+    std::fs::write(blobs.join(hex), bytes).unwrap();
+    digest
+}
+
+#[tokio::test]
+async fn push_preserves_exact_content_addressed_manifest_bytes() {
+    let fixture = PushRegistryFixture::start().await;
+    let layout = tempfile::tempdir().unwrap();
+    let config = br#"{"architecture":"amd64","os":"linux"}"#;
+    let first_layer = b"a3s-box-registry-push-layer-one";
+    let second_layer = b"a3s-box-registry-push-layer-two";
+    let config_digest = write_blob(layout.path(), config);
+    let first_layer_digest = write_blob(layout.path(), first_layer);
+    let second_layer_digest = write_blob(layout.path(), second_layer);
+    let manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": config_digest,
+            "size": config.len()
+        },
+        "layers": [
+            {
+                "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                "digest": first_layer_digest,
+                "size": first_layer.len()
+            },
+            {
+                "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                "digest": second_layer_digest,
+                "size": second_layer.len()
+            }
+        ]
+    });
+    let manifest_bytes = serde_json::to_vec_pretty(&manifest).unwrap();
+    let manifest_digest = write_blob(layout.path(), &manifest_bytes);
+    std::fs::write(
+        layout.path().join("index.json"),
+        serde_json::json!({
+            "schemaVersion": 2,
+            "manifests": [{
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": manifest_digest,
+                "size": manifest_bytes.len()
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let pusher =
+        RegistryPusher::with_auth_and_protocol(RegistryAuth::anonymous(), RegistryProtocol::Http);
+    let result = pusher
+        .push(&fixture.reference, layout.path())
+        .await
+        .unwrap();
+
+    assert_eq!(result.manifest_digest, manifest_digest);
+    assert_eq!(fixture.pushed_manifest(), manifest_bytes);
+}


### PR DESCRIPTION
## Summary

- mount an ephemeral guest-native `/dev` for chrooted Dockerfile and container processes, then bind the guest's real standard devices into it
- fail safely before touching image-backed `/dev` when the private tmpfs cannot be established
- upload the exact locally verified OCI manifest bytes while preserving bounded concurrent blob uploads
- add a real warm-pool device smoke test, a two-layer in-process registry regression, and a deliberately non-canonical OCI fixture

## Why

A Linux character node created on a rootfs transported through macOS VirtioFS reappears as device `0:0`; opening `/dev/null` then fails with `ENXIO`. Runtime-only devices belong to the guest mount namespace, not to an image layer or a macOS host filesystem.

The registry client also reserialized a typed manifest before upload. Equivalent JSON has a different content digest when formatting changes, so a locally verified pretty-printed manifest was pushed under different bytes and failed post-push verification.

## Validation

- unchanged Dockerfile from the fixed ShuanOS commit `cffa702ff4de0ed9aa01bf66bdd3d68d7889821a` completed all 124 steps with the supported warm-pool path
  - `WORKDIR /app` was honored
  - the supplied Alpine mirror `ARG` was available to `RUN`
  - finalization produced a 58-layer Linux/arm64 image without a missing layer
- a second build completed from cache
- `--plain-http` pushed the resulting image to a local Distribution Registry without rewriting its manifest digest
- a blank A3S home pulled all 58 layers back and inspected the expected working directory, user, command, ports, healthcheck, size, and exact digest
- real Apple Silicon/HVF `--no-cache` build opened `/dev/urandom`, wrote `/dev/null`, and completed successfully
- registry tests: 59 passed, including exact pretty-manifest bytes across two concurrent layers
- guest-init tests: 141 passed
- strict focused Clippy passed
- `aarch64-unknown-linux-musl` guest-init release cross-build passed

The ShuanOS repository was used only as the fixed regression fixture; this PR does not modify or release ShuanOS.

Fixes #166.
