### PR TITLE
release: publish a3s-box 3.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,30 @@ jobs:
             echo "::error title=Workspace library test failure::$diagnostic"
           fi
           exit "$status"
+      - name: Verify crates.io package boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd src
+          metadata="$(cargo metadata --locked --no-deps --format-version 1)"
+          version="$(
+            jq -r '.packages[] | select(.name == "a3s-box-runtime") | .version' \
+              <<< "$metadata"
+          )"
+          cargo package --locked -p a3s-box-mkext4
+          if ! jq -e --arg version "$version" '
+            (.packages[] | select(.name == "a3s-box-mkext4") | .version) == $version
+            and
+            (.packages[] | select(.name == "a3s-box-runtime") |
+              .dependencies[] |
+              select(.name == "a3s-box-mkext4")) as $dependency |
+            $dependency.rename == "mkext4"
+            and $dependency.req == ("=" + $version)
+            and $dependency.path != null
+          ' <<< "$metadata" >/dev/null; then
+            echo 'Runtime must exactly pin the publishable A3S ext4 package at the Box version' >&2
+            exit 1
+          fi
       - name: Test deterministic CLI workflows
         run: |
           cd src

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -920,10 +920,12 @@ jobs:
           esac
 
           # Order matters: a dependent is published AFTER its internal deps so
-          # the index has them. libkrun-sys is deliberately excluded: its
-          # dedicated workflow performs native clean-package, size, and
-          # corresponding-source gates that this stub-mode job cannot bypass.
-          for crate in a3s-box-core a3s-box-netproxy a3s-box-runtime a3s-box-sdk; do
+          # the index has them. The A3S ext4 fork must precede Runtime so its
+          # normalized registry manifest cannot fall back to upstream mkext4.
+          # libkrun-sys is deliberately excluded: its dedicated workflow
+          # performs native clean-package, size, and corresponding-source gates
+          # that this stub-mode job cannot bypass.
+          for crate in a3s-box-mkext4 a3s-box-core a3s-box-netproxy a3s-box-runtime a3s-box-sdk; do
             code="$(crate_status "$crate")"
             case "$code" in
               200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+## [3.2.1] — 2026-09-02
+
 ### Added
 
 - **Mount-free guest-native filesystem snapshots on macOS.** Clean stopped
@@ -28,6 +30,10 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Published `a3s-box-runtime` packages now retain the audited raw-byte ext4
+  writer through the explicit `a3s-box-mkext4` package. Registry consumers no
+  longer fall back to upstream `mkext4` and fail to compile the guest-native
+  rootfs implementation that passed in-repository tests.
 - macOS lifecycle reconciliation now records each shim's native process start
   identity, treats an unreaped zombie as exited, and lets the owning monitor
   reap it before applying restart policy. A short-lived service can no longer

--- a/README.md
+++ b/README.md
@@ -350,8 +350,9 @@ immutable artifact cache is enabled. New generations do not create a
 guest-named host directory or attach an `A3SRootfs` DiskImage.
 The raw-byte logical assembler preserves Linux filenames, symlink targets,
 hardlinks, whiteouts, xattrs, ownership, modes, and timestamps before invoking
-the vendored ext4 writer. The macOS staging codec remains only for directory
-transport and legacy APFS migration; directory transports fail closed when a
+the audited, separately publishable `a3s-box-mkext4` writer. The macOS staging
+codec remains only for directory transport and legacy APFS migration;
+directory transports fail closed when a
 guest name cannot be represented losslessly.
 Boot configuration and exact workload exit status use private guest-control
 handoffs rather than host access to the active root disk. The first pristine
@@ -616,6 +617,7 @@ src/sdk/           native Rust SDK and machine bridge
 src/cri/           CRI v1 adapter
 src/shim/          current host/guest MicroVM control
 src/guest/init/    current guest init and execution service
