### PR TITLE
chore: pin OCI Runtime Secret environment fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 438e4b7936cd08d408160fe9341a21786f60cd26
+  A3S_OCI_RUNTIME_REV: 7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3
+  A3S_OCI_RUNTIME_REV: 878f8414cef3b85bef1b51fe6735017b25828252
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3
+  A3S_OCI_RUNTIME_REV: 878f8414cef3b85bef1b51fe6735017b25828252
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 438e4b7936cd08d408160fe9341a21786f60cd26
+  A3S_OCI_RUNTIME_REV: 7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,7 +166,7 @@ later lifecycle, session, observability, filesystem, restart, and cleanup calls
 use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
-`7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3` is the exact source for the Rust
+`878f8414cef3b85bef1b51fe6735017b25828252` is the exact source for the Rust
 SDK dependency, CI-built runtime and agent, and release artifacts. It retains
 the matching long-lived, multi-container Native Linux host owner, the
 generation-safe bundle handoff used by the preparation context above, and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,7 +166,7 @@ later lifecycle, session, observability, filesystem, restart, and cleanup calls
 use that record-level choice and never fall back after an error. Records written
 before this field are recovered from an exact OCI binding or the absence of a
 Box-owned exec endpoint. The pinned OCI Runtime revision
-`438e4b7936cd08d408160fe9341a21786f60cd26` is the exact source for the Rust
+`7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3` is the exact source for the Rust
 SDK dependency, CI-built runtime and agent, and release artifacts. It retains
 the matching long-lived, multi-container Native Linux host owner, the
 generation-safe bundle handoff used by the preparation context above, and

--- a/docs/cross-platform-oci-runtime-development-plan.md
+++ b/docs/cross-platform-oci-runtime-development-plan.md
@@ -61,7 +61,7 @@ Box now:
 - rejects any reintroduction of the removed integration symbols in CI.
 
 The exact integration revision is
-`438e4b7936cd08d408160fe9341a21786f60cd26`. The Rust SDK dependency and the
+`7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3`. The Rust SDK dependency and the
 runtime and agent built by CI and release workflows all use this same source
 revision. It retains the qualified control/workload cgroup and read-only bind
 behavior, deterministic multi-driver registration, isolation selection, and

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3#7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=878f8414cef3b85bef1b51fe6735017b25828252#878f8414cef3b85bef1b51fe6735017b25828252"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3#7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=878f8414cef3b85bef1b51fe6735017b25828252#878f8414cef3b85bef1b51fe6735017b25828252"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=438e4b7936cd08d408160fe9341a21786f60cd26#438e4b7936cd08d408160fe9341a21786f60cd26"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3#7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=438e4b7936cd08d408160fe9341a21786f60cd26#438e4b7936cd08d408160fe9341a21786f60cd26"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3#7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "438e4b7936cd08d408160fe9341a21786f60cd26" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "7f071e0fe6e3daf48e3878a14640fbe47eb9b5d3" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "878f8414cef3b85bef1b51fe6735017b25828252" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -2768,16 +2768,27 @@ fn configure_child_process(
             // would make a later capset fail (breaking RunAsUser containers). A
             // keep-set (the CRI default for a non-privileged container) reduces
             // to exactly those caps; the legacy drop-list path remains for
-            // explicit-drop-only callers. The default keep-set retains
-            // CAP_SETUID/CAP_SETGID so the subsequent user.apply still works.
+            // explicit-drop-only callers. An explicit user transition gets a
+            // temporary CAP_SETUID/CAP_SETGID pair, finalized after setuid.
             #[cfg(target_os = "linux")]
             if let Some(cap_keep) = &cap_keep {
-                crate::namespace::restrict_capabilities_to_keep(cap_keep)?;
+                if let Some(process_user) = user {
+                    crate::namespace::restrict_capabilities_to_keep_for_user(
+                        cap_keep,
+                        process_user,
+                    )?;
+                } else {
+                    crate::namespace::restrict_capabilities_to_keep(cap_keep)?;
+                }
             } else if !cap_drop.is_empty() {
                 crate::namespace::drop_capabilities(&cap_drop)?;
             }
             if let Some(user) = user {
                 user.apply()?;
+                #[cfg(target_os = "linux")]
+                if let Some(cap_keep) = &cap_keep {
+                    crate::namespace::finalize_capabilities_to_keep(cap_keep)?;
+                }
             }
             // Set no_new_privs before installing seccomp: a single prctl
             // (async-signal-safe) that prevents any later execve from gaining

