### PR TITLE
test(soak): record per-capability results

### DIFF
--- a/deploy/scripts/soak-evidence-self-test.sh
+++ b/deploy/scripts/soak-evidence-self-test.sh
@@ -830,6 +830,26 @@ EOF
 expect_failure host-resource-metrics-bad 'host resource sample counters must be non-negative integers' \
     "$VERIFY_SCRIPT" --kind host "$host_resource_metrics_bad"
 
+log "Verifying versioned host capability results"
+host_capability_results_missing="$TMP_ROOT/host-capability-results-missing"
+make_host_bundle "$host_capability_results_missing"
+printf 'host_capability_results_version=1\n' >>"$host_capability_results_missing/metadata.txt"
+expect_failure host-capability-results-missing 'missing required file: .*capability-results.tsv' \
+    "$VERIFY_SCRIPT" --kind host "$host_capability_results_missing"
+
+host_capability_results_bad="$TMP_ROOT/host-capability-results-bad"
+make_host_bundle "$host_capability_results_bad"
+printf 'host_capability_results_version=1\n' >>"$host_capability_results_bad/metadata.txt"
+cat >"$host_capability_results_bad/capability-results.tsv" <<'EOF'
+iteration	capability	started_at	finished_at	duration_secs	result	exit_code
+1	bench-leak	2026-06-29T00:00:00Z	2026-06-29T00:00:01Z	1	pass	0
+1	bench-race	2026-06-29T00:00:02Z	2026-06-29T00:00:01Z	1	pass	0
+2	bench-leak	2026-06-29T00:00:03Z	2026-06-29T00:00:04Z	1	pass	0
+2	bench-race	2026-06-29T00:00:05Z	2026-06-29T00:00:06Z	1	pass	0
+EOF
+expect_failure host-capability-results-bad 'host capability result finishes before it starts' \
+    "$VERIFY_SCRIPT" --kind host "$host_capability_results_bad"
+
 log "Verifying host soak runner rehearsal summary"
 host_runner_dir="$TMP_ROOT/host-runner"
 "$HOST_INTEGRATION" --no-pure --linux-run --soak --soak-no-bench \
@@ -838,8 +858,12 @@ host_runner_dir="$TMP_ROOT/host-runner"
 require_grep '^result=pass$' "$host_runner_dir/summary.txt"
 require_grep '^duration_secs=[0-9]+$' "$host_runner_dir/summary.txt"
 require_grep '^host_resource_metrics_version=1$' "$host_runner_dir/metadata.txt"
+require_grep '^host_capability_results_version=1$' "$host_runner_dir/metadata.txt"
 require_grep '^timestamp	phase	shims	mounts	box_dirs	socket_dirs	a3s_home_bytes	process_rss_bytes	process_fd_count$' \
     "$host_runner_dir/resource-samples.tsv"
+require_grep '^iteration	capability	started_at	finished_at	duration_secs	result	exit_code$' \
+    "$host_runner_dir/capability-results.tsv"
+require_grep '^1	linux-run	.*	pass	0$' "$host_runner_dir/capability-results.tsv"
 require_grep 'PASS: host soak evidence verified' "$host_runner_dir/verify.out"
 "$VERIFY_SCRIPT" --kind host "$host_runner_dir" >"$host_runner_dir.verify.out"
 require_grep 'PASS: host soak evidence verified' "$host_runner_dir.verify.out"

--- a/deploy/scripts/verify-soak-evidence.sh
+++ b/deploy/scripts/verify-soak-evidence.sh
@@ -1009,6 +1009,121 @@ require_host_declared_suite_logs() {
     done
 }
 
