### PR TITLE
fix: plan legacy Sandbox anonymous volumes before reservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Legacy `VmLocalExecutionBackend` now derives and persists Sandbox image-owned
+  anonymous-volume identities during the durable create reservation. Sandbox
+  launches no longer fail the ownership-drift check when the OCI image declares
+  a `VOLUME` and the migration router is not enabled.
+
 ## [3.2.2] — 2026-09-02
 
 ### Fixed

--- a/src/runtime/src/a3s_runtime_driver/tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/tests.rs
@@ -892,7 +892,11 @@ async fn metadata_rejects_a_record_created_for_another_box_isolation_backend() {
     let reservation = driver
         .manager
         .create(
-            creation_request(&spec, ExecutionIsolation::Sandbox).unwrap(),
+            // Use the MicroVM path for this metadata-only test so resource
+            // planning does not need to resolve the deliberately synthetic
+            // registry digest. The validation below still asks whether that
+            // record can be treated as a Sandbox execution and must reject it.
+            creation_request(&spec, ExecutionIsolation::Microvm).unwrap(),
             &operation_id,
         )
         .await
@@ -908,7 +912,7 @@ async fn metadata_rejects_a_record_created_for_another_box_isolation_backend() {
         validate_record_for_spec(
             &record,
             &spec,
-            ExecutionIsolation::Microvm,
+            ExecutionIsolation::Sandbox,
             None,
             &driver.config.secret_root,
         ),

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use a3s_box_core::{
-    EventEmitter, ExecutionBackend, ExecutionId, ExecutionManagerError, ExecutionManagerResult,
-    ExecutionState, KillOutcome, DEFAULT_SHUTDOWN_TIMEOUT_MS,
+    BoxError, EventEmitter, ExecutionBackend, ExecutionId, ExecutionManagerError,
+    ExecutionManagerResult, ExecutionState, KillOutcome, DEFAULT_SHUTDOWN_TIMEOUT_MS,
 };
 use async_trait::async_trait;
 use dashmap::mapref::entry::Entry;
@@ -23,7 +23,7 @@ use super::vm_process::{locate_microvm_process, LocatedProcess};
 use super::TransientRegistryAuthBroker;
 use super::{
     LocalExecutionBackend, LocalExecutionHandle, LocalExecutionObservation,
-    LocalExecutionTermination,
+    LocalExecutionResourcePlan, LocalExecutionTermination,
 };
 use crate::vm::{TERMINAL_EXIT_POLL_INTERVAL, TERMINAL_EXIT_POLL_TIMEOUT};
 use crate::{
@@ -625,6 +625,32 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
         _record: &BoxRecord,
     ) -> ExecutionManagerResult<crate::ManagedRuntimeRoute> {
         Ok(crate::ManagedRuntimeRoute::BoxVm)
+    }
+
+    async fn plan_create_resources(
+        &self,
+        record: &BoxRecord,
+    ) -> ExecutionManagerResult<LocalExecutionResourcePlan> {
+        let metadata = self.metadata(record)?;
+        if !metadata.plan.backend.is_sandbox() {
+            return Ok(LocalExecutionResourcePlan::default());
+        }
+
+        // Resolve only the immutable image metadata needed to derive stable
+        // anonymous-volume identities. The actual VolumeStore claims remain
+        // in `start`, after the reservation has durably recorded ownership.
+        let mut manager = self.new_manager(record)?;
+        let anonymous_volumes = manager
+            .plan_image_anonymous_volumes()
+            .await
+            .map_err(|error| match error {
+                BoxError::ConfigError(message) => ExecutionManagerError::InvalidRequest(message),
+                error => ExecutionManagerError::Unavailable(format!(
+                    "Box image resource planning failed for {}: {error}",
+                    record.id
+                )),
+            })?;
+        Ok(LocalExecutionResourcePlan { anonymous_volumes })
     }
 
     async fn start(&self, record: &BoxRecord) -> ExecutionManagerResult<LocalExecutionHandle> {

--- a/src/runtime/src/local_execution/vm_backend_tests.rs
+++ b/src/runtime/src/local_execution/vm_backend_tests.rs
@@ -37,6 +37,42 @@ fn record(home_dir: &Path, isolation: ExecutionIsolation) -> BoxRecord {
     .unwrap()
 }
 
+#[tokio::test]
+async fn sandbox_resource_planning_persists_image_volume_ownership_without_runtime_side_effects() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = VmLocalExecutionBackend::new(temporary.path());
+    let record = record(temporary.path(), ExecutionIsolation::Sandbox);
+    std::fs::create_dir_all(&record.box_dir).unwrap();
+    crate::resolved_image::persist_resolved_image_config(
+        &record.box_dir,
+        &crate::oci::OciImageConfig {
+            entrypoint: None,
+            cmd: None,
+            env: Vec::new(),
+            working_dir: None,
+            user: None,
+            exposed_ports: Vec::new(),
+            labels: std::collections::HashMap::new(),
+            volumes: vec!["/data".to_string(), "/data/./".to_string()],
+            stop_signal: None,
+            health_check: None,
+            onbuild: Vec::new(),
+        },
+    )
+    .unwrap();
+
+    let plan = backend.plan_create_resources(&record).await.unwrap();
+
+    assert_eq!(plan.anonymous_volumes.len(), 1);
+    assert!(plan.anonymous_volumes[0].starts_with("anon_11111111_"));
+    assert!(!temporary.path().join("images").exists());
+    assert!(!temporary.path().join("volumes.json").exists());
+    assert!(!temporary.path().join("volumes").exists());
+    assert!(!record.box_dir.join("rootfs").exists());
+    assert!(!record.box_dir.join("workspace").exists());
+    assert!(!record.box_dir.join("sockets").exists());
+}
+
 struct DelayedExitStatusHandler {
     exit_polls: Arc<AtomicUsize>,
     stop_calls: Arc<AtomicUsize>,


### PR DESCRIPTION
## Summary\n- derive deterministic image-owned anonymous-volume identities in the legacy VmLocalExecutionBackend before durable reservation\n- preserve side-effect-free planning and map configuration errors cleanly\n- add regression coverage and changelog entry\n\n## Validation\n- cargo fmt --all -- --check\n- cargo test --manifest-path src/Cargo.toml --locked -p a3s-box-runtime (1403 passed, 1 ignored)