+src/third_party/mkext4/  release-owned byte-preserving ext4 writer
 sdk/               Python, TypeScript, and Go packages
 containerd-shim/   RuntimeClass integration
 ```

--- a/deploy/scripts/install-runtimeclass.sh
+++ b/deploy/scripts/install-runtimeclass.sh
@@ -16,7 +16,7 @@
 # Usage:
 #   install-runtimeclass.sh [--version vX.Y.Z] [--repo OWNER/REPO] [--from-dir DIR]
 #
-#   --version   release tag to install                 (default: v3.2.0)
+#   --version   release tag to install                 (default: v3.2.1)
 #   --repo      GitHub repo to download artifacts from (default: A3S-Lab/Box)
 #   --from-dir  install from a local directory instead of downloading; the dir must
 #               contain a3s-box-<version>-linux-<arch>.tar.gz, its .sha256 file,
@@ -28,7 +28,7 @@
 # Idempotent: safe to re-run (re-installs binaries, rewrites the containerd drop-in).
 set -euo pipefail
 
-VERSION="v3.2.0"
+VERSION="v3.2.1"
 REPO="A3S-Lab/Box"
 FROM_DIR=""
 WARMUP_IMAGE="busybox:latest"   # first box on a fresh node builds a one-time cache

--- a/deploy/scripts/test-install-runtimeclass.sh
+++ b/deploy/scripts/test-install-runtimeclass.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALLER="$SCRIPT_DIR/install-runtimeclass.sh"
-VERSION="v3.2.0"
+VERSION="v3.2.1"
 ARCH="x86_64"
 PACKAGE_DIR="a3s-box-${VERSION}-linux-${ARCH}"
 TARBALL="${PACKAGE_DIR}.tar.gz"
@@ -35,7 +35,7 @@ make_assets() {
 
   cat > "$fixture/a3s-box" <<'SCRIPT'
 #!/usr/bin/env bash
-echo "a3s-box 3.2.0"
+echo "a3s-box 3.2.1"
 SCRIPT
   cat > "$fixture/a3s-box-cri" <<'SCRIPT'
 #!/usr/bin/env bash

--- a/docs/guest-native-rootfs-design.md
+++ b/docs/guest-native-rootfs-design.md
@@ -273,15 +273,18 @@ The implementation can be an audited in-process writer or a helper shipped in
 the release archive. Tool discovery from the user's shell is acceptable only
 for development diagnostics, never as the default production path.
 
-The release-owned writer pins `mkext4` exactly at `0.0.3` and compiles
-it into the runtime. The source is vendored from upstream commit
+The release-owned writer is derived from `mkext4` 0.0.3 at upstream commit
 `645ba8f39e0a935511e233874f7217bcb6e0e4d8`; the A3S patch changes only
 directory-entry and symlink-target inputs from UTF-8 strings to byte slices.
-Runtime uses a direct versioned path dependency, rather than a workspace-only
-Cargo patch, so Git consumers compile this same audited implementation.
-The writer's validation, hashing, layout, and streaming algorithms remain
-upstream. Its independent reader verifies that arbitrary Linux filename and
-symlink-target bytes round-trip exactly.
+It is published under the explicit `a3s-box-mkext4` package name at the Box
+product version and Runtime pins that exact version alongside the direct path.
+Cargo therefore gives workspace, Git, and crates.io consumers the same audited
+implementation instead of falling back to upstream `mkext4`. The writer's
+validation, hashing, layout, and streaming algorithms remain upstream. Its
+independent reader verifies that arbitrary Linux filename and symlink-target
+bytes round-trip exactly. The cache-schema identity remains based on the
+upstream writer contract, so this packaging-only change does not invalidate
+existing raw disks.
 
 A3S owns the tree adapter, capacity policy, OCI ownership replay, sparse-file
 discovery, xattr filtering, structural validation, and generation-directory

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ guest executable are not separated from `a3s-box`.
 
 | Behavior | Linux/macOS | Windows |
 | --- | --- | --- |
-| Pin a release | `--version v3.2.0` | `-Version v3.2.0` |
+| Pin a release | `--version v3.2.1` | `-Version v3.2.1` |
 | Choose destination | `--install-dir PATH` | `-InstallDir PATH` |
 | Do not change `PATH` | `--no-modify-path` | `-NoModifyPath` |
 | Replace an unmanaged directory | `--force` | `-Force` |
@@ -81,7 +81,7 @@ Pass Unix options after `sh -s --` when using a pipe:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.0 --no-modify-path
+  sh -s -- --version v3.2.1 --no-modify-path
 ```
 
 Invoke the downloaded PowerShell text as a script block when options are