--- a/src/guest/init/src/namespace.rs
+++ b/src/guest/init/src/namespace.rs
@@ -567,8 +567,15 @@ fn apply_security_before_exec(
             }
 
             // 3. Drop capabilities (while still root, before the uid switch).
+            // An explicit non-root user needs CAP_SETUID/CAP_SETGID during the
+            // transition even when the final keep-set is empty. Keep those
+            // bits only until the identity switch, then finalize below.
             if let Some(cap_keep) = &cap_keep {
-                restrict_capabilities_to_keep(cap_keep)?;
+                if let Some(user) = process_user {
+                    restrict_capabilities_to_keep_for_user(cap_keep, user)?;
+                } else {
+                    restrict_capabilities_to_keep(cap_keep)?;
+                }
             } else if should_drop_caps(&cap_drop) {
                 drop_capabilities(&cap_drop)?;
             }
@@ -576,6 +583,9 @@ fn apply_security_before_exec(
             // 4. Drop to the target uid/gid (image USER / --user).
             if let Some(user) = process_user {
                 user.apply()?;
+                if let Some(cap_keep) = &cap_keep {
+                    finalize_capabilities_to_keep(cap_keep)?;
+                }
             }
 
             // 5. Apply seccomp filter (prebuilt before fork)
@@ -827,7 +837,59 @@ fn clear_effective_caps(cap_drop: &[String]) -> Result<(), std::io::Error> {
 /// the post-fork child.
 #[cfg(target_os = "linux")]
 pub(crate) fn restrict_capabilities_to_keep(keep: &[String]) -> Result<(), std::io::Error> {
-    // Resolve the keep names into a 64-bit capability bitmask.
+    let mask = capability_mask(keep);
+    drop_bounding_capabilities_not_in_mask(mask)?;
+    set_capability_sets(mask)?;
+    clear_ambient_and_inheritable_caps()?;
+    Ok(())
+}
+
+/// Prepare a capability keep-set before switching to an explicit container
+/// user. Linux requires `CAP_SETUID`/`CAP_SETGID` while changing identity, even
+/// when the final keep-set intentionally drops both (for example
+/// `cap_drop=ALL`). The transition bits are kept only in the current sets;
+/// they are still removed from the bounding set so the workload cannot regain
+/// them through a later exec. Non-root users retain the final permitted set
+/// long enough for the post-switch finalization, matching OCI capability
+/// semantics without allowing any additional capability to be raised.
+#[cfg(target_os = "linux")]
+pub(crate) fn restrict_capabilities_to_keep_for_user(
+    keep: &[String],
+    user: crate::user::ProcessUser,
+) -> Result<(), std::io::Error> {
+    let mask = capability_mask(keep);
+    drop_bounding_capabilities_not_in_mask(mask)?;
+
+    let transition_mask = capability_mask_for_user(mask, user);
+    if user.uid != 0 {
+        // PR_SET_KEEPCAPS = 8. Keep the permitted set across setuid so the
+        // final capset can apply the exact requested profile for non-root
+        // users. The bit is reset by Linux after the identity transition.
+        let ret = unsafe { libc::prctl(8, 1, 0, 0, 0) };
+        if ret != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    set_capability_sets(transition_mask)?;
+    clear_ambient_and_inheritable_caps()?;
+    Ok(())
+}
+
+/// Apply the exact keep-set after an explicit user transition. This removes
+/// the temporary identity-transition capabilities for root targets and
+/// finalizes the retained permitted set for non-root targets.
+#[cfg(target_os = "linux")]
+pub(crate) fn finalize_capabilities_to_keep(keep: &[String]) -> Result<(), std::io::Error> {
+    let mask = capability_mask(keep);
+    set_capability_sets(mask)?;
+    clear_ambient_and_inheritable_caps()?;
+    Ok(())
+}
+
+/// Resolve capability names into the two-word Linux capability mask used by
+/// `capset(2)`.
+#[cfg(target_os = "linux")]
+fn capability_mask(keep: &[String]) -> [u32; 2] {
     let mut mask = [0u32; 2];
     for name in keep {
         if let Some(cap) = cap_name_to_number(name) {
@@ -837,9 +899,27 @@ pub(crate) fn restrict_capabilities_to_keep(keep: &[String]) -> Result<(), std::
             }
         }
     }
+    mask
+}
 
-    // Drop every capability not kept from the bounding set so a future execve
-    // cannot regain it.
+/// Add the identity-transition capabilities required before applying a
+/// non-root OCI user. These bits are deliberately temporary and are removed by
+/// [`finalize_capabilities_to_keep`] after `setgid`/`setuid` completes.
+#[cfg(target_os = "linux")]
+fn capability_mask_for_user(mask: [u32; 2], user: crate::user::ProcessUser) -> [u32; 2] {
+    if user.uid == 0 {
+        return mask;
+    }
+    let mut transition_mask = mask;
+    const CAP_SETGID: i32 = 6;
+    const CAP_SETUID: i32 = 7;
+    transition_mask[0] |= (1u32 << CAP_SETGID) | (1u32 << CAP_SETUID);
+    transition_mask
+}
+
+/// Drop every capability not present in `mask` from the bounding set.
+#[cfg(target_os = "linux")]
+fn drop_bounding_capabilities_not_in_mask(mask: [u32; 2]) -> Result<(), std::io::Error> {
     for cap in 0..=40_i32 {
         let word = (cap / 32) as usize;
         let kept = word < mask.len() && (mask[word] & (1u32 << (cap % 32))) != 0;
@@ -847,9 +927,6 @@ pub(crate) fn restrict_capabilities_to_keep(keep: &[String]) -> Result<(), std::
             drop_bounding_capability(cap)?;
         }
     }
-
-    set_capability_sets(mask)?;
-    clear_ambient_and_inheritable_caps()?;
     Ok(())
 }
 
@@ -931,12 +1008,15 @@ fn set_capability_sets(mask: [u32; 2]) -> Result<(), std::io::Error> {
         CapData {
             effective: mask[0],
             permitted: mask[0],
-            inheritable: mask[0],
+            // OCI's inheritable set is intentionally empty. Keeping a
+            // capability inheritable would allow a later execve of a
+            // file-capability binary to reintroduce it despite the keep-set.
+            inheritable: 0,
         },
         CapData {
             effective: mask[1],
             permitted: mask[1],
-            inheritable: mask[1],
+            inheritable: 0,
         },
     ];
 
@@ -1472,6 +1552,40 @@ mod tests {
     fn test_cap_name_to_number_unknown() {
         assert_eq!(cap_name_to_number("NONEXISTENT"), None);
         assert_eq!(cap_name_to_number(""), None);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn non_root_capability_transition_retains_only_identity_bits() {
+        let mask = capability_mask(&["CHOWN".to_string()]);
+        let transition = capability_mask_for_user(
+            mask,
+            crate::user::ProcessUser {
+                uid: 65532,
+                gid: Some(65532),
+            },
+        );
+
+        assert_ne!(transition[0] & (1u32 << 0), 0);
+        assert_ne!(transition[0] & (1u32 << 6), 0);
+        assert_ne!(transition[0] & (1u32 << 7), 0);
+        assert_eq!(transition[0] & !(1u32 << 0 | 1u32 << 6 | 1u32 << 7), 0);
+        assert_eq!(transition[1], 0);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn root_capability_transition_does_not_add_identity_bits() {
+        let mask = capability_mask(&["CHOWN".to_string()]);
+        let transition = capability_mask_for_user(
+            mask,
+            crate::user::ProcessUser {
+                uid: 0,
+                gid: Some(0),
+            },
+        );
+
+        assert_eq!(transition, mask);
     }
 
     #[test]

--- a/src/guest/init/src/namespace.rs
+++ b/src/guest/init/src/namespace.rs
@@ -694,26 +694,12 @@ pub(crate) fn drop_capabilities(cap_drop: &[String]) -> Result<(), std::io::Erro
         // Drop all capabilities by clearing the bounding set
         // Iterate through all known capabilities (0..CAP_LAST_CAP)
         for cap in 0..=40_i32 {
-            // PR_CAPBSET_DROP = 24
-            let ret = unsafe { libc::prctl(24, cap, 0, 0, 0) };
-            if ret != 0 {
-                let err = std::io::Error::last_os_error();
-                // EINVAL means capability doesn't exist, which is fine
-                if err.raw_os_error() != Some(libc::EINVAL) {
-                    return Err(err);
-                }
-            }
+            drop_bounding_capability(cap)?;
         }
     } else {
         for cap_name in cap_drop {
             if let Some(cap_num) = cap_name_to_number(cap_name) {
-                let ret = unsafe { libc::prctl(24, cap_num, 0, 0, 0) };
-                if ret != 0 {
-                    let err = std::io::Error::last_os_error();
-                    if err.raw_os_error() != Some(libc::EINVAL) {
-                        return Err(err);
-                    }
-                }
+                drop_bounding_capability(cap_num)?;
             }
         }
     }
@@ -858,19 +844,64 @@ pub(crate) fn restrict_capabilities_to_keep(keep: &[String]) -> Result<(), std::
         let word = (cap / 32) as usize;
         let kept = word < mask.len() && (mask[word] & (1u32 << (cap % 32))) != 0;
         if !kept {
-            let ret = unsafe { libc::prctl(24, cap, 0, 0, 0) }; // PR_CAPBSET_DROP
-            if ret != 0 {
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINVAL) {
-                    return Err(err);
-                }
-            }
+            drop_bounding_capability(cap)?;
         }
     }
 
     set_capability_sets(mask)?;
     clear_ambient_and_inheritable_caps()?;
     Ok(())
+}
+
+/// Remove one capability from the Linux bounding set, treating an already
+/// absent bit as success.
+///
+/// `PR_CAPBSET_DROP` is not idempotent when the caller lacks `CAP_SETPCAP`:
+/// Linux returns `EPERM` even if the requested bit is already absent. OCI
+/// runtimes commonly start guest-init with a pre-trimmed bounding set, so
+/// blindly issuing the drop turns a safe no-op into a failed container launch.
+/// Probe first and only issue the mutating syscall when the bit is present.
+/// `EINVAL` denotes a capability number newer than the running kernel and is
+/// also an intentional no-op. Both syscalls are async-signal-safe and use no
+/// heap allocation, which keeps this helper safe in post-fork `pre_exec` code.
+#[cfg(target_os = "linux")]
+fn drop_bounding_capability(capability: i32) -> Result<(), std::io::Error> {
+    // PR_CAPBSET_READ = 23, PR_CAPBSET_DROP = 24. Use the numeric values here
+    // because the musl libc headers used by guest-init do not expose these
+    // prctl operation constants on every supported toolchain.
+    let present = unsafe { libc::prctl(23, capability, 0, 0, 0) };
+    if present == 0 {
+        return Ok(());
+    }
+    if present < 0 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::EINVAL) {
+            return Ok(());
+        }
+        return Err(error);
+    }
+
+    let dropped = unsafe { libc::prctl(24, capability, 0, 0, 0) };
+    if dropped == 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::EINVAL) {
+        return Ok(());
+    }
+
+    // Keep the operation fail-closed if a concurrent actor changed the bit
+    // between the read and drop. This is mostly defensive (guest-init's child
+    // setup is single-threaded), but avoids reporting a false failure when the
+    // requested state is already satisfied.
+    let still_present = unsafe { libc::prctl(23, capability, 0, 0, 0) };
+    if still_present == 0
+        || (still_present < 0
+            && std::io::Error::last_os_error().raw_os_error() == Some(libc::EINVAL))
+    {
+        return Ok(());
+    }
+    Err(error)
 }
 
 /// Set the effective/permitted/inheritable capability sets to exactly `mask`
