### PR TITLE
release: prepare a3s-box 3.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+## [3.2.5] — 2026-09-06
+
+### Added
+
+- Soak evidence now records per-capability results and versioned host-resource
+  samples, making long-running runtime checks easier to compare across hosts.
+
 ### Fixed
 
 - Warm-pool shutdown joins in-progress replenishment before draining idle VMs,
@@ -14,6 +21,14 @@ All notable changes to A3S Box will be documented in this file.
 - macOS shim builds stage the fully versioned runtime dylibs and aliases
   without rewriting their already-signed install names. Packaging preserves
   valid code signatures instead of producing libraries rejected by the loader.
+- CRI `RunPodSandbox` smoke requests now use a bounded 120-second
+  cancellation deadline so cold MicroVM boot and guest-native rootfs assembly
+  are not cancelled by a short client default.
+- OCI-only runtime builds keep cleanup and socket-layout support without pulling
+  hypervisor modules into the build; optional scale and Compose test features
+  remain correctly wired.
+- Orphan-sweep integration checks require `/proc` liveness evidence before
+  reclaiming a process, while non-Linux hosts use the safe unit contract.
 
 ## [3.2.4] — 2026-09-05
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,27 @@ unchanged. Windows x86_64 also has an explicit qualification-only
 `microvm`/`all` composition for the externally launched OCI Runtime WHPX
 service; it is not enabled by default and is not yet a production claim.
 
+> **Looking for a lightweight Agent sandbox?** See [`a3s-sandbox`](https://github.com/A3S-Lab/Sandbox).
+> That project focuses on lightweight cross-platform command sandboxing;
+> **A3S Box** focuses on local OCI workloads, Docker-like lifecycle
+> management, and explicit MicroVM or shared-kernel isolation boundaries.
+
+## Current release line
+
+The `3.2.5` release line keeps the public SDK contract stable while packaging
+the latest runtime and integration fixes from `main`:
+
+| Area | Latest behavior |
+| --- | --- |
+| Warm pools | Shutdown joins replenishment and tears down owned VMs with bounded concurrency, preventing orphaned shims and sockets. |
+| CRI | PodSandbox creation defers the agent workload until `StartContainer`, with fail-closed resource validation and a bounded cold-boot smoke deadline. |
+| Runtime builds | OCI-only builds retain durable cleanup and socket handling without hypervisor dependencies. |
+| Evidence | Soak runs record per-capability results and versioned host-resource samples for reproducible comparisons. |
+
+Installers, native binaries, and the Rust, Python, TypeScript, and Go SDK
+artifacts are published from the same versioned release tag. See the
+[Changelog](CHANGELOG.md) for the complete patch history.
+
 > [!NOTE]
 > The current SDK-only Sandbox adapter now covers five exact-generation rails:
 >

--- a/deploy/scripts/install-runtimeclass.sh
+++ b/deploy/scripts/install-runtimeclass.sh
@@ -16,7 +16,7 @@
 # Usage:
 #   install-runtimeclass.sh [--version vX.Y.Z] [--repo OWNER/REPO] [--from-dir DIR]
 #
-#   --version   release tag to install                 (default: v3.2.4)
+#   --version   release tag to install                 (default: v3.2.5)
 #   --repo      GitHub repo to download artifacts from (default: A3S-Lab/Box)
 #   --from-dir  install from a local directory instead of downloading; the dir must
 #               contain a3s-box-<version>-linux-<arch>.tar.gz, its .sha256 file,
@@ -28,7 +28,7 @@
 # Idempotent: safe to re-run (re-installs binaries, rewrites the containerd drop-in).
 set -euo pipefail
 
-VERSION="v3.2.4"
+VERSION="v3.2.5"
 REPO="A3S-Lab/Box"
 FROM_DIR=""
 WARMUP_IMAGE="busybox:latest"   # first box on a fresh node builds a one-time cache

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ guest executable are not separated from `a3s-box`.
 
 | Behavior | Linux/macOS | Windows |
 | --- | --- | --- |
-| Pin a release | `--version v3.2.4` | `-Version v3.2.4` |
+| Pin a release | `--version v3.2.5` | `-Version v3.2.5` |
 | Choose destination | `--install-dir PATH` | `-InstallDir PATH` |
 | Do not change `PATH` | `--no-modify-path` | `-NoModifyPath` |
 | Replace an unmanaged directory | `--force` | `-Force` |
@@ -81,7 +81,7 @@ Pass Unix options after `sh -s --` when using a pipe:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.4 --no-modify-path
+  sh -s -- --version v3.2.5 --no-modify-path
 ```
 
 Invoke the downloaded PowerShell text as a script block when options are
@@ -89,7 +89,7 @@ needed:
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.4 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.5 -NoModifyPath
 ```
 
 The corresponding environment variables are `A3S_BOX_VERSION`,
@@ -108,8 +108,8 @@ Linux or macOS:
 
 ```bash
 sh ./install.sh \
-  --version v3.2.4 \
-  --archive ./a3s-box-v3.2.4-linux-x86_64.tar.gz \
+  --version v3.2.5 \
+  --archive ./a3s-box-v3.2.5-linux-x86_64.tar.gz \
   --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
@@ -117,8 +117,8 @@ Windows:
 
 ```powershell
 .\install.ps1 `
-  -Version v3.2.4 `
-  -ArchivePath .\a3s-box-v3.2.4-windows-x86_64.zip `
+  -Version v3.2.5 `
+  -ArchivePath .\a3s-box-v3.2.5-windows-x86_64.zip `
   -Sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 

--- a/docs/production-cluster-tests.md
+++ b/docs/production-cluster-tests.md
@@ -103,7 +103,7 @@ directory must contain the platform tarball, the matching standalone
 
 ```bash
 sudo deploy/scripts/install-runtimeclass.sh \
-  --version v3.2.4 \
+  --version v3.2.5 \
   --from-dir /opt/a3s-box-artifacts \
   --warmup-image docker.m.daocloud.io/library/busybox:latest
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -48,7 +48,7 @@ function Get-NormalizedTag {
         $number -notmatch '^[0-9A-Za-z.+-]+$' -or
         $number -notmatch '^[^.]+\.[^.]+\.[^.]+'
     ) {
-        throw "Invalid version '$Candidate'; expected a release such as v3.2.4."
+        throw "Invalid version '$Candidate'; expected a release such as v3.2.5."
     }
     return $tag
 }

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ Usage:
   install.sh [options]
 
 Options:
-  --version VERSION       Install a release such as v3.2.4 (default: latest).
+  --version VERSION       Install a release such as v3.2.5 (default: latest).
   --install-dir PATH      Install the self-contained distribution at PATH.
   --archive PATH          Install a local release tarball without downloading.
   --sha256 HEX            Expected SHA-256 for --archive.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "a3s-box"
-version = "3.2.4"
+version = "3.2.5"
 description = "Local-first Python SDK for the native A3S Box Sandbox API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -234,9 +234,9 @@ def response_for(request: Mapping[str, object]) -> dict[str, Any]:
         return {"names": ["old-network"]}
     if operation == "runtime_diagnostics":
         return {
-            "core_version": "3.2.4",
-            "runtime_version": "3.2.4",
-            "sdk_version": "3.2.4",
+            "core_version": "3.2.5",
+            "runtime_version": "3.2.5",
+            "sdk_version": "3.2.5",
             "home": "/tmp/a3s",
             "virtualization": {
                 "available": True,
@@ -1591,7 +1591,7 @@ class AsyncSdkTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(events.next_sequence, 11)
         self.assertEqual(sandboxes[0].id, "sandbox-local-1")
         self.assertEqual(snapshot.id, "ci-async")
-        self.assertEqual(diagnostics.sdk_version, "3.2.4")
+        self.assertEqual(diagnostics.sdk_version, "3.2.5")
         self.assertEqual(disk.snapshots_bytes, 4)
         restart = next(
             request

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/box",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "20.19.9",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Local-first TypeScript SDK for the native A3S Box Sandbox API",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -90,9 +90,9 @@ class FakeRuntime {
         return { names: ['old-network'] }
       case 'runtime_diagnostics':
         return {
-          core_version: '3.2.4',
-          runtime_version: '3.2.4',
-          sdk_version: '3.2.4',
+          core_version: '3.2.5',
+          runtime_version: '3.2.5',
+          sdk_version: '3.2.5',
           home: '/tmp/a3s',
           virtualization: {
             available: true,

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cli"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-core"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "a3s-acl",
  "a3s-common",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cri"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-guest-init"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "a3s-box-core",
  "a3s-common",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-mkext4"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "crc32c",
  "proptest",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-netproxy"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "a3s-box-core",
  "libc",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-runtime"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "a3s-acl",
  "a3s-box-core",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-sdk"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-shim"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-libkrun-sys"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "libc",
  "num_cpus",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 h2 = { path = "third_party/h2" }
 
 [workspace.package]
-version = "3.2.4"
+version = "3.2.5"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -122,7 +122,7 @@ xattr = "1.6"
 # workspace consumers on the same audited source. Keep the exact version
 # because a writer bump is a cache-schema migration rather than a routine
 # dependency update. See third_party/mkext4/A3S_PATCHES.md.
-mkext4 = { package = "a3s-box-mkext4", version = "=3.2.4", path = "../third_party/mkext4" }
+mkext4 = { package = "a3s-box-mkext4", version = "=3.2.5", path = "../third_party/mkext4" }
 
 # TEE attestation verification
 p384 = { workspace = true }

--- a/website/docs/v3/en/guide/installation.mdx
+++ b/website/docs/v3/en/guide/installation.mdx
@@ -64,7 +64,7 @@ a3s-box info
 
 | Behavior                       | Linux/macOS                   | Windows                         |
 | ------------------------------ | ----------------------------- | ------------------------------- |
-| Pin a release                  | `--version v3.2.4`            | `-Version v3.2.4`               |
+| Pin a release                  | `--version v3.2.5`            | `-Version v3.2.5`               |
 | Choose destination             | `--install-dir PATH`          | `-InstallDir PATH`              |
 | Do not change `PATH`           | `--no-modify-path`            | `-NoModifyPath`                 |
 | Replace an unmanaged directory | `--force`                     | `-Force`                        |
@@ -75,14 +75,14 @@ Pass Unix options after `sh -s --`:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.4 --no-modify-path
+  sh -s -- --version v3.2.5 --no-modify-path
 ```
 
 Invoke downloaded PowerShell text as a script block when options are needed:
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.4 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.5 -NoModifyPath
 ```
 
 The corresponding environment variables are `A3S_BOX_VERSION`,

--- a/website/docs/v3/zh/guide/installation.mdx
+++ b/website/docs/v3/zh/guide/installation.mdx
@@ -66,7 +66,7 @@ brew install a3s-lab/tap/a3s-box
 
 | 行为                 | Linux/macOS                   | Windows                         |
 | -------------------- | ----------------------------- | ------------------------------- |
-| 固定版本             | `--version v3.2.4`            | `-Version v3.2.4`               |
+| 固定版本             | `--version v3.2.5`            | `-Version v3.2.5`               |
 | 指定目录             | `--install-dir PATH`          | `-InstallDir PATH`              |
 | 不修改 `PATH`        | `--no-modify-path`            | `-NoModifyPath`                 |
 | 替换非安装器管理目录 | `--force`                     | `-Force`                        |
@@ -77,14 +77,14 @@ brew install a3s-lab/tap/a3s-box
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.4 --no-modify-path
+  sh -s -- --version v3.2.5 --no-modify-path
 ```
 
 Windows 带参数安装：
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.4 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.5 -NoModifyPath
 ```
 
 ## 离线安装
@@ -93,15 +93,15 @@ $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
 
 ```bash
 sh ./install.sh \
-  --version v3.2.4 \
-  --archive ./a3s-box-v3.2.4-linux-x86_64.tar.gz \
+  --version v3.2.5 \
+  --archive ./a3s-box-v3.2.5-linux-x86_64.tar.gz \
   --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 ```powershell
 .\install.ps1 `
-  -Version v3.2.4 `
-  -ArchivePath .\a3s-box-v3.2.4-windows-x86_64.zip `
+  -Version v3.2.5 `
+  -ArchivePath .\a3s-box-v3.2.5-windows-x86_64.zip `
   -Sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 


### PR DESCRIPTION
## Summary

Prepare the next A3S Box patch release, `3.2.5`, from the post-3.2.4 mainline.

- align the Rust workspace, Python package, and TypeScript package versions
- keep the public SDK contract stable while publishing the runtime fixes in the same release artifacts
- document the warm-pool, CRI, OCI-only build, and soak-evidence updates
- clarify that users seeking a lightweight Agent sandbox should use [`a3s-sandbox`](https://github.com/A3S-Lab/Sandbox), while Box targets local OCI workloads and explicit isolation boundaries
- update installer and installation examples to `v3.2.5`

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `cargo test --locked -p a3s-box-core`
- `cargo test --locked -p a3s-box-runtime --lib`
- TypeScript SDK `npm ci --ignore-scripts && npm test`
- README audit via `audit_readme.py`
- Python wheel build succeeded; Python tests require Python 3.10+ and the local machine has Python 3.9