@@ -89,7 +89,7 @@ needed:
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.0 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.1 -NoModifyPath
 ```
 
 The corresponding environment variables are `A3S_BOX_VERSION`,
@@ -108,8 +108,8 @@ Linux or macOS:
 
 ```bash
 sh ./install.sh \
-  --version v3.2.0 \
-  --archive ./a3s-box-v3.2.0-linux-x86_64.tar.gz \
+  --version v3.2.1 \
+  --archive ./a3s-box-v3.2.1-linux-x86_64.tar.gz \
   --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
@@ -117,8 +117,8 @@ Windows:
 
 ```powershell
 .\install.ps1 `
-  -Version v3.2.0 `
-  -ArchivePath .\a3s-box-v3.2.0-windows-x86_64.zip `
+  -Version v3.2.1 `
+  -ArchivePath .\a3s-box-v3.2.1-windows-x86_64.zip `
   -Sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 

--- a/docs/production-cluster-tests.md
+++ b/docs/production-cluster-tests.md
@@ -103,7 +103,7 @@ directory must contain the platform tarball, the matching standalone
 
 ```bash
 sudo deploy/scripts/install-runtimeclass.sh \
-  --version v3.2.0 \
+  --version v3.2.1 \
   --from-dir /opt/a3s-box-artifacts \
   --warmup-image docker.m.daocloud.io/library/busybox:latest
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -48,7 +48,7 @@ function Get-NormalizedTag {
         $number -notmatch '^[0-9A-Za-z.+-]+$' -or
         $number -notmatch '^[^.]+\.[^.]+\.[^.]+'
     ) {
-        throw "Invalid version '$Candidate'; expected a release such as v3.2.0."
+        throw "Invalid version '$Candidate'; expected a release such as v3.2.1."
     }
     return $tag
 }

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ Usage:
   install.sh [options]
 
 Options:
-  --version VERSION       Install a release such as v3.2.0 (default: latest).
+  --version VERSION       Install a release such as v3.2.1 (default: latest).
   --install-dir PATH      Install the self-contained distribution at PATH.
   --archive PATH          Install a local release tarball without downloading.
   --sha256 HEX            Expected SHA-256 for --archive.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "a3s-box"
-version = "3.2.0"
+version = "3.2.1"
 description = "Local-first Python SDK for the native A3S Box Sandbox API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -234,9 +234,9 @@ def response_for(request: Mapping[str, object]) -> dict[str, Any]:
         return {"names": ["old-network"]}
     if operation == "runtime_diagnostics":
         return {
-            "core_version": "3.2.0",
-            "runtime_version": "3.2.0",
-            "sdk_version": "3.2.0",
+            "core_version": "3.2.1",
+            "runtime_version": "3.2.1",
+            "sdk_version": "3.2.1",
             "home": "/tmp/a3s",
             "virtualization": {
                 "available": True,
@@ -1591,7 +1591,7 @@ class AsyncSdkTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(events.next_sequence, 11)
         self.assertEqual(sandboxes[0].id, "sandbox-local-1")
         self.assertEqual(snapshot.id, "ci-async")
-        self.assertEqual(diagnostics.sdk_version, "3.2.0")
+        self.assertEqual(diagnostics.sdk_version, "3.2.1")
         self.assertEqual(disk.snapshots_bytes, 4)
         restart = next(
             request

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/box",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "20.19.9",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Local-first TypeScript SDK for the native A3S Box Sandbox API",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -90,9 +90,9 @@ class FakeRuntime {
         return { names: ['old-network'] }
       case 'runtime_diagnostics':
         return {
-          core_version: '3.2.0',
-          runtime_version: '3.2.0',
-          sdk_version: '3.2.0',
+          core_version: '3.2.1',
+          runtime_version: '3.2.1',
+          sdk_version: '3.2.1',
           home: '/tmp/a3s',
           virtualization: {
             available: true,

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cli"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -30,7 +30,7 @@ dependencies = [
  "hex",
  "libc",
  "oci-spec",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-core"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "a3s-acl",
  "a3s-common",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cri"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-guest-init"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "a3s-box-core",
  "a3s-common",
@@ -124,8 +124,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "a3s-box-mkext4"
+version = "3.2.1"
+dependencies = [
+ "crc32c",
+ "proptest",
+]
+
+[[package]]
 name = "a3s-box-netproxy"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "a3s-box-core",
  "libc",
@@ -137,10 +145,11 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-runtime"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "a3s-acl",
  "a3s-box-core",
+ "a3s-box-mkext4",
  "a3s-box-netproxy",
  "a3s-common",
  "a3s-oci-sdk",
@@ -159,14 +168,13 @@ dependencies = [
  "futures",
  "hex",
  "libc",
- "mkext4",
  "oci-distribution",
  "oci-spec",
  "p256",
  "p384",
  "parking_lot",
  "prometheus",
- "rand",
+ "rand 0.8.5",
  "rcgen",
  "reqwest 0.11.27",
  "reqwest 0.12.28",
@@ -196,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-sdk"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -217,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-shim"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -254,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-libkrun-sys"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "libc",
  "num_cpus",
@@ -904,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1171,7 +1179,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1234,7 +1242,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1517,7 +1525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1810,7 +1818,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2283,13 +2291,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mkext4"
-version = "0.0.3"
-dependencies = [
- "crc32c",
 ]
 
 [[package]]
@@ -2818,6 +2819,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,6 +2897,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,8 +2924,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2909,7 +2945,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2919,6 +2965,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3247,6 +3311,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,7 +3565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3723,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3985,7 +4061,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -4127,6 +4203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4334,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -4750,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -9,8 +9,8 @@ members = [
     "cri",
     "cli",
     "sdk",
+    "third_party/mkext4",
 ]
-exclude = ["third_party/mkext4"]
 resolver = "2"
 
 [patch.crates-io]
@@ -23,7 +23,7 @@ resolver = "2"
 h2 = { path = "third_party/h2" }
 
 [workspace.package]
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -130,3 +130,8 @@ a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtim
 
 # Metrics
 prometheus = "0.13"
+
+# The release-owned ext4 writer keeps its upstream test profile while sharing
+# the Box workspace version and publication lifecycle.
+[profile.test.package.a3s-box-mkext4]
+opt-level = 2

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -117,11 +117,12 @@ a3s-box-netproxy = { version = "3.2", path = "../netproxy" }
 filetime = "0.2"
 xattr = "1.6"
 
-# Guest-native rootfs artifact writer. The direct path is intentional: Cargo
-# does not propagate workspace-root patches to Git consumers. Keep the exact
-# version because a writer bump is a cache-schema migration rather than a
-# routine dependency update. See third_party/mkext4/A3S_PATCHES.md.
-mkext4 = { version = "=0.0.3", path = "../third_party/mkext4" }
+# Guest-native rootfs artifact writer. The explicit package name makes the A3S
+# fork available to crates.io consumers, while the direct path keeps Git and
+# workspace consumers on the same audited source. Keep the exact version
+# because a writer bump is a cache-schema migration rather than a routine
+# dependency update. See third_party/mkext4/A3S_PATCHES.md.
+mkext4 = { package = "a3s-box-mkext4", version = "=3.2.1", path = "../third_party/mkext4" }
 
 # TEE attestation verification
 p384 = { workspace = true }

--- a/src/third_party/mkext4/A3S_PATCHES.md
+++ b/src/third_party/mkext4/A3S_PATCHES.md
@@ -1,7 +1,9 @@
 # A3S mkext4 patch inventory
 
 This directory vendors `mkext4` 0.0.3 from upstream commit
-`645ba8f39e0a935511e233874f7217bcb6e0e4d8`.
+`645ba8f39e0a935511e233874f7217bcb6e0e4d8`. The fork is published as
+`a3s-box-mkext4` at the matching A3S Box product version so downstream
+`a3s-box-runtime` packages never fall back to the unpatched upstream crate.
 
 A3S changes the namespace input boundary in `src/build/mod.rs`:
 
@@ -15,11 +17,12 @@ the macOS staging adapter restore OCI path bytes without lossy UTF-8 conversion.
 The integration test in `tests/writer.rs` verifies raw names and link targets
 through mkext4's independent reader.
 
-`a3s-box-runtime` selects this checkout with a direct, versioned path
-dependency. A workspace-root `[patch]` is deliberately not used because Cargo
-does not propagate it when Runtime is consumed from the Box Git repository.
-The direct dependency keeps Box binaries and downstream Git consumers on this
-same audited source.
+`a3s-box-runtime` selects this checkout with a renamed, exact-version path
+dependency. Cargo preserves the package name and version when it normalizes the
+published Runtime manifest, so crates.io consumers resolve the same source.
+A workspace-root `[patch]` is deliberately not used because Cargo does not
+propagate patches to Git or registry consumers. The Box release workflow
+publishes and verifies this support crate before Runtime.
 
 Existing test call sites drop obsolete borrows introduced by the generic byte
 input. Those mechanical changes do not alter test coverage or writer behavior.

--- a/src/third_party/mkext4/Cargo.toml
+++ b/src/third_party/mkext4/Cargo.toml
@@ -1,17 +1,24 @@
 [package]
-name = "mkext4"
-version = "0.0.3"
-edition = "2021"
+name = "a3s-box-mkext4"
+version.workspace = true
+edition.workspace = true
 rust-version = "1.75"
+authors.workspace = true
 license = "Apache-2.0"
-description = "Deterministic, streaming, pure-Rust ext4 image builder with a verification-grade reader"
-repository = "https://github.com/cortexapps/mkext4"
+description = "A3S Box deterministic ext4 image builder with raw Linux path byte support"
+repository.workspace = true
+readme = "README.md"
 keywords = ["ext4", "filesystem", "mkfs", "deterministic", "reproducible"]
 categories = ["filesystem"]
 # testdata/ and tools/ ship in the package so `cargo test` works from
 # the published tarball (the unit tests read testdata/vectors/, the
 # differential tests invoke tools/mkrefs.sh).
 exclude = ["/build", "/.github"]
+
+[lib]
+# Keep the audited upstream import surface while publishing the fork under an
+# explicit A3S-owned package name.
+name = "mkext4"
 
 [dependencies]
 # Hardware-accelerated CRC32C (SSE4.2 / ARMv8 CRC); wrapped by src/csum.rs
@@ -25,8 +32,5 @@ missing_docs = "warn"
 # The test suite builds and verifies multi-GiB images (checksums, hashes,
 # gigabyte memcpys); unoptimized it is minutes instead of seconds.
 # debug_assertions stay on.
-[profile.test]
-opt-level = 2
-
 [dev-dependencies]
 proptest = "1.8.0"

--- a/src/third_party/mkext4/README.md
+++ b/src/third_party/mkext4/README.md
@@ -1,8 +1,13 @@
-# mkext4
+# a3s-box-mkext4
 
-[![crates.io](https://img.shields.io/crates/v/mkext4)](https://crates.io/crates/mkext4)
-[![docs.rs](https://img.shields.io/docsrs/mkext4)](https://docs.rs/mkext4)
-[![CI](https://github.com/cortexapps/mkext4/actions/workflows/ci.yml/badge.svg)](https://github.com/cortexapps/mkext4/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/a3s-box-mkext4)](https://crates.io/crates/a3s-box-mkext4)
+[![docs.rs](https://img.shields.io/docsrs/a3s-box-mkext4)](https://docs.rs/a3s-box-mkext4)
+[![CI](https://github.com/A3S-Lab/Box/actions/workflows/ci.yml/badge.svg)](https://github.com/A3S-Lab/Box/actions/workflows/ci.yml)
+
+This is the A3S Box release-owned fork of upstream `mkext4` 0.0.3. It keeps
+the upstream implementation and adds byte-preserving Linux directory-entry and
+symbolic-link inputs required by Box's guest-native rootfs builder. See
+[`A3S_PATCHES.md`](A3S_PATCHES.md) for the exact provenance and patch boundary.
 
 Deterministic, streaming, pure-Rust ext4 image builder — plus a
 verification-grade reader. No C dependencies, no kernel mounts, no clocks,
@@ -144,7 +149,7 @@ mount read-write on any modern Linux kernel.
 ## Installing
 
 ```sh
