### PR TITLE
fix: harden VM shutdown, detached health, and macOS runtime staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Warm-pool shutdown joins in-progress replenishment before draining idle VMs,
+  and destroys owned VMs with bounded concurrency. In-flight request ownership
+  is retained until cleanup completes, preventing orphaned shims and sockets.
+- Detached CLI health workers now own independent Unix sessions, so terminal
+  or job process-group cleanup cannot stop probes for still-running boxes.
+- macOS shim builds stage the fully versioned runtime dylibs and aliases
+  without rewriting their already-signed install names. Packaging preserves
+  valid code signatures instead of producing libraries rejected by the loader.
+
 ## [3.2.4] — 2026-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ a3s-box compose -f compose.acl up -d
 
 Compose resolves relative bind mounts from the Compose file's directory, so
 `-f /path/to/compose.yaml` can be invoked from another working directory.
+Detached CLI health workers use generation-fenced, independent Unix sessions;
+their probes survive cleanup of the launching terminal or job's process group.
 
 Compose can project caller-owned process environment values without placing
 their bytes in ACL, `.env`, `BoxConfig`, labels, or state records:

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -9,6 +9,10 @@ capability scenarios and `R0`, `G2`, `R24`, or `E72` profile a change requires.
 This guide supplies host commands; it does not by itself prove that every
 capability scenario has soak coverage.
 
+The [2026-09-06 local Dify validation](local-dify-validation-2026-09-06.md)
+records measured convergence, CPU, memory, and health persistence, together
+with the limits of that local evidence.
+
 ## Validation ladder
 
 | Level | Host requirements | Command |
@@ -70,6 +74,15 @@ Linux it is normally a dynamically linked host ELF. Neither is accepted as a
 guest PID 1 artifact. The runner builds and selects
 `src/target/<linux-musl-target>/debug/a3s-box-guest-init` from the current
 checkout.
+
+macOS runtime libraries are staged byte-for-byte from the signed libkrun-sys
+artifacts, including the fully versioned dylib and aliases. Do not rewrite their
+install names after signing. Validate source-package staging with:
+
+```bash
+cd src
+cargo test -p a3s-box-shim --bin a3s-box-shim macos_runtime_assets
+```
 
 ## Linux core smoke
 
@@ -376,6 +389,10 @@ convergence timeout are unchanged; this only removes an avoidable polling gap
 before dependent Dify services start. The first health probe runs as soon as
 the configured `start_period` ends, and subsequent probes keep the configured
 interval.
+Detached CLI health workers own separate Unix sessions and process groups.
+The core health-worker smoke signals the finished launcher's process group,
+then changes guest readiness and requires a fresh successful probe; cached
+`healthy` state alone cannot satisfy this regression.
 
 Lazy pool initialization is serialized per exact image/resource shape, so
 requests for the same pool cannot race duplicate startup while unrelated image
@@ -387,6 +404,11 @@ Pool socket frames are capped at 16 MiB and incomplete request frames time out
 after 15 seconds; payloads larger than this are rejected.
 On shutdown, the daemon drains idle pools and waits up to one minute for
 in-flight socket requests to finish before exiting.
+Pool cleanup first stops and joins replenishment so a late boot cannot publish
+a VM after the idle list was drained. Destruction has bounded fan-out (four
+VMs per batch), and persistent pools retain the normal graceful-stop deadline.
+The host smoke allows 90 seconds for daemon shutdown and asserts that no new
+host socket directory remains afterward.
 If one of several explicitly pre-warmed images fails during startup, the daemon
 cleans up earlier pools and removes the temporary socket before reporting the
 failure.

--- a/docs/local-dify-validation-2026-09-06.md
+++ b/docs/local-dify-validation-2026-09-06.md
@@ -1,0 +1,91 @@
+# Local Dify Validation — 2026-09-06
+
+This is a local qualification snapshot, not a cross-platform release or soak
+certificate. The workload is Dify 1.16.1 on the locally built Box 3.2.4 package
+with the unreleased shutdown, health-worker, and macOS staging fixes.
+
+## Environment and identity
+
+- Source baseline: `fddb5b0df7edf8fd335c6e4b99e56dfce1dc6341`.
+- Host: macOS 26.6.2, Apple Silicon `Mac17,6`, 18 logical CPUs, 64 GiB RAM.
+- Build toolchain: Rust/Cargo 1.98.1 in the Box `src/` workspace.
+- Backend: libkrun/HVF, with signed runtime dylibs and static Linux ARM64 guest
+  init. The local version string remains `3.2.4`; no new release was published.
+- Installed CLI SHA-256:
+  `58b58b5d7294ee86201f18ca4289f9e0deff87958c4feee0c1c891a9fa48bd9b`.
+- Installed, entitlement-signed shim SHA-256:
+  `51e98eb5b5ab8ac98911f215a9bf64aa1afd5133692aa51ab9e9d0aa86d7e3f1`.
+
+## Deployment and measurements
+
+The local package redeployed the existing Compose project without deleting its
+seven named volumes. All 15 long-running services use the new package. The
+`init_permissions` one-shot completed with exit code 0; the existing setup state
+still reports `finished`. Two superseded local installation directories were
+moved to the user's Trash for recoverable cleanup.
+
+| Measurement | Result | Scope |
+| --- | --- | --- |
+| Unchanged `compose up --detach` | 2.99 s wall time | Cached images; all 15 long-running services reused; permission-init one-shot rerun |
+| HTTP health | 12/12 responses were 200; 16.001–24.518 ms | One request approximately every five seconds |
+| CPU | 15.24% of one logical CPU | Aggregate CPU-time delta for 15 shims and four health workers over 60.687 s |
+| Resident memory | 9,121.97–9,123.88 MiB | Sum of RSS for those 19 processes; includes VM workload memory |
+| Process stability | All 19 PIDs unchanged | The same observation window |
+| Health persistence | Four healthy services, with advancing timestamps | PostgreSQL, Redis, sandbox, and API, after the Compose launcher exited |
+| Host socket directories | 19 before and after isolated HVF regressions | Existing baseline retained; no new directory remained |
+
+Resource sampling started at `2026-09-06T01:01:35.445088Z`. CPU is computed as
+`100 × sum(process CPU-time deltas) / elapsed wall time`, not by adding stale
+`ps %cpu` snapshots. On this 18-CPU host it is about 0.85% of total logical CPU
+capacity. RSS is an aggregate process measure, not proportional set size or
+incremental virtualization overhead.
+
+The public web page also returned HTTP 200 after redirects. These are local
+idle-workload observations, not throughput or latency-under-load benchmarks.
+The 2.99-second result is convergence, not a full cold deployment. No matched
+before/after cold-start or memory-reduction percentage is claimed. Roughly
+8.91 GiB of RSS remains a resource-optimization target.
+
+## Regression evidence
+
+- `scripts/host-integration-smoke.sh --pure` passed formatting, workspace
+  all-target/all-feature clippy with warnings denied, library tests, and
+  integration tests. Host-dependent tests remain explicitly ignored in this
+  baseline, not silently counted as executed.
+- The additional `drain_idle_signals_and_joins_in_progress_maintenance` test
+  passed. It holds maintenance cleanup open and verifies that draining signals
+  shutdown but cannot return until cleanup completes.
+- All 28 shim unit tests passed, including byte-for-byte signed dylib staging,
+  versioned aliases, same-file/hard-link protection, and raw-disk ownership.
+- Before isolating the immediate lock-release assertion, 100 serial shim-suite
+  runs passed but 39 of 100 parallel runs failed. After isolation, all 100
+  parallel runs passed. The production disk-lock behavior was not relaxed.
+- Final real-HVF health-worker regression passed in 7.01 s. It sends SIGTERM to
+  the completed launcher's isolated process group, changes guest readiness,
+  and requires a new healthy probe.
+- Final real-HVF multi-image warm-pool regression passed in 32.73 s. It covers
+  direct and routed pool runs, concurrent requests, lazy initialization, and
+  shutdown with no new host socket directory left behind.
+- Every installed runtime dylib passed `codesign --verify`; the shim's
+  hypervisor entitlement signature also verified.
+
+For focused reproduction after preparing the host assets:
+
+```bash
+cd src
+export A3S_BOX_TEST_ALPINE_TAR=/path/to/alpine-oci.tar
+cargo test --locked -p a3s-box-cli -p a3s-box-shim \
+  --test core_smoke --test host_smoke -- --ignored --nocapture --test-threads=1 \
+  real_core_detached_health_worker_survives_run_cli_exit test_real_pool_warm_run
+```
+
+## Remaining gates
+
+- A matched cold-deployment benchmark and longer steady-state/load observation
+  are still needed before claiming startup or memory efficiency improvements.
+- This macOS run does not certify Linux KVM, Windows WHPX, or confidential
+  hardware. PR #243 still needs its Windows-specific validation after its
+  unrelated base clippy failure is corrected.
+- Issue #172 remains open for the joint Box/Cloud sole-provider acceptance,
+  including Cloud's Docker/Bollard removal, clean-host recovery, and hardware
+  confidentiality evidence. Local Dify success does not satisfy that gate.

