### PR TITLE
fix: authenticate sandbox resource planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to A3S Box will be documented in this file.
   anonymous-volume identities during the durable create reservation. Sandbox
   launches no longer fail the ownership-drift check when the OCI image declares
   a `VOLUME` and the migration router is not enabled.
+- Sandbox image planning now receives request-scoped registry credentials before
+  the durable reservation, then transfers the zeroizing in-memory handoff to
+  the execution boot. Private-registry images with anonymous volumes no longer
+  fail during pre-reservation metadata resolution, and credentials are still
+  resolved exactly once without entering persistent state.
 
 ## [3.2.2] — 2026-09-02
 

--- a/src/runtime/src/a3s_runtime_driver/lifecycle.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle.rs
@@ -47,6 +47,11 @@ impl BoxRuntimeDriver {
             }
         }
 
+        // A legacy Sandbox planner may need authenticated image metadata before
+        // Box allocates an execution ID. Keep the promoted handoff alive until
+        // the create/start path has either claimed it or failed, so an error
+        // before boot cannot leave an in-memory credential behind.
+        let mut _promoted_registry_auth = None;
         let record = match record {
             Some(record) => record,
             None => {
@@ -59,6 +64,19 @@ impl BoxRuntimeDriver {
                     &storage,
                 )?;
                 let operation_id = operation(spec)?;
+                let staged_registry_auth = if request.config.isolation.is_sandbox() {
+                    self.secret_materialization
+                        .prepare_registry_auth_for_create(
+                            spec,
+                            &request,
+                            &operation_id,
+                            &self.config.home_dir,
+                            self.transient_registry_auth.as_ref(),
+                        )
+                        .await?
+                } else {
+                    None
+                };
                 let reservation = self
                     .bounded("reservation", async {
                         self.manager
@@ -67,6 +85,27 @@ impl BoxRuntimeDriver {
                             .map_err(|error| map_execution_error(&spec.unit_id, error))
                     })
                     .await?;
+                if staged_registry_auth.is_some() {
+                    let broker = self.transient_registry_auth.as_ref().ok_or_else(|| {
+                        RuntimeError::Protocol(
+                            "Box lost the transient registry authorization broker after staging"
+                                .into(),
+                        )
+                    })?;
+                    _promoted_registry_auth = Some(
+                        broker
+                            .promote(operation_id.as_str(), reservation.execution_id.as_str())
+                            .map_err(|error| {
+                                RuntimeError::ProviderUnavailable(format!(
+                                    "Box transient registry credential handoff failed: {error}"
+                                ))
+                            })?,
+                    );
+                }
+                // The source lease only guards the pre-reservation key. The
+                // target lease above owns cleanup for the durable execution
+                // key until boot claims its authorization.
+                drop(staged_registry_auth);
                 let record = self
                     .manager
                     .managed_record(&reservation.execution_id)

--- a/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
+++ b/src/runtime/src/a3s_runtime_driver/lifecycle_tests.rs
@@ -93,6 +93,59 @@ fn registry_secret(reference: &str) -> SecretReference {
 }
 
 #[tokio::test]
+async fn uncached_sandbox_registry_credentials_are_staged_before_resource_planning() {
+    let directory = tempfile::tempdir().unwrap();
+    let secret_root = directory.path().join("runtime-secrets");
+    let materializer = Arc::new(DriverFakeSecretMaterializer::default());
+    let reference = "secret://registry/credential/preflight";
+    materializer.insert_registry_credential(reference, "plan-user", "plan-password");
+    let (driver, _backend) =
+        fake_driver_with_secret_materializer(&directory, secret_root, materializer.clone());
+
+    let mut spec = runtime_spec("registry-preflight", 1, RuntimeUnitClass::Service);
+    let digest = format!("sha256:{}", "b".repeat(64));
+    spec.artifact.uri = format!("oci://registry.example/a3s/runtime@{digest}");
+    spec.artifact.digest = digest;
+    spec.secrets.push(registry_secret(reference));
+
+    let request =
+        super::mapping::creation_request(&spec, a3s_box_core::ExecutionIsolation::Sandbox).unwrap();
+    let operation_id = super::mapping::operation(&spec).unwrap();
+    let staged = driver
+        .secret_materialization
+        .prepare_registry_auth_for_create(
+            &spec,
+            &request,
+            &operation_id,
+            &driver.config.home_dir,
+            driver.transient_registry_auth.as_ref(),
+        )
+        .await
+        .unwrap();
+
+    assert!(staged.is_some());
+    assert_eq!(materializer.calls(), 1);
+    let broker = driver.transient_registry_auth.as_ref().unwrap();
+    assert_eq!(
+        broker
+            .clone_auth(operation_id.as_str())
+            .and_then(|auth| auth.basic_credentials()),
+        Some(("plan-user".into(), "plan-password".into()))
+    );
+
+    let execution_lease = broker.promote(operation_id.as_str(), "execution").unwrap();
+    drop(staged);
+    assert_eq!(broker.pending(), 1);
+    assert!(!driver
+        .config
+        .home_dir
+        .join("auth/credentials.json")
+        .exists());
+    drop(execution_lease);
+    assert_eq!(broker.pending(), 0);
+}
+
+#[tokio::test]
 async fn unconfigured_secret_port_rejects_before_provider_mutation() {
     let directory = tempfile::tempdir().unwrap();
     let (driver, backend) = fake_driver(&directory);

--- a/src/runtime/src/a3s_runtime_driver/secret.rs
+++ b/src/runtime/src/a3s_runtime_driver/secret.rs
@@ -17,6 +17,7 @@ use a3s_box_core::secret::{
     validate_environment_variable_name, SecretEnvironmentBinding, SECRET_ENVIRONMENT_MANIFEST,
     SECRET_GUEST_ROOT,
 };
+use a3s_box_core::{CreateExecutionRequest, OperationId};
 
 use crate::local_execution::{TransientRegistryAuthBroker, TransientRegistryAuthLease};
 use crate::{BoxRecord, ImagePuller, ImageReference, ImageStore, RegistryAuth, VmManager};
@@ -430,6 +431,15 @@ impl SecretMaterializationOwner {
             }
             return Ok(None);
         };
+        // A Sandbox resource-planning pass may already have resolved the
+        // caller credential before the durable execution ID existed. Reuse
+        // that in-memory handoff instead of resolving the Secret a second
+        // time. The boot path still consumes the broker entry exactly once.
+        if registry_reference.is_some() {
+            if let Some(lease) = broker.lease(&record.id) {
+                return Ok(Some(lease));
+            }
+        }
         let metadata = record.managed_execution.as_ref().ok_or_else(|| {
             RuntimeError::Protocol("Box execution lost managed creation metadata".into())
         })?;
@@ -459,6 +469,63 @@ impl SecretMaterializationOwner {
                 "Box transient registry credential handoff failed: {error}"
             ))
         })
