### PR TITLE
release: prepare a3s-box 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+## [3.2.3] — 2026-09-02
+
 ### Fixed
 
 - Legacy `VmLocalExecutionBackend` now derives and persists Sandbox image-owned

--- a/deploy/scripts/install-runtimeclass.sh
+++ b/deploy/scripts/install-runtimeclass.sh
@@ -16,7 +16,7 @@
 # Usage:
 #   install-runtimeclass.sh [--version vX.Y.Z] [--repo OWNER/REPO] [--from-dir DIR]
 #
-#   --version   release tag to install                 (default: v3.2.2)
+#   --version   release tag to install                 (default: v3.2.3)
 #   --repo      GitHub repo to download artifacts from (default: A3S-Lab/Box)
 #   --from-dir  install from a local directory instead of downloading; the dir must
 #               contain a3s-box-<version>-linux-<arch>.tar.gz, its .sha256 file,
@@ -28,7 +28,7 @@
 # Idempotent: safe to re-run (re-installs binaries, rewrites the containerd drop-in).
 set -euo pipefail
 
-VERSION="v3.2.2"
+VERSION="v3.2.3"
 REPO="A3S-Lab/Box"
 FROM_DIR=""
 WARMUP_IMAGE="busybox:latest"   # first box on a fresh node builds a one-time cache

--- a/deploy/scripts/test-install-runtimeclass.sh
+++ b/deploy/scripts/test-install-runtimeclass.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALLER="$SCRIPT_DIR/install-runtimeclass.sh"
-VERSION="v3.2.2"
+VERSION="v3.2.3"
 ARCH="x86_64"
 PACKAGE_DIR="a3s-box-${VERSION}-linux-${ARCH}"
 TARBALL="${PACKAGE_DIR}.tar.gz"
@@ -35,7 +35,7 @@ make_assets() {
 
   cat > "$fixture/a3s-box" <<'SCRIPT'
 #!/usr/bin/env bash
-echo "a3s-box 3.2.2"
+echo "a3s-box 3.2.3"
 SCRIPT
   cat > "$fixture/a3s-box-cri" <<'SCRIPT'
 #!/usr/bin/env bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ guest executable are not separated from `a3s-box`.
 
 | Behavior | Linux/macOS | Windows |
 | --- | --- | --- |
-| Pin a release | `--version v3.2.2` | `-Version v3.2.2` |
+| Pin a release | `--version v3.2.3` | `-Version v3.2.3` |
 | Choose destination | `--install-dir PATH` | `-InstallDir PATH` |
 | Do not change `PATH` | `--no-modify-path` | `-NoModifyPath` |
 | Replace an unmanaged directory | `--force` | `-Force` |
@@ -81,7 +81,7 @@ Pass Unix options after `sh -s --` when using a pipe:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.2 --no-modify-path
+  sh -s -- --version v3.2.3 --no-modify-path
 ```
 
 Invoke the downloaded PowerShell text as a script block when options are
@@ -89,7 +89,7 @@ needed:
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.2 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.3 -NoModifyPath
 ```
 
 The corresponding environment variables are `A3S_BOX_VERSION`,
@@ -108,8 +108,8 @@ Linux or macOS:
 
 ```bash
 sh ./install.sh \
-  --version v3.2.2 \
-  --archive ./a3s-box-v3.2.2-linux-x86_64.tar.gz \
+  --version v3.2.3 \
+  --archive ./a3s-box-v3.2.3-linux-x86_64.tar.gz \
   --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
@@ -117,8 +117,8 @@ Windows:
 
 ```powershell
 .\install.ps1 `
-  -Version v3.2.2 `
-  -ArchivePath .\a3s-box-v3.2.2-windows-x86_64.zip `
+  -Version v3.2.3 `
+  -ArchivePath .\a3s-box-v3.2.3-windows-x86_64.zip `
   -Sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 

--- a/docs/production-cluster-tests.md
+++ b/docs/production-cluster-tests.md
@@ -103,7 +103,7 @@ directory must contain the platform tarball, the matching standalone
 
 ```bash
 sudo deploy/scripts/install-runtimeclass.sh \
-  --version v3.2.2 \
+  --version v3.2.3 \
   --from-dir /opt/a3s-box-artifacts \
   --warmup-image docker.m.daocloud.io/library/busybox:latest
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -48,7 +48,7 @@ function Get-NormalizedTag {
         $number -notmatch '^[0-9A-Za-z.+-]+$' -or
         $number -notmatch '^[^.]+\.[^.]+\.[^.]+'
     ) {
-        throw "Invalid version '$Candidate'; expected a release such as v3.2.2."
+        throw "Invalid version '$Candidate'; expected a release such as v3.2.3."
     }
     return $tag
 }

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ Usage:
   install.sh [options]
 
 Options:
-  --version VERSION       Install a release such as v3.2.2 (default: latest).
+  --version VERSION       Install a release such as v3.2.3 (default: latest).
   --install-dir PATH      Install the self-contained distribution at PATH.
   --archive PATH          Install a local release tarball without downloading.
   --sha256 HEX            Expected SHA-256 for --archive.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "a3s-box"