--- a/docs/productization-plan.md
+++ b/docs/productization-plan.md
@@ -153,6 +153,10 @@ Current notes:
   logic. The long-running `monitor` command runs due probes itself, so detached
   boxes no longer depend on short-lived CLI health-check tasks to move from
   `starting` to `healthy`/`unhealthy` and trigger restart policy handling.
+- Detached CLI health workers also own independent Unix sessions. The local
+  regression kills the launcher's process group and requires a new successful
+  guest readiness probe, preventing a stale health snapshot from hiding a
+  prematurely terminated worker.
 - The A3S Runtime provider pins Runtime 0.5.0 and advertises HTTP, TCP, and
   command readiness plus the atomic `ServiceLifecycle` feature. Readiness and
   liveness have independent start periods and success/failure thresholds; HTTP
@@ -735,6 +739,11 @@ Current notes:
   `pool start --lease-ttl <duration>` reclaims idle internal leases whose client
   disappeared before release, while leaving active lease execs alone. The
   default is `1h`; `0` disables lease reclamation.
+- Pool shutdown now joins in-progress maintenance and retains request ownership
+  through VM cleanup. Idle VMs and leases drain with bounded concurrency;
+  persistent VMs retain their normal graceful-stop deadline. The
+  [local Dify qualification](local-dify-validation-2026-09-06.md) records the
+  accompanying health, resource, and no-leftover-socket regressions.
 - Volume-bound build leases are treated as short-lived stage helpers and are
   filled on demand (`min_idle=0`) instead of pre-warming a whole pool for each
   unique stage rootfs mount.
@@ -794,6 +803,9 @@ Acceptance criteria:
 
 Current notes:
 
+- macOS shim staging preserves libkrun-sys's signed dylib bytes, versioned
+  install names, and aliases. Packaging tests verify signatures and guard
+  same-file/hard-link staging against truncation; no version is hard-coded.
 - Windows packaging now chooses the native WHPX path explicitly. The Windows
   release package ships `a3s-box.exe`, `a3s-box-shim.exe`, the Linux
   `a3s-box-guest-init` binary that runs inside the MicroVM, `krun.dll`, and the

--- a/src/cli/src/commands/compose/wait.rs
+++ b/src/cli/src/commands/compose/wait.rs
@@ -43,19 +43,6 @@ pub(super) async fn wait_for_healthy(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::HEALTH_WAIT_POLL_INTERVAL;
-
-    #[test]
-    fn health_wait_poll_interval_is_subsecond() {
-        assert_eq!(
-            HEALTH_WAIT_POLL_INTERVAL,
-            std::time::Duration::from_millis(500)
-        );
-    }
-}
-
 pub(super) fn validate_compose_up_platform_support() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(windows)]
     {
@@ -144,5 +131,18 @@ pub(super) async fn wait_for_completed(
         }
 
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HEALTH_WAIT_POLL_INTERVAL;
+
+    #[test]
+    fn health_wait_poll_interval_is_subsecond() {
+        assert_eq!(
+            HEALTH_WAIT_POLL_INTERVAL,
+            std::time::Duration::from_millis(500)
+        );
     }
 }

--- a/src/cli/src/commands/pool.rs
+++ b/src/cli/src/commands/pool.rs
@@ -32,6 +32,8 @@ use a3s_box_runtime::pool::{
     PoolRunResponse, PoolStatusResponse,
 };
 use a3s_box_runtime::pool::{PoolStats, WarmPool};
+#[cfg(not(windows))]
+use tokio::task::JoinSet;
 
 /// Default Unix socket the `pool` daemon listens on.
 pub(crate) const DEFAULT_SOCKET: &str = "/tmp/a3s-box-pool.sock";
@@ -41,6 +43,8 @@ const DEFAULT_POOL_MEMORY_MB: u32 = 512;
 const DEFAULT_POOL_LEASE_TTL_SECS: u64 = 3600;
 const DEFAULT_POOL_BOOT_CONCURRENCY: usize = 2;
 const POOL_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+#[cfg(not(windows))]
+const POOL_DRAIN_CONCURRENCY: usize = 4;
 pub(crate) const DEFAULT_AUTOSTART_POOL_SIZE: usize = 1;
 pub(crate) const DEFAULT_AUTOSTART_POOL_MAX: usize = 8;
 
@@ -731,10 +735,45 @@ impl PoolRegistry {
         // concurrent lease requests cannot be blocked by a slow teardown.
         let leases = {
             let mut leases = self.leases.lock().await;
-            leases.drain().map(|(_, leased)| leased).collect::<Vec<_>>()
+            leases.drain().collect::<Vec<_>>()
         };
-        for leased in leases {
-            let _ = leased.vm.lock().await.destroy().await;
+
+        // Lease teardown is independent per VM. Keep a small bounded fan-out so
+        // a large lease set does not serialize shutdown or overwhelm the host.
+        let mut pending_leases = leases.into_iter();
+        let mut lease_tasks = JoinSet::new();
+        for _ in 0..POOL_DRAIN_CONCURRENCY {
+            if let Some((lease_id, leased)) = pending_leases.next() {
+                lease_tasks.spawn(async move {
+                    let result = {
+                        let mut vm = leased.vm.lock().await;
+                        vm.destroy().await
+                    };
+                    (lease_id, result)
+                });
+            }
+        }
+        while let Some(result) = lease_tasks.join_next().await {
+            match result {
+                Ok((lease_id, Ok(()))) => {
+                    tracing::debug!(%lease_id, "Destroyed warm-pool lease during shutdown");
+                }
+                Ok((lease_id, Err(error))) => {
+                    tracing::warn!(%lease_id, %error, "Failed to destroy warm-pool lease during shutdown");
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "Warm-pool lease teardown task failed");
+                }
+            }
+            if let Some((lease_id, leased)) = pending_leases.next() {
+                lease_tasks.spawn(async move {
+                    let result = {
+                        let mut vm = leased.vm.lock().await;
+                        vm.destroy().await
+                    };
+                    (lease_id, result)
+                });
+            }
         }
 
         // Snapshot pool handles and release the map lock before draining. Each
@@ -747,9 +786,33 @@ impl PoolRegistry {
                 .map(|entry| entry.pool.clone())
                 .collect::<Vec<_>>()
         };
-        for pool in pools {
+        // Broadcast the stop signal before awaiting any teardown so every
+        // maintenance loop exits promptly, even when there are more pools than
+        // drain workers.
+        for pool in &pools {
             pool.signal_shutdown();
-            let _ = pool.drain_idle().await;
+        }
+
+        let mut pending_pools = pools.into_iter();
+        let mut pool_tasks = JoinSet::new();
+        for _ in 0..POOL_DRAIN_CONCURRENCY {
+            if let Some(pool) = pending_pools.next() {
+                pool_tasks.spawn(async move { pool.drain_idle().await });
+            }
+        }
+        while let Some(result) = pool_tasks.join_next().await {
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::warn!(%error, "Failed to drain warm pool during shutdown");
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "Warm-pool drain task failed");
+                }
+            }
+            if let Some(pool) = pending_pools.next() {
+                pool_tasks.spawn(async move { pool.drain_idle().await });
+            }
         }
     }
 