+    }
+
+    /// Resolve a registry Secret before a new execution is reserved.
+    ///
+    /// Sandbox resource planning needs authenticated image metadata in order
+    /// to derive stable anonymous-volume identities. The create operation is
+    /// the only stable key available before Box allocates its internal
+    /// execution ID, so the credential is staged under that key and promoted
+    /// by the lifecycle owner after reservation succeeds.
+    pub(super) async fn prepare_registry_auth_for_create(
+        &self,
+        spec: &RuntimeUnitSpec,
+        request: &CreateExecutionRequest,
+        operation_id: &OperationId,
+        home_dir: &Path,
+        broker: Option<&TransientRegistryAuthBroker>,
+    ) -> RuntimeResult<Option<TransientRegistryAuthLease>> {
+        let registry_reference = registry_reference(spec)?;
+        let Some(reference) = registry_reference else {
+            return Ok(None);
+        };
+        let Some(broker) = broker else {
+            return Err(RuntimeError::UnsupportedCapabilities(vec![
+                "feature:RegistryCredentials".into(),
+            ]));
+        };
+
+        // A cached image can be planned without caller credentials. Keep the
+        // existing lazy-start behavior and avoid resolving a Secret that will
+        // never cross the registry boundary.
+        if image_is_cached(home_dir, &request.config.image).await? {
+            return Ok(None);
+        }
+
+        let registry = ImageReference::parse(&request.config.image)
+            .map_err(|_| {
+                RuntimeError::Protocol(
+                    "Box managed artifact has an invalid registry identity".into(),
+                )
+            })?
+            .registry;
+        let materializer = self.materializer.as_ref().ok_or_else(|| {
+            RuntimeError::UnsupportedCapabilities(vec!["feature:SecretReferences".into()])
+        })?;
+        let credential = materializer
+            .materialize_registry_credential(reference, &registry)
+            .await
+            .map_err(map_materialization_error)?;
+        let auth = RegistryAuth::basic(credential.username(), credential.password());
+        broker
+            .bind(operation_id.as_str(), auth)
+            .map(Some)
+            .map_err(|error| {
+                RuntimeError::ProviderUnavailable(format!(
+                    "Box transient registry credential handoff failed: {error}"
+                ))
+            })
     }
 
     pub(super) async fn cleanup_spec(&self, spec: &RuntimeUnitSpec) -> RuntimeResult<()> {

--- a/src/runtime/src/local_execution/transient_registry_auth.rs
+++ b/src/runtime/src/local_execution/transient_registry_auth.rs
@@ -21,35 +21,103 @@ struct PendingRegistryAuth {
 impl TransientRegistryAuthBroker {
     pub(crate) fn bind(
         &self,
-        execution_id: &str,
+        key: &str,
         auth: RegistryAuth,
     ) -> ExecutionManagerResult<TransientRegistryAuthLease> {
         let token = uuid::Uuid::new_v4();
-        match self.entries.entry(execution_id.to_owned()) {
+        match self.entries.entry(key.to_owned()) {
             Entry::Vacant(entry) => {
                 entry.insert(PendingRegistryAuth { token, auth });
             }
             Entry::Occupied(_) => {
                 return Err(ExecutionManagerError::Unavailable(format!(
-                    "execution {execution_id} already has a pending transient registry credential"
+                    "transient registry authorization for {key} is already pending"
                 )));
             }
         }
         Ok(TransientRegistryAuthLease {
             broker: self.clone(),
-            execution_id: execution_id.to_owned(),
+            key: key.to_owned(),
             token,
         })
     }
 
-    pub(crate) fn take(&self, execution_id: &str) -> Option<RegistryAuth> {
-        self.entries
-            .remove(execution_id)
-            .map(|(_, pending)| pending.auth)
+    pub(crate) fn take(&self, key: &str) -> Option<RegistryAuth> {
+        self.entries.remove(key).map(|(_, pending)| pending.auth)
     }
 
-    fn release(&self, execution_id: &str, token: uuid::Uuid) {
-        if let Entry::Occupied(entry) = self.entries.entry(execution_id.to_owned()) {
+    /// Clone an authorization for a pre-reservation planning pass.
+    ///
+    /// Planning must be able to inspect a private image before the execution
+    /// has an internal ID, but the same authorization still has to remain
+    /// available for the subsequent boot pull. Keeping the value in this
+    /// in-memory broker avoids writing caller credentials to the durable Box
+    /// record or credential store.
+    pub(crate) fn clone_auth(&self, key: &str) -> Option<RegistryAuth> {
+        self.entries.get(key).map(|pending| pending.auth.clone())
+    }
+
+    /// Create a lease for an authorization that is already staged under `key`.
+    ///
+    /// The lease is intentionally independent of the entry's ownership. The
+    /// boot path consumes the entry, after which dropping this lease is a safe
+    /// no-op. If boot never claims it, dropping the lease removes the pending
+    /// credential and closes the transient handoff.
+    pub(crate) fn lease(&self, key: &str) -> Option<TransientRegistryAuthLease> {
+        let token = self.entries.get(key)?.token;
+        Some(TransientRegistryAuthLease {
+            broker: self.clone(),
+            key: key.to_owned(),
+            token,
+        })
+    }
+
+    /// Move a pre-reservation authorization to the durable execution key.
+    ///
+    /// The source lease remains valid and only releases the source key. The
+    /// caller should retain the returned target lease until the execution has
+    /// either claimed the authorization during boot or failed before boot.
+    pub(crate) fn promote(
+        &self,
+        source: &str,
+        target: &str,
+    ) -> ExecutionManagerResult<TransientRegistryAuthLease> {
+        if source == target {
+            return self.lease(target).ok_or_else(|| {
+                ExecutionManagerError::Unavailable(format!(
+                    "transient registry authorization for {target} is no longer pending"
+                ))
+            });
+        }
+
+        let (_, pending) = self.entries.remove(source).ok_or_else(|| {
+            ExecutionManagerError::Unavailable(format!(
+                "transient registry authorization for {source} is no longer pending"
+            ))
+        })?;
+        let token = pending.token;
+        match self.entries.entry(target.to_owned()) {
+            Entry::Vacant(entry) => {
+                entry.insert(pending);
+                Ok(TransientRegistryAuthLease {
+                    broker: self.clone(),
+                    key: target.to_owned(),
+                    token,
+                })
+            }
+            Entry::Occupied(_) => {
+                // Preserve the source on a conflict so the caller's source
+                // lease can still clean up the credential deterministically.
+                self.entries.insert(source.to_owned(), pending);
+                Err(ExecutionManagerError::Unavailable(format!(
+                    "transient registry authorization for {target} is already pending"
+                )))
+            }
+        }
+    }
+
+    fn release(&self, key: &str, token: uuid::Uuid) {
+        if let Entry::Occupied(entry) = self.entries.entry(key.to_owned()) {
             if entry.get().token == token {
                 entry.remove();
             }
@@ -64,13 +132,13 @@ impl TransientRegistryAuthBroker {
 
 pub(crate) struct TransientRegistryAuthLease {
     broker: TransientRegistryAuthBroker,
-    execution_id: String,
+    key: String,
     token: uuid::Uuid,
 }
 
 impl Drop for TransientRegistryAuthLease {
     fn drop(&mut self) {
-        self.broker.release(&self.execution_id, self.token);
+        self.broker.release(&self.key, self.token);
     }
 }
 
@@ -93,6 +161,49 @@ mod tests {
 
         assert_eq!(broker.pending(), 1);
         drop(second);
+        assert_eq!(broker.pending(), 0);
+    }
+
+    #[test]
+    fn planning_can_clone_and_promote_authorization_without_persisting_it() {
+        let broker = TransientRegistryAuthBroker::default();
+        let source = broker
+            .bind("operation", RegistryAuth::basic("user", "password"))
+            .unwrap();
+
+        assert_eq!(
+            broker
+                .clone_auth("operation")
+                .and_then(|auth| auth.basic_credentials()),
+            Some(("user".into(), "password".into()))
+        );
+
+        let target = broker.promote("operation", "execution").unwrap();
+        assert!(broker.clone_auth("operation").is_none());
+        assert_eq!(
+            broker
+                .clone_auth("execution")
+                .and_then(|auth| auth.basic_credentials()),
+            Some(("user".into(), "password".into()))
+        );
+
+        drop(source);
+        assert_eq!(broker.pending(), 1);
+        drop(target);
+        assert_eq!(broker.pending(), 0);
+    }
+
+    #[test]
+    fn existing_authorization_can_be_leased_for_boot() {
+        let broker = TransientRegistryAuthBroker::default();
+        let staged = broker
+            .bind("execution", RegistryAuth::basic("user", "password"))
+            .unwrap();
+        let boot = broker.lease("execution").unwrap();
+        assert_eq!(broker.pending(), 1);
+        assert!(broker.take("execution").is_some());
+        drop(boot);
+        drop(staged);
         assert_eq!(broker.pending(), 0);
     }
 }

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -640,6 +640,17 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
         // anonymous-volume identities. The actual VolumeStore claims remain
         // in `start`, after the reservation has durably recorded ownership.
         let mut manager = self.new_manager(record)?;
+        #[cfg(target_os = "linux")]
+        {
+            // A Runtime registry credential is staged under the idempotent
+            // create operation before this pre-reservation pass. Clone it for
+            // the metadata pull, while leaving the broker entry available for
+            // the later boot pull. The credential never enters the durable
+            // BoxRecord.
+            if let Some(broker) = &self.transient_registry_auth {
+                manager.transient_registry_auth = broker.clone_auth(metadata.operation_id.as_str());
+            }
+        }
         let anonymous_volumes = manager
             .plan_image_anonymous_volumes()
             .await


### PR DESCRIPTION
## Summary\n- stage request-scoped registry credentials under the idempotent create operation before Sandbox resource planning\n- reuse the in-memory credential for metadata resolution and promote it to the execution key after reservation\n- add lease/zeroization regression coverage and document the private-registry fix\n\n## Validation\n- cargo fmt --manifest-path src/Cargo.toml --all -- --check\n- Linux WSL: cargo test --manifest-path src/Cargo.toml --locked -p a3s-box-runtime --lib (1848 passed, 5 ignored)\n- Linux WSL: focused registry lifecycle and handoff tests\n- Linux WSL: cargo clippy --manifest-path src/Cargo.toml --locked -p a3s-box-runtime --all-targets -- -D warnings -A clippy::uninlined_format_args\n- Windows host: cargo test --manifest-path src/Cargo.toml --locked -p a3s-box-runtime (1404 non-Linux tests)\n\nFixes the R17 private-registry Sandbox gate where anonymous-volume planning pulled a protected manifest before the start-time credential handoff.