### PR TITLE
test(windows): respect symlink privilege diagnostics

### DIFF
--- a/src/cli/src/commands/compose/wait.rs
+++ b/src/cli/src/commands/compose/wait.rs
@@ -43,19 +43,6 @@ pub(super) async fn wait_for_healthy(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::HEALTH_WAIT_POLL_INTERVAL;
-
-    #[test]
-    fn health_wait_poll_interval_is_subsecond() {
-        assert_eq!(
-            HEALTH_WAIT_POLL_INTERVAL,
-            std::time::Duration::from_millis(500)
-        );
-    }
-}
-
 pub(super) fn validate_compose_up_platform_support() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(windows)]
     {
@@ -144,5 +131,18 @@ pub(super) async fn wait_for_completed(
         }
 
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HEALTH_WAIT_POLL_INTERVAL;
+
+    #[test]
+    fn health_wait_poll_interval_is_subsecond() {
+        assert_eq!(
+            HEALTH_WAIT_POLL_INTERVAL,
+            std::time::Duration::from_millis(500)
+        );
     }
 }

--- a/src/core/src/windows_file.rs
+++ b/src/core/src/windows_file.rs
@@ -141,11 +141,14 @@ pub fn replace_regular_file(path: &Path, contents: &[u8]) -> io::Result<WindowsF
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::windows_symlink::{is_capability_denial, WindowsSymlinkPrivilegeGuard};
 
     fn symlink_file_or_skip(target: &Path, link: &Path) -> bool {
+        let guard = WindowsSymlinkPrivilegeGuard::acquire();
+        let assigned_privilege_enabled = guard.assigned_privilege_enabled();
         match std::os::windows::fs::symlink_file(target, link) {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error) if is_capability_denial(&error, assigned_privilege_enabled) => false,
             Err(error) => panic!("failed to create test symlink: {error}"),
         }
     }

--- a/src/core/src/windows_symlink.rs
+++ b/src/core/src/windows_symlink.rs
@@ -69,6 +69,22 @@ pub fn denial_diagnostic(assigned_privilege_enabled: bool) -> &'static str {
     }
 }
 
+/// Returns whether a failed link creation means that this process simply lacks
+/// the Windows capability required to create OCI links.
+///
+/// `ERROR_ACCESS_DENIED` is only treated as an expected capability denial when
+/// the token does not contain an assigned symbolic-link privilege. If the
+/// privilege was assigned and enabled, access denied is preserved as a real
+/// ACL or endpoint-security failure instead of being hidden by a test skip.
+#[doc(hidden)]
+pub fn is_capability_denial(error: &std::io::Error, assigned_privilege_enabled: bool) -> bool {
+    match error.raw_os_error() {
+        Some(1314) => true,
+        Some(5) => !assigned_privilege_enabled,
+        _ => false,
+    }
+}
+
 struct WindowsTokenPrivilegeGuard {
     token: windows_sys::Win32::Foundation::HANDLE,
     previous: windows_sys::Win32::Security::TOKEN_PRIVILEGES,
@@ -202,6 +218,22 @@ mod tests {
         let unavailable = denial_diagnostic(false);
         assert!(unavailable.contains("enable Windows Developer Mode"));
         assert!(unavailable.contains("grant SeCreateSymbolicLinkPrivilege"));
+    }
+
+    #[test]
+    fn capability_denial_does_not_hide_acl_errors_when_privilege_is_enabled() {
+        assert!(is_capability_denial(
+            &std::io::Error::from_raw_os_error(1314),
+            true
+        ));
+        assert!(is_capability_denial(
+            &std::io::Error::from_raw_os_error(5),
+            false
+        ));
+        assert!(!is_capability_denial(
+            &std::io::Error::from_raw_os_error(5),
+            true
+        ));
     }
 
     #[test]

--- a/src/cri/src/server.rs
+++ b/src/cri/src/server.rs
@@ -208,6 +208,35 @@ impl CriServer {
     }
 }
 
