### PR TITLE
test(runtime): use guaranteed writable quota probe path

### DIFF
--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/resources_profile.rs
@@ -101,7 +101,7 @@ pub(super) async fn run(
                 vec![
                     "/bin/sh".into(),
                     "-c".into(),
-                    "path=/var/lib/.a3s-r17-ephemeral-quota; rm -f \"$path\"; if dd if=/dev/zero of=\"$path\" bs=1048576 count=192 2>/dev/null; then printf 'quota-not-enforced\\n'; exit 71; fi; actual=$(wc -c <\"$path\"); test \"$actual\" -gt 0; test \"$actual\" -lt 201326592; printf 'quota-enforced:%s\\n' \"$actual\"; rm -f \"$path\"".into(),
+                    "path=/tmp/.a3s-r17-ephemeral-quota; rm -f \"$path\"; if dd if=/dev/zero of=\"$path\" bs=1048576 count=192 2>/dev/null; then printf 'quota-not-enforced\\n'; exit 71; fi; actual=$(wc -c <\"$path\"); test \"$actual\" -gt 0; test \"$actual\" -lt 201326592; printf 'quota-enforced:%s\\n' \"$actual\"; rm -f \"$path\"".into(),
                 ],
                 20_000,
             ))


### PR DESCRIPTION
## Summary\n- keep the R17 ephemeral writable-layer probe in the guaranteed /tmp directory\n- preserve the exact byte-quota enforcement assertion without assuming /var/lib exists in every OCI fixture image\n\n## Validation\n- cargo fmt --manifest-path src/Cargo.toml --all\n- cargo test --locked -p a3s-box-runtime --lib (1404 passed, 1 ignored)\n- follows merged Box PR #238 bounded writable-layer implementation