### PR TITLE
test(windows): skip symlink fixtures on access denied

### DIFF
--- a/src/core/src/windows_file.rs
+++ b/src/core/src/windows_file.rs
@@ -145,7 +145,7 @@ mod tests {
     fn symlink_file_or_skip(target: &Path, link: &Path) -> bool {
         match std::os::windows::fs::symlink_file(target, link) {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => false,
             Err(error) => panic!("failed to create test symlink: {error}"),
         }
     }

--- a/src/runtime/src/oci/image.rs
+++ b/src/runtime/src/oci/image.rs
@@ -1081,7 +1081,7 @@ mod tests {
     fn windows_symlink_for_test(create: impl FnOnce() -> std::io::Result<()>) -> bool {
         match create() {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => false,
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
     }

--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -1552,7 +1552,7 @@ mod tests {
     fn push_test_windows_symlink(create: impl FnOnce() -> std::io::Result<()>) -> bool {
         match create() {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => false,
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
     }

--- a/src/runtime/src/oci/rootfs.rs
+++ b/src/runtime/src/oci/rootfs.rs
@@ -1264,7 +1264,7 @@ mod tests {
     fn create_windows_symlink(create: impl FnOnce() -> std::io::Result<()>) -> bool {
         match create() {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => false,
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
     }

--- a/src/runtime/src/oci/store.rs
+++ b/src/runtime/src/oci/store.rs
@@ -1862,7 +1862,7 @@ mod tests {
         std::fs::write(&host_file, b"secret").unwrap();
         match std::os::windows::fs::symlink_file(&host_file, &link) {
             Ok(()) => {}
-            Err(error) if error.raw_os_error() == Some(1314) => return,
+            Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => return,
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
         let store = ImageStore::new(&store_dir, u64::MAX).unwrap();

--- a/src/runtime/src/vm/network.rs
+++ b/src/runtime/src/vm/network.rs
@@ -372,7 +372,7 @@ mod tests {
     fn create_dir_symlink(target: &Path, link: &Path) -> bool {
         match std::os::windows::fs::symlink_dir(target, link) {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => false,
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
     }

--- a/src/runtime/src/vm/spec/tests.rs
+++ b/src/runtime/src/vm/spec/tests.rs
@@ -24,7 +24,7 @@ fn create_file_symlink(target: &Path, link: &Path) -> bool {
 fn create_file_symlink(target: &Path, link: &Path) -> bool {
     match std::os::windows::fs::symlink_file(target, link) {
         Ok(()) => true,
-        Err(error) if error.raw_os_error() == Some(1314) => false,
+        Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => false,
         Err(error) => panic!("failed to create Windows test symlink: {error}"),
     }
 }
@@ -33,7 +33,7 @@ fn create_file_symlink(target: &Path, link: &Path) -> bool {
 fn create_dir_symlink(target: &Path, link: &Path) -> bool {
     match std::os::windows::fs::symlink_dir(target, link) {
         Ok(()) => true,
-        Err(error) if error.raw_os_error() == Some(1314) => false,
+        Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => false,
         Err(error) => panic!("failed to create Windows test symlink: {error}"),
     }
 }

--- a/src/runtime/src/vm/tests/platform.rs
+++ b/src/runtime/src/vm/tests/platform.rs
@@ -129,7 +129,7 @@ fn test_collect_windows_guest_result_replaces_marker_symlink_without_touching_ta
     let marker = rootfs.join(WINDOWS_GUEST_RESULT_MARKER);
     match std::os::windows::fs::symlink_file(&host_target, &marker) {
         Ok(()) => {}
-        Err(error) if error.raw_os_error() == Some(1314) => return,
+        Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => return,
         Err(error) => panic!("failed to create marker symlink: {error}"),
     }
 
@@ -160,7 +160,7 @@ fn test_collect_windows_guest_result_refuses_stream_symlink() {
     std::fs::write(&host_secret, "must not be logged\n").unwrap();
     match std::os::windows::fs::symlink_file(&host_secret, rootfs.join(WINDOWS_GUEST_STDOUT)) {
         Ok(()) => {}
-        Err(error) if error.raw_os_error() == Some(1314) => return,
+        Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => return,
         Err(error) => panic!("failed to create stream symlink: {error}"),
     }
     std::fs::write(rootfs.join(WINDOWS_GUEST_STDERR), "").unwrap();

--- a/src/shim/src/tests.rs
+++ b/src/shim/src/tests.rs
@@ -166,7 +166,7 @@ fn test_prepare_windows_guest_unlinks_stream_reparse_without_touching_target() {
     let stream = rootfs.join(WINDOWS_GUEST_STDOUT);
     match std::os::windows::fs::symlink_file(&host_target, &stream) {
         Ok(()) => {}
-        Err(error) if error.raw_os_error() == Some(1314) => return,
+        Err(error) if matches!(error.raw_os_error(), Some(5) | Some(1314)) => return,
         Err(error) => panic!("failed to create stream symlink: {error}"),
     }
 


### PR DESCRIPTION
## Problem

Windows hosts without Developer Mode or `SeCreateSymbolicLinkPrivilege` can report either `ERROR_PRIVILEGE_NOT_HELD (1314)` or `ERROR_ACCESS_DENIED (5)` when the test fixture creates a symbolic link. The Windows-only tests only skipped 1314, so an otherwise expected capability denial failed the test suite.

## Change

Treat both documented Windows denial codes as an unavailable symlink capability in the Windows fixture helpers. Runtime extraction behavior is unchanged: OCI symlinks are still preserved and never flattened.

## Validation

- `cargo fmt --manifest-path src/Cargo.toml --all -- --check`
- `cargo test --manifest-path src/Cargo.toml -p a3s-box-core -p a3s-box-runtime --lib --no-run`
- `git diff --check`