@@ -1454,6 +1485,39 @@ mod tests {
     fn test_should_drop_caps_nonempty() {
         assert!(should_drop_caps(&["ALL".to_string()]));
         assert!(should_drop_caps(&["NET_RAW".to_string()]));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn dropping_an_already_absent_bounding_capability_is_a_noop() {
+        // The test runner may itself have a fully populated bounding set. When
+        // it does not, exercise the exact pre-stripped state that OCI runtimes
+        // hand to guest-init. The helper must not require CAP_SETPCAP merely to
+        // confirm that an absent bit is already in the desired state.
+        let absent = (0..=40_i32).find(|cap| {
+            // SAFETY: PR_CAPBSET_READ only inspects the calling thread's
+            // capability bounding set and does not mutate process state.
+            unsafe { libc::prctl(23, *cap, 0, 0, 0) == 0 }
+        });
+        if let Some(capability) = absent {
+            assert!(drop_bounding_capability(capability).is_ok());
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn empty_capability_profile_accepts_a_prestripped_bounding_set() {
+        let has_bounding_capability = (0..=40_i32).any(|cap| {
+            // SAFETY: PR_CAPBSET_READ only inspects the calling thread's
+            // capability bounding set and does not mutate process state.
+            unsafe { libc::prctl(23, cap, 0, 0, 0) == 1 }
+        });
+        if has_bounding_capability {
+            return;
+        }
+
+        restrict_capabilities_to_keep(&[])
+            .expect("an already empty capability profile must remain launchable");
     }
 
     #[test]

--- a/src/guest/init/src/namespace.rs
+++ b/src/guest/init/src/namespace.rs
@@ -902,12 +902,14 @@ fn capability_mask(keep: &[String]) -> [u32; 2] {
     mask
 }
 
-/// Add the identity-transition capabilities required before applying a
-/// non-root OCI user. These bits are deliberately temporary and are removed by
-/// [`finalize_capabilities_to_keep`] after `setgid`/`setuid` completes.
+/// Add the identity-transition capabilities required before applying an
+/// explicit OCI user. These bits are deliberately temporary and are removed by
+/// [`finalize_capabilities_to_keep`] after `setgid`/`setuid` completes. A root
+/// UID with a non-root GID still needs `CAP_SETGID`, so inspect both fields.
 #[cfg(target_os = "linux")]
 fn capability_mask_for_user(mask: [u32; 2], user: crate::user::ProcessUser) -> [u32; 2] {
-    if user.uid == 0 {
+    let needs_identity_transition = user.uid != 0 || user.gid.is_some_and(|gid| gid != 0);
+    if !needs_identity_transition {
         return mask;
     }
     let mut transition_mask = mask;
@@ -1586,6 +1588,22 @@ mod tests {
         );
 
         assert_eq!(transition, mask);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn root_uid_with_non_root_gid_retains_identity_bits() {
+        let mask = capability_mask(&["CHOWN".to_string()]);
+        let transition = capability_mask_for_user(
+            mask,
+            crate::user::ProcessUser {
+                uid: 0,
+                gid: Some(1000),
+            },
+        );
+
+        assert_ne!(transition[0] & (1u32 << 6), 0);
+        assert_ne!(transition[0] & (1u32 << 7), 0);
     }
 
     #[test]

--- a/src/guest/init/src/pty_server.rs
+++ b/src/guest/init/src/pty_server.rs
@@ -420,7 +420,12 @@ fn handle_pty_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::er
             #[cfg(target_os = "linux")]
             {
                 if let Some(ref keep) = sec_cap_keep {
-                    if let Err(error) = crate::namespace::restrict_capabilities_to_keep(keep) {
+                    let result = if let Some(user) = process_user {
+                        crate::namespace::restrict_capabilities_to_keep_for_user(keep, user)
+                    } else {
+                        crate::namespace::restrict_capabilities_to_keep(keep)
+                    };
+                    if let Err(error) = result {
                         eprintln!("Failed to restrict PTY capabilities: {}", error);
                         std::process::exit(127);
                     }
@@ -436,6 +441,13 @@ fn handle_pty_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::er
                 if let Err(error) = user.apply() {
                     eprintln!("Failed to apply PTY user: {}", error);
                     std::process::exit(127);
+                }
+                #[cfg(target_os = "linux")]
+                if let Some(ref keep) = sec_cap_keep {
+                    if let Err(error) = crate::namespace::finalize_capabilities_to_keep(keep) {
+                        eprintln!("Failed to finalize PTY capabilities: {}", error);
+                        std::process::exit(127);
+                    }
                 }
             }
 


### PR DESCRIPTION
Update the Box workspace's exact OCI Runtime dependency and lock entry to the Secret environment materialization fix required by direct Sandbox PID1 launches.\n\nValidation: cargo check --locked -p a3s-box-runtime.