### PR TITLE
feat(runtime): enforce Sandbox writable-layer quotas

### DIFF
--- a/src/core/src/config.rs
+++ b/src/core/src/config.rs
@@ -599,6 +599,16 @@ pub struct ResourceConfig {
     /// Disk space in MB
     pub disk_mb: u32,
 
+    /// Optional writable-layer quota in bytes.
+    ///
+    /// This is distinct from `disk_mb`: the latter describes the logical
+    /// capacity of a MicroVM root disk, while this bound applies to the
+    /// mutable overlay layer used by the Linux Sandbox provider. Providers
+    /// that cannot enforce the byte-precise limit must reject the request
+    /// rather than silently treating it as an unbounded filesystem.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ephemeral_storage_bytes: Option<u64>,
+
     /// Box lifetime timeout in seconds (0 = unlimited)
     pub timeout: u64,
 }
@@ -609,6 +619,7 @@ impl Default for ResourceConfig {
             vcpus: DEFAULT_VCPUS,
             memory_mb: 1024,
             disk_mb: 4096,
+            ephemeral_storage_bytes: None,
             timeout: 3600, // 1 hour
         }
     }
@@ -714,6 +725,7 @@ mod tests {
         assert_eq!(config.vcpus, DEFAULT_VCPUS);
         assert_eq!(config.memory_mb, 1024);
         assert_eq!(config.disk_mb, 4096);
+        assert_eq!(config.ephemeral_storage_bytes, None);
         assert_eq!(config.timeout, 3600);
     }
 
@@ -737,12 +749,14 @@ mod tests {
             vcpus: 4,
             memory_mb: 2048,
             disk_mb: 8192,
+            ephemeral_storage_bytes: None,
             timeout: 7200,
         };
 
         assert_eq!(config.vcpus, 4);
         assert_eq!(config.memory_mb, 2048);
         assert_eq!(config.disk_mb, 8192);
+        assert_eq!(config.ephemeral_storage_bytes, None);
         assert_eq!(config.timeout, 7200);
     }
 
@@ -791,6 +805,7 @@ mod tests {
             vcpus: 8,
             memory_mb: 4096,
             disk_mb: 16384,
+            ephemeral_storage_bytes: None,
             timeout: 0,
         };
 
