### PR TITLE
fix(macos): reconcile exited shim processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- macOS lifecycle reconciliation now records each shim's native process start
+  identity, treats an unreaped zombie as exited, and lets the owning monitor
+  reap it before applying restart policy. A short-lived service can no longer
+  remain falsely `running` forever or leave a defunct shim behind after its
+  guest workload exits.
 - Warm-pool Dockerfile `RUN` now mounts an ephemeral guest-native `/dev` and
   binds the guest's standard devices before chroot. Character device numbers
   are no longer persisted through macOS VirtioFS as unusable `0:0` nodes, so

--- a/src/cli/src/process.rs
+++ b/src/cli/src/process.rs
@@ -1,6 +1,9 @@
 //! Shared process management utilities for CLI commands.
 
-pub use a3s_box_runtime::{is_process_alive, is_process_alive_with_identity, pid_start_time};
+pub use a3s_box_runtime::{
+    is_process_alive, is_process_alive_with_identity, is_process_running_with_identity,
+    pid_start_time,
+};
 
 /// Result of asking a VM/shim process to stop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,10 +38,16 @@ pub fn is_process_exited(pid: u32) -> bool {
         // Format: "<pid> (<comm>) <state> ...". comm may contain spaces/parens,
         // so scan past the final ')'. Z (zombie) or X (dead) => exited.
         Ok(stat) => match stat.rfind(')') {
-            Some(idx) => matches!(
-                stat[idx + 1..].trim_start().chars().next(),
-                Some('Z') | Some('X')
-            ),
+            Some(idx)
+                if matches!(
+                    stat[idx + 1..].trim_start().chars().next(),
+                    Some('Z') | Some('X')
+                ) =>
+            {
+                reap_exited_child(pid);
+                true
+            }
+            Some(_) => false,
             None => false,
         },
         // No /proc entry => the process is gone.
@@ -58,14 +67,25 @@ pub fn is_process_exited(pid: u32) -> bool {
     }
 
     // `waitpid` returns ECHILD for processes owned by another parent. Fall
-    // back to the portable liveness probe for those and for a child that is
-    // still running. This also handles a PID that disappeared between probes.
+    // back to the portable existence probe; record reconciliation follows with
+    // the identity-aware running-state probe, which detects a foreign zombie.
     !is_process_alive(pid)
 }
 
 #[cfg(not(unix))]
 pub fn is_process_exited(pid: u32) -> bool {
     !is_process_alive(pid)
+}
+
+#[cfg(target_os = "linux")]
+fn reap_exited_child(pid: u32) {
+    let Ok(raw_pid) = i32::try_from(pid) else {
+        return;
+    };
+    let mut status = 0;
+    // Reap only this known PID and never block. ECHILD simply means another
+    // process owns it, which is valid after monitor or CLI recovery.
+    let _ = unsafe { libc::waitpid(raw_pid, &mut status, libc::WNOHANG) };
 }
 
 /// Terminate a process immediately.

--- a/src/cli/src/state/policy.rs
+++ b/src/cli/src/state/policy.rs
@@ -2,13 +2,14 @@
 
 use super::BoxRecord;
 
-/// Record-level liveness with PID-identity verification: live only if the
-/// recorded PID exists AND its start-time identity still matches (when one was
-/// recorded). Prevents a reused PID after a crash/reboot from keeping a dead box
-/// "running". See [`crate::process::is_process_alive_with_identity`].
+/// Record-level execution liveness with PID-identity verification: live only if
+/// the recorded PID is actively executing (not an unreaped zombie) AND its
+/// start-time identity still matches. Prevents both an exited child and a reused
+/// PID from keeping a dead box "running".
 pub(crate) fn is_record_pid_live(record: &BoxRecord) -> bool {
     record.pid.is_some_and(|pid| {
-        crate::process::is_process_alive_with_identity(pid, record.pid_start_time)
+        !crate::process::is_process_exited(pid)
+            && crate::process::is_process_running_with_identity(pid, record.pid_start_time)
     })
 }
 
@@ -172,4 +173,35 @@ pub fn generate_name() -> String {
     let adj = ADJECTIVES[rng.gen_range(0..ADJECTIVES.len())];
     let noun = NOUNS[rng.gen_range(0..NOUNS.len())];
     format!("{adj}_{noun}")
+}
+
+#[cfg(test)]
+mod process_liveness_tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    #[allow(clippy::zombie_processes)] // Intentionally retain Child until state reconciliation.
+    fn exited_child_is_not_a_live_box_process() {
+        let mut child = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        let mut record = crate::test_helpers::fixtures::make_record(
+            "process-liveness",
+            "process-liveness",
+            "running",
+            Some(pid),
+        );
+        record.pid_start_time = crate::process::pid_start_time(pid);
+        child.kill().expect("terminate child without reaping it");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while is_record_pid_live(&record) && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        assert!(!is_record_pid_live(&record));
+        let _ = child.wait();
+    }
 }

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -97,7 +97,10 @@ pub use managed_execution_store::{
     ManagedExecutionReservation, ManagedExecutionStore, ManagedExecutionStoreError,
     ManagedExecutionStoreResult,
 };
-pub use process::{is_process_alive, is_process_alive_with_identity, pid_start_time};
+pub use process::{
+    is_process_alive, is_process_alive_with_identity, is_process_running_with_identity,
+    pid_start_time,
+};
 
 // gRPC clients
 #[cfg(unix)]

--- a/src/runtime/src/process.rs
+++ b/src/runtime/src/process.rs
@@ -37,19 +37,23 @@ pub fn is_process_alive(_pid: u32) -> bool {
     false
 }
 
-/// Read a process's Linux start time as a stable PID identity token.
+/// Read a process start time as a stable PID identity token.
 ///