@@ -1389,17 +1452,22 @@ async fn handle_conn(
 
     let bytes = serde_json::to_vec(&resp)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    write_frame(stream, &bytes).await?;
 
-    // Tear down the used sandbox in the background so neither the client nor the
-    // daemon's accept loop blocks on it; release the concurrency permit afterwards.
+    // The response is sent before teardown, so the client does not pay for VM
+    // destruction. Keep the teardown in this request task instead of detaching
+    // it: the request guard remains live until the VM and its host resources are
+    // actually gone, allowing daemon shutdown to wait for a complete cleanup.
+    // This task does not block the accept loop because every connection already
+    // runs in its own Tokio task. Perform cleanup even when the client disconnects
+    // while the response is being written.
+    let write_result = write_frame(stream, &bytes).await;
     if let Some((mut vm, permit)) = used {
-        tokio::spawn(async move {
-            let _ = vm.destroy().await;
-            drop(permit);
-        });
+        if let Err(error) = vm.destroy().await {
+            tracing::warn!(%error, "failed to destroy pooled VM after request");
+        }
+        drop(permit);
     }
-    Ok(())
+    write_result
 }
 
 #[cfg(not(windows))]

--- a/src/cli/src/health.rs
+++ b/src/cli/src/health.rs
@@ -60,11 +60,7 @@ pub(crate) fn spawn_detached_health_checker(record: &BoxRecord) -> Result<(), St
         .map_err(|error| format!("failed to locate a3s-box for health checker: {error}"))?;
     let arguments = detached_health_worker_args(&record.id, generation);
 
-    std::process::Command::new(executable)
-        .args(arguments)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+    detached_health_worker_command(&executable, &arguments)
         .spawn()
         .map(|_| ())
         .map_err(|error| {
@@ -73,6 +69,35 @@ pub(crate) fn spawn_detached_health_checker(record: &BoxRecord) -> Result<(), St
                 record.name
             )
         })
+}
+
+#[cfg(not(windows))]
+fn detached_health_worker_command(
+    executable: &Path,
+    arguments: &[String],
+) -> std::process::Command {
+    use std::os::unix::process::CommandExt;
+
+    let mut command = std::process::Command::new(executable);
+    command
+        .args(arguments)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    // Detached workloads outlive terminal/job process-group cleanup. Give the
+    // health owner the same independent lifetime as the workload's shim.
+    // SAFETY: only the async-signal-safe setsid syscall runs between fork and
+    // exec; no shared Rust state or allocation is accessed in the child.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    command
 }
 
 #[cfg(any(not(windows), test))]