+/// Resolves when the process receives a termination signal, driving a graceful
+/// gRPC server shutdown so the CRI can reap its sandbox VMs.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        match (
+            signal(SignalKind::terminate()),
+            signal(SignalKind::interrupt()),
+        ) {
+            (Ok(mut sigterm), Ok(mut sigint)) => {
+                tokio::select! {
+                    _ = sigterm.recv() => tracing::info!("Received SIGTERM, shutting down CRI"),
+                    _ = sigint.recv() => tracing::info!("Received SIGINT, shutting down CRI"),
+                }
+            }
+            _ => {
+                tracing::error!("Failed to install signal handlers; graceful shutdown disabled");
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+        tracing::info!("Received Ctrl-C, shutting down CRI");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,34 +277,5 @@ mod tests {
             .expect_err("a regular file must not be unlinked");
         assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
         assert_eq!(std::fs::read(&path).unwrap(), b"keep me");
-    }
-}
-
-/// Resolves when the process receives a termination signal, driving a graceful
-/// gRPC server shutdown so the CRI can reap its sandbox VMs.
-async fn shutdown_signal() {
-    #[cfg(unix)]
-    {
-        use tokio::signal::unix::{signal, SignalKind};
-        match (
-            signal(SignalKind::terminate()),
-            signal(SignalKind::interrupt()),
-        ) {
-            (Ok(mut sigterm), Ok(mut sigint)) => {
-                tokio::select! {
-                    _ = sigterm.recv() => tracing::info!("Received SIGTERM, shutting down CRI"),
-                    _ = sigint.recv() => tracing::info!("Received SIGINT, shutting down CRI"),
-                }
-            }
-            _ => {
-                tracing::error!("Failed to install signal handlers; graceful shutdown disabled");
-                std::future::pending::<()>().await;
-            }
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = tokio::signal::ctrl_c().await;
-        tracing::info!("Received Ctrl-C, shutting down CRI");
     }
 }

--- a/src/runtime/src/oci/image.rs
+++ b/src/runtime/src/oci/image.rs
@@ -1079,9 +1079,18 @@ mod tests {
 
     #[cfg(windows)]
     fn windows_symlink_for_test(create: impl FnOnce() -> std::io::Result<()>) -> bool {
+        let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+        let assigned_privilege_enabled = guard.assigned_privilege_enabled();
         match create() {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error)
+                if a3s_box_core::windows_symlink::is_capability_denial(
+                    &error,
+                    assigned_privilege_enabled,
+                ) =>
+            {
+                false
+            }
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
     }

--- a/src/runtime/src/oci/registry.rs
+++ b/src/runtime/src/oci/registry.rs
@@ -1550,9 +1550,18 @@ mod tests {
 
     #[cfg(windows)]
     fn push_test_windows_symlink(create: impl FnOnce() -> std::io::Result<()>) -> bool {
+        let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+        let assigned_privilege_enabled = guard.assigned_privilege_enabled();
         match create() {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error)
+                if a3s_box_core::windows_symlink::is_capability_denial(
+                    &error,
+                    assigned_privilege_enabled,
+                ) =>
+            {
+                false
+            }
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
     }

--- a/src/runtime/src/oci/rootfs.rs
+++ b/src/runtime/src/oci/rootfs.rs
@@ -1262,9 +1262,18 @@ mod tests {
 
     #[cfg(windows)]
     fn create_windows_symlink(create: impl FnOnce() -> std::io::Result<()>) -> bool {
+        let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+        let assigned_privilege_enabled = guard.assigned_privilege_enabled();
         match create() {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error)
+                if a3s_box_core::windows_symlink::is_capability_denial(
+                    &error,
+                    assigned_privilege_enabled,
+                ) =>
+            {
+                false
+            }
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
     }

--- a/src/runtime/src/oci/store.rs
+++ b/src/runtime/src/oci/store.rs
@@ -1860,9 +1860,18 @@ mod tests {
         let link = source_dir.join("extra-blob");
         create_test_oci_layout(&source_dir);
         std::fs::write(&host_file, b"secret").unwrap();
+        let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+        let assigned_privilege_enabled = guard.assigned_privilege_enabled();
         match std::os::windows::fs::symlink_file(&host_file, &link) {
             Ok(()) => {}
-            Err(error) if error.raw_os_error() == Some(1314) => return,
+            Err(error)
+                if a3s_box_core::windows_symlink::is_capability_denial(
+                    &error,
+                    assigned_privilege_enabled,
+                ) =>
+            {
+                return
+            }
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
         let store = ImageStore::new(&store_dir, u64::MAX).unwrap();

--- a/src/runtime/src/pool/warm_pool.rs
+++ b/src/runtime/src/pool/warm_pool.rs
@@ -175,6 +175,23 @@ enum InitialFill {
     FirstReady,
 }
 
+/// Inputs for one bounded warm-pool boot batch.
+///
+/// Keeping the batch request together makes the concurrency boundary explicit
+/// and avoids a long parameter list that is easy to get out of sync when new
+/// pool-wide controls are added.
+struct BootBatch<'a> {
+    snapshot_fork: bool,
+    box_config: &'a BoxConfig,
+    event_emitter: &'a EventEmitter,
+    template: &'a Arc<Mutex<TemplateState>>,
+    needed: usize,
+    max_concurrent_boots: usize,
+    metrics: Option<crate::prom::RuntimeMetrics>,
+    boot_limiter: Arc<Semaphore>,
+    global_boot_limiter: Option<Arc<Semaphore>>,
+}
+
 impl WarmPool {
     /// Create and start the warm pool.
     ///
@@ -721,34 +738,25 @@ impl WarmPool {
     /// resource burst, so only `max_concurrent_boots` tasks are in flight at
     /// once. Each task owns cloned inputs, allowing the set to remain
     /// `'static` while the caller retains its pool state.
-    async fn boot_batch(
-        snapshot_fork: bool,
-        box_config: &BoxConfig,
-        event_emitter: &EventEmitter,
-        template: &Arc<Mutex<TemplateState>>,
-        needed: usize,
-        max_concurrent_boots: usize,
-        metrics: Option<crate::prom::RuntimeMetrics>,
-        boot_limiter: Arc<Semaphore>,
-        global_boot_limiter: Option<Arc<Semaphore>>,
-    ) -> Vec<Result<VmManager>> {
-        if needed == 0 {
+    async fn boot_batch(batch: BootBatch<'_>) -> Vec<Result<VmManager>> {
+        if batch.needed == 0 {
             return Vec::new();
         }
 
-        let limit = bounded_boot_limit(needed, max_concurrent_boots);
+        let limit = bounded_boot_limit(batch.needed, batch.max_concurrent_boots);
         let mut set = tokio::task::JoinSet::new();
         let mut launched = 0usize;
-        let mut results = Vec::with_capacity(needed);
+        let mut results = Vec::with_capacity(batch.needed);
 
-        while launched < needed || !set.is_empty() {
-            while launched < needed && set.len() < limit {
-                let config = box_config.clone();
-                let emitter = event_emitter.clone();
-                let shared_template = Arc::clone(template);
-                let boot_metrics = metrics.clone();
-                let pool_boot_limiter = boot_limiter.clone();
-                let daemon_boot_limiter = global_boot_limiter.clone();
+        while launched < batch.needed || !set.is_empty() {
+            while launched < batch.needed && set.len() < limit {
+                let config = batch.box_config.clone();
+                let emitter = batch.event_emitter.clone();
+                let shared_template = Arc::clone(batch.template);
+                let boot_metrics = batch.metrics.clone();
+                let pool_boot_limiter = batch.boot_limiter.clone();
+                let daemon_boot_limiter = batch.global_boot_limiter.clone();
+                let snapshot_fork = batch.snapshot_fork;
                 set.spawn(async move {
                     let _boot_permits =
                         acquire_boot_permits(pool_boot_limiter, daemon_boot_limiter).await?;
@@ -767,7 +775,7 @@ impl WarmPool {
                     ))),
                 };
                 if result.is_err() {
-                    if let Some(metrics) = &metrics {
+                    if let Some(metrics) = &batch.metrics {
                         metrics.warm_pool_boot_failures_total.inc();
                     }
                 }
@@ -976,17 +984,17 @@ impl WarmPool {
         // Track VMs added in this fill attempt so we can clean up on failure.
         let mut added_ids: Vec<String> = Vec::new();
         let mut failed = false;
-        let results = Self::boot_batch(
-            self.config.snapshot_fork,
-            &self.box_config,
-            &self.event_emitter,
-            &self.template,
+        let results = Self::boot_batch(BootBatch {
+            snapshot_fork: self.config.snapshot_fork,
+            box_config: &self.box_config,
+            event_emitter: &self.event_emitter,
+            template: &self.template,
             needed,
-            self.config.max_concurrent_boots,
-            self.metrics.clone(),
-            self.boot_limiter.clone(),
-            self.global_boot_limiter.clone(),
-        )
+            max_concurrent_boots: self.config.max_concurrent_boots,
+            metrics: self.metrics.clone(),
+            boot_limiter: self.boot_limiter.clone(),
+            global_boot_limiter: self.global_boot_limiter.clone(),
+        })
         .await;
 
         for result in results {
@@ -1120,17 +1128,17 @@ impl WarmPool {
 
                             // Overlap readiness waits while keeping the number of
                             // expensive VM boots bounded by configuration.
-                            let results = Self::boot_batch(
-                                config.snapshot_fork,
-                                &box_config,
-                                &event_emitter,
-                                &template,
+                            let results = Self::boot_batch(BootBatch {
+                                snapshot_fork: config.snapshot_fork,
+                                box_config: &box_config,
+                                event_emitter: &event_emitter,
+                                template: &template,
                                 needed,
-                                config.max_concurrent_boots,
-                                metrics.clone(),
-                                boot_limiter.clone(),
-                                global_boot_limiter.clone(),
-                            )
+                                max_concurrent_boots: config.max_concurrent_boots,
+                                metrics: metrics.clone(),
+                                boot_limiter: boot_limiter.clone(),
+                                global_boot_limiter: global_boot_limiter.clone(),
+                            })
                             .await;
                             let mut batch_failed = false;
                             for result in results {

--- a/src/runtime/src/vm/network.rs
+++ b/src/runtime/src/vm/network.rs
@@ -370,9 +370,18 @@ mod tests {
 
     #[cfg(windows)]
     fn create_dir_symlink(target: &Path, link: &Path) -> bool {
+        let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+        let assigned_privilege_enabled = guard.assigned_privilege_enabled();
         match std::os::windows::fs::symlink_dir(target, link) {
             Ok(()) => true,
-            Err(error) if error.raw_os_error() == Some(1314) => false,
+            Err(error)
+                if a3s_box_core::windows_symlink::is_capability_denial(
+                    &error,
+                    assigned_privilege_enabled,
+                ) =>
+            {
+                false
+            }
             Err(error) => panic!("failed to create Windows test symlink: {error}"),
         }
     }

--- a/src/runtime/src/vm/spec/tests.rs
+++ b/src/runtime/src/vm/spec/tests.rs
@@ -22,18 +22,36 @@ fn create_file_symlink(target: &Path, link: &Path) -> bool {
 
 #[cfg(windows)]
 fn create_file_symlink(target: &Path, link: &Path) -> bool {
+    let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+    let assigned_privilege_enabled = guard.assigned_privilege_enabled();
     match std::os::windows::fs::symlink_file(target, link) {
         Ok(()) => true,
-        Err(error) if error.raw_os_error() == Some(1314) => false,
+        Err(error)
+            if a3s_box_core::windows_symlink::is_capability_denial(
+                &error,
+                assigned_privilege_enabled,
+            ) =>
+        {
+            false
+        }
         Err(error) => panic!("failed to create Windows test symlink: {error}"),
     }
 }
 
 #[cfg(windows)]
 fn create_dir_symlink(target: &Path, link: &Path) -> bool {
+    let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+    let assigned_privilege_enabled = guard.assigned_privilege_enabled();
     match std::os::windows::fs::symlink_dir(target, link) {
         Ok(()) => true,
-        Err(error) if error.raw_os_error() == Some(1314) => false,
+        Err(error)
+            if a3s_box_core::windows_symlink::is_capability_denial(
+                &error,
+                assigned_privilege_enabled,
+            ) =>
+        {
+            false
+        }
         Err(error) => panic!("failed to create Windows test symlink: {error}"),
     }
 }

--- a/src/runtime/src/vm/tests/platform.rs
+++ b/src/runtime/src/vm/tests/platform.rs
@@ -127,9 +127,18 @@ fn test_collect_windows_guest_result_replaces_marker_symlink_without_touching_ta
     let host_target = tmp.path().join("host-target.txt");
     std::fs::write(&host_target, "host secret").unwrap();
     let marker = rootfs.join(WINDOWS_GUEST_RESULT_MARKER);
+    let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+    let assigned_privilege_enabled = guard.assigned_privilege_enabled();
     match std::os::windows::fs::symlink_file(&host_target, &marker) {
         Ok(()) => {}
-        Err(error) if error.raw_os_error() == Some(1314) => return,
+        Err(error)
+            if a3s_box_core::windows_symlink::is_capability_denial(
+                &error,
+                assigned_privilege_enabled,
+            ) =>
+        {
+            return
+        }
         Err(error) => panic!("failed to create marker symlink: {error}"),
     }
 
@@ -158,9 +167,18 @@ fn test_collect_windows_guest_result_refuses_stream_symlink() {
     std::fs::create_dir_all(&rootfs).unwrap();
     let host_secret = tmp.path().join("host-secret.txt");
     std::fs::write(&host_secret, "must not be logged\n").unwrap();
+    let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+    let assigned_privilege_enabled = guard.assigned_privilege_enabled();
     match std::os::windows::fs::symlink_file(&host_secret, rootfs.join(WINDOWS_GUEST_STDOUT)) {
         Ok(()) => {}
-        Err(error) if error.raw_os_error() == Some(1314) => return,
+        Err(error)
+            if a3s_box_core::windows_symlink::is_capability_denial(
+                &error,
+                assigned_privilege_enabled,
+            ) =>
+        {
+            return
+        }
         Err(error) => panic!("failed to create stream symlink: {error}"),
     }
     std::fs::write(rootfs.join(WINDOWS_GUEST_STDERR), "").unwrap();

--- a/src/shim/src/tests.rs
+++ b/src/shim/src/tests.rs
@@ -164,9 +164,18 @@ fn test_prepare_windows_guest_unlinks_stream_reparse_without_touching_target() {
     let host_target = temp.path().join("host-target.txt");
     fs::write(&host_target, b"host secret").unwrap();
     let stream = rootfs.join(WINDOWS_GUEST_STDOUT);
+    let guard = a3s_box_core::windows_symlink::WindowsSymlinkPrivilegeGuard::acquire();
+    let assigned_privilege_enabled = guard.assigned_privilege_enabled();
     match std::os::windows::fs::symlink_file(&host_target, &stream) {
         Ok(()) => {}
-        Err(error) if error.raw_os_error() == Some(1314) => return,
+        Err(error)
+            if a3s_box_core::windows_symlink::is_capability_denial(
+                &error,
+                assigned_privilege_enabled,
+            ) =>
+        {
+            return
+        }
         Err(error) => panic!("failed to create stream symlink: {error}"),
     }
 


### PR DESCRIPTION
## Problem

Windows symlink fixtures currently skip only `ERROR_PRIVILEGE_NOT_HELD (1314)`. On a host without Developer Mode, the same capability denial may be surfaced as `ERROR_ACCESS_DENIED (5)`. Treating every error 5 as skippable is unsafe because error 5 can also mean an ACL or endpoint-security denial.

## Change

- Reuse the production `WindowsSymlinkPrivilegeGuard` in every Windows symlink fixture.
- Add one shared capability classifier that skips error 1314, and skips error 5 only when the process token has no assigned symbolic-link privilege.
- Preserve error 5 as a test failure when the privilege is assigned, so ACL and endpoint-security regressions remain visible.
- Add unit coverage for both branches.

Runtime extraction behavior is unchanged: OCI symlinks are still preserved and never flattened.

## Validation

- `cargo fmt --manifest-path src/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src/Cargo.toml -p a3s-box-core --all-targets -- -D warnings`
- `cargo test --manifest-path src/Cargo.toml -p a3s-box-core -p a3s-box-runtime --lib --no-run`
- `git diff --check`

Supersedes the overly broad test-only change in #242.