-version = "3.2.2"
+version = "3.2.3"
 description = "Local-first Python SDK for the native A3S Box Sandbox API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -234,9 +234,9 @@ def response_for(request: Mapping[str, object]) -> dict[str, Any]:
         return {"names": ["old-network"]}
     if operation == "runtime_diagnostics":
         return {
-            "core_version": "3.2.2",
-            "runtime_version": "3.2.2",
-            "sdk_version": "3.2.2",
+            "core_version": "3.2.3",
+            "runtime_version": "3.2.3",
+            "sdk_version": "3.2.3",
             "home": "/tmp/a3s",
             "virtualization": {
                 "available": True,
@@ -1591,7 +1591,7 @@ class AsyncSdkTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(events.next_sequence, 11)
         self.assertEqual(sandboxes[0].id, "sandbox-local-1")
         self.assertEqual(snapshot.id, "ci-async")
-        self.assertEqual(diagnostics.sdk_version, "3.2.2")
+        self.assertEqual(diagnostics.sdk_version, "3.2.3")
         self.assertEqual(disk.snapshots_bytes, 4)
         restart = next(
             request

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/box",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "20.19.9",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Local-first TypeScript SDK for the native A3S Box Sandbox API",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -90,9 +90,9 @@ class FakeRuntime {
         return { names: ['old-network'] }
       case 'runtime_diagnostics':
         return {
-          core_version: '3.2.2',
-          runtime_version: '3.2.2',
-          sdk_version: '3.2.2',
+          core_version: '3.2.3',
+          runtime_version: '3.2.3',
+          sdk_version: '3.2.3',
           home: '/tmp/a3s',
           virtualization: {
             available: true,

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cli"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-core"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "a3s-acl",
  "a3s-common",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cri"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-guest-init"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "a3s-box-core",
  "a3s-common",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-mkext4"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "crc32c",
  "proptest",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-netproxy"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "a3s-box-core",
  "libc",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-runtime"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "a3s-acl",
  "a3s-box-core",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-sdk"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-shim"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-libkrun-sys"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "libc",
  "num_cpus",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 h2 = { path = "third_party/h2" }
 
 [workspace.package]
-version = "3.2.2"
+version = "3.2.3"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -122,7 +122,7 @@ xattr = "1.6"
 # workspace consumers on the same audited source. Keep the exact version
 # because a writer bump is a cache-schema migration rather than a routine
 # dependency update. See third_party/mkext4/A3S_PATCHES.md.
-mkext4 = { package = "a3s-box-mkext4", version = "=3.2.2", path = "../third_party/mkext4" }
+mkext4 = { package = "a3s-box-mkext4", version = "=3.2.3", path = "../third_party/mkext4" }
 
 # TEE attestation verification
 p384 = { workspace = true }

--- a/website/docs/v3/en/guide/installation.mdx
+++ b/website/docs/v3/en/guide/installation.mdx
@@ -64,7 +64,7 @@ a3s-box info
 
 | Behavior                       | Linux/macOS                   | Windows                         |
 | ------------------------------ | ----------------------------- | ------------------------------- |
-| Pin a release                  | `--version v3.2.2`            | `-Version v3.2.2`               |
+| Pin a release                  | `--version v3.2.3`            | `-Version v3.2.3`               |
 | Choose destination             | `--install-dir PATH`          | `-InstallDir PATH`              |
 | Do not change `PATH`           | `--no-modify-path`            | `-NoModifyPath`                 |
 | Replace an unmanaged directory | `--force`                     | `-Force`                        |
@@ -75,14 +75,14 @@ Pass Unix options after `sh -s --`:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.2 --no-modify-path
+  sh -s -- --version v3.2.3 --no-modify-path
 ```
 
 Invoke downloaded PowerShell text as a script block when options are needed:
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.2 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.3 -NoModifyPath
 ```
 
 The corresponding environment variables are `A3S_BOX_VERSION`,

--- a/website/docs/v3/zh/guide/installation.mdx
+++ b/website/docs/v3/zh/guide/installation.mdx
@@ -66,7 +66,7 @@ brew install a3s-lab/tap/a3s-box
 
 | 行为                 | Linux/macOS                   | Windows                         |
 | -------------------- | ----------------------------- | ------------------------------- |
-| 固定版本             | `--version v3.2.2`            | `-Version v3.2.2`               |
+| 固定版本             | `--version v3.2.3`            | `-Version v3.2.3`               |
 | 指定目录             | `--install-dir PATH`          | `-InstallDir PATH`              |
 | 不修改 `PATH`        | `--no-modify-path`            | `-NoModifyPath`                 |
 | 替换非安装器管理目录 | `--force`                     | `-Force`                        |
@@ -77,14 +77,14 @@ brew install a3s-lab/tap/a3s-box
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.2 --no-modify-path
+  sh -s -- --version v3.2.3 --no-modify-path
 ```
 
 Windows 带参数安装：
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.2 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.3 -NoModifyPath
 ```
 
 ## 离线安装
@@ -93,15 +93,15 @@ $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
 
 ```bash
 sh ./install.sh \
-  --version v3.2.2 \
-  --archive ./a3s-box-v3.2.2-linux-x86_64.tar.gz \
+  --version v3.2.3 \
+  --archive ./a3s-box-v3.2.3-linux-x86_64.tar.gz \
   --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 ```powershell
 .\install.ps1 `
-  -Version v3.2.2 `
-  -ArchivePath .\a3s-box-v3.2.2-windows-x86_64.zip `
+  -Version v3.2.3 `
+  -ArchivePath .\a3s-box-v3.2.3-windows-x86_64.zip `
   -Sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 


### PR DESCRIPTION
## Summary

- publish the legacy Sandbox anonymous-volume planning fix as Box 3.2.3
- align all Rust crates, SDK packages, installers, and documentation
- keep the exact mkext4 dependency closure and release metadata in lockstep

## Validation

- cargo metadata --manifest-path src/Cargo.toml --locked --no-deps
- cargo fmt --manifest-path src/Cargo.toml --all -- --check
- shell syntax and TypeScript syntax checks
- targeted legacy Sandbox resource-planning regression (passed on the preceding fix commit)
- full cross-platform CI and release workflow remain required before tagging