-cargo add mkext4
+cargo add a3s-box-mkext4 --rename mkext4
 ```
 
 Early release (0.0.x): the API may still move before 0.1.

--- a/website/docs/v3/en/guide/installation.mdx
+++ b/website/docs/v3/en/guide/installation.mdx
@@ -64,7 +64,7 @@ a3s-box info
 
 | Behavior                       | Linux/macOS                   | Windows                         |
 | ------------------------------ | ----------------------------- | ------------------------------- |
-| Pin a release                  | `--version v3.2.0`            | `-Version v3.2.0`               |
+| Pin a release                  | `--version v3.2.1`            | `-Version v3.2.1`               |
 | Choose destination             | `--install-dir PATH`          | `-InstallDir PATH`              |
 | Do not change `PATH`           | `--no-modify-path`            | `-NoModifyPath`                 |
 | Replace an unmanaged directory | `--force`                     | `-Force`                        |
@@ -75,14 +75,14 @@ Pass Unix options after `sh -s --`:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.0 --no-modify-path
+  sh -s -- --version v3.2.1 --no-modify-path
 ```
 
 Invoke downloaded PowerShell text as a script block when options are needed:
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.0 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.1 -NoModifyPath
 ```
 
 The corresponding environment variables are `A3S_BOX_VERSION`,

--- a/website/docs/v3/zh/guide/installation.mdx
+++ b/website/docs/v3/zh/guide/installation.mdx
@@ -66,7 +66,7 @@ brew install a3s-lab/tap/a3s-box
 
 | 行为                 | Linux/macOS                   | Windows                         |
 | -------------------- | ----------------------------- | ------------------------------- |
-| 固定版本             | `--version v3.2.0`            | `-Version v3.2.0`               |
+| 固定版本             | `--version v3.2.1`            | `-Version v3.2.1`               |
 | 指定目录             | `--install-dir PATH`          | `-InstallDir PATH`              |
 | 不修改 `PATH`        | `--no-modify-path`            | `-NoModifyPath`                 |
 | 替换非安装器管理目录 | `--force`                     | `-Force`                        |
@@ -77,14 +77,14 @@ brew install a3s-lab/tap/a3s-box
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.0 --no-modify-path
+  sh -s -- --version v3.2.1 --no-modify-path
 ```
 
 Windows 带参数安装：
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.0 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.1 -NoModifyPath
 ```
 
 ## 离线安装
@@ -93,15 +93,15 @@ $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
 
 ```bash
 sh ./install.sh \