@@ -513,6 +538,50 @@ mod tests {
                 "--health-generation",
                 "1234",
             ]
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_health_generation_survives_state_round_trip() {
+        let mut record = crate::test_helpers::fixtures::make_record(
+            "health-generation-id",
+            "health-generation",
+            "running",
+            Some(1),
+        );
+        record.started_at = Some(
+            chrono::DateTime::parse_from_rfc3339("2026-09-06T00:13:02.508035123Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        );
+
+        let persisted: BoxRecord =
+            serde_json::from_value(serde_json::to_value(&record).unwrap()).unwrap();
+        assert_eq!(record.started_at, persisted.started_at);
+        assert_eq!(health_generation(&record), Some(1_788_653_582_508_035_123));
+        assert_eq!(health_generation(&record), health_generation(&persisted));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_detached_health_worker_owns_a_separate_session() {
+        let mut child = detached_health_worker_command(Path::new("/bin/sleep"), &["30".into()])
+            .spawn()
+            .unwrap();
+        let pid = child.id() as libc::pid_t;
+        // SAFETY: these read-only process queries take a live child PID.
+        let session = unsafe { libc::getsid(pid) };
+        let group = unsafe { libc::getpgid(pid) };
+        child.kill().unwrap();
+        child.wait().unwrap();
+        assert_eq!(
+            session, pid,
+            "worker must not inherit the launching session"
+        );
+        assert_eq!(
+            group, pid,
+            "worker must not inherit the launching process group"
         );
     }
 

--- a/src/cli/tests/core_smoke.rs
+++ b/src/cli/tests/core_smoke.rs
@@ -2307,11 +2307,9 @@ fn real_core_commit_preserves_guest_ownership_and_modes_after_stop() {
 #[test]
 #[ignore]
 fn real_core_snapshot_cow_isolation_and_rm_guard() {
-    // Copy-on-write snapshot restore: forks share the snapshot's rootfs as a
-    // read-only overlay lower, each writing to its own upper. Verifies (1) fork
-    // isolation — a write in one fork is invisible to another, (2) the shared
-    // lower stays pristine, and (3) `snapshot rm` refuses while a fork still
-    // references the snapshot, then succeeds once the forks are gone.
+    // Directory restores share an immutable lower; guest-native ext4 restores
+    // own independent writable clones. Both must preserve fork isolation.
+    // Deletion is fenced only while a restore depends on the snapshot store.
     let smoke = CoreSmoke::new();
     let image = smoke_image();
     let base = format!("{}-cow-base", smoke.name);
@@ -2368,9 +2366,14 @@ fn real_core_snapshot_cow_isolation_and_rm_guard() {
         "snapshot id: {snapshot_id}"
     );
     snapshot_cleanup.id = Some(snapshot_id.clone());
+    let store = a3s_box_runtime::SnapshotStore::new(&smoke.home_path().join("snapshots"))
+        .expect("open snapshot store");
+    let rootfs_format = store
+        .rootfs_format(&snapshot_id)
+        .expect("validate snapshot rootfs format");
     smoke.ok(&["rm", &base]);
 
-    // Fork A: sees the warmed state, then writes to its own upper.
+    // Fork A sees the warmed state, then mutates its private writable state.
     smoke.ok(&["snapshot", "restore", &snapshot_id, "--name", &fork_a]);
     smoke.ok(&["start", &fork_a]);
     smoke.wait_for_named_running(&fork_a);
@@ -2395,18 +2398,8 @@ fn real_core_snapshot_cow_isolation_and_rm_guard() {
         "printf A-WROTE >>/tmp/cow-shared.txt",
     ]);
 
-    // rm guard: the snapshot is still referenced by fork A -> must be refused.
-    let guarded = smoke.output(&["snapshot", "rm", &snapshot_id]);
-    assert!(
-        !guarded.success,
-        "snapshot rm must be refused while a fork references it\nstdout:\n{}\nstderr:\n{}",
-        guarded.stdout, guarded.stderr
-    );
-    assert_contains(&guarded.stderr, "still used", "rm guard message");
-    smoke.ok(&["snapshot", "inspect", &snapshot_id]); // still present
-
     // Fork B from the SAME snapshot must NOT see fork A's write (isolation +
-    // pristine shared lower).
+    // pristine snapshot source).
     smoke.ok(&["snapshot", "restore", &snapshot_id, "--name", &fork_b]);
     smoke.ok(&["start", &fork_b]);
     smoke.wait_for_named_running(&fork_b);
@@ -2423,13 +2416,57 @@ fn real_core_snapshot_cow_isolation_and_rm_guard() {
         "fork B must not see fork A's write (CoW isolation)"
     );
 
-    // Remove the forks, then `snapshot rm` succeeds (guard clears).
+    match rootfs_format {
+        a3s_box_runtime::SnapshotRootfsFormat::Directory => {
+            let guarded = smoke.output(&["snapshot", "rm", &snapshot_id]);
+            assert!(
+                !guarded.success,
+                "snapshot rm must be refused while forks reference its lower\nstdout:\n{}\nstderr:\n{}",
+                guarded.stdout, guarded.stderr
+            );
+            assert_contains(&guarded.stderr, "still used", "rm guard message");
+            smoke.ok(&["snapshot", "inspect", &snapshot_id]);
+        }
+        a3s_box_runtime::SnapshotRootfsFormat::GuestNativeExt4 => {
+            smoke.ok(&["snapshot", "rm", &snapshot_id]);
+            snapshot_cleanup.id = None;
+            assert!(
+                !smoke
+                    .home_path()
+                    .join("snapshots")
+                    .join(&snapshot_id)
+                    .exists(),
+                "independent raw-ext4 forks must not retain the source snapshot"
+            );
+            // A restart proves independence beyond an already-open disk handle.
+            smoke.ok(&["restart", &fork_a]);
+            smoke.wait_for_named_running(&fork_a);
+            for (fork, expected) in [(&fork_a, "BASEA-WROTE"), (&fork_b, "BASE")] {
+                assert_eq!(
+                    smoke.ok(&[
+                        "exec",
+                        fork,
+                        "--",
+                        "/bin/sh",
+                        "-c",
+                        "cat /tmp/cow-shared.txt"
+                    ]),
+                    expected,
+                    "fork state must survive source snapshot deletion"
+                );
+            }
+        }
+    }
+
+    // Removing the forks releases any directory snapshot's shared-lower guard.
     smoke.ok(&["stop", &fork_a]);
     smoke.ok(&["rm", &fork_a]);
     smoke.ok(&["stop", &fork_b]);
     smoke.ok(&["rm", &fork_b]);
-    smoke.ok(&["snapshot", "rm", &snapshot_id]);
-    snapshot_cleanup.id = None;
+    if snapshot_cleanup.id.is_some() {
+        smoke.ok(&["snapshot", "rm", &snapshot_id]);
+        snapshot_cleanup.id = None;
+    }
 }
 
 #[cfg(unix)]
@@ -2500,6 +2537,8 @@ fn real_core_restart_policy_monitor_recovers_dead_box() {
 #[test]
 #[ignore]
 fn real_core_detached_health_worker_survives_run_cli_exit() {
+    use std::os::unix::process::CommandExt;
+
     let smoke = CoreSmoke::new();
     let image = smoke_image();
     seed_smoke_image(&smoke, &image);
@@ -2508,13 +2547,13 @@ fn real_core_detached_health_worker_survives_run_cli_exit() {
         name: smoke.name.clone(),
     };
 
-    smoke.ok(&[
+    let mut launcher = smoke.command(&[
         "run",
         "--detach",
         "--name",
         &smoke.name,
         "--health-cmd",
-        "true",
+        "test -f /tmp/health-ready",
         "--health-interval",
         "1s",
         "--health-timeout",
@@ -2527,6 +2566,44 @@ fn real_core_detached_health_worker_survives_run_cli_exit() {
         "-c",
         "sleep 300",
     ]);
+    let mut child = launcher
+        .process_group(0)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn detached-run launcher in its own process group");
+    let launcher_group = child.id() as libc::pid_t;
+    let deadline = Instant::now() + smoke.timeout;
+    while child
+        .try_wait()
+        .expect("poll detached-run launcher")
+        .is_none()
+    {
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("detached-run launcher timed out");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let output = child
+        .wait_with_output()
+        .expect("collect detached-run output");
+    assert!(
+        output.status.success(),
+        "detached-run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Simulate a terminal/job supervisor cleaning up the finished launcher's
+    // process group. Only the isolated group created above is signalled.
+    // SAFETY: the negative PID addresses that specific child process group.
+    let signal_result = unsafe { libc::kill(-launcher_group, libc::SIGTERM) };
+    assert!(
+        signal_result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH),
+        "failed to signal detached-run process group"
+    );
+    smoke.ok(&["exec", &smoke.name, "--", "touch", "/tmp/health-ready"]);
 
     let healthy = smoke.wait_for_named_health(&smoke.name, "healthy");
     assert_eq!(json_string_field(&healthy, "health_status"), "healthy");

--- a/src/cli/tests/host_smoke.rs
+++ b/src/cli/tests/host_smoke.rs
@@ -773,6 +773,7 @@ volume "data" {{
 fn test_real_pool_warm_run() {
     let cli = CliTest::new();
     let image = host_smoke_image();
+    let socket_dirs_before = host_socket_dirs();
     seed_runnable_alpine_image(&cli, &image);
     // A second image (retag of the first) the daemon pre-warms at startup via --warm.
     let second = format!("coverage-pool-second:{}", unique_tag("img2"));
@@ -950,6 +951,7 @@ fn test_real_pool_warm_run() {
     );
 
     daemon.interrupt();
+    assert_no_new_host_socket_dirs(&socket_dirs_before);
 }
 
 /// Dockerfile RUN over the warm-pool lease path: one build stage keeps a pooled

--- a/src/cli/tests/support/mod.rs
+++ b/src/cli/tests/support/mod.rs
@@ -16,6 +16,12 @@ use flate2::Compression;
 use sha2::{Digest, Sha256};
 
 pub const COMMAND_TIMEOUT: Duration = Duration::from_secs(300);
+/// Allow daemon shutdown to finish its documented warm-pool drain window.
+/// Pool teardown can include a final guest boot already in progress; killing
+/// the daemon after a shorter fixed wait leaves its shim orphaned and makes a
+/// resource-leak assertion report a test-harness artifact instead of a daemon
+/// bug.
+const BACKGROUND_INTERRUPT_TIMEOUT: Duration = Duration::from_secs(90);
 pub const HOST_SMOKE_IMAGE_ENV: &str = "A3S_BOX_HOST_SMOKE_IMAGE";
 pub const HOST_SMOKE_TIMEOUT_SECS_ENV: &str = "A3S_BOX_HOST_SMOKE_TIMEOUT_SECS";
 pub const TEST_ALPINE_TAR_ENV: &str = "A3S_BOX_TEST_ALPINE_TAR";
@@ -217,7 +223,7 @@ impl CliTest {
         }
 
         let start = Instant::now();
-        while start.elapsed() < Duration::from_secs(30) {
+        while start.elapsed() < BACKGROUND_INTERRUPT_TIMEOUT {
             match child.try_wait() {
                 Ok(Some(_)) => return,
                 Ok(None) => std::thread::sleep(Duration::from_millis(100)),

--- a/src/cri/src/server.rs
+++ b/src/cri/src/server.rs
@@ -208,6 +208,35 @@ impl CriServer {
     }
 }
 
+/// Resolves when the process receives a termination signal, driving a graceful
+/// gRPC server shutdown so the CRI can reap its sandbox VMs.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        match (
+            signal(SignalKind::terminate()),
+            signal(SignalKind::interrupt()),
+        ) {
+            (Ok(mut sigterm), Ok(mut sigint)) => {
+                tokio::select! {
+                    _ = sigterm.recv() => tracing::info!("Received SIGTERM, shutting down CRI"),
+                    _ = sigint.recv() => tracing::info!("Received SIGINT, shutting down CRI"),
+                }
+            }
+            _ => {
+                tracing::error!("Failed to install signal handlers; graceful shutdown disabled");
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+        tracing::info!("Received Ctrl-C, shutting down CRI");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,34 +277,5 @@ mod tests {
             .expect_err("a regular file must not be unlinked");
         assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
         assert_eq!(std::fs::read(&path).unwrap(), b"keep me");
-    }
-}
-
-/// Resolves when the process receives a termination signal, driving a graceful
-/// gRPC server shutdown so the CRI can reap its sandbox VMs.
-async fn shutdown_signal() {
-    #[cfg(unix)]
-    {
-        use tokio::signal::unix::{signal, SignalKind};
-        match (
-            signal(SignalKind::terminate()),
-            signal(SignalKind::interrupt()),
-        ) {
-            (Ok(mut sigterm), Ok(mut sigint)) => {
-                tokio::select! {
-                    _ = sigterm.recv() => tracing::info!("Received SIGTERM, shutting down CRI"),
-                    _ = sigint.recv() => tracing::info!("Received SIGINT, shutting down CRI"),
-                }
-            }
-            _ => {
-                tracing::error!("Failed to install signal handlers; graceful shutdown disabled");
-                std::future::pending::<()>().await;
-            }
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = tokio::signal::ctrl_c().await;
-        tracing::info!("Received Ctrl-C, shutting down CRI");
     }
 }

--- a/src/runtime/src/pool/warm_pool.rs
+++ b/src/runtime/src/pool/warm_pool.rs
@@ -12,7 +12,7 @@ use a3s_box_core::config::{BoxConfig, PoolConfig};
 use a3s_box_core::error::{BoxError, Result};
 use a3s_box_core::event::{BoxEvent, EventEmitter};
 use tokio::sync::{watch, Mutex, OwnedSemaphorePermit, Semaphore};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 
 use crate::pool::scaler::PoolScaler;
 use crate::vm::VmManager;
@@ -112,7 +112,12 @@ pub struct WarmPool {
     /// Event emitter for pool lifecycle events.
     event_emitter: EventEmitter,
     /// Background replenishment task handle.
-    replenish_handle: Option<JoinHandle<()>>,
+    ///
+    /// The handle is behind a mutex because daemon shutdown owns pools through
+    /// `Arc<WarmPool>`. Taking and awaiting it during `drain_idle` is required:
+    /// dropping a maintenance task while it is booting can leave its newly
+    /// created VM (and shim) detached from the pool's idle list.
+    replenish_handle: Mutex<Option<JoinHandle<()>>>,
     /// Shutdown signal sender.
     shutdown_tx: watch::Sender<bool>,
     /// Shutdown signal receiver (cloned for background task).
@@ -150,6 +155,18 @@ struct PoolTemplate {
 /// the whole pool to cold-boot on a one-off hiccup, while still giving up on a
 /// genuinely-unsupported host after a few attempts.
 const MAX_TEMPLATE_BUILD_FAILURES: u32 = 3;
+
+/// Bound concurrent VM teardown so a large pool does not turn shutdown into a
+/// host-resource spike. Teardown is I/O-heavy and independent per VM, so a
+/// small fixed fan-out shortens the critical path without overwhelming the
+/// hypervisor or filesystem.
+const MAX_DRAIN_CONCURRENCY: usize = 4;
+
+/// Warm-pool VMs are ephemeral (`persistent = false` in the pool daemon). Give
+/// the guest a short graceful window during daemon shutdown, then let the VM
+/// lifecycle's force-stop fallback finish host cleanup. This keeps shutdown
+/// bounded when a keepalive process ignores SIGTERM.
+const EPHEMERAL_DRAIN_TIMEOUT_MS: u64 = 2_000;
 
 /// Cached state of the snapshot-fork template.
 enum TemplateState {
@@ -315,13 +332,13 @@ impl WarmPool {
         };
 
         let boot_limiter = Arc::new(Semaphore::new(config.max_concurrent_boots));
-        let mut pool = Self {
+        let pool = Self {
             config,
             box_config,
             idle,
             stats,
             event_emitter,
-            replenish_handle: None,
+            replenish_handle: Mutex::new(None),
             shutdown_tx,
             shutdown_rx,
             scaler,
@@ -351,7 +368,7 @@ impl WarmPool {
 
         // Start background maintenance loop
         let handle = pool.spawn_maintenance_loop();
-        pool.replenish_handle = Some(handle);
+        *pool.replenish_handle.lock().await = Some(handle);
 
         tracing::info!(
             min_idle = pool.config.min_idle,
@@ -521,7 +538,7 @@ impl WarmPool {
         let _ = self.shutdown_tx.send(true);
 
         // Wait for background task to finish
-        if let Some(handle) = self.replenish_handle.take() {
+        if let Some(handle) = self.replenish_handle.lock().await.take() {
             let _ = handle.await;
         }
 
@@ -536,16 +553,7 @@ impl WarmPool {
         };
         let count = idle_vms.len();
 
-        for warm_vm in idle_vms {
-            let mut vm = warm_vm.vm;
-            if let Err(e) = vm.destroy().await {
-                tracing::warn!(
-                    box_id = %vm.box_id(),
-                    error = %e,
-                    "Failed to destroy pooled VM during drain"
-                );
-            }
-        }
+        Self::destroy_vms(idle_vms, None, "drain").await;
 
         let mut stats = self.stats.lock().await;
         stats.idle_count = 0;
@@ -559,9 +567,17 @@ impl WarmPool {
 
     /// Destroy all idle VMs without consuming the pool (`&self`), so it can be
     /// shut down from behind an `Arc` (e.g. a daemon serving concurrent requests).
-    /// Pair with [`Self::signal_shutdown`] first to stop the background replenisher;
-    /// its task then exits on its own (it watches the shutdown channel).
+    /// This method signals and joins the background replenisher before taking
+    /// the idle snapshot, then tears down VMs with bounded concurrency.
     pub async fn drain_idle(&self) -> Result<()> {
+        // Stop and join the maintenance loop before taking the idle snapshot.
+        // Otherwise a replenishment batch can finish after this method drains
+        // the vector and publish a VM that no owner remains to destroy.
+        self.signal_shutdown();
+        if let Some(handle) = self.replenish_handle.lock().await.take() {
+            let _ = handle.await;
+        }
+
         // Detach idle VMs before destroying them. Keeping `idle` locked while
         // awaiting VM teardown blocks concurrent acquire/release operations and
         // widens the shutdown race window for a replenishment batch.
@@ -572,19 +588,58 @@ impl WarmPool {
             idle_vms
         };
         let count = idle_vms.len();
-        for warm_vm in idle_vms {
-            let mut vm = warm_vm.vm;
-            if let Err(e) = vm.destroy().await {
-                tracing::warn!(
-                    box_id = %vm.box_id(),
-                    error = %e,
-                    "Failed to destroy pooled VM during drain_idle"
-                );
-            }
-        }
+        let timeout_ms = (!self.box_config.persistent).then_some(EPHEMERAL_DRAIN_TIMEOUT_MS);
+        Self::destroy_vms(idle_vms, timeout_ms, "drain_idle").await;
         self.stats.lock().await.idle_count = 0;
         tracing::info!(destroyed = count, "Warm pool idle VMs drained");
         Ok(())
+    }
+
+    /// Destroy detached VMs in a bounded fan-out. The caller must remove the
+    /// VMs from the pool before invoking this helper so no pool lock is held
+    /// while a hypervisor teardown is in progress.
+    async fn destroy_vms(vms: Vec<WarmVm>, timeout_ms: Option<u64>, operation: &'static str) {
+        if vms.is_empty() {
+            return;
+        }
+
+        let concurrency = vms.len().min(MAX_DRAIN_CONCURRENCY);
+        let mut pending = vms.into_iter();
+        let mut tasks = JoinSet::new();
+
+        for _ in 0..concurrency {
+            if let Some(warm_vm) = pending.next() {
+                tasks.spawn(Self::destroy_one(warm_vm, timeout_ms));
+            }
+        }
+
+        while let Some(result) = tasks.join_next().await {
+            match result {
+                Ok((box_id, Ok(()))) => {
+                    tracing::debug!(%box_id, operation, "Destroyed pooled VM");
+                }
+                Ok((box_id, Err(error))) => {
+                    tracing::warn!(%box_id, %error, operation, "Failed to destroy pooled VM");
+                }
+                Err(error) => {
+                    tracing::warn!(%error, operation, "Pooled VM teardown task failed");
+                }
+            }
+
+            if let Some(warm_vm) = pending.next() {
+                tasks.spawn(Self::destroy_one(warm_vm, timeout_ms));
+            }
+        }
+    }
+
+    async fn destroy_one(warm_vm: WarmVm, timeout_ms: Option<u64>) -> (String, Result<()>) {
+        let box_id = warm_vm.vm.box_id().to_string();
+        let mut vm = warm_vm.vm;
+        let result = match timeout_ms {
+            Some(timeout_ms) => vm.destroy_with_timeout(timeout_ms).await,
+            None => vm.destroy().await,
+        };
+        (box_id, result)
     }
 
     /// Remove and destroy specific idle VMs by their box IDs.
@@ -628,20 +683,8 @@ impl WarmPool {
             Self::sync_idle_metric(self.metrics.as_ref(), idle_count);
         }
 
-        // Destroy collected VMs (outside of pool lock)
-        for warm_vm in to_destroy {
-            let box_id = warm_vm.vm.box_id().to_string();
-            let mut vm = warm_vm.vm;
-            if let Err(e) = vm.destroy().await {
-                tracing::warn!(
-                    box_id = %box_id,
-                    error = %e,
-                    "Failed to destroy VM during pool fill rollback"
-                );
-            } else {
-                tracing::debug!(box_id = %box_id, "Destroyed VM during pool fill rollback");
-            }
-        }
+        // Destroy collected VMs (outside of pool lock).
+        Self::destroy_vms(to_destroy, None, "fill rollback").await;
     }
 
     /// Boot a new VM using the pool's template config.
@@ -1240,10 +1283,7 @@ impl WarmPool {
 
         let evicted_count = expired.len();
         Self::sync_idle_metric(metrics, after_count);
-        for warm_vm in expired {
-            let mut vm = warm_vm.vm;
-            let _ = vm.destroy().await;
-        }
+        Self::destroy_vms(expired, None, "eviction").await;
 
         if evicted_count > 0 {
             let mut s = stats.lock().await;
@@ -1283,6 +1323,9 @@ fn replenish_backoff_delay(failures: u32, check_interval: Duration) -> Duration 
         .min(300);
     Duration::from_secs(delay_secs)
 }
+
+#[cfg(test)]
+mod shutdown_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/runtime/src/pool/warm_pool.rs
+++ b/src/runtime/src/pool/warm_pool.rs
@@ -175,6 +175,23 @@ enum InitialFill {
     FirstReady,
 }
 
+/// Inputs for one bounded warm-pool boot batch.
+///
+/// Keeping the batch request together makes the concurrency boundary explicit
+/// and avoids a long parameter list that is easy to get out of sync when new
+/// pool-wide controls are added.
+struct BootBatch<'a> {
+    snapshot_fork: bool,
+    box_config: &'a BoxConfig,
+    event_emitter: &'a EventEmitter,
+    template: &'a Arc<Mutex<TemplateState>>,
+    needed: usize,
+    max_concurrent_boots: usize,
+    metrics: Option<crate::prom::RuntimeMetrics>,
+    boot_limiter: Arc<Semaphore>,
+    global_boot_limiter: Option<Arc<Semaphore>>,
+}
+
 impl WarmPool {
     /// Create and start the warm pool.
     ///
@@ -721,34 +738,25 @@ impl WarmPool {
     /// resource burst, so only `max_concurrent_boots` tasks are in flight at
     /// once. Each task owns cloned inputs, allowing the set to remain
     /// `'static` while the caller retains its pool state.
-    async fn boot_batch(
-        snapshot_fork: bool,
-        box_config: &BoxConfig,
-        event_emitter: &EventEmitter,
-        template: &Arc<Mutex<TemplateState>>,
-        needed: usize,
-        max_concurrent_boots: usize,
-        metrics: Option<crate::prom::RuntimeMetrics>,
-        boot_limiter: Arc<Semaphore>,
-        global_boot_limiter: Option<Arc<Semaphore>>,
-    ) -> Vec<Result<VmManager>> {
-        if needed == 0 {
+    async fn boot_batch(batch: BootBatch<'_>) -> Vec<Result<VmManager>> {
+        if batch.needed == 0 {
             return Vec::new();
         }
 
-        let limit = bounded_boot_limit(needed, max_concurrent_boots);
+        let limit = bounded_boot_limit(batch.needed, batch.max_concurrent_boots);
         let mut set = tokio::task::JoinSet::new();
         let mut launched = 0usize;
-        let mut results = Vec::with_capacity(needed);
+        let mut results = Vec::with_capacity(batch.needed);
 
-        while launched < needed || !set.is_empty() {
-            while launched < needed && set.len() < limit {
-                let config = box_config.clone();
-                let emitter = event_emitter.clone();
-                let shared_template = Arc::clone(template);
-                let boot_metrics = metrics.clone();
-                let pool_boot_limiter = boot_limiter.clone();
-                let daemon_boot_limiter = global_boot_limiter.clone();
+        while launched < batch.needed || !set.is_empty() {
+            while launched < batch.needed && set.len() < limit {
+                let config = batch.box_config.clone();
+                let emitter = batch.event_emitter.clone();
+                let shared_template = Arc::clone(batch.template);
+                let boot_metrics = batch.metrics.clone();
+                let pool_boot_limiter = batch.boot_limiter.clone();
+                let daemon_boot_limiter = batch.global_boot_limiter.clone();
+                let snapshot_fork = batch.snapshot_fork;
                 set.spawn(async move {
                     let _boot_permits =
                         acquire_boot_permits(pool_boot_limiter, daemon_boot_limiter).await?;
@@ -767,7 +775,7 @@ impl WarmPool {
                     ))),
                 };
                 if result.is_err() {
-                    if let Some(metrics) = &metrics {
+                    if let Some(metrics) = &batch.metrics {
                         metrics.warm_pool_boot_failures_total.inc();
                     }
                 }
@@ -976,17 +984,17 @@ impl WarmPool {
         // Track VMs added in this fill attempt so we can clean up on failure.
         let mut added_ids: Vec<String> = Vec::new();
         let mut failed = false;
-        let results = Self::boot_batch(
-            self.config.snapshot_fork,
-            &self.box_config,
-            &self.event_emitter,
-            &self.template,
+        let results = Self::boot_batch(BootBatch {
+            snapshot_fork: self.config.snapshot_fork,
+            box_config: &self.box_config,
+            event_emitter: &self.event_emitter,
+            template: &self.template,
             needed,
-            self.config.max_concurrent_boots,
-            self.metrics.clone(),
-            self.boot_limiter.clone(),
-            self.global_boot_limiter.clone(),
-        )
+            max_concurrent_boots: self.config.max_concurrent_boots,
+            metrics: self.metrics.clone(),
+            boot_limiter: self.boot_limiter.clone(),
+            global_boot_limiter: self.global_boot_limiter.clone(),
+        })
         .await;
 
         for result in results {
@@ -1120,17 +1128,17 @@ impl WarmPool {
 
                             // Overlap readiness waits while keeping the number of
                             // expensive VM boots bounded by configuration.
-                            let results = Self::boot_batch(
-                                config.snapshot_fork,
-                                &box_config,
-                                &event_emitter,
-                                &template,
+                            let results = Self::boot_batch(BootBatch {
+                                snapshot_fork: config.snapshot_fork,
+                                box_config: &box_config,
+                                event_emitter: &event_emitter,
+                                template: &template,
                                 needed,
-                                config.max_concurrent_boots,
-                                metrics.clone(),
-                                boot_limiter.clone(),
-                                global_boot_limiter.clone(),
-                            )
+                                max_concurrent_boots: config.max_concurrent_boots,
+                                metrics: metrics.clone(),
+                                boot_limiter: boot_limiter.clone(),
+                                global_boot_limiter: global_boot_limiter.clone(),
+                            })
                             .await;
                             let mut batch_failed = false;
                             for result in results {

--- a/src/runtime/src/pool/warm_pool/shutdown_tests.rs
+++ b/src/runtime/src/pool/warm_pool/shutdown_tests.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+#[tokio::test]
+async fn drain_idle_signals_and_joins_in_progress_maintenance() {
+    let pool = WarmPool::start(
+        PoolConfig {
+            min_idle: 0,
+            max_size: 1,
+            ..PoolConfig::default()
+        },
+        BoxConfig::default(),
+        EventEmitter::new(10),
+    )
+    .await
+    .expect("start an empty pool without a hypervisor");
+
+    pool.signal_shutdown();
+    pool.replenish_handle
+        .lock()
+        .await
+        .take()
+        .unwrap()
+        .await
+        .unwrap();
+    pool.shutdown_tx.send(false).unwrap();
+
+    let mut shutdown = pool.shutdown_rx.clone();
+    let (observed_tx, observed_rx) = tokio::sync::oneshot::channel();
+    let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+    *pool.replenish_handle.lock().await = Some(tokio::spawn(async move {
+        shutdown.wait_for(|stop| *stop).await.unwrap();
+        observed_tx.send(()).unwrap();
+        // Model the cleanup of a VM whose boot finished during shutdown.
+        finish_rx.await.unwrap();
+    }));
+
+    let mut draining = Box::pin(pool.drain_idle());
+    tokio::select! {
+        result = &mut draining => {
+            panic!("drain returned before maintenance cleanup finished: {result:?}");
+        }
+        observed = tokio::time::timeout(Duration::from_secs(5), observed_rx) => {
+            observed.expect("drain must signal shutdown").unwrap();
+        }
+    }
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut draining)
+            .await
+            .is_err(),
+        "drain must retain maintenance ownership while its cleanup is pending"
+    );
+    finish_tx.send(()).unwrap();
+    tokio::time::timeout(Duration::from_secs(5), draining)
+        .await
+        .expect("drain completes after maintenance cleanup")
+        .unwrap();
+    assert!(pool.replenish_handle.lock().await.is_none());
+    assert_eq!(pool.idle_count().await, 0);
+    assert_eq!(pool.stats().await.idle_count, 0);
+}

--- a/src/shim/build.rs
+++ b/src/shim/build.rs
@@ -1,3 +1,7 @@
+#[cfg(target_os = "macos")]
+#[path = "build_support/macos.rs"]
+mod macos;
+
 fn main() {
     // Read libkrun library paths from libkrun-sys build metadata.
     // Cargo derives the DEP_* prefix from `links = "a3s_krun"` in
@@ -15,13 +19,13 @@ fn main() {
     #[cfg(target_os = "macos")]
     copy_runtime_dylibs(&libkrun_dir, &libkrunfw_dir);
 
-    // On macOS, use @executable_path so the binary finds libkrun next to itself.
+    // On macOS, use an rpath rooted at the installed binary's sibling `lib`
+    // directory. The runtime launcher also exports that directory through
+    // DYLD_LIBRARY_PATH for libkrunfw's lazily loaded dependency.
     // On Linux, emit rpath to the build directory (runtime discovery is handled differently).
     #[cfg(target_os = "macos")]
     {
-        // Use @executable_path/../lib to find libkrun in the same directory as the binary.
-        // At runtime, libkrun.1.dylib and libkrun.dylib must be copied next to the binary.
-        // This is handled by the SDK's ensure_shim() function.
+        // Use @executable_path/../lib to find libkrun in the installed package.
         println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/../lib");
     }
     #[cfg(all(not(target_os = "macos"), not(windows)))]
@@ -40,66 +44,22 @@ fn main() {
 }
 
 #[cfg(target_os = "macos")]
-fn copy_runtime_dylibs(libkrun_dir: &str, _libkrunfw_dir: &str) {
+fn copy_runtime_dylibs(libkrun_dir: &str, libkrunfw_dir: &str) {
     use std::path::{Path, PathBuf};
-
-    fn copy_if_present(src_dir: &str, file_name: &str, bin_dir: &Path) {
-        if src_dir.is_empty() || src_dir == "/nonexistent" {
-            return;
-        }
-
-        let src = PathBuf::from(src_dir).join(file_name);
-        if !src.exists() {
-            println!("cargo:warning={} not found at {}", file_name, src.display());
-            return;
-        }
-
-        let dst = bin_dir.join(file_name);
-        use std::os::unix::fs::MetadataExt;
-        let same_file = src == dst
-            || std::fs::metadata(&dst).is_ok_and(|destination| {
-                std::fs::metadata(&src).is_ok_and(|source| {
-                    source.dev() == destination.dev() && source.ino() == destination.ino()
-                })
-            });
-        if same_file {
-            println!(
-                "cargo:warning={} is already staged at {}",
-                file_name,
-                dst.display()
-            );
-        } else {
-            std::fs::copy(&src, &dst)
-                .unwrap_or_else(|e| panic!("failed to copy {}: {}", file_name, e));
-            println!(
-                "cargo:warning=copied {} -> {}",
-                src.display(),
-                dst.display()
-            );
-        }
-        println!("cargo:rerun-if-changed={}", src.display());
-
-        // Also fix the install name to use @executable_path
-        let install_name = format!("@executable_path/{}", file_name);
-        let status = std::process::Command::new("install_name_tool")
-            .args(["-id", &install_name, dst.to_str().unwrap()])
-            .status();
-        if let Ok(s) = status {
-            if s.success() {
-                println!("cargo:warning=fixed install name to {}", install_name);
-            }
-        }
-    }
-
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let bin_dir = out_dir
         .ancestors()
         .nth(3)
         .expect("unexpected OUT_DIR depth");
 
-    // Copy libkrun and its alias
-    copy_if_present(libkrun_dir, "libkrun.1.dylib", bin_dir);
-    copy_if_present(libkrun_dir, "libkrun.dylib", bin_dir);
+    for source in [libkrun_dir, libkrunfw_dir] {
+        if source.is_empty() || source == "/nonexistent" {
+            continue;
+        }
+        macos::stage_runtime_dylibs(Path::new(source), bin_dir).unwrap_or_else(|error| {
+            panic!("failed to stage runtime dylibs from {source}: {error}")
+        });
+    }
 }
 
 #[cfg(windows)]

--- a/src/shim/build_support/macos.rs
+++ b/src/shim/build_support/macos.rs
@@ -1,0 +1,41 @@
+//! Stage already-signed macOS runtime assets without changing their identities.
+
+use std::fs;
+use std::io;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+pub fn stage_runtime_dylibs(source_dir: &Path, destination_dir: &Path) -> io::Result<()> {
+    println!("cargo:rerun-if-changed={}", source_dir.display());
+    let mut entries = fs::read_dir(source_dir)?.collect::<io::Result<Vec<_>>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let name = entry.file_name();
+        let name_text = name.to_string_lossy();
+        if !name_text.ends_with(".dylib")
+            || !(name_text.starts_with("libkrun.") || name_text.starts_with("libkrunfw."))
+        {
+            continue;
+        }
+        let source = entry.path();
+        let destination = destination_dir.join(&name);
+        let source_metadata = fs::metadata(&source)?;
+        if !source_metadata.is_file() {
+            continue;
+        }
+        let same_file = fs::metadata(&destination).is_ok_and(|metadata| {
+            metadata.dev() == source_metadata.dev() && metadata.ino() == source_metadata.ino()
+        });
+        if !same_file {
+            // libkrun-sys already fixes @rpath install names and signs each
+            // dylib. Rewriting an alias ID with install_name_tool invalidates
+            // that signature. Preserve the exact bytes, including SONAMEs,
+            // and include fully versioned files rather than guessing the ABI.
+            fs::copy(&source, &destination)?;
+        }
+        println!("cargo:rerun-if-changed={}", source.display());
+        println!("cargo:warning=staged {}", destination.display());
+    }
+    Ok(())
+}

--- a/src/shim/src/tests.rs
+++ b/src/shim/src/tests.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(target_os = "macos")]
+mod macos_runtime_assets;
+
 #[cfg(not(target_os = "windows"))]
 mod raw_disk_ownership;
 

--- a/src/shim/src/tests/macos_runtime_assets.rs
+++ b/src/shim/src/tests/macos_runtime_assets.rs
@@ -1,0 +1,76 @@
+#![cfg(target_os = "macos")]
+
+#[path = "../../build_support/macos.rs"]
+mod macos;
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::process::Command;
+
+#[test]
+fn stages_versioned_dylibs_and_aliases_without_invalidating_signatures() {
+    let source = tempfile::tempdir().unwrap();
+    let destination = tempfile::tempdir().unwrap();
+    let source_code = source.path().join("fixture.c");
+    fs::write(&source_code, "int runtime_fixture(void) { return 42; }\n").unwrap();
+    let versioned_name = "libkrun.9.42.0.dylib";
+    let library = source.path().join(versioned_name);
+    let output = Command::new("cc")
+        .args([
+            "-dynamiclib",
+            "-Wl,-install_name,@rpath/libkrun.9.42.0.dylib",
+        ])
+        .arg(&source_code)
+        .arg("-o")
+        .arg(&library)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(Command::new("codesign")
+        .args(["--force", "--sign", "-"])
+        .arg(&library)
+        .status()
+        .unwrap()
+        .success());
+    symlink(versioned_name, source.path().join("libkrun.9.dylib")).unwrap();
+    symlink("libkrun.9.dylib", source.path().join("libkrun.dylib")).unwrap();
+    fs::write(
+        source.path().join("unrelated.dylib"),
+        "not a runtime library",
+    )
+    .unwrap();
+    let signed_bytes = fs::read(&library).unwrap();
+
+    macos::stage_runtime_dylibs(source.path(), destination.path()).unwrap();
+    for name in [versioned_name, "libkrun.9.dylib", "libkrun.dylib"] {
+        let staged = destination.path().join(name);
+        assert_eq!(fs::read(&staged).unwrap(), signed_bytes);
+        assert!(Command::new("codesign")
+            .arg("--verify")
+            .arg(&staged)
+            .status()
+            .unwrap()
+            .success());
+    }
+    assert!(!destination.path().join("unrelated.dylib").exists());
+}
+
+#[test]
+fn staging_same_file_or_hard_link_does_not_truncate_it() {
+    let source = tempfile::tempdir().unwrap();
+    let destination = tempfile::tempdir().unwrap();
+    let library = source.path().join("libkrunfw.5.dylib");
+    fs::write(&library, "signed firmware fixture").unwrap();
+    fs::hard_link(&library, destination.path().join("libkrunfw.5.dylib")).unwrap();
+
+    macos::stage_runtime_dylibs(source.path(), source.path()).unwrap();
+    macos::stage_runtime_dylibs(source.path(), destination.path()).unwrap();
+    assert_eq!(
+        fs::read_to_string(&library).unwrap(),
+        "signed firmware fixture"
+    );
+}

--- a/src/shim/src/tests/raw_disk_ownership.rs
+++ b/src/shim/src/tests/raw_disk_ownership.rs
@@ -47,6 +47,30 @@ fn rejects_reserved_or_repeated_auxiliary_raw_disks() {
 #[cfg(unix)]
 #[test]
 fn raw_disk_ownership_lock_rejects_a_second_a3s_owner() {
+    const CHILD_ENV: &str = "A3S_BOX_TEST_RAW_DISK_RELEASE_CHILD";
+    if std::env::var_os(CHILD_ENV).is_none() {
+        // Concurrent process spawns in other tests can briefly inherit our
+        // flock descriptor before exec closes it. Check immediate release in
+        // an isolated process so those unrelated children cannot extend the
+        // descriptor's lifetime after the owner is dropped.
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tests::raw_disk_ownership::raw_disk_ownership_lock_rejects_a_second_a3s_owner",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("spawn isolated raw-disk lock release check");
+        assert!(
+            output.status.success(),
+            "isolated raw-disk lock release check failed:\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return;
+    }
+
     let temp = tempfile::tempdir().unwrap();
     let rootfs = temp.path().join("rootfs");
     let disk = temp.path().join("data.ext4");


### PR DESCRIPTION
## Summary

- Join warm-pool maintenance before draining; retain socket-request ownership through cleanup and bound VM/lease destruction concurrency.
- Give detached health workers independent Unix sessions so terminal/job process-group cleanup cannot terminate ongoing probes.
- Stage macOS libkrun/libkrunfw dylibs and all versioned aliases without mutating signed install names.
- Unblock workspace clippy after the preceding pool changes with a typed boot-batch request and test-module ordering fixes.
- Correct the snapshot smoke for independent ext4 restores, isolate the raw-disk lock-release assertion from parallel child spawns, and record local Dify evidence.

## Local validation

- `scripts/host-integration-smoke.sh --pure`: passed fmt, workspace all-target/all-feature clippy, library tests, and integration tests.
- Final all-target/all-feature clippy: passed with warnings denied.
- Deterministic delayed-maintenance drain regression: passed.
- All 28 shim unit tests: passed; the parallel shim suite passed 100/100 repeated runs after isolating the descriptor-lifetime assertion.
- Real HVF detached-health regression: passed in 7.01 s, including launcher process-group termination followed by a fresh successful guest probe.
- Real HVF multi-image warm-pool regression: passed in 32.73 s, including concurrent and lazy runs and no remaining new host socket directory.
- Local release CLI/shim built successfully; installed dylib signatures and shim hypervisor entitlement verified.
- Existing Dify 1.16.1 redeployed from the local package without deleting named volumes. All 15 long-running services and four independent health workers remain live; setup state is retained.
- Unchanged Compose convergence: 2.99 s. A 60.687-second observation recorded 12/12 HTTP 200 responses (16–25 ms), stable PIDs, 15.24% aggregate CPU on a one-core scale, and about 8.91 GiB aggregate RSS.

Details and measurement limits: `docs/local-dify-validation-2026-09-06.md`.

## Scope limits

This is local macOS/HVF evidence, not a new published release or a cross-platform/soak certificate. The convergence result is not a cold-deployment benchmark, and no memory reduction percentage is claimed. Issue #172 remains open for joint Box/Cloud and hardware acceptance. The standalone clippy fix can unblock PR #243 without mixing in these runtime changes.
