### PR TITLE
test(soak): verify versioned host resource metrics

### DIFF
--- a/deploy/scripts/soak-evidence-self-test.sh
+++ b/deploy/scripts/soak-evidence-self-test.sh
@@ -812,6 +812,24 @@ rm "$host_missing_declared_log/iteration-2-bench-race.log"
 expect_failure host-missing-declared-log 'missing required file: .*iteration-2-bench-race.log' \
     "$VERIFY_SCRIPT" --kind host "$host_missing_declared_log"
 
+log "Verifying versioned host resource metrics"
+host_resource_metrics_missing="$TMP_ROOT/host-resource-metrics-missing"
+make_host_bundle "$host_resource_metrics_missing"
+printf 'host_resource_metrics_version=1\n' >>"$host_resource_metrics_missing/metadata.txt"
+expect_failure host-resource-metrics-missing 'missing required column' \
+    "$VERIFY_SCRIPT" --kind host "$host_resource_metrics_missing"
+
+host_resource_metrics_bad="$TMP_ROOT/host-resource-metrics-bad"
+make_host_bundle "$host_resource_metrics_bad"
+printf 'host_resource_metrics_version=1\n' >>"$host_resource_metrics_bad/metadata.txt"
+cat >"$host_resource_metrics_bad/resource-samples.tsv" <<'EOF'
+timestamp	phase	shims	mounts	box_dirs	socket_dirs	a3s_home_bytes	process_rss_bytes	process_fd_count
+2026-06-29T00:00:00Z	start	1	1	1	1	100	oops	3
+2026-06-29T00:01:00Z	final	1	1	1	1	100	200	3
+EOF
+expect_failure host-resource-metrics-bad 'host resource sample counters must be non-negative integers' \
+    "$VERIFY_SCRIPT" --kind host "$host_resource_metrics_bad"
+
 log "Verifying host soak runner rehearsal summary"
 host_runner_dir="$TMP_ROOT/host-runner"
 "$HOST_INTEGRATION" --no-pure --linux-run --soak --soak-no-bench \
@@ -819,6 +837,9 @@ host_runner_dir="$TMP_ROOT/host-runner"
     >"$host_runner_dir.out"
 require_grep '^result=pass$' "$host_runner_dir/summary.txt"
 require_grep '^duration_secs=[0-9]+$' "$host_runner_dir/summary.txt"
+require_grep '^host_resource_metrics_version=1$' "$host_runner_dir/metadata.txt"
+require_grep '^timestamp	phase	shims	mounts	box_dirs	socket_dirs	a3s_home_bytes	process_rss_bytes	process_fd_count$' \
+    "$host_runner_dir/resource-samples.tsv"
 require_grep 'PASS: host soak evidence verified' "$host_runner_dir/verify.out"
 "$VERIFY_SCRIPT" --kind host "$host_runner_dir" >"$host_runner_dir.verify.out"
 require_grep 'PASS: host soak evidence verified' "$host_runner_dir.verify.out"

--- a/deploy/scripts/verify-soak-evidence.sh
+++ b/deploy/scripts/verify-soak-evidence.sh
@@ -1467,6 +1467,18 @@ verify_host() {
     require_kv_non_negative_int "$metadata" soak_duration_secs "host" >/dev/null
     require_kv_non_negative_int "$metadata" soak_iterations "host" >/dev/null
     require_kv_non_negative_int "$metadata" soak_interval_secs "host" >/dev/null
+    local resource_metrics_version
+    resource_metrics_version="$(kv_get "$metadata" host_resource_metrics_version)"
+    if [ -n "$resource_metrics_version" ]; then
+        is_non_negative_int "$resource_metrics_version" ||
+            fail "host metadata host_resource_metrics_version is not a non-negative integer: $resource_metrics_version"
+        [ "$resource_metrics_version" -eq 1 ] ||
+            fail "host metadata host_resource_metrics_version is unsupported: $resource_metrics_version"
+    else
+        # Bundles created before process-level resource metrics were added are
+        # still readable. New runners always emit version 1 below.
+        resource_metrics_version=0
+    fi
     apply_metadata_verifier_gates \
         "$metadata" \
         "host" \
@@ -1475,8 +1487,19 @@ verify_host() {
         soak_verify_min_sample_span_secs \
         soak_verify_max_sample_gap_secs
     require_nonempty_file "$samples"
-    tsv_require_columns "$samples" timestamp phase shims mounts box_dirs socket_dirs
-    tsv_require_non_negative_int_columns "$samples" "host" shims mounts box_dirs socket_dirs
+    if [ "$resource_metrics_version" -ge 1 ]; then
+        tsv_require_columns \
+            "$samples" \
+            timestamp phase shims mounts box_dirs socket_dirs \
+            a3s_home_bytes process_rss_bytes process_fd_count
+        tsv_require_non_negative_int_columns \
+            "$samples" \
+            "host" \
+            shims mounts box_dirs socket_dirs a3s_home_bytes process_rss_bytes process_fd_count
+    else
+        tsv_require_columns "$samples" timestamp phase shims mounts box_dirs socket_dirs
+        tsv_require_non_negative_int_columns "$samples" "host" shims mounts box_dirs socket_dirs
+    fi
     tsv_require_monotonic_timestamps "$samples" "host"
     tsv_require_phase_count "$samples" start 1 "host"
     tsv_require_phase_count "$samples" final 1 "host"

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -550,6 +550,10 @@ runs so the runner also enforces minimum duration, sample span, and sample count
 before returning success. Saved bundles keep those gate values in `metadata.txt`,
 so later verifier runs enforce the recorded gates even when the re-check command
 does not repeat every `--min-*` option.
+Current host bundles set `host_resource_metrics_version=1` and include
+`a3s_home_bytes`, `process_rss_bytes`, and `process_fd_count` in every resource
+sample. The verifier validates these process-level counters as non-negative
+integers; older bundles without the version key remain readable for migration.
 Failed host soaks write `result=fail` plus the failed
 iteration count and, when available, `exit_code`, `failed_at`, and
 `failed_command`; to re-check a saved bundle, run:

--- a/scripts/host-integration-smoke.sh
+++ b/scripts/host-integration-smoke.sh
@@ -655,6 +655,10 @@ write_soak_metadata() {
         echo "soak_iterations=$SOAK_ITERATIONS"
         echo "soak_interval_secs=$SOAK_INTERVAL_SECS"
         echo "soak_sample_interval_secs=$SOAK_SAMPLE_INTERVAL_SECS"
+        # Version the host resource schema so the verifier can enforce the
+        # process-level metrics emitted by current runners while retaining
+        # compatibility with older evidence bundles.
+        echo "host_resource_metrics_version=1"
         echo "soak_verify_min_duration_secs=$SOAK_VERIFY_MIN_DURATION_SECS"
         echo "soak_verify_min_samples=$SOAK_VERIFY_MIN_SAMPLES"
         echo "soak_verify_min_sample_span_secs=$SOAK_VERIFY_MIN_SAMPLE_SPAN_SECS"


### PR DESCRIPTION
## Summary
- version host soak resource samples so current evidence declares its schema
- make the verifier validate disk bytes, Box process RSS, and open-file counts for version 1 bundles
- keep pre-version bundles readable for migration and add malformed/missing metric self-tests
- document the evidence contract

## Validation
- `bash -n scripts/host-integration-smoke.sh deploy/scripts/verify-soak-evidence.sh deploy/scripts/soak-evidence-self-test.sh`
- `deploy/scripts/soak-evidence-self-test.sh`
- `git diff --check`