-  --version v3.2.0 \
-  --archive ./a3s-box-v3.2.0-linux-x86_64.tar.gz \
+  --version v3.2.1 \
+  --archive ./a3s-box-v3.2.1-linux-x86_64.tar.gz \
   --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 ```powershell
 .\install.ps1 `
-  -Version v3.2.0 `
-  -ArchivePath .\a3s-box-v3.2.0-windows-x86_64.zip `
+  -Version v3.2.1 `
+  -ArchivePath .\a3s-box-v3.2.1-windows-x86_64.zip `
   -Sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 


### PR DESCRIPTION
## Summary

- bump the Box workspace, native SDKs, installers, and current installation docs to 3.2.1
- publish the byte-preserving ext4 fork as the explicit a3s-box-mkext4 support crate so registry consumers use the same audited writer as Git and workspace builds
- enforce the exact Runtime dependency boundary in CI and publish the support crate before Runtime
- record the macOS shim reconciliation and deterministic libkrun source archive fixes in the release changelog

## Validation

- cargo fmt --all -- --check
- cargo test --locked --workspace --lib: 3,649 passed, 0 failed, 1 ignored
- cargo clippy --locked --workspace --all-targets -- -D warnings
- cargo package --locked -p a3s-box-mkext4: 76 files, clean package verification passed
- raw Linux directory-name and symlink-target round-trip test passed
- Python SDK: 37 tests passed; TypeScript build/tests/package dry-run passed
- RuntimeClass and one-click installer suites passed
- macOS arm64 nginx MicroVM returned HTTP 200; forced shim exit reconciled dead state, restart policy recovered once, and user stop suppressed restart with no residual shim

Before tagging v3.2.1, publish and verify a3s-libkrun-sys 3.2.1 through its dedicated workflow.