@@ -799,7 +814,30 @@ mod tests {
 
         assert_eq!(parsed.vcpus, 8);
         assert_eq!(parsed.memory_mb, 4096);
+        assert_eq!(parsed.ephemeral_storage_bytes, None);
         assert_eq!(parsed.timeout, 0); // Unlimited
+    }
+
+    #[test]
+    fn test_resource_config_ephemeral_storage_roundtrip_and_legacy_shape() {
+        let config = ResourceConfig {
+            ephemeral_storage_bytes: Some(64 * 1024 * 1024),
+            ..ResourceConfig::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("ephemeral_storage_bytes"));
+        let parsed: ResourceConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            parsed.ephemeral_storage_bytes,
+            config.ephemeral_storage_bytes
+        );
+
+        let legacy = r#"{"vcpus":1,"memory_mb":128,"disk_mb":512,"timeout":0}"#;
+        let parsed: ResourceConfig = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.ephemeral_storage_bytes, None);
+        assert!(!serde_json::to_string(&parsed)
+            .unwrap()
+            .contains("ephemeral_storage_bytes"));
     }
 
     #[test]

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -760,7 +760,7 @@ impl RuntimeConformanceFixture for BoxRuntimeConformanceFixture {
             RuntimeConformanceProfile::Mounts => super::mounts_profile::run(self, client).await,
             RuntimeConformanceProfile::Health => super::health_profile::run(self, client).await,
             RuntimeConformanceProfile::Resources => {
-                super::resources_profile::run(self, client).await
+                super::resources_profile::run(self, client, capabilities).await
             }
             RuntimeConformanceProfile::Logs => super::logs_profile::run(self, client).await,
             RuntimeConformanceProfile::Exec => super::exec_profile::run(self, client).await,

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
@@ -3,7 +3,9 @@ use std::time::Instant;
 
 use a3s_box_core::ExecutionIsolation;
 use a3s_oci_sdk::{CONTROL_CGROUP_NAME, WORKLOAD_CGROUP_NAME};
-use a3s_runtime::contract::{RuntimeInspection, RuntimeUnitState};
+use a3s_runtime::contract::{
+    ResourceControl, RuntimeCapabilities, RuntimeInspection, RuntimeUnitState,
+};
 use a3s_runtime::RuntimeClient;
 
 use super::cases::ResourceShape;
@@ -17,12 +19,18 @@ const MEMORY_BYTES: u64 = 128 * 1024 * 1024;
 const PIDS: u32 = 32;
 const TASK_EXECUTION_TIMEOUT_MS: u64 = 400;
 const TASK_TIMEOUT_MAX_RUNTIME_MS: u64 = 5_000;
+const EPHEMERAL_STORAGE_BYTES: u64 = 128 * 1024 * 1024;
 
 pub(super) async fn run(
     fixture: &BoxRuntimeConformanceFixture,
     client: &dyn RuntimeClient,
+    capabilities: &RuntimeCapabilities,
 ) -> Result<()> {
-    let service = fixture.cases.apply(
+    let ephemeral_supported = capabilities
+        .resource_controls
+        .contains(&ResourceControl::EphemeralStorage);
+    let execution_isolation = fixture.driver.execution_isolation();
+    let mut service = fixture.cases.apply(
         "resources-service",
         a3s_runtime::contract::RuntimeUnitClass::Service,
         "printf 'r17-resources-ready\\n'; exec sleep 3600",
@@ -34,6 +42,9 @@ pub(super) async fn run(
         },
         a3s_runtime::contract::RestartPolicy::Never,
     );
+    if ephemeral_supported {
+        service.spec.resources.ephemeral_storage_bytes = Some(EPHEMERAL_STORAGE_BYTES);
+    }
     let running = client.apply(&service).await?;
     require(
         running.state == RuntimeUnitState::Running,
@@ -46,7 +57,6 @@ pub(super) async fn run(
         .ok_or_else(|| super::protocol("resource fixture lost managed metadata"))?
         .request
         .config;
-    let execution_isolation = fixture.driver.execution_isolation();
     require(
         config.resource_limits.cpu_quota == Some(CPU_QUOTA_US as i64)
             && config.resource_limits.cpu_period == Some(CPU_PERIOD_US),
@@ -70,11 +80,42 @@ pub(super) async fn run(
         config.resource_limits.pids_limit == Some(u64::from(PIDS)),
         "PID limit changed before provider launch",
     )?;
+    if ephemeral_supported {
+        require(
+            execution_isolation == ExecutionIsolation::Sandbox
+                && config.resources.ephemeral_storage_bytes == Some(EPHEMERAL_STORAGE_BYTES),
+            "ephemeral storage quota did not reach the Sandbox provider",
+        )?;
+    }
 
     let sandbox_management = match execution_isolation {
         ExecutionIsolation::Sandbox => Some(sandbox_management_cgroup(&record)?),
         ExecutionIsolation::Microvm => None,
     };
+
+    if ephemeral_supported {
+        let quota = client
+            .exec(&fixture.cases.exec(
+                "resources-ephemeral-storage-behavior",
+                &service.spec,
+                vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    "path=/var/lib/.a3s-r17-ephemeral-quota; rm -f \"$path\"; if dd if=/dev/zero of=\"$path\" bs=1048576 count=192 2>/dev/null; then printf 'quota-not-enforced\\n'; exit 71; fi; actual=$(wc -c <\"$path\"); test \"$actual\" -gt 0; test \"$actual\" -lt 201326592; printf 'quota-enforced:%s\\n' \"$actual\"; rm -f \"$path\"".into(),
+                ],
+                20_000,
+            ))
+            .await?;
+        require(
+            quota.exit_code == 0
+                && quota.stdout.starts_with("quota-enforced:")
+                && quota.stderr.is_empty(),
+            format!(
+                "ephemeral writable-layer quota was not enforced: exit_code={} stdout={:?} stderr={:?}",
+                quota.exit_code, quota.stdout, quota.stderr
+            ),
+        )?;
+    }
 
     let visible = client
         .exec(&fixture.cases.exec(

--- a/src/runtime/src/a3s_runtime_driver/mapping.rs
+++ b/src/runtime/src/a3s_runtime_driver/mapping.rs
@@ -112,6 +112,7 @@ pub(super) fn creation_request_for(
             vcpus,
             memory_mb,
             disk_mb: BoxConfig::default().resources.disk_mb,
+            ephemeral_storage_bytes: spec.resources.ephemeral_storage_bytes,
             timeout: task_timeout_secs.unwrap_or(0),
         },
         cmd,
@@ -268,10 +269,19 @@ fn validate_supported_shape(
             "feature:ServiceUdp".into(),
         ]));
     }
-    if spec.resources.ephemeral_storage_bytes.is_some() {
-        return Err(RuntimeError::UnsupportedCapabilities(vec![
-            "resource_control:EphemeralStorage".into(),
-        ]));
+    if let Some(bytes) = spec.resources.ephemeral_storage_bytes {
+        if bytes == 0 {
+            return Err(RuntimeError::InvalidRequest(
+                "Runtime ephemeral storage limit must be greater than zero".into(),
+            ));
+        }
+        if execution_isolation != ExecutionIsolation::Sandbox
+            || !crate::rootfs::writable_layer_quota_supported()
+        {
+            return Err(RuntimeError::UnsupportedCapabilities(vec![
+                "resource_control:EphemeralStorage".into(),
+            ]));
+        }
     }
     match (&spec.class, &spec.restart) {
         (RuntimeUnitClass::Task, RestartPolicy::Never | RestartPolicy::OnFailure { .. })

--- a/src/runtime/src/a3s_runtime_driver/mod.rs
+++ b/src/runtime/src/a3s_runtime_driver/mod.rs
@@ -99,6 +99,10 @@ pub struct BoxRuntimeDriver {
     port_connector: Arc<dyn ExecutionPortConnector>,
     service_endpoints: ServiceEndpointOwner,
     execution_isolation: ExecutionIsolation,
+    /// Whether this concrete provider instance can enforce a byte-precise
+    /// Sandbox writable-layer quota. Qualification backends deliberately do
+    /// not inherit the production host probe.
+    supports_ephemeral_storage: bool,
     sev_snp: Option<BoxRuntimeSevSnpConfig>,
     attestation: AttestationArtifactOwner,
     artifact_storage: ArtifactStorageOwner,
@@ -144,6 +148,8 @@ impl BoxRuntimeDriver {
             None,
             None,
             Some(broker),
+            execution_isolation == ExecutionIsolation::Sandbox
+                && crate::rootfs::writable_layer_quota_supported(),
         )
     }
 
@@ -183,6 +189,7 @@ impl BoxRuntimeDriver {
             None,
             None,
             Some(TransientRegistryAuthBroker::default()),
+            false,
         )?;
         driver.provider_build.set(provider_build).map_err(|_| {
             RuntimeError::Protocol(
@@ -216,6 +223,7 @@ impl BoxRuntimeDriver {
         self
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn with_manager_connector_and_materializer(
         config: BoxRuntimeDriverConfig,
         manager: LocalExecutionManager,
@@ -224,6 +232,7 @@ impl BoxRuntimeDriver {
         materializer: Option<Arc<dyn BoxSecretMaterializer>>,
         artifact_port: Option<Arc<dyn BoxArtifactPort>>,
         transient_registry_auth: Option<TransientRegistryAuthBroker>,
+        supports_ephemeral_storage: bool,
     ) -> RuntimeResult<Self> {
         validate_config(&config)?;
         let endpoint_connector = Arc::clone(&connector);
@@ -237,6 +246,7 @@ impl BoxRuntimeDriver {
             port_connector: connector,
             service_endpoints: ServiceEndpointOwner::new(endpoint_connector),
             execution_isolation,
+            supports_ephemeral_storage,
             sev_snp: None,
             attestation: AttestationArtifactOwner::default(),
             artifact_storage,
@@ -554,6 +564,15 @@ impl RuntimeDriver for BoxRuntimeDriver {
         if self.sev_snp.is_some() {
             isolation_levels.push(IsolationLevel::Confidential);
         }
+        let mut resource_controls = vec![
+            ResourceControl::Cpu,
+            ResourceControl::Memory,
+            ResourceControl::Pids,
+        ];
+        if self.supports_ephemeral_storage {
+            resource_controls.push(ResourceControl::EphemeralStorage);
+        }
+        resource_controls.push(ResourceControl::ExecutionTimeout);
         let capabilities = RuntimeCapabilities {
             schema: RuntimeCapabilities::SCHEMA.into(),
             provider_id: self.provider_id.clone(),
@@ -570,12 +589,7 @@ impl RuntimeDriver for BoxRuntimeDriver {
                 HealthCheckKind::Tcp,
                 HealthCheckKind::Command,
             ],
-            resource_controls: vec![
-                ResourceControl::Cpu,
-                ResourceControl::Memory,
-                ResourceControl::Pids,
-                ResourceControl::ExecutionTimeout,
-            ],
+            resource_controls,
             features,
         };
         capabilities.validate().map_err(RuntimeError::Protocol)?;

--- a/src/runtime/src/a3s_runtime_driver/test_support.rs
+++ b/src/runtime/src/a3s_runtime_driver/test_support.rs
@@ -545,6 +545,7 @@ where
         None,
         None,
         Some(TransientRegistryAuthBroker::default()),
+        false,
     )
     .unwrap()
     .with_attestation_transport(transport);
@@ -653,6 +654,7 @@ fn configured_driver_with_materializer(
         materializer,
         None,
         Some(TransientRegistryAuthBroker::default()),
+        false,
     )
     .unwrap();
     driver

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -4861,6 +4861,7 @@ fn request(external_id: &str, isolation: ExecutionIsolation) -> CreateExecutionR
                 vcpus: 1,
                 memory_mb: 128,
                 disk_mb: 512,
+                ephemeral_storage_bytes: None,
                 timeout: 300,
             },
             ..Default::default()

--- a/src/runtime/src/local_execution/remove.rs
+++ b/src/runtime/src/local_execution/remove.rs
@@ -92,6 +92,8 @@ fn cleanup_execution_paths(home_dir: &Path, record: &BoxRecord) -> ExecutionMana
     crate::network::terminate_passt(&socket_dir);
 
     crate::rootfs::unmount_box_overlay(&record.box_dir.join("merged"));
+    crate::rootfs::cleanup_bounded_writable_layer_for_removal(&record.box_dir)
+        .map_err(|error| cleanup_error(record, "detach bounded writable-layer mounts", error))?;
     crate::rootfs::unmount_box_rootfs(&record.box_dir.join("rootfs"));
 
     remove_tree_if_present(&record.box_dir)

--- a/src/runtime/src/local_execution/tests.rs
+++ b/src/runtime/src/local_execution/tests.rs
@@ -367,6 +367,7 @@ fn request(external_id: &str) -> CreateExecutionRequest {
                 vcpus: 1,
                 memory_mb: 128,
                 disk_mb: 512,
+                ephemeral_storage_bytes: None,
                 timeout: 300,
             },
             ..Default::default()

--- a/src/runtime/src/rootfs/mod.rs
+++ b/src/runtime/src/rootfs/mod.rs
@@ -49,14 +49,43 @@ pub use guest_native_ext4::GuestNativeExt4Provider;
 pub use layout::{GuestLayout, GUEST_WORKDIR};
 pub use provider::{
     default_provider, default_provider_for_box, CopyProvider, OverlayProvider, ResumedRootfs,
-    RootfsArtifactCacheOptions, RootfsFinalizeOptions, RootfsOciPrepareOptions, RootfsProvider,
-    RootfsResumeOptions,
+    RootfsArtifactCacheOptions, RootfsFinalizeOptions, RootfsOciPrepareOptions,
+    RootfsPrepareOptions, RootfsProvider, RootfsResumeOptions,
 };
 pub(crate) use provider::{default_provider_for_boot, default_provider_for_box_boot};
 pub(crate) use staging_path::{
     ensure_directory_transport_is_lossless, host_staging_path, logical_path_for_staged_child,
     staging_path_map,
 };
+
+/// Whether the host path is a mount point, including bind mounts.
+///
+/// The overlay module owns the Linux `/proc/self/mountinfo` parser so all
+/// rootfs lifecycle callers use the same mount semantics.
+pub(crate) fn is_mountpoint(path: &Path) -> bool {
+    overlay::is_mountpoint(path)
+}
+
+/// Whether the selected Linux rootfs provider can enforce a real writable
+/// layer byte quota.
+#[allow(dead_code)]
+pub(crate) fn writable_layer_quota_supported() -> bool {
+    overlay::writable_layer_quota_supported()
+}
+
+/// Release any host mounts owned by a bounded Sandbox writable layer before
+/// the execution directory is removed.
+///
+/// Persistent executions intentionally keep their quota tmpfs mounted across a
+/// normal stop so the next start can reuse the same writable generation. The
+/// durable removal path must nevertheless force that state down before it
+/// deletes `box_dir`; otherwise the aliases and tmpfs would outlive the Box
+/// record and leak host mounts.
+pub(crate) fn cleanup_bounded_writable_layer_for_removal(
+    box_dir: &Path,
+) -> a3s_box_core::error::Result<()> {
+    overlay::cleanup_bounded_writable_layer(box_dir, false)
+}
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -453,21 +482,6 @@ pub(crate) fn unmount_box_overlay_for_reuse(merged: &Path) -> a3s_box_core::erro
         )));
     }
     Ok(())
-}
-
-/// True if `path` is a mountpoint (its device id differs from its parent's).
-#[cfg(unix)]
-pub(crate) fn is_mountpoint(path: &Path) -> bool {
-    use std::os::unix::fs::MetadataExt;
-    match (std::fs::metadata(path), std::fs::metadata(path.join(".."))) {
-        (Ok(here), Ok(parent)) => here.dev() != parent.dev(),
-        _ => false,
-    }
-}
-
-#[cfg(not(unix))]
-pub(crate) fn is_mountpoint(_path: &Path) -> bool {
-    false
 }
 
 /// Unmount a platform-specific writable rootfs mount.

--- a/src/runtime/src/rootfs/overlay.rs
+++ b/src/runtime/src/rootfs/overlay.rs
@@ -4,9 +4,104 @@
 //! unprivileged overlayfs is available in user namespaces. Falls back to
 //! `mount(2)` syscall or `mount` command.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use a3s_box_core::error::{BoxError, Result};
+
+/// Directory and marker names used for a bounded Linux Sandbox writable layer.
+///
+/// The layer itself is a private, size-limited tmpfs. `upper` and `work` are
+/// bind-mounted aliases kept at the historical Box paths so metadata and
+/// lifecycle code do not need a second rootfs layout.
+pub(crate) const WRITABLE_LAYER_DIR_NAME: &str = ".writable-layer";
+pub(crate) const WRITABLE_LAYER_MARKER_NAME: &str = ".writable-layer-bytes";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MountInfo {
+    pub root: PathBuf,
+    pub mount_point: PathBuf,
+    pub mount_options: String,
+    pub filesystem: String,
+    pub source: String,
+    pub super_options: String,
+}
+
+/// Read one mountinfo record for an exact mount point.
+///
+/// `/proc/self/mountinfo` is used instead of comparing device IDs: bind mounts
+/// intentionally retain the source device and therefore look like ordinary
+/// directories to `stat(2)`.
+#[cfg(target_os = "linux")]
+pub(crate) fn mount_info(path: &Path) -> Option<MountInfo> {
+    let wanted = path.to_string_lossy();
+    let contents = std::fs::read_to_string("/proc/self/mountinfo").ok()?;
+    contents
+        .lines()
+        .filter_map(parse_mountinfo_line)
+        // A crashed/restarted owner can briefly leave stacked mounts at the
+        // same path. The last record is the top-most mount and is the one a
+        // subsequent unmount or validation will observe first.
+        .rfind(|info| info.mount_point.to_string_lossy() == wanted)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn mount_info(_path: &Path) -> Option<MountInfo> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn parse_mountinfo_line(line: &str) -> Option<MountInfo> {
+    let (left, right) = line.split_once(" - ")?;
+    let left = left.split_whitespace().collect::<Vec<_>>();
+    let right = right.split_whitespace().collect::<Vec<_>>();
+    // mountinfo fields 4 and 5 are root, mount point, and the per-mount
+    // options respectively. The post-separator fields start with fstype.
+    if left.len() < 6 || right.len() < 3 {
+        return None;
+    }
+    Some(MountInfo {
+        root: PathBuf::from(unescape_mountinfo(left[3])),
+        mount_point: PathBuf::from(unescape_mountinfo(left[4])),
+        mount_options: left[5].to_string(),
+        filesystem: right[0].to_string(),
+        source: unescape_mountinfo(right[1]).to_string(),
+        super_options: right[2].to_string(),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn unescape_mountinfo(value: &str) -> String {
+    value
+        .replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\")
+}
+
+/// True when `path` is a mount point, including a bind mount.
+pub(crate) fn is_mountpoint(path: &Path) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        if mount_info(path).is_some() {
+            return true;
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        match (std::fs::metadata(path), std::fs::metadata(path.join(".."))) {
+            (Ok(here), Ok(parent)) => here.dev() != parent.dev(),
+            _ => false,
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        false
+    }
+}
 
 /// Mount an overlayfs at `merged` with `lower` (read-only), `upper` (writes), `work`.
 ///
@@ -201,6 +296,461 @@ fn overlay_unmount_with_mode(merged: &Path, lazy: bool) -> Result<()> {
     }
 }
 
+/// Host-side paths for a bounded writable layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoundedWritableLayer {
+    /// The historical Box path consumed by overlayfs as `upperdir`.
+    pub upper: PathBuf,
+    /// The historical Box path consumed by overlayfs as `workdir`.
+    pub work: PathBuf,
+    /// The private tmpfs mount which owns both directories.
+    pub mount: PathBuf,
+}
+
+/// Prepare a size-limited writable layer for the Linux Sandbox provider.
+///
+/// A tmpfs parent owns `upper` and `work`; bind aliases preserve the existing
+/// Box layout (`box_dir/upper` and `box_dir/work`). This gives overlayfs a
+/// genuinely bounded filesystem rather than merely recording a requested
+/// number in metadata. Existing mounts are reused only when their recorded
+/// quota matches exactly; a changed quota fails closed.
+pub(crate) fn prepare_bounded_writable_layer(
+    box_dir: &Path,
+    bytes: u64,
+) -> Result<BoundedWritableLayer> {
+    if bytes == 0 {
+        return Err(BoxError::ConfigError(
+            "Sandbox writable-layer quota must be greater than zero".into(),
+        ));
+    }
+    if !writable_layer_quota_supported() {
+        return Err(BoxError::ConfigError(
+            "Linux Sandbox writable-layer quotas require root tmpfs and overlayfs support".into(),
+        ));
+    }
+
+    std::fs::create_dir_all(box_dir).map_err(|error| {
+        BoxError::BuildError(format!(
+            "Failed to create Box directory {} for bounded writable layer: {error}",
+            box_dir.display()
+        ))
+    })?;
+
+    let mount = box_dir.join(WRITABLE_LAYER_DIR_NAME);
+    let marker = box_dir.join(WRITABLE_LAYER_MARKER_NAME);
+    let upper_source = mount.join("upper");
+    let work_source = mount.join("work");
+    let upper = box_dir.join("upper");
+    let work = box_dir.join("work");
+
+    let marker_present = validate_existing_quota_marker(&marker, bytes, &mount)?;
+    ensure_directory_path(&mount, "bounded writable-layer mount")?;
+
+    if is_mountpoint(&mount) {
+        let info = mount_info(&mount).ok_or_else(|| {
+            BoxError::StateError(format!(
+                "Cannot inspect bounded writable-layer mount {}",
+                mount.display()
+            ))
+        })?;
+        validate_tmpfs_size(&info, bytes, &mount)?;
+    } else {
+        if marker_present {
+            return Err(BoxError::StateError(format!(
+                "Writable-layer quota marker {} exists but its tmpfs mount {} is absent; refusing to recreate a potentially lost persistent generation",
+                marker.display(),
+                mount.display()
+            )));
+        }
+        let mut entries = std::fs::read_dir(&mount).map_err(|error| {
+            BoxError::BuildError(format!(
+                "Failed to inspect bounded writable-layer directory {}: {error}",
+                mount.display()
+            ))
+        })?;
+        if entries.next().is_some() {
+            return Err(BoxError::StateError(format!(
+                "Unmanaged files remain in {} where a bounded tmpfs would be mounted",
+                mount.display()
+            )));
+        }
+        mount_tmpfs(&mount, bytes)?;
+    }
+
+    ensure_directory_path(&upper_source, "bounded writable-layer upper")?;
+    ensure_directory_path(&work_source, "bounded writable-layer work")?;
+    ensure_directory_path(&upper, "overlay upper alias")?;
+    ensure_directory_path(&work, "overlay work alias")?;
+
+    bind_alias(&upper_source, &upper)?;
+    if let Err(error) = bind_alias(&work_source, &work) {
+        let _ = unmount_path(&upper, true);
+        return Err(error);
+    }
+
+    // The marker lives outside tmpfs so a process restart can validate the
+    // quota before touching the mount. Write it only after all mounts succeed.
+    write_quota_marker(&marker, bytes)?;
+
+    Ok(BoundedWritableLayer { upper, work, mount })
+}
+
+/// Release a bounded writable layer. Persistent boxes retain the tmpfs and
+/// aliases so their overlay contents survive stop/start; non-persistent boxes
+/// synchronously detach all mounts before their directory is removed.
+pub(crate) fn cleanup_bounded_writable_layer(box_dir: &Path, persistent: bool) -> Result<()> {
+    let mount = box_dir.join(WRITABLE_LAYER_DIR_NAME);
+    let marker = box_dir.join(WRITABLE_LAYER_MARKER_NAME);
+    let upper = box_dir.join("upper");
+    let work = box_dir.join("work");
+
+    let managed =
+        marker.exists() || is_mountpoint(&mount) || is_mountpoint(&upper) || is_mountpoint(&work);
+    if !managed {
+        return Ok(());
+    }
+    if persistent {
+        // The mounted tmpfs is the durable writable generation for this host.
+        // Keeping it mounted avoids copying potentially large data out of the
+        // quota filesystem and lets the next boot reattach the same aliases.
+        return Ok(());
+    }
+
+    let mut first_error = None;
+    // Overlay must already be detached by the provider. Detach aliases before
+    // the tmpfs parent so the source directories remain reachable during
+    // unmount.
+    for path in [&work, &upper, &mount] {
+        for _ in 0..8 {
+            if !is_mountpoint(path) {
+                break;
+            }
+            match unmount_path(path, false) {
+                Ok(()) => continue,
+                Err(synchronous) => {
+                    // A discarded box has no future writer; a lazy detach is
+                    // a safe last resort, but retain the synchronous failure
+                    // if both paths fail so the caller can retry instead of
+                    // claiming clean removal.
+                    if unmount_path(path, true).is_err() {
+                        if first_error.is_none() {
+                            first_error = Some(synchronous);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        if is_mountpoint(path) && first_error.is_none() {
+            first_error = Some(BoxError::StateError(format!(
+                "Writable-layer mount {} remained attached after cleanup",
+                path.display()
+            )));
+        }
+    }
+
+    // Keep the marker when any mount is still attached: it is the durable
+    // signal that cleanup must be retried and prevents a later boot from
+    // treating an orphaned tmpfs as an untracked directory.
+    if ![&work, &upper, &mount]
+        .iter()
+        .any(|path| is_mountpoint(path))
+    {
+        if let Err(error) = std::fs::remove_file(&marker) {
+            if error.kind() != std::io::ErrorKind::NotFound && first_error.is_none() {
+                first_error = Some(BoxError::BuildError(format!(
+                    "Failed to remove writable-layer quota marker {}: {error}",
+                    marker.display()
+                )));
+            }
+        }
+    }
+    if let Some(error) = first_error {
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn validate_existing_quota_marker(marker: &Path, bytes: u64, mount: &Path) -> Result<bool> {
+    let metadata = match std::fs::symlink_metadata(marker) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(BoxError::StateError(format!(
+                "Failed to inspect writable-layer quota marker {}: {error}",
+                marker.display()
+            )))
+        }
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(BoxError::StateError(format!(
+            "Writable-layer quota marker {} is not a regular file",
+            marker.display()
+        )));
+    }
+    let contents = match std::fs::read_to_string(marker) {
+        Ok(contents) => contents,
+        Err(error) => {
+            return Err(BoxError::StateError(format!(
+                "Failed to read writable-layer quota marker {}: {error}",
+                marker.display()
+            )))
+        }
+    };
+    let recorded = contents.trim().parse::<u64>().map_err(|error| {
+        BoxError::StateError(format!(
+            "Invalid writable-layer quota marker {}: {error}",
+            marker.display()
+        ))
+    })?;
+    if recorded != bytes {
+        return Err(BoxError::ConfigError(format!(
+            "Writable-layer quota for {} is retained at {recorded} bytes; requested {bytes} bytes",
+            mount.display()
+        )));
+    }
+    Ok(true)
+}
+
+fn write_quota_marker(marker: &Path, bytes: u64) -> Result<()> {
+    let temporary = marker.with_extension(format!("tmp-{}", std::process::id()));
+    std::fs::write(&temporary, format!("{bytes}\n")).map_err(|error| {
+        BoxError::BuildError(format!(
+            "Failed to write writable-layer quota marker {}: {error}",
+            temporary.display()
+        ))
+    })?;
+    if let Err(error) = std::fs::rename(&temporary, marker) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(BoxError::BuildError(format!(
+            "Failed to publish writable-layer quota marker {}: {error}",
+            marker.display()
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_directory_path(path: &Path, label: &str) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => Err(
+            BoxError::StateError(format!("{label} {} is not a directory", path.display())),
+        ),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => std::fs::create_dir_all(path)
+            .map_err(|error| {
+                BoxError::BuildError(format!(
+                    "Failed to create {label} {}: {error}",
+                    path.display()
+                ))
+            }),
+        Err(error) => Err(BoxError::BuildError(format!(
+            "Failed to inspect {label} {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+fn validate_tmpfs_size(info: &MountInfo, bytes: u64, mount: &Path) -> Result<()> {
+    if info.filesystem != "tmpfs" {
+        return Err(BoxError::StateError(format!(
+            "Bounded writable-layer path {} is mounted as {}, not tmpfs",
+            mount.display(),
+            info.filesystem
+        )));
+    }
+    let recorded_size = info
+        .super_options
+        .split(',')
+        .chain(info.mount_options.split(','))
+        .find_map(|option| option.strip_prefix("size="))
+        .and_then(parse_size_bytes);
+    if recorded_size != Some(bytes) {
+        return Err(BoxError::StateError(format!(
+            "Bounded writable-layer tmpfs {} has size {:?}, expected {bytes} bytes",
+            mount.display(),
+            recorded_size
+        )));
+    }
+    Ok(())
+}
+
+fn parse_size_bytes(value: &str) -> Option<u64> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let (number, multiplier) = match value.as_bytes().last().copied() {
+        Some(b'k' | b'K') => (&value[..value.len() - 1], 1024),
+        Some(b'm' | b'M') => (&value[..value.len() - 1], 1024 * 1024),
+        Some(b'g' | b'G') => (&value[..value.len() - 1], 1024 * 1024 * 1024),
+        Some(b't' | b'T') => (&value[..value.len() - 1], 1024_u64.pow(4)),
+        _ => (value, 1),
+    };
+    number.parse::<u64>().ok()?.checked_mul(multiplier)
+}
+
+#[cfg(target_os = "linux")]
+fn mount_tmpfs(target: &Path, bytes: u64) -> Result<()> {
+    use std::ffi::CString;
+
+    let source = CString::new("tmpfs").unwrap();
+    let target_string = target.to_string_lossy();
+    let target_c = CString::new(target_string.as_ref())
+        .map_err(|error| BoxError::BuildError(format!("Invalid tmpfs target path: {error}")))?;
+    let fstype = CString::new("tmpfs").unwrap();
+    let data = CString::new(format!("size={bytes},mode=0700,nosuid,nodev"))
+        .map_err(|error| BoxError::BuildError(format!("Invalid tmpfs mount options: {error}")))?;
+    let flags = libc::MS_NOSUID | libc::MS_NODEV;
+    let ret = unsafe {
+        libc::mount(
+            source.as_ptr(),
+            target_c.as_ptr(),
+            fstype.as_ptr(),
+            flags,
+            data.as_ptr() as *const libc::c_void,
+        )
+    };
+    if ret == 0 {
+        return Ok(());
+    }
+    let syscall_error = std::io::Error::last_os_error();
+    let status = std::process::Command::new("mount")
+        .args(["-t", "tmpfs", "tmpfs", "-o"])
+        .arg(format!("size={bytes},mode=0700,nosuid,nodev"))
+        .arg(target)
+        .status()
+        .map_err(|error| {
+            BoxError::BuildError(format!("Failed to run tmpfs mount command: {error}"))
+        })?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(BoxError::BuildError(format!(
+            "Failed to mount bounded writable-layer tmpfs at {}: mount(2) returned {}; mount command exited with {}",
+            target.display(), syscall_error, status
+        )))
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn mount_tmpfs(_target: &Path, _bytes: u64) -> Result<()> {
+    Err(BoxError::ConfigError(
+        "Bounded writable-layer tmpfs is only supported on Linux".into(),
+    ))
+}
+
+fn bind_alias(source: &Path, target: &Path) -> Result<()> {
+    if is_mountpoint(target) {
+        let info = mount_info(target).ok_or_else(|| {
+            BoxError::StateError(format!(
+                "Cannot inspect existing overlay alias mount {}",
+                target.display()
+            ))
+        })?;
+        if info.filesystem != "tmpfs" {
+            return Err(BoxError::StateError(format!(
+                "Overlay alias {} is mounted as {}, expected tmpfs",
+                target.display(),
+                info.filesystem
+            )));
+        }
+        return Ok(());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use std::ffi::CString;
+        let source_c = CString::new(source.to_string_lossy().as_ref()).map_err(|error| {
+            BoxError::BuildError(format!("Invalid writable-layer source path: {error}"))
+        })?;
+        let target_c = CString::new(target.to_string_lossy().as_ref()).map_err(|error| {
+            BoxError::BuildError(format!("Invalid writable-layer alias path: {error}"))
+        })?;
+        let ret = unsafe {
+            libc::mount(
+                source_c.as_ptr(),
+                target_c.as_ptr(),
+                std::ptr::null(),
+                libc::MS_BIND,
+                std::ptr::null(),
+            )
+        };
+        if ret == 0 {
+            return Ok(());
+        }
+        let syscall_error = std::io::Error::last_os_error();
+        let status = std::process::Command::new("mount")
+            .arg("--bind")
+            .arg(source)
+            .arg(target)
+            .status()
+            .map_err(|error| {
+                BoxError::BuildError(format!("Failed to run bind mount command: {error}"))
+            })?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(BoxError::BuildError(format!(
+                "Failed to bind writable-layer alias {} -> {}: mount(2) returned {}; mount command exited with {}",
+                target.display(),
+                source.display(),
+                syscall_error,
+                status
+            )))
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (source, target);
+        Err(BoxError::ConfigError(
+            "Bounded writable-layer aliases are only supported on Linux".into(),
+        ))
+    }
+}
+
+fn unmount_path(path: &Path, lazy: bool) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::ffi::CString;
+        let target = CString::new(path.to_string_lossy().as_ref()).map_err(|error| {
+            BoxError::BuildError(format!("Invalid path for writable-layer unmount: {error}"))
+        })?;
+        let flags = if lazy { libc::MNT_DETACH } else { 0 };
+        let ret = unsafe { libc::umount2(target.as_ptr(), flags) };
+        if ret == 0 {
+            return Ok(());
+        }
+        let syscall_error = std::io::Error::last_os_error();
+        let mut command = std::process::Command::new("umount");
+        if lazy {
+            command.arg("-l");
+        }
+        let status = command.arg(path).status().map_err(|error| {
+            BoxError::BuildError(format!(
+                "Failed to run writable-layer umount command: {error}"
+            ))
+        })?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(BoxError::BuildError(format!(
+                "Failed to {}unmount writable-layer path {}: umount2 returned {}; umount command exited with {}",
+                if lazy { "lazily " } else { "synchronously " },
+                path.display(),
+                syscall_error,
+                status
+            )))
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (path, lazy);
+        Ok(())
+    }
+}
+
 /// Check if overlayfs is supported on this system.
 ///
 /// Always returns `false` on non-Linux platforms (compile-time).
@@ -261,6 +811,48 @@ pub(crate) fn is_overlay_supported() -> bool {
     false
 }
 
+/// Check whether this host can enforce a byte-precise Sandbox writable-layer
+/// quota. The probe requires the same privileges and filesystems used by the
+/// production path; callers must not advertise the capability on a mere
+/// kernel-version guess.
+pub(crate) fn writable_layer_quota_supported() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        static SUPPORTED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *SUPPORTED.get_or_init(probe_writable_layer_quota_support)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn probe_writable_layer_quota_support() -> bool {
+    if unsafe { libc::geteuid() } != 0 || !is_overlay_supported() {
+        return false;
+    }
+
+    let temp = match tempfile::TempDir::new() {
+        Ok(temp) => temp,
+        Err(_) => return false,
+    };
+    let mount = temp.path().join("quota");
+    if std::fs::create_dir(&mount).is_err() {
+        return false;
+    }
+    // A small probe keeps the operation cheap while exercising the exact
+    // `size=` option used by production. Use a page-aligned value accepted by
+    // old util-linux versions as well.
+    let bytes = 4 * 1024 * 1024;
+    let mounted = mount_tmpfs(&mount, bytes).is_ok();
+    if mounted {
+        let _ = unmount_path(&mount, false);
+    }
+    mounted && !is_mountpoint(&mount)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -269,6 +861,27 @@ mod tests {
     fn test_is_overlay_supported_returns_bool() {
         // Just verify it doesn't panic
         let _supported = is_overlay_supported();
+    }
+
+    #[test]
+    fn quota_size_parser_accepts_binary_suffixes() {
+        assert_eq!(parse_size_bytes("4096"), Some(4096));
+        assert_eq!(parse_size_bytes("4k"), Some(4096));
+        assert_eq!(parse_size_bytes("4M"), Some(4 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("2g"), Some(2 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("bad"), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mountinfo_parser_decodes_paths_and_filesystem() {
+        let line =
+            "42 1 0:44 /source\\040dir /target\\040dir rw,relatime - tmpfs tmpfs rw,size=4096";
+        let info = parse_mountinfo_line(line).unwrap();
+        assert_eq!(info.root, PathBuf::from("/source dir"));
+        assert_eq!(info.mount_point, PathBuf::from("/target dir"));
+        assert_eq!(info.filesystem, "tmpfs");
+        assert_eq!(info.super_options, "rw,size=4096");
     }
 
     #[cfg(target_os = "linux")]

--- a/src/runtime/src/rootfs/overlay.rs
+++ b/src/runtime/src/rootfs/overlay.rs
@@ -856,15 +856,27 @@ fn probe_writable_layer_quota_support() -> bool {
     let layout_ready =
         std::fs::create_dir_all(&upper).is_ok() && std::fs::create_dir_all(&work).is_ok();
     let overlay_mounted = layout_ready && overlay_mount(&lower, &upper, &work, &merged).is_ok();
-    if overlay_mounted {
+    let overlay_sync_ok = if overlay_mounted {
         // The parent tmpfs is torn down immediately below. A lazy detach can
         // leave the overlay mount alive through an open namespace reference,
         // making a healthy host look unsupported because the tmpfs is still
         // busy. Use the same synchronous path required before layer reuse.
-        let _ = overlay_unmount_for_reuse(&merged);
+        let sync_ok = overlay_unmount_for_reuse(&merged).is_ok();
+        if !sync_ok {
+            // Do not leave a probe mount behind if the strict cleanup path
+            // fails. The result remains false so callers fail closed.
+            let _ = overlay_unmount(&merged);
+        }
+        sync_ok && !is_mountpoint(&merged)
+    } else {
+        false
+    };
+    let tmpfs_sync_ok = unmount_path(&mount, false).is_ok();
+    if !tmpfs_sync_ok {
+        let _ = unmount_path(&mount, true);
     }
-    let tmpfs_unmounted = unmount_path(&mount, false).is_ok() && !is_mountpoint(&mount);
-    overlay_mounted && tmpfs_unmounted
+    let tmpfs_unmounted = !is_mountpoint(&mount);
+    overlay_mounted && overlay_sync_ok && tmpfs_sync_ok && tmpfs_unmounted
 }
 
 #[cfg(test)]

--- a/src/runtime/src/rootfs/overlay.rs
+++ b/src/runtime/src/rootfs/overlay.rs
@@ -835,18 +835,32 @@ fn probe_writable_layer_quota_support() -> bool {
         Err(_) => return false,
     };
     let mount = temp.path().join("quota");
-    if std::fs::create_dir(&mount).is_err() {
+    let lower = temp.path().join("lower");
+    let merged = temp.path().join("merged");
+    if std::fs::create_dir_all(&mount).is_err()
+        || std::fs::create_dir_all(&lower).is_err()
+        || std::fs::create_dir_all(&merged).is_err()
+    {
         return false;
     }
-    // A small probe keeps the operation cheap while exercising the exact
-    // `size=` option used by production. Use a page-aligned value accepted by
-    // old util-linux versions as well.
+    // Exercise the exact layout used by production, not only an isolated
+    // tmpfs mount. OverlayFS requires upperdir and workdir to resolve through
+    // the same mount; this catches kernels that reject a bounded layer before
+    // the provider advertises EphemeralStorage.
     let bytes = 4 * 1024 * 1024;
-    let mounted = mount_tmpfs(&mount, bytes).is_ok();
-    if mounted {
-        let _ = unmount_path(&mount, false);
+    if mount_tmpfs(&mount, bytes).is_err() {
+        return false;
     }
-    mounted && !is_mountpoint(&mount)
+    let upper = mount.join("upper");
+    let work = mount.join("work");
+    let layout_ready =
+        std::fs::create_dir_all(&upper).is_ok() && std::fs::create_dir_all(&work).is_ok();
+    let overlay_mounted = layout_ready && overlay_mount(&lower, &upper, &work, &merged).is_ok();
+    if overlay_mounted {
+        let _ = overlay_unmount(&merged);
+    }
+    let tmpfs_unmounted = unmount_path(&mount, false).is_ok() && !is_mountpoint(&mount);
+    overlay_mounted && tmpfs_unmounted
 }
 
 #[cfg(test)]

--- a/src/runtime/src/rootfs/overlay.rs
+++ b/src/runtime/src/rootfs/overlay.rs
@@ -296,13 +296,9 @@ fn overlay_unmount_with_mode(merged: &Path, lazy: bool) -> Result<()> {
     }
 }
 
-/// Host-side paths for a bounded writable layer.
+/// Host-side mount for a bounded writable layer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BoundedWritableLayer {
-    /// The historical Box path consumed by overlayfs as `upperdir`.
-    pub upper: PathBuf,
-    /// The historical Box path consumed by overlayfs as `workdir`.
-    pub work: PathBuf,
     /// The private tmpfs mount which owns both directories.
     pub mount: PathBuf,
 }
@@ -392,7 +388,7 @@ pub(crate) fn prepare_bounded_writable_layer(
     // quota before touching the mount. Write it only after all mounts succeed.
     write_quota_marker(&marker, bytes)?;
 
-    Ok(BoundedWritableLayer { upper, work, mount })
+    Ok(BoundedWritableLayer { mount })
 }
 
 /// Release a bounded writable layer. Persistent boxes retain the tmpfs and

--- a/src/runtime/src/rootfs/overlay.rs
+++ b/src/runtime/src/rootfs/overlay.rs
@@ -857,7 +857,11 @@ fn probe_writable_layer_quota_support() -> bool {
         std::fs::create_dir_all(&upper).is_ok() && std::fs::create_dir_all(&work).is_ok();
     let overlay_mounted = layout_ready && overlay_mount(&lower, &upper, &work, &merged).is_ok();
     if overlay_mounted {
-        let _ = overlay_unmount(&merged);
+        // The parent tmpfs is torn down immediately below. A lazy detach can
+        // leave the overlay mount alive through an open namespace reference,
+        // making a healthy host look unsupported because the tmpfs is still
+        // busy. Use the same synchronous path required before layer reuse.
+        let _ = overlay_unmount_for_reuse(&merged);
     }
     let tmpfs_unmounted = unmount_path(&mount, false).is_ok() && !is_mountpoint(&mount);
     overlay_mounted && tmpfs_unmounted

--- a/src/runtime/src/rootfs/provider.rs
+++ b/src/runtime/src/rootfs/provider.rs
@@ -325,7 +325,15 @@ impl RootfsProvider for OverlayProvider {
         let lower = Self::lower_dir(box_dir, cache_dir)?;
         let (upper, work) = if let Some(bytes) = options.writable_layer_bytes {
             let layer = super::overlay::prepare_bounded_writable_layer(box_dir, bytes)?;
-            (layer.upper, layer.work)
+            // OverlayFS requires the upperdir and workdir paths to resolve
+            // through the same mount (not merely the same superblock). The
+            // bounded layer keeps historical bind-mounted aliases at
+            // `box_dir/upper` and `box_dir/work`, but those aliases are two
+            // distinct mounts and are rejected by the kernel with EINVAL.
+            // Pass the source directories below the single quota tmpfs
+            // instead; the aliases remain available to lifecycle and
+            // inspection code.
+            (layer.mount.join("upper"), layer.mount.join("work"))
         } else {
             (box_dir.join("upper"), box_dir.join("work"))
         };

--- a/src/runtime/src/rootfs/provider.rs
+++ b/src/runtime/src/rootfs/provider.rs
@@ -36,6 +36,16 @@ pub struct RootfsResumeOptions {
     pub snapshot: bool,
 }
 
+/// Resource bounds supplied while preparing a writable rootfs generation.
+///
+/// The optional byte limit is intentionally carried separately from the
+/// logical VM disk size. A provider may only accept it when it can enforce a
+/// real writable-layer quota; the default implementation fails closed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RootfsPrepareOptions {
+    pub writable_layer_bytes: Option<u64>,
+}
+
 /// A validated rootfs generation that no longer has a host directory view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResumedRootfs {
@@ -102,6 +112,24 @@ pub trait RootfsProvider: Send + Sync {
     /// still inspect and update it until [`Self::finalize_for_boot`] is called.
     fn prepare(&self, box_dir: &Path, cache_dir: &Path) -> Result<PathBuf>;
 
+    /// Prepare a rootfs while applying provider-specific writable-layer
+    /// bounds. Providers that do not implement the bound reject it instead of
+    /// silently falling back to an unbounded directory.
+    fn prepare_with_options(
+        &self,
+        box_dir: &Path,
+        cache_dir: &Path,
+        options: RootfsPrepareOptions,
+    ) -> Result<PathBuf> {
+        if options.writable_layer_bytes.is_some() {
+            return Err(BoxError::ConfigError(format!(
+                "rootfs provider {} cannot enforce a writable-layer byte quota",
+                self.name()
+            )));
+        }
+        self.prepare(box_dir, cache_dir)
+    }
+
     /// Prepare an empty writable rootfs for an OCI cache miss.
     fn prepare_empty(&self, box_dir: &Path) -> Result<PathBuf> {
         let rootfs = box_dir.join("rootfs");
@@ -112,6 +140,21 @@ pub trait RootfsProvider: Send + Sync {
             ))
         })?;
         Ok(rootfs)
+    }
+
+    /// Prepare an empty rootfs while applying provider-specific bounds.
+    fn prepare_empty_with_options(
+        &self,
+        box_dir: &Path,
+        options: RootfsPrepareOptions,
+    ) -> Result<PathBuf> {
+        if options.writable_layer_bytes.is_some() {
+            return Err(BoxError::ConfigError(format!(
+                "rootfs provider {} cannot enforce a writable-layer byte quota",
+                self.name()
+            )));
+        }
+        self.prepare_empty(box_dir)
     }
 
     /// Finalize the staged tree and choose the root filesystem transport.
@@ -270,9 +313,22 @@ impl OverlayProvider {
 
 impl RootfsProvider for OverlayProvider {
     fn prepare(&self, box_dir: &Path, cache_dir: &Path) -> Result<PathBuf> {
+        self.prepare_with_options(box_dir, cache_dir, RootfsPrepareOptions::default())
+    }
+
+    fn prepare_with_options(
+        &self,
+        box_dir: &Path,
+        cache_dir: &Path,
+        options: RootfsPrepareOptions,
+    ) -> Result<PathBuf> {
         let lower = Self::lower_dir(box_dir, cache_dir)?;
-        let upper = box_dir.join("upper");
-        let work = box_dir.join("work");
+        let (upper, work) = if let Some(bytes) = options.writable_layer_bytes {
+            let layer = super::overlay::prepare_bounded_writable_layer(box_dir, bytes)?;
+            (layer.upper, layer.work)
+        } else {
+            (box_dir.join("upper"), box_dir.join("work"))
+        };
         let merged = box_dir.join("merged");
 
         for dir in [&upper, &work, &merged] {
@@ -303,8 +359,71 @@ impl RootfsProvider for OverlayProvider {
         Ok(merged)
     }
 
+    fn prepare_empty_with_options(
+        &self,
+        box_dir: &Path,
+        options: RootfsPrepareOptions,
+    ) -> Result<PathBuf> {
+        if options.writable_layer_bytes.is_none() {
+            return self.prepare_empty(box_dir);
+        }
+
+        // This path is useful to callers that want a bounded empty rootfs.
+        // OCI image extraction deliberately uses an unbounded staging tree and
+        // mounts the quota only after the immutable image has been built (see
+        // VmManager::prepare_layout), so image bytes do not consume the
+        // workload's writable-layer allowance.
+        let rootfs = box_dir.join("rootfs");
+        ensure_empty_rootfs_directory(&rootfs)?;
+        self.prepare_with_options(box_dir, &rootfs, options)
+    }
+
     fn cleanup(&self, box_dir: &Path, persistent: bool) -> Result<()> {
         let merged = box_dir.join("merged");
+
+        let bounded = box_dir
+            .join(super::overlay::WRITABLE_LAYER_MARKER_NAME)
+            .exists()
+            || super::overlay::is_mountpoint(
+                &box_dir.join(super::overlay::WRITABLE_LAYER_DIR_NAME),
+            )
+            || super::overlay::is_mountpoint(&box_dir.join("upper"))
+            || super::overlay::is_mountpoint(&box_dir.join("work"));
+
+        if bounded {
+            if persistent {
+                // Release the overlay view before removing its host directory,
+                // but retain the quota tmpfs and aliases as the durable
+                // writable generation for the next start.
+                super::unmount_box_overlay_for_reuse(&merged)?;
+                if merged.exists() && !super::overlay::is_mountpoint(&merged) {
+                    if let Err(error) = std::fs::remove_dir_all(&merged) {
+                        tracing::warn!(path = %merged.display(), %error, "Failed to remove bounded overlay view");
+                    }
+                }
+                super::overlay::cleanup_bounded_writable_layer(box_dir, true)?;
+                tracing::info!("Persistent box: keeping bounded writable-layer tmpfs and aliases");
+                return Ok(());
+            }
+
+            super::unmount_box_overlay(&merged);
+            super::overlay::cleanup_bounded_writable_layer(box_dir, false)?;
+            for dir_name in &[
+                "rootfs",
+                "merged",
+                "upper",
+                "work",
+                super::overlay::WRITABLE_LAYER_DIR_NAME,
+            ] {
+                let dir = box_dir.join(dir_name);
+                if dir.exists() && !super::overlay::is_mountpoint(&dir) {
+                    if let Err(error) = std::fs::remove_dir_all(&dir) {
+                        tracing::warn!(path = %dir.display(), %error, "Failed to remove bounded overlay directory");
+                    }
+                }
+            }
+            return Ok(());
+        }
 
         if persistent {
             // A retained upper is about to become the next generation's
@@ -349,6 +468,30 @@ impl RootfsProvider for OverlayProvider {
 
     fn name(&self) -> &'static str {
         "overlay"
+    }
+}
+
+fn ensure_empty_rootfs_directory(rootfs: &Path) -> Result<()> {
+    match std::fs::symlink_metadata(rootfs) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            Err(BoxError::StateError(format!(
+                "Rootfs staging path {} is not a directory",
+                rootfs.display()
+            )))
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(rootfs).map_err(|error| {
+                BoxError::BuildError(format!(
+                    "Failed to create rootfs {}: {error}",
+                    rootfs.display()
+                ))
+            })
+        }
+        Err(error) => Err(BoxError::BuildError(format!(
+            "Failed to inspect rootfs {}: {error}",
+            rootfs.display()
+        ))),
     }
 }
 
@@ -1052,5 +1195,59 @@ mod tests {
         );
 
         provider.cleanup(&box_dir, false).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn bounded_overlay_enforces_the_declared_writable_layer_size() {
+        if !super::super::overlay::writable_layer_quota_supported() {
+            return;
+        }
+
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().join("cache");
+        let box_dir = tmp.path().join("box");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::create_dir_all(&box_dir).unwrap();
+        make_sample_rootfs(&cache_dir);
+
+        let provider = OverlayProvider;
+        let quota = 2 * 1024 * 1024;
+        let merged = provider
+            .prepare_with_options(
+                &box_dir,
+                &cache_dir,
+                RootfsPrepareOptions {
+                    writable_layer_bytes: Some(quota),
+                },
+            )
+            .unwrap();
+
+        let payload = vec![0x5a_u8; 512 * 1024];
+        let mut rejected = false;
+        for index in 0..16 {
+            let path = merged.join(format!("quota-{index}"));
+            match std::fs::write(path, &payload) {
+                Ok(()) => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WriteZero
+                            | std::io::ErrorKind::StorageFull
+                            | std::io::ErrorKind::Other
+                    ) =>
+                {
+                    rejected = true;
+                    break;
+                }
+                Err(error) => panic!("unexpected bounded overlay write error: {error}"),
+            }
+        }
+        assert!(rejected, "writes exceeded the declared tmpfs quota");
+
+        provider.cleanup(&box_dir, false).unwrap();
+        assert!(!box_dir
+            .join(super::super::overlay::WRITABLE_LAYER_DIR_NAME)
+            .exists());
     }
 }

--- a/src/runtime/src/vm/layout.rs
+++ b/src/runtime/src/vm/layout.rs
@@ -105,6 +105,16 @@ impl VmManager {
             })?;
 
         let snapshot_requested = super::rootfs_snapshot_requested(&self.config);
+        let rootfs_prepare_options = crate::rootfs::RootfsPrepareOptions {
+            writable_layer_bytes: self.config.resources.ephemeral_storage_bytes,
+        };
+        if rootfs_prepare_options.writable_layer_bytes.is_some()
+            && !self.config.isolation.is_sandbox()
+        {
+            return Err(BoxError::ConfigError(
+                "Ephemeral storage quotas are supported only for Sandbox isolation".into(),
+            ));
+        }
         if !self.config.isolation.is_sandbox() {
             let resume = self.rootfs_provider.resume_for_boot(
                 &box_dir,
@@ -178,7 +188,11 @@ impl VmManager {
                     lower = %lower.display(),
                     "Restoring snapshot via copy-on-write overlay lower"
                 );
-                let rootfs_path = self.rootfs_provider.prepare(&box_dir, &lower)?;
+                let rootfs_path = self.rootfs_provider.prepare_with_options(
+                    &box_dir,
+                    &lower,
+                    rootfs_prepare_options,
+                )?;
                 // Refresh the guest init on the merged view (the write lands in
                 // the per-box upper, never mutating the shared lower) in case the
                 // snapshot carries an older binary than the current runtime.
@@ -245,10 +259,23 @@ impl VmManager {
                 rootfs = %prebuilt_rootfs.display(),
                 "Booting from pre-populated rootfs (snapshot restore)"
             );
+            // A restored snapshot normally boots its populated tree directly.
+            // When a writable-layer quota is requested, put that tree behind a
+            // bounded overlay so snapshot writes receive the same enforcement
+            // as a cold Sandbox boot.
+            let rootfs_path = if rootfs_prepare_options.writable_layer_bytes.is_some() {
+                self.rootfs_provider.prepare_with_options(
+                    &box_dir,
+                    &prebuilt_rootfs,
+                    rootfs_prepare_options,
+                )?
+            } else {
+                prebuilt_rootfs.clone()
+            };
             // Refresh the guest init in case the snapshot carries an older binary
             // than the current runtime.
             if let Ok(guest_init_path) = Self::find_guest_init() {
-                if let Err(e) = OciRootfsBuilder::new(&prebuilt_rootfs)
+                if let Err(e) = OciRootfsBuilder::new(&rootfs_path)
                     .with_guest_init(guest_init_path)
                     .install_guest_init_only()
                 {
@@ -257,7 +284,7 @@ impl VmManager {
             }
             let tee_instance_config = self.generate_tee_config(&box_dir)?;
             return Ok(BoxLayout {
-                rootfs_path: prebuilt_rootfs,
+                rootfs_path,
                 resumed_rootfs: None,
                 exec_socket_path: socket_dir.join("exec.sock"),
                 pty_socket_path: socket_dir.join("pty.sock"),
@@ -292,7 +319,11 @@ impl VmManager {
                 None => None,
             };
             let (cache_key, cached_path) = require_snapshot_restore_rootfs(cache_key, cached_path)?;
-            let rootfs_path = self.rootfs_provider.prepare(&box_dir, &cached_path)?;
+            let rootfs_path = self.rootfs_provider.prepare_with_options(
+                &box_dir,
+                &cached_path,
+                rootfs_prepare_options,
+            )?;
             // Record that this box holds `cache_key` as its overlay lower, so a
             // concurrent box's cache prune won't evict it mid-mount (ENOENT).
             self.mark_rootfs_cache_key(&box_dir, cache_key);
@@ -404,95 +435,119 @@ impl VmManager {
 
         // Try rootfs cache first — on hit, use the rootfs provider (overlay or copy)
         let cache_key = RootfsCache::compute_image_key(reference, &manifest_digest);
-        let (rootfs_path, oci_config, prefer_image_rootfs_metadata) =
-            if let Some(cached_path) = self.try_rootfs_cache_path(&cache_key)? {
-                tracing::info!(
-                    cache_key = %&cache_key[..12],
-                    reference = %reference,
-                    provider = self.rootfs_provider.name(),
-                    "Rootfs cache hit"
-                );
-                if let Some(ref prom) = self.prom {
-                    prom.rootfs_cache_hits.inc();
-                }
-                let rootfs_path = self.rootfs_provider.prepare(&box_dir, &cached_path)?;
-                // Record that this box holds `cache_key` as its overlay lower, so a
-                // concurrent box's cache prune won't evict it mid-mount (ENOENT).
-                self.mark_rootfs_cache_key(&box_dir, &cache_key);
+        let (rootfs_path, oci_config, prefer_image_rootfs_metadata) = if let Some(cached_path) =
+            self.try_rootfs_cache_path(&cache_key)?
+        {
+            tracing::info!(
+                cache_key = %&cache_key[..12],
+                reference = %reference,
+                provider = self.rootfs_provider.name(),
+                "Rootfs cache hit"
+            );
+            if let Some(ref prom) = self.prom {
+                prom.rootfs_cache_hits.inc();
+            }
+            let rootfs_path = self.rootfs_provider.prepare_with_options(
+                &box_dir,
+                &cached_path,
+                rootfs_prepare_options,
+            )?;
+            // Record that this box holds `cache_key` as its overlay lower, so a
+            // concurrent box's cache prune won't evict it mid-mount (ENOENT).
+            self.mark_rootfs_cache_key(&box_dir, &cache_key);
 
+            if let Ok(guest_init_path) = Self::find_guest_init() {
+                tracing::info!(
+                    guest_init = %guest_init_path.display(),
+                    "Refreshing guest init on cached rootfs"
+                );
+                OciRootfsBuilder::new(&rootfs_path)
+                    .with_guest_init(guest_init_path)
+                    .install_guest_init_only()?;
+            }
+
+            let builder = OciRootfsBuilder::new(&rootfs_path).with_image(&image_path);
+            (
+                rootfs_path,
+                Some(builder.image_config()?),
+                !has_persistent_rootfs_generation,
+            )
+        } else {
+            tracing::info!(
+                image = %image_path.display(),
+                "Building rootfs from pulled OCI image (cache miss)"
+            );
+            if let Some(ref prom) = self.prom {
+                prom.rootfs_cache_misses.inc();
+            }
+
+            let staged_rootfs_path = self.rootfs_provider.prepare_empty(&box_dir)?;
+            let rootfs_populated = std::fs::read_dir(&staged_rootfs_path)
+                .map(|mut entries| entries.next().is_some())
+                .map_err(|error| {
+                    BoxError::BuildError(format!(
+                        "Failed to inspect rootfs {}: {error}",
+                        staged_rootfs_path.display()
+                    ))
+                })?;
+            let mut builder = OciRootfsBuilder::new(&staged_rootfs_path).with_image(&image_path);
+
+            // A persistent copy/APFS provider already contains the prior
+            // terminal rootfs generation. Re-extracting the image would
+            // overwrite guest changes and fails on existing layer
+            // hardlinks. The image config remains immutable OCI metadata,
+            // so read it without rebuilding the filesystem.
+            if rootfs_populated {
+                tracing::info!(
+                    rootfs = %staged_rootfs_path.display(),
+                    "Reusing populated persistent rootfs"
+                );
+                let config = builder.image_config()?;
+                let rootfs_path = if rootfs_prepare_options.writable_layer_bytes.is_some() {
+                    self.rootfs_provider.prepare_with_options(
+                        &box_dir,
+                        &staged_rootfs_path,
+                        rootfs_prepare_options,
+                    )?
+                } else {
+                    staged_rootfs_path
+                };
+                (rootfs_path, Some(config), false)
+            } else {
+                // Install guest init if available (runs as PID 1, mounts virtiofs shares,
+                // then execs the container entrypoint)
                 if let Ok(guest_init_path) = Self::find_guest_init() {
                     tracing::info!(
                         guest_init = %guest_init_path.display(),
-                        "Refreshing guest init on cached rootfs"
+                        "Installing guest init"
                     );
-                    OciRootfsBuilder::new(&rootfs_path)
-                        .with_guest_init(guest_init_path)
-                        .install_guest_init_only()?;
-                }
-
-                let builder = OciRootfsBuilder::new(&rootfs_path).with_image(&image_path);
-                (
-                    rootfs_path,
-                    Some(builder.image_config()?),
-                    !has_persistent_rootfs_generation,
-                )
-            } else {
-                tracing::info!(
-                    image = %image_path.display(),
-                    "Building rootfs from pulled OCI image (cache miss)"
-                );
-                if let Some(ref prom) = self.prom {
-                    prom.rootfs_cache_misses.inc();
-                }
-
-                let rootfs_path = self.rootfs_provider.prepare_empty(&box_dir)?;
-                let rootfs_populated = std::fs::read_dir(&rootfs_path)
-                    .map(|mut entries| entries.next().is_some())
-                    .map_err(|error| {
-                        BoxError::BuildError(format!(
-                            "Failed to inspect rootfs {}: {error}",
-                            rootfs_path.display()
-                        ))
-                    })?;
-                let mut builder = OciRootfsBuilder::new(&rootfs_path).with_image(&image_path);
-
-                // A persistent copy/APFS provider already contains the prior
-                // terminal rootfs generation. Re-extracting the image would
-                // overwrite guest changes and fails on existing layer
-                // hardlinks. The image config remains immutable OCI metadata,
-                // so read it without rebuilding the filesystem.
-                if rootfs_populated {
-                    tracing::info!(
-                        rootfs = %rootfs_path.display(),
-                        "Reusing populated persistent rootfs"
-                    );
-                    let config = builder.image_config()?;
-                    (rootfs_path, Some(config), false)
+                    builder = builder.with_guest_init(guest_init_path);
                 } else {
-                    // Install guest init if available (runs as PID 1, mounts virtiofs shares,
-                    // then execs the container entrypoint)
-                    if let Ok(guest_init_path) = Self::find_guest_init() {
-                        tracing::info!(
-                            guest_init = %guest_init_path.display(),
-                            "Installing guest init"
-                        );
-                        builder = builder.with_guest_init(guest_init_path);
-                    } else {
-                        tracing::warn!(
-                            "Guest init binary not found; container entrypoint will run as PID 1"
-                        );
-                    }
-
-                    builder.build()?;
-                    let config = builder.image_config()?;
-
-                    // Store in cache for next time
-                    self.store_rootfs_cache(&cache_key, &rootfs_path, reference);
-                    self.mark_rootfs_cache_key(&box_dir, &cache_key);
-
-                    (rootfs_path, Some(config), true)
+                    tracing::warn!(
+                        "Guest init binary not found; container entrypoint will run as PID 1"
+                    );
                 }
-            };
+
+                builder.build()?;
+                let config = builder.image_config()?;
+
+                // Store in cache for next time
+                self.store_rootfs_cache(&cache_key, &staged_rootfs_path, reference);
+                self.mark_rootfs_cache_key(&box_dir, &cache_key);
+
+                let rootfs_path = if rootfs_prepare_options.writable_layer_bytes.is_some() {
+                    self.rootfs_provider.prepare_with_options(
+                        &box_dir,
+                        &staged_rootfs_path,
+                        rootfs_prepare_options,
+                    )?
+                } else {
+                    staged_rootfs_path
+                };
+
+                (rootfs_path, Some(config), true)
+            }
+        };
 
         if let Some(config) = oci_config.as_ref() {
             crate::resolved_image::persist_resolved_image_config(&box_dir, config)?;
@@ -754,6 +809,9 @@ impl VmManager {
     /// filesystem-only pause without pulling an image or starting a runtime.
     pub(crate) fn prepare_preserved_rootfs(&self) -> Result<PathBuf> {
         let box_dir = self.home_dir.join("boxes").join(&self.box_id);
+        let rootfs_prepare_options = crate::rootfs::RootfsPrepareOptions {
+            writable_layer_bytes: self.config.resources.ephemeral_storage_bytes,
+        };
         let rootfs = box_dir.join("rootfs");
         let populated_rootfs = std::fs::read_dir(&rootfs)
             .map(|mut entries| entries.next().is_some())
@@ -786,14 +844,19 @@ impl VmManager {
         } else {
             #[cfg(target_os = "macos")]
             if box_dir.join("rootfs-apfs-v2.sparseimage").is_file() {
-                return self.rootfs_provider.prepare(&box_dir, &rootfs);
+                return self.rootfs_provider.prepare_with_options(
+                    &box_dir,
+                    &rootfs,
+                    rootfs_prepare_options,
+                );
             }
             return Err(BoxError::StateError(format!(
                 "Retained rootfs lower is missing for {}",
                 self.box_id
             )));
         };
-        self.rootfs_provider.prepare(&box_dir, &lower)
+        self.rootfs_provider
+            .prepare_with_options(&box_dir, &lower, rootfs_prepare_options)
     }
 
     /// Unmount a rootfs exposed for a quiescent operation while keeping its


### PR DESCRIPTION
## Summary\n- carry an optional ephemeral-storage byte limit through Box resource mapping\n- enforce Sandbox writable-layer quotas with a private tmpfs and fail-closed lifecycle cleanup\n- advertise the control only when the host can enforce it and certify it in R17\n\n## Validation\n- cargo check --workspace --locked (Ubuntu WSL)\n- cargo test -p a3s-box-runtime rootfs --locked (202 tests)\n- cargo test -p a3s-box-runtime a3s_runtime_driver::tests --locked (25 tests)\n- cargo clippy --locked -p a3s-box-runtime --all-targets -- -D warnings\n- cargo check -p a3s-box-runtime --locked (Windows)\n\nThis is required by A3S Cloud's real Box A0.4 consumer gate, which requests a positive Sandbox ephemeral-storage limit.