+require_host_capability_results() {
+    local path="$1"
+    local suites="$2"
+    local iterations="$3"
+
+    require_nonempty_file "$path"
+    tsv_require_columns \
+        "$path" \
+        iteration capability started_at finished_at duration_secs result exit_code
+
+    awk -F '\t' -v suites="$suites" -v iterations="$iterations" '
+        BEGIN {
+            selected_count = split(suites, selected_tokens, " ")
+            for (i = 1; i <= selected_count; i++) {
+                split(selected_tokens[i], pair, "=")
+                selected[pair[1]] = pair[2]
+            }
+            expected_caps = ""
+            if (selected["core"] == "1") {
+                expected_caps = expected_caps "core "
+            }
+            if (selected["host"] == "1") {
+                expected_caps = expected_caps "host "
+            }
+            if (selected["linux_run"] == "1") {
+                expected_caps = expected_caps "linux-run "
+            }
+            if (selected["cri"] == "1") {
+                expected_caps = expected_caps "cri "
+            }
+            if (selected["bench"] == "1") {
+                expected_caps = expected_caps "bench-leak bench-race "
+            }
+            expected_count = split(expected_caps, expected, " ")
+            # split() counts the trailing empty token on some awk versions.
+            if (expected[expected_count] == "") {
+                expected_count--
+            }
+        }
+        NR == 1 {
+            for (i = 1; i <= NF; i++) {
+                index_by_name[$i] = i
+            }
+            next
+        }
+        NF > 0 {
+            row_iteration = $(index_by_name["iteration"])
+            capability = $(index_by_name["capability"])
+            result = $(index_by_name["result"])
+            exit_code = $(index_by_name["exit_code"])
+            duration = $(index_by_name["duration_secs"])
+            if (row_iteration !~ /^[1-9][0-9]*$/ || row_iteration + 0 > iterations) {
+                printf "capability result has invalid iteration: %s\n", row_iteration > "/dev/stderr"
+                bad = 1
+            }
+            allowed = 0
+            for (i = 1; i <= expected_count; i++) {
+                if (capability == expected[i]) {
+                    allowed = 1
+                    break
+                }
+            }
+            if (!allowed) {
+                printf "capability result has unexpected capability: %s\n", capability > "/dev/stderr"
+                bad = 1
+            }
+            key = row_iteration SUBSEP capability
+            if (seen[key]) {
+                printf "capability result is duplicated: iteration=%s capability=%s\n", row_iteration, capability > "/dev/stderr"
+                bad = 1
+            }
+            seen[key] = 1
+            if (duration !~ /^[0-9]+$/) {
+                printf "capability result duration is not a non-negative integer: %s\n", duration > "/dev/stderr"
+                bad = 1
+            }
+            if (result != "pass") {
+                printf "capability result is not pass: iteration=%s capability=%s result=%s\n", row_iteration, capability, result > "/dev/stderr"
+                bad = 1
+            }
+            if (exit_code != "0") {
+                printf "capability result exit code is not zero: iteration=%s capability=%s exit_code=%s\n", row_iteration, capability, exit_code > "/dev/stderr"
+                bad = 1
+            }
+            rows++
+        }
+        END {
+            for (iteration = 1; iteration <= iterations; iteration++) {
+                for (i = 1; i <= expected_count; i++) {
+                    key = iteration SUBSEP expected[i]
+                    if (!seen[key]) {
+                        printf "capability result missing: iteration=%d capability=%s\n", iteration, expected[i] > "/dev/stderr"
+                        bad = 1
+                    }
+                }
+            }
+            if (rows == 0 || bad) {
+                exit 1
+            }
+        }
+    ' "$path" ||
+        fail "host capability results must contain one passing row for every selected suite and iteration"
+
+    local iteration capability started finished started_epoch finished_epoch
+    while IFS=$'\t' read -r iteration capability started finished _ _ _; do
+        [ "$iteration" = "iteration" ] && continue
+        started_epoch="$(iso_to_epoch "$started")" ||
+            fail "host capability result start timestamp is not parseable: $started"
+        finished_epoch="$(iso_to_epoch "$finished")" ||
+            fail "host capability result finish timestamp is not parseable: $finished"
+        [ "$finished_epoch" -ge "$started_epoch" ] ||
+            fail "host capability result finishes before it starts: iteration=$iteration capability=$capability"
+    done <"$path"
+}
+
 tsv_value() {
     local file="$1"
     local phase="$2"
@@ -1479,6 +1594,17 @@ verify_host() {
         # still readable. New runners always emit version 1 below.
         resource_metrics_version=0
     fi
+    local capability_results_version
+    capability_results_version="$(kv_get "$metadata" host_capability_results_version)"
+    if [ -n "$capability_results_version" ]; then
+        is_non_negative_int "$capability_results_version" ||
+            fail "host metadata host_capability_results_version is not a non-negative integer: $capability_results_version"
+        [ "$capability_results_version" -eq 1 ] ||
+            fail "host metadata host_capability_results_version is unsupported: $capability_results_version"
+    else
+        # Pre-version bundles have no per-capability result artifact.
+        capability_results_version=0
+    fi
     apply_metadata_verifier_gates \
         "$metadata" \
         "host" \
@@ -1527,6 +1653,12 @@ verify_host() {
         require_nonempty_file "$EVIDENCE_DIR/iteration-${iteration}-cli-snapshot.txt"
     done
     require_host_declared_suite_logs "$selected_suites" "$iterations"
+    if [ "$capability_results_version" -ge 1 ]; then
+        require_host_capability_results \
+            "$EVIDENCE_DIR/capability-results.tsv" \
+            "$selected_suites" \
+            "$iterations"
+    fi
 
     local metric start final
     for metric in shims mounts box_dirs socket_dirs; do

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -534,8 +534,9 @@ scripts/host-integration-smoke.sh \
   --soak-duration 0
 ```
 
-The evidence directory contains `metadata.txt`, `resource-samples.tsv`, per-step
-iteration logs, CLI state snapshots, `summary.txt`, and `verify.out`. Keep the
+The evidence directory contains `metadata.txt`, `resource-samples.tsv`,
+`capability-results.tsv`, per-step iteration logs, CLI state snapshots,
+`summary.txt`, and `verify.out`. Keep the
 directory with the release candidate when the soak is used as a gate. The runner
 verifies the bundle before returning success, including resource counters and
 required snapshot/log files. `metadata.txt` must include parseable `started_at`,
@@ -553,7 +554,11 @@ does not repeat every `--min-*` option.
 Current host bundles set `host_resource_metrics_version=1` and include
 `a3s_home_bytes`, `process_rss_bytes`, and `process_fd_count` in every resource
 sample. The verifier validates these process-level counters as non-negative
-integers; older bundles without the version key remain readable for migration.
+integers. They also set `host_capability_results_version=1` and write
+`capability-results.tsv`, one row per selected suite and iteration, with start
+and finish timestamps, elapsed seconds, result, and exit code. The verifier
+requires every current row to be a passing, non-overlapping result; older
+bundles without either version key remain readable for migration.
 Failed host soaks write `result=fail` plus the failed
 iteration count and, when available, `exit_code`, `failed_at`, and
 `failed_command`; to re-check a saved bundle, run:

--- a/docs/soak-test-plan.md
+++ b/docs/soak-test-plan.md
@@ -35,7 +35,7 @@ evidence system.
 
 | Entry point | Existing coverage | Current limitation |
 | --- | --- | --- |
-| `scripts/host-integration-smoke.sh --soak` | Repeats real MicroVM core, host command, Dockerfile `RUN`, Compose, CRI, leak, and state-race suites; records host resource counts and verifies evidence | Records independent periodic host samples, including Box-process RSS and FD totals; it still does not report per-capability operation rates |
+| `scripts/host-integration-smoke.sh --soak` | Repeats real MicroVM core, host command, Dockerfile `RUN`, Compose, CRI, leak, and state-race suites; records host resource counts and verifies evidence | Records independent periodic host samples, including Box-process RSS and FD totals, plus per-suite iteration timing/results; it still does not report per-operation rates |
 | `scripts/local-sdk-smoke.sh` | One real Rust/Python/TypeScript/Go pass for MicroVM or certified Sandbox execution, including builders, lifecycle, resources, diagnostics, and snapshots | Functional smoke only; no duration loop, concurrency mix, cancellation, or longitudinal resource gates |
 | `scripts/macos-fault-soak.sh` | Isolated Apple Silicon/HVF lifecycle churn with CLI/shim termination and resource samples | Covers lifecycle recovery, not the complete image/build/storage/network/SDK surface |
 | `scripts/windows-whpx-soak.ps1` | Repeats the eleven Windows-supported real tests and rejects residual A3S Box processes | Uses a Windows-specific summary and has no shared cross-capability verifier or long-term handle/RSS slope gate |

--- a/scripts/host-integration-smoke.sh
+++ b/scripts/host-integration-smoke.sh
@@ -611,6 +611,30 @@ write_resource_sample() {
         "$(a3s_process_fd_count)" >>"$file"
 }
 
+write_capability_results_header() {
+    printf 'iteration\tcapability\tstarted_at\tfinished_at\tduration_secs\tresult\texit_code\n' \
+        >"$SOAK_EVIDENCE_DIR/capability-results.tsv"
+}
+
+append_capability_result() {
+    local iteration="$1"
+    local capability="$2"
+    local started_at="$3"
+    local finished_at="$4"
+    local duration_secs="$5"
+    local result="$6"
+    local exit_code="$7"
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$iteration" \
+        "$capability" \
+        "$started_at" \
+        "$finished_at" \
+        "$duration_secs" \
+        "$result" \
+        "$exit_code" >>"$SOAK_EVIDENCE_DIR/capability-results.tsv"
+}
+
 start_periodic_soak_sampler() {
     if [ "$SOAK_SAMPLE_INTERVAL_SECS" -eq 0 ]; then
         return
@@ -659,6 +683,7 @@ write_soak_metadata() {
         # process-level metrics emitted by current runners while retaining
         # compatibility with older evidence bundles.
         echo "host_resource_metrics_version=1"
+        echo "host_capability_results_version=1"
         echo "soak_verify_min_duration_secs=$SOAK_VERIFY_MIN_DURATION_SECS"
         echo "soak_verify_min_samples=$SOAK_VERIFY_MIN_SAMPLES"
         echo "soak_verify_min_sample_span_secs=$SOAK_VERIFY_MIN_SAMPLE_SPAN_SECS"
@@ -734,12 +759,31 @@ run_soak_step() {
     shift 2
 
     local log_file="$SOAK_EVIDENCE_DIR/iteration-${iteration}-${name}.log"
+    local started_epoch started_at finished_epoch finished_at duration_secs result
+    started_epoch="$(date +%s)"
+    started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     log "Soak iteration $iteration: $name (log: $log_file)"
 
     set +e
     ( "$@" ) >"$log_file" 2>&1
     local rc=$?
     set -e
+    finished_epoch="$(date +%s)"
+    finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    duration_secs=$((finished_epoch - started_epoch))
+    if [ "$rc" -eq 0 ]; then
+        result="pass"
+    else
+        result="fail"
+    fi
+    append_capability_result \
+        "$iteration" \
+        "$name" \
+        "$started_at" \
+        "$finished_at" \
+        "$duration_secs" \
+        "$result" \
+        "$rc"
 
     if [ "$rc" -eq 0 ]; then
         echo "  PASS: $name"
@@ -906,6 +950,7 @@ run_soak_suite() {
 
     log "Writing soak evidence to $SOAK_EVIDENCE_DIR"
     write_soak_metadata
+    write_capability_results_header
     write_resource_sample "start"
     capture_cli_snapshot "start"
     start_periodic_soak_sampler


### PR DESCRIPTION
## Summary
- emit versioned `capability-results.tsv` rows for every selected soak suite and iteration
- record start/finish timestamps, elapsed seconds, result, and exit code
- verify complete, passing, non-overlapping capability coverage while retaining legacy evidence compatibility
- document the speed/stability evidence contract and add malformed-bundle self-tests

## Validation
- `bash -n scripts/host-integration-smoke.sh deploy/scripts/verify-soak-evidence.sh deploy/scripts/soak-evidence-self-test.sh`
- `deploy/scripts/soak-evidence-self-test.sh`
- `git diff --check`