-/// The value is field 22 of `/proc/<pid>/stat`, measured in clock ticks since
-/// boot. It distinguishes a recorded process from a later process that reused
-/// the same PID. Other platforms return `None` until they provide an equivalent
-/// stable token.
+/// Linux returns field 22 of `/proc/<pid>/stat`, measured in clock ticks since
+/// boot. macOS returns the `proc_bsdinfo` start timestamp in microseconds. Both
+/// distinguish a recorded process from a later process that reused the same PID.
 #[cfg(target_os = "linux")]
 pub fn pid_start_time(pid: u32) -> Option<u64> {
     let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
     linux_process_identity_from_stat(&stat).map(|(_, start_time)| start_time)
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
+pub fn pid_start_time(pid: u32) -> Option<u64> {
+    macos_process_identity(pid).map(|identity| identity.start_time)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn pid_start_time(_pid: u32) -> Option<u64> {
     None
 }
@@ -88,9 +92,62 @@ pub fn is_process_running_with_identity(pid: u32, expected_start_time: Option<u6
     })
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
+pub fn is_process_running_with_identity(pid: u32, expected_start_time: Option<u64>) -> bool {
+    match macos_process_identity(pid) {
+        Some(identity) => {
+            identity.running
+                && expected_start_time
+                    .map(|expected| expected == identity.start_time)
+                    .unwrap_or(true)
+        }
+        // A legacy record without an identity token can retain the portable
+        // existence fallback if libproc denies inspection. New records fail
+        // closed because signalling a PID with an unverified identity is unsafe.
+        None => expected_start_time.is_none() && is_process_alive(pid),
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn is_process_running_with_identity(pid: u32, expected_start_time: Option<u64>) -> bool {
     is_process_alive_with_identity(pid, expected_start_time)
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MacosProcessIdentity {
+    start_time: u64,
+    running: bool,
+}
+
+#[cfg(target_os = "macos")]
+fn macos_process_identity(pid: u32) -> Option<MacosProcessIdentity> {
+    let raw_pid = i32::try_from(pid).ok().filter(|pid| *pid > 0)?;
+    let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+    let expected_size = std::mem::size_of::<libc::proc_bsdinfo>();
+    // SAFETY: `info` points to writable storage of exactly the size passed to
+    // libproc. A full-size return is required before the value is initialized.
+    let read = unsafe {
+        libc::proc_pidinfo(
+            raw_pid,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            i32::try_from(expected_size).ok()?,
+        )
+    };
+    if read != i32::try_from(expected_size).ok()? {
+        return None;
+    }
+    // SAFETY: proc_pidinfo returned the complete proc_bsdinfo payload above.
+    let info = unsafe { info.assume_init() };
+    Some(MacosProcessIdentity {
+        start_time: info
+            .pbi_start_tvsec
+            .saturating_mul(1_000_000)
+            .saturating_add(info.pbi_start_tvusec),
+        running: info.pbi_status != libc::SZOMB,
+    })
 }
 
 /// Wait until a process identity is no longer actively executing.
@@ -158,7 +215,7 @@ pub(crate) fn wait_for_process_exit_with_identity(
 ///
 /// Returns `true` once the recorded identity has disappeared. `false` means
 /// the process is still present and must be reaped by its owning parent.
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn try_reap_exited_child_with_identity(pid: u32, expected_start_time: u64) -> bool {
     if !is_process_alive_with_identity(pid, Some(expected_start_time)) {
         return true;
@@ -172,7 +229,7 @@ fn try_reap_exited_child_with_identity(pid: u32, expected_start_time: u64) -> bo
     waited == raw_pid || !is_process_alive_with_identity(pid, Some(expected_start_time))
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(unix))]
 #[allow(dead_code)]
 fn try_reap_exited_child_with_identity(pid: u32, expected_start_time: u64) -> bool {
     !is_process_alive_with_identity(pid, Some(expected_start_time))
@@ -208,6 +265,42 @@ mod tests {
     #[test]
     fn missing_process_is_not_alive() {
         assert!(!is_process_alive(0x7fff_fffe));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_identity_distinguishes_a_reused_pid() {
+        let pid = std::process::id();
+        let start_time = pid_start_time(pid);
+        assert!(
+            start_time.is_some(),
+            "live process must have a start-time token"
+        );
+        assert!(is_process_alive_with_identity(pid, start_time));
+        assert!(!is_process_alive_with_identity(pid, Some(u64::MAX)));
+        assert!(is_process_running_with_identity(pid, start_time));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[allow(clippy::zombie_processes)] // Intentionally retain Child until state inspection.
+    fn macos_running_identity_rejects_a_zombie() {
+        let mut child = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        let start_time = pid_start_time(pid).expect("capture child identity");
+        child.kill().expect("terminate child without reaping it");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while is_process_running_with_identity(pid, Some(start_time))
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        assert!(!is_process_running_with_identity(pid, Some(start_time)));
+        let _ = child.wait();
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

- record native macOS process start identity with libproc
- classify unreaped shim zombies as exited during state reconciliation
- reap monitor-owned exited children before restart-policy evaluation
- retain PID-reuse fencing on Linux and macOS

## Why

A completed a3s-box-shim remains visible to kill(pid, 0) until its parent reaps it. The monitor therefore kept a failed Compose service recorded as running and never applied its restart policy. macOS records also lacked a stable process identity token.

## Validation

- cargo fmt --all -- --check
- cargo test --locked -p a3s-box-runtime -p a3s-box-cli (1751 passed, 0 failed, 1 ignored)
- macOS zombie and state-reconciliation regression tests repeated 10 times
- cargo clippy --locked -p a3s-box-runtime -p a3s-box-cli --all-targets -- -D warnings
- git diff --check