### PR TITLE
Migrate Sandbox OCI owners into delegated cgroup children

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,6 +581,11 @@ jobs:
         run: |
           cd src
           # Compile as the runner; execute under setpriv (rustc cannot run AT_SECURE).
+          # Match composition: euid==ruid for peer auth, elevate only the owner
+          # child so native-linux-service can bootstrap rootless device policy.
+          sudo chown -R "${A3S_BOX_CI_SANDBOX_UID}:${A3S_BOX_CI_SANDBOX_GID}" "$A3S_HOME"
+          export A3S_BOX_CI_SETPRIV_MATCHED_CREDS=1
+          export A3S_BOX_CI_SETPRIV_WRAPPER="$GITHUB_WORKSPACE/scripts/run-linux-sandbox-ci.sh"
           export A3S_DEPS_STUB=1
           export A3S_HOME
           export A3S_BOX_OCI_RUNTIME_PATH A3S_BOX_OCI_AGENT_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 1e0eba9aba93dbd97d3bd0241faddd47e63c5177
+  A3S_OCI_RUNTIME_REV: 0f6908e5bb01cfe0b056509e4cc30789f3c6a987
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,7 +593,9 @@ jobs:
           bash ../scripts/run-linux-sandbox-cargo-test.sh \
             --locked -p a3s-box-runtime --lib \
             box_runtime_passes_all_advertised_profiles \
-            -- --ignored --nocapture --exact box_runtime_passes_all_advertised_profiles --test-threads=1
+            -- --ignored --nocapture --exact \
+              a3s_runtime_driver::conformance_tests::box_runtime_passes_all_advertised_profiles \
+              --test-threads=1
       - name: Exercise production Box-to-OCI owner composition
         run: |
           cd src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: fb517c6fe7793911c860f07143f6f1b4cb37eae7
+  A3S_OCI_RUNTIME_REV: 1e0eba9aba93dbd97d3bd0241faddd47e63c5177
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,11 +581,9 @@ jobs:
         run: |
           cd src
           # Compile as the runner; execute under setpriv (rustc cannot run AT_SECURE).
-          # Match composition: euid==ruid for peer auth, elevate only the owner
-          # child so native-linux-service can bootstrap rootless device policy.
-          sudo chown -R "${A3S_BOX_CI_SANDBOX_UID}:${A3S_BOX_CI_SANDBOX_GID}" "$A3S_HOME"
-          export A3S_BOX_CI_SETPRIV_MATCHED_CREDS=1
-          export A3S_BOX_CI_SETPRIV_WRAPPER="$GITHUB_WORKSPACE/scripts/run-linux-sandbox-ci.sh"
+          # Keep euid 0 (default setpriv): native-linux-service bootstraps device
+          # policy then drops to the sandbox ruid. Matched creds + elevate wrappers
+          # break inherited control FDs and host mounts required by R17.
           export A3S_DEPS_STUB=1
           export A3S_HOME
           export A3S_BOX_OCI_RUNTIME_PATH A3S_BOX_OCI_AGENT_PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 1e0eba9aba93dbd97d3bd0241faddd47e63c5177
+  A3S_OCI_RUNTIME_REV: 0f6908e5bb01cfe0b056509e4cc30789f3c6a987
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: fb517c6fe7793911c860f07143f6f1b4cb37eae7
+  A3S_OCI_RUNTIME_REV: 1e0eba9aba93dbd97d3bd0241faddd47e63c5177
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ All notable changes to A3S Box will be documented in this file.
   `setpriv` (non-root real UID/GID, effective root) so rootless device-policy
   bootstrap works when the packaged launcher lives on a nosuid `/tmp` mount;
   `A3S_BOX_SANDBOX_DELEGATED_CGROUP_ROOT` overrides the default systemd path.
-- Bump the pinned OCI Runtime revision to `1e0eba9a` so rootless durable
+- Bump the pinned OCI Runtime revision to `0f6908e5` so rootless durable
   owners skip detached `open_tree` RO binds after device-policy drop (Box R17
   mounts profile) while host-service owners keep the previous clone path.
 - Bump the pinned OCI Runtime revision to `fb517c6f` so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ All notable changes to A3S Box will be documented in this file.
   unmount. The controller no longer permanently drops euid after owner spawn —
   it only matches the real UID around OCI SDK connect (`SO_PEERCRED` accept)
   so overlay mounts, TCP endpoint relays, and Runtime state ownership keep
-  effective root / capabilities for the full R17 profile set.
+  effective root / capabilities for the full R17 profile set. Box trees under
+  `A3S_HOME/boxes/<id>` (including rootfs) are still chowned to the real UID so
+  the durable owner can scan device nodes after its own credential drop.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ All notable changes to A3S Box will be documented in this file.
   device nodes after its own credential drop without following rootfs symlinks
   into host packaging paths. Sandbox log workers clear the setpriv euid/ruid
   mismatch before exec and prepend the shim `lib/` dir to `LD_LIBRARY_PATH` so
-  secure-execution mode cannot hide bundled libkrun.
+  secure-execution mode cannot hide bundled libkrun. Crash-recovery / inspect
+  endpoint checks accept real-UID-owned `runtime.sock` under effective-root
+  controllers (same contract as private socket readiness).
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ All notable changes to A3S Box will be documented in this file.
   matches the certified `a3s-oci` artifact (CI installs them as sibling copies).
   Subsequent Sandbox boots restore effective root before overlay mounts so
   multi-case R17 profiles are not stuck without CAP_SYS_ADMIN after the first
-  peer-auth drop.
+  peer-auth drop. Restore only runs when saved UID/GID remain 0 (the
+  `setresuid`/`setresgid` contract), so ordinary unit tests that never dropped
+  do not hit `seteuid(0)` EPERM; after restore, `A3S_HOME` is reclaimed to the
+  current effective owner so Runtime state ownership checks pass.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ All notable changes to A3S Box will be documented in this file.
   `setpriv` (non-root real UID/GID, effective root) so rootless device-policy
   bootstrap works when the packaged launcher lives on a nosuid `/tmp` mount;
   `A3S_BOX_SANDBOX_DELEGATED_CGROUP_ROOT` overrides the default systemd path.
+- Bump the pinned OCI Runtime revision to `1e0eba9a` so rootless durable
+  owners skip detached `open_tree` RO binds after device-policy drop (Box R17
+  mounts profile) while host-service owners keep the previous clone path.
 - Bump the pinned OCI Runtime revision to `fb517c6f` so
   `native-linux-host-service --delegated-cgroup-root` bootstraps rootless
   device policy (required for Sandbox creates through the durable host owner).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ All notable changes to A3S Box will be documented in this file.
   real-UID owner (not `geteuid`) so effective-root harnesses can wait for the
   dropped owner endpoint. After owner spawn the controller drops euid/egid to
   that real identity via `setresuid`/`setresgid` (saved IDs stay 0) so Unix SDK
-  `SO_PEERCRED` same-UID auth succeeds; R17 cleanup restores effective root
-  before deleting prepare-time state trees.
+  `SO_PEERCRED` same-UID auth succeeds; prepare-time `A3S_HOME` trees are
+  reassigned to the real UID first so lifecycle locks remain usable, and R17
+  cleanup can still restore effective root for any leftover root-owned paths.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,14 @@ All notable changes to A3S Box will be documented in this file.
   unmount. The controller no longer permanently drops euid after owner spawn —
   it only matches the real UID around OCI SDK connect (`SO_PEERCRED` accept)
   so overlay mounts, TCP endpoint relays, and Runtime state ownership keep
-  effective root / capabilities for the full R17 profile set. Box trees under
-  `A3S_HOME/boxes/<id>` (including rootfs) are still chowned to the real UID so
-  the durable owner can scan device nodes after its own credential drop.
+  effective root / capabilities for the full R17 profile set. Temporary
+  peer-auth `seteuid` uses `PR_SET_KEEPCAPS` so permitted capabilities survive
+  the round-trip. Box trees under `A3S_HOME/boxes/<id>` (including rootfs) are
+  still chowned with `lchown` to the real UID so the durable owner can scan
+  device nodes after its own credential drop without following rootfs symlinks
+  into host packaging paths. Sandbox log workers clear the setpriv euid/ruid
+  mismatch before exec and prepend the shim `lib/` dir to `LD_LIBRARY_PATH` so
+  secure-execution mode cannot hide bundled libkrun.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ All notable changes to A3S Box will be documented in this file.
   also assign the service-root parent to the real UID before spawn so
   `prepare_private_directory` succeeds after rootless device-policy drop; R17
   keeps euid 0 (no setpriv elevate wrapper) so inherited `--a3s-box-control-fds`
-  remain Unix stream listeners.
+  remain Unix stream listeners. Private runtime socket readiness accepts the
+  real-UID owner (not `geteuid`) so effective-root harnesses can wait for the
+  dropped owner endpoint.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ All notable changes to A3S Box will be documented in this file.
   reassigned to the real UID first so lifecycle locks remain usable, and R17
   cleanup can still restore effective root for any leftover root-owned paths.
   Capability probing under effective root plans rootless UID/GID mappings for
-  the real UID so the bundle matches the post-bootstrap owner identity.
+  the real UID so the bundle matches the post-bootstrap owner identity. Owner
+  identity checks accept the Sandbox OCI launcher executable when its digest
+  matches the certified `a3s-oci` artifact (CI installs them as sibling copies).
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ All notable changes to A3S Box will be documented in this file.
 - Linux Sandbox `native-linux-service` owners now migrate into a child of the
   empty delegated cgroup root before exec, matching host-service composition.
   Advertised Runtime profiles can start when the CI harness lives in a sibling
-  probe cgroup rather than under the delegated tree.
+  probe cgroup rather than under the delegated tree. The same matched-cred /
+  setpriv-wrapper elevation used for host-service composition is applied so
+  rootless device-policy bootstrap can succeed on nosuid CI mounts.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ All notable changes to A3S Box will be documented in this file.
   keeps euid 0 (no setpriv elevate wrapper) so inherited `--a3s-box-control-fds`
   remain Unix stream listeners. Private runtime socket readiness accepts the
   real-UID owner (not `geteuid`) so effective-root harnesses can wait for the
-  dropped owner endpoint.
+  dropped owner endpoint. After owner spawn the controller permanently drops
+  euid/egid to that real identity so Unix SDK `SO_PEERCRED` same-UID auth
+  succeeds without matched-cred setpriv (which would break control-FD inheritance).
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,13 +46,13 @@ All notable changes to A3S Box will be documented in this file.
   so overlay mounts, TCP endpoint relays, and Runtime state ownership keep
   effective root / capabilities for the full R17 profile set. Temporary
   peer-auth `seteuid` uses `PR_SET_KEEPCAPS` so permitted capabilities survive
-  the round-trip. The prepared `boxes/<id>/rootfs` tree is chowned with `lchown`
-  to the real UID (skipping `EROFS` bind attachments) so the durable owner can
-  scan device nodes after its own credential drop without following rootfs
-  symlinks into host packaging paths or failing on read-only mounts. Sandbox
-  log workers clear the setpriv euid/ruid mismatch before exec and prepend the
-  shim `lib/` dir to `LD_LIBRARY_PATH` so secure-execution mode cannot hide
-  bundled libkrun. Crash-recovery / inspect endpoint checks accept
+  the round-trip. Box trees under `A3S_HOME/boxes/<id>` are chowned with `lchown`
+  to the real UID so the durable owner can scan device nodes after its own
+  credential drop; recursion skips `sandbox/attachments` bind mounts and
+  ignores `EROFS` so R17 read-only volume cases cannot fail the handoff.
+  Sandbox log workers clear the setpriv euid/ruid mismatch before exec and
+  prepend the shim `lib/` dir to `LD_LIBRARY_PATH` so secure-execution mode
+  cannot hide bundled libkrun. Crash-recovery / inspect endpoint checks accept
   real-UID-owned `runtime.sock` under effective-root controllers (same contract
   as private socket readiness).
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,10 @@ All notable changes to A3S Box will be documented in this file.
   and PTY control sockets under `/tmp/a3s-box-sockets` are chowned to the real
   UID after bind so post-drop readiness heartbeats can connect to mode `0600`
   endpoints; boot-failure cleanup also restores effective root before overlay
-  unmount.
+  unmount. The controller no longer permanently drops euid after owner spawn —
+  it only matches the real UID around OCI SDK connect (`SO_PEERCRED` accept)
+  so overlay mounts, TCP endpoint relays, and Runtime state ownership keep
+  effective root / capabilities for the full R17 profile set.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ All notable changes to A3S Box will be documented in this file.
   keeps euid 0 (no setpriv elevate wrapper) so inherited `--a3s-box-control-fds`
   remain Unix stream listeners. Private runtime socket readiness accepts the
   real-UID owner (not `geteuid`) so effective-root harnesses can wait for the
-  dropped owner endpoint. After owner spawn the controller permanently drops
-  euid/egid to that real identity so Unix SDK `SO_PEERCRED` same-UID auth
-  succeeds without matched-cred setpriv (which would break control-FD inheritance).
+  dropped owner endpoint. After owner spawn the controller drops euid/egid to
+  that real identity via `setresuid`/`setresgid` (saved IDs stay 0) so Unix SDK
+  `SO_PEERCRED` same-UID auth succeeds; R17 cleanup restores effective root
+  before deleting prepare-time state trees.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,14 +46,15 @@ All notable changes to A3S Box will be documented in this file.
   so overlay mounts, TCP endpoint relays, and Runtime state ownership keep
   effective root / capabilities for the full R17 profile set. Temporary
   peer-auth `seteuid` uses `PR_SET_KEEPCAPS` so permitted capabilities survive
-  the round-trip. Box trees under `A3S_HOME/boxes/<id>` (including rootfs) are
-  still chowned with `lchown` to the real UID so the durable owner can scan
-  device nodes after its own credential drop without following rootfs symlinks
-  into host packaging paths. Sandbox log workers clear the setpriv euid/ruid
-  mismatch before exec and prepend the shim `lib/` dir to `LD_LIBRARY_PATH` so
-  secure-execution mode cannot hide bundled libkrun. Crash-recovery / inspect
-  endpoint checks accept real-UID-owned `runtime.sock` under effective-root
-  controllers (same contract as private socket readiness).
+  the round-trip. The prepared `boxes/<id>/rootfs` tree is chowned with `lchown`
+  to the real UID (skipping `EROFS` bind attachments) so the durable owner can
+  scan device nodes after its own credential drop without following rootfs
+  symlinks into host packaging paths or failing on read-only mounts. Sandbox
+  log workers clear the setpriv euid/ruid mismatch before exec and prepend the
+  shim `lib/` dir to `LD_LIBRARY_PATH` so secure-execution mode cannot hide
+  bundled libkrun. Crash-recovery / inspect endpoint checks accept
+  real-UID-owned `runtime.sock` under effective-root controllers (same contract
+  as private socket readiness).
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,11 @@ All notable changes to A3S Box will be documented in this file.
   peer-auth drop. Restore only runs when saved UID/GID remain 0 (the
   `setresuid`/`setresgid` contract), so ordinary unit tests that never dropped
   do not hit `seteuid(0)` EPERM; after restore, `A3S_HOME` is reclaimed to the
-  current effective owner so Runtime state ownership checks pass.
+  current effective owner so Runtime state ownership checks pass. Sandbox exec
+  and PTY control sockets under `/tmp/a3s-box-sockets` are chowned to the real
+  UID after bind so post-drop readiness heartbeats can connect to mode `0600`
+  endpoints; boot-failure cleanup also restores effective root before overlay
+  unmount.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ All notable changes to A3S Box will be documented in this file.
 - Linux Sandbox `native-linux-service` owners now migrate into a child of the
   empty delegated cgroup root before exec, matching host-service composition.
   Advertised Runtime profiles can start when the CI harness lives in a sibling
-  probe cgroup rather than under the delegated tree. The same matched-cred /
-  setpriv-wrapper elevation used for host-service composition is applied so
-  rootless device-policy bootstrap can succeed on nosuid CI mounts.
+  probe cgroup rather than under the delegated tree. Effective-root launchers
+  also assign the service-root parent to the real UID before spawn so
+  `prepare_private_directory` succeeds after rootless device-policy drop; R17
+  keeps euid 0 (no setpriv elevate wrapper) so inherited `--a3s-box-control-fds`
+  remain Unix stream listeners.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to A3S Box will be documented in this file.
   `SO_PEERCRED` same-UID auth succeeds; prepare-time `A3S_HOME` trees are
   reassigned to the real UID first so lifecycle locks remain usable, and R17
   cleanup can still restore effective root for any leftover root-owned paths.
+  Capability probing under effective root plans rootless UID/GID mappings for
+  the real UID so the bundle matches the post-bootstrap owner identity.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ All notable changes to A3S Box will be documented in this file.
   the real UID so the bundle matches the post-bootstrap owner identity. Owner
   identity checks accept the Sandbox OCI launcher executable when its digest
   matches the certified `a3s-oci` artifact (CI installs them as sibling copies).
+  Subsequent Sandbox boots restore effective root before overlay mounts so
+  multi-case R17 profiles are not stuck without CAP_SYS_ADMIN after the first
+  peer-auth drop.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Linux Sandbox `native-linux-service` owners now migrate into a child of the
+  empty delegated cgroup root before exec, matching host-service composition.
+  Advertised Runtime profiles can start when the CI harness lives in a sibling
+  probe cgroup rather than under the delegated tree.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=fb517c6fe7793911c860f07143f6f1b4cb37eae7#fb517c6fe7793911c860f07143f6f1b4cb37eae7"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=1e0eba9aba93dbd97d3bd0241faddd47e63c5177#1e0eba9aba93dbd97d3bd0241faddd47e63c5177"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=fb517c6fe7793911c860f07143f6f1b4cb37eae7#fb517c6fe7793911c860f07143f6f1b4cb37eae7"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=1e0eba9aba93dbd97d3bd0241faddd47e63c5177#1e0eba9aba93dbd97d3bd0241faddd47e63c5177"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=1e0eba9aba93dbd97d3bd0241faddd47e63c5177#1e0eba9aba93dbd97d3bd0241faddd47e63c5177"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0f6908e5bb01cfe0b056509e4cc30789f3c6a987#0f6908e5bb01cfe0b056509e4cc30789f3c6a987"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=1e0eba9aba93dbd97d3bd0241faddd47e63c5177#1e0eba9aba93dbd97d3bd0241faddd47e63c5177"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=0f6908e5bb01cfe0b056509e4cc30789f3c6a987#0f6908e5bb01cfe0b056509e4cc30789f3c6a987"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "fb517c6fe7793911c860f07143f6f1b4cb37eae7" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "1e0eba9aba93dbd97d3bd0241faddd47e63c5177" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "1e0eba9aba93dbd97d3bd0241faddd47e63c5177" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "0f6908e5bb01cfe0b056509e4cc30789f3c6a987" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/runtime/examples/linux_kvm_oci_qualification.rs
+++ b/src/runtime/examples/linux_kvm_oci_qualification.rs
@@ -527,7 +527,10 @@ mod qualification {
                 report.restart_observed_running = true;
                 break;
             }
-            if matches!(status.state, ExecutionState::Failed | ExecutionState::Stopped) {
+            if matches!(
+                status.state,
+                ExecutionState::Failed | ExecutionState::Stopped
+            ) {
                 return Err(failure(
                     "runtime-restart generation left running before Host Service SIGKILL",
                 ));
@@ -654,7 +657,10 @@ mod qualification {
         Ok(())
     }
 
-    fn restart_host_service(service: &ServiceRestartInputs, endpoint: &Path) -> Result<(), AnyError> {
+    fn restart_host_service(
+        service: &ServiceRestartInputs,
+        endpoint: &Path,
+    ) -> Result<(), AnyError> {
         // SAFETY: qualification-only SIGKILL of the exact operator-supplied pid.
         let kill_rc = unsafe { libc::kill(service.pid as i32, libc::SIGKILL) };
         if kill_rc != 0 {
@@ -732,10 +738,8 @@ mod qualification {
     }
 
     async fn connect(inputs: &Inputs) -> Result<LocalExecutionManager, AnyError> {
-        let config = LinuxKvmOciMigrationConfig::new(
-            inputs.runtime_root.clone(),
-            inputs.endpoint.clone(),
-        )?;
+        let config =
+            LinuxKvmOciMigrationConfig::new(inputs.runtime_root.clone(), inputs.endpoint.clone())?;
         Ok(LocalExecutionManager::with_linux_kvm_oci_qualification(
             &inputs.state_path,
             &inputs.home_dir,

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -650,10 +650,10 @@ impl BoxRuntimeConformanceFixture {
         }
 
         // Sandbox controller drops euid to the real UID for SO_PEERCRED after
-        // owner spawn, retaining saved UID 0. Restore before deleting state
-        // trees created as effective root during prepare.
+        // owner spawn (saved UID stays 0). Restore before deleting any
+        // prepare-time trees that remain root-owned.
         #[cfg(target_os = "linux")]
-        if let Err(error) = crate::sandbox::restore_effective_root_if_saved() {
+        if let Err(error) = crate::sandbox::a3s_oci_controller::restore_effective_root_if_saved() {
             failures.push(format!("restore effective root for R17 cleanup: {error}"));
         }
 

--- a/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
+++ b/src/runtime/src/a3s_runtime_driver/conformance_tests/fixture.rs
@@ -649,6 +649,14 @@ impl BoxRuntimeConformanceFixture {
             }
         }
 
+        // Sandbox controller drops euid to the real UID for SO_PEERCRED after
+        // owner spawn, retaining saved UID 0. Restore before deleting state
+        // trees created as effective root during prepare.
+        #[cfg(target_os = "linux")]
+        if let Err(error) = crate::sandbox::restore_effective_root_if_saved() {
+            failures.push(format!("restore effective root for R17 cleanup: {error}"));
+        }
+
         for root in self.state_roots.lock().unwrap().iter() {
             if let Err(error) = remove_tree(root) {
                 failures.push(format!("remove Runtime state {}: {error}", root.display()));

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -1366,7 +1366,10 @@ impl OciBundleProvider for FakeBundleProvider {
         _binding: &OciRuntimeBinding,
     ) -> ExecutionManagerResult<()> {
         self.projection_ensures.fetch_add(1, Ordering::SeqCst);
-        if self.fail_projection_exited_before_drain.load(Ordering::SeqCst) {
+        if self
+            .fail_projection_exited_before_drain
+            .load(Ordering::SeqCst)
+        {
             return Err(ExecutionManagerError::Unavailable(
                 "managed OCI log worker for fake generation 1 exited before drain; refusing to replay its Box log projection".to_string(),
             ));

--- a/src/runtime/src/local_execution/oci_portable_rootfs.rs
+++ b/src/runtime/src/local_execution/oci_portable_rootfs.rs
@@ -634,7 +634,11 @@ mod tests {
 
         publish_portable_bundle(&source, &spec, &bundle).unwrap();
 
-        let mode = std::fs::symlink_metadata(&bundle).unwrap().permissions().mode() & 0o777;
+        let mode = std::fs::symlink_metadata(&bundle)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
         assert_eq!(mode, 0o700);
         let operation_mode = std::fs::symlink_metadata(bundle.parent().unwrap())
             .unwrap()
@@ -651,12 +655,17 @@ mod tests {
         assert!(bundle.join("config.json").is_file());
         assert!(bundle.join("rootfs").is_dir());
         assert!(
-            !bundle.join("rootfs").join(PORTABLE_ROOTFS_METADATA_FILE).exists(),
+            !bundle
+                .join("rootfs")
+                .join(PORTABLE_ROOTFS_METADATA_FILE)
+                .exists(),
             "default Spec must not publish portable rootfs metadata"
         );
     }
 
-    fn portable_bundle_fixture(temporary: &tempfile::TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
+    fn portable_bundle_fixture(
+        temporary: &tempfile::TempDir,
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
         let source = temporary.path().join("source-rootfs");
         std::fs::create_dir_all(&source).unwrap();
         write_source(
@@ -695,13 +704,23 @@ mod tests {
         let (source, bundle) = portable_bundle_fixture(&temporary);
 
         publish_portable_bundle(&source, &Spec::default(), &bundle).unwrap();
-        assert!(!bundle.join("rootfs").join(PORTABLE_ROOTFS_METADATA_FILE).exists());
+        assert!(!bundle
+            .join("rootfs")
+            .join(PORTABLE_ROOTFS_METADATA_FILE)
+            .exists());
 
         let temporary = tempfile::tempdir().unwrap();
         let (source, bundle) = portable_bundle_fixture(&temporary);
-        publish_portable_bundle(&source, &spec_requesting_portable_rootfs_metadata(), &bundle)
-            .unwrap();
-        assert!(bundle.join("rootfs").join(PORTABLE_ROOTFS_METADATA_FILE).is_file());
+        publish_portable_bundle(
+            &source,
+            &spec_requesting_portable_rootfs_metadata(),
+            &bundle,
+        )
+        .unwrap();
+        assert!(bundle
+            .join("rootfs")
+            .join(PORTABLE_ROOTFS_METADATA_FILE)
+            .is_file());
         assert!(!bundle
             .join("rootfs")
             .join(IMAGE_ROOTFS_METADATA_PATH.trim_start_matches('/'))
@@ -728,6 +747,9 @@ mod tests {
             .unwrap();
 
         publish_portable_bundle(&source, &spec, &bundle).unwrap();
-        assert!(!bundle.join("rootfs").join(PORTABLE_ROOTFS_METADATA_FILE).exists());
+        assert!(!bundle
+            .join("rootfs")
+            .join(PORTABLE_ROOTFS_METADATA_FILE)
+            .exists());
     }
 }

--- a/src/runtime/src/local_execution/remove.rs
+++ b/src/runtime/src/local_execution/remove.rs
@@ -106,6 +106,15 @@ impl LocalExecutionManager {
 fn cleanup_execution_paths(home_dir: &Path, record: &BoxRecord) -> ExecutionManagerResult<()> {
     validate_owned_paths(home_dir, record)?;
 
+    // Sandbox peer-auth may have dropped this process to the real UID. Overlay
+    // unmount and mount-alias detach need effective root / CAP_SYS_ADMIN.
+    #[cfg(target_os = "linux")]
+    crate::sandbox::a3s_oci_controller::restore_effective_root_if_saved().map_err(|error| {
+        ExecutionManagerError::Internal(format!(
+            "failed to restore effective root before execution cleanup: {error}"
+        ))
+    })?;
+
     if record.isolation.is_sandbox() {
         #[cfg(feature = "vm")]
         crate::vm::reap::cleanup_recorded_sandbox_runtime_in(home_dir, &record.box_dir, &record.id)

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -784,7 +784,7 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
             // dead-end on "already has an in-process runtime owner".
             self.remove_manager(&record.id, &manager);
             return Err(ExecutionManagerError::Unavailable(format!(
-                "execution {} completed during startup",
+                "execution {} completed during startup (exit_code={exit_code:?})",
                 record.id
             )));
         }

--- a/src/runtime/src/local_execution/vm_backend.rs
+++ b/src/runtime/src/local_execution/vm_backend.rs
@@ -747,7 +747,7 @@ impl LocalExecutionBackend for VmLocalExecutionBackend {
                 drop(guard);
                 self.remove_manager(&record.id, &manager);
                 return Err(ExecutionManagerError::Unavailable(format!(
-                    "execution {} completed during startup",
+                    "execution {} completed during startup ({error})",
                     record.id
                 )));
             }

--- a/src/runtime/src/sandbox/a3s_oci_client.rs
+++ b/src/runtime/src/sandbox/a3s_oci_client.rs
@@ -229,10 +229,19 @@ fn run_client_worker(
             return;
         }
     };
-    let client = match runtime.block_on(RuntimeClient::connect(&endpoint)) {
-        Ok(client) => client,
-        Err(error) => {
+    let client = match super::a3s_oci_controller::with_real_owner_euid(|| {
+        runtime.block_on(RuntimeClient::connect(&endpoint))
+    }) {
+        Ok(Ok(client)) => client,
+        Ok(Err(error)) => {
             let _ = ready.send(Err(error));
+            return;
+        }
+        Err(error) => {
+            let _ = ready.send(Err(a3s_oci_sdk::Error::new(
+                a3s_oci_sdk::ErrorCode::PermissionDenied,
+                error.to_string(),
+            )));
             return;
         }
     };

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -147,12 +147,10 @@ impl A3sOciController {
         drop((inherited_exec, inherited_pty, inherited_log));
         drop((exec_listener, pty_listener, init_log));
 
-        // Owner inherits effective root for device-policy bootstrap, then drops
-        // to the real UID before publishing the SDK socket. Hand prepare-time
-        // home/state trees to that UID first so lifecycle locks and Runtime
-        // state remain writable after the controller matches SO_PEERCRED.
-        reassign_sandbox_home_to_real_owner()?;
-        drop_effective_root_to_real_owner()?;
+        // Keep the controller at effective root for overlay mounts, network
+        // relays, and Runtime state ownership. SO_PEERCRED is checked only at
+        // SDK connect time — [`super::a3s_oci_client`] temporarily matches the
+        // real UID for that handshake.
 
         let owner_pid = owner.id();
         let owner_pid_start_time = crate::process::pid_start_time(owner_pid).ok_or_else(|| {
@@ -609,15 +607,18 @@ fn expected_owner_uid() -> u32 {
     expected_owner_ids().0
 }
 
-/// Match the Sandbox controller to the post-bootstrap owner UID for SDK auth.
+/// Temporarily match the real UID/GID for Unix SDK `SO_PEERCRED` handshakes.
 ///
-/// Effective-root CI / setuid launchers keep euid 0 through rootfs prep and
-/// owner spawn so `native-linux-service` can install the device-policy helper.
-/// After spawn, the owner drops to the real UID and rejects other peer UIDs on
-/// the SDK socket. Keep saved UID/GID 0 so callers can restore effective root
-/// when they still need to delete prepare-time trees that escaped reassignment.
-fn drop_effective_root_to_real_owner() -> Result<()> {
-    let (ruid, rgid, euid, _egid) = unsafe {
+/// Effective-root CI / setuid launchers keep euid 0 for mounts and network
+/// relays. The durable OCI owner publishes its SDK socket as the real UID, so
+/// connect must briefly match that identity. Peer auth is checked only at
+/// accept time; credentials are restored before returning.
+pub(crate) fn with_real_owner_euid<T, F>(f: F) -> Result<T>
+where
+    F: FnOnce() -> T,
+{
+    // SAFETY: credential queries have no pointer arguments or failure results.
+    let (ruid, rgid, euid, egid) = unsafe {
         (
             libc::getuid(),
             libc::getgid(),
@@ -626,49 +627,55 @@ fn drop_effective_root_to_real_owner() -> Result<()> {
         )
     };
     if euid != 0 || ruid == 0 {
-        return Ok(());
+        return Ok(f());
     }
-    // SAFETY: setresgid/setresuid take gid_t/uid_t; keep saved IDs at 0 so the
-    // process can restore effective root for cleanup without CAP_SETUID.
-    if unsafe { libc::setresgid(rgid, rgid, 0) } != 0 {
+    // SAFETY: seteuid/setegid use the retained saved IDs from setpriv / setuid.
+    if unsafe { libc::setegid(rgid) } != 0 {
         return Err(BoxError::BoxBootError {
             message: format!(
-                "failed to drop Sandbox controller to rgid {rgid} (saved 0): {}",
+                "failed to match Sandbox controller egid {rgid} for SDK peer auth: {}",
                 std::io::Error::last_os_error()
             ),
             hint: None,
         });
     }
-    if unsafe { libc::setresuid(ruid, ruid, 0) } != 0 {
+    if unsafe { libc::seteuid(ruid) } != 0 {
+        let _ = unsafe { libc::setegid(egid) };
         return Err(BoxError::BoxBootError {
             message: format!(
-                "failed to drop Sandbox controller to ruid {ruid} (saved 0): {}",
+                "failed to match Sandbox controller euid {ruid} for SDK peer auth: {}",
                 std::io::Error::last_os_error()
             ),
             hint: None,
         });
     }
-    Ok(())
-}
-
-fn reassign_sandbox_home_to_real_owner() -> Result<()> {
-    let euid = unsafe { libc::geteuid() };
-    let ruid = unsafe { libc::getuid() };
-    if euid != 0 || ruid == 0 {
-        return Ok(());
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    let restore_gid = unsafe { libc::setegid(0) };
+    let restore_uid = unsafe { libc::seteuid(0) };
+    if restore_gid != 0 || restore_uid != 0 {
+        return Err(BoxError::BoxBootError {
+            message: format!(
+                "failed to restore Sandbox controller effective root after SDK peer auth: {}",
+                std::io::Error::last_os_error()
+            ),
+            hint: None,
+        });
     }
-    let Some(home) = std::env::var_os("A3S_HOME").filter(|value| !value.is_empty()) else {
-        return Ok(());
-    };
-    chown_tree_to_ids(Path::new(&home), expected_owner_ids())
+    match result {
+        Ok(value) => Ok(value),
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
 }
 
 fn chown_to_real_owner(path: &Path) -> Result<()> {
     chown_path_to_ids(path, expected_owner_ids())
 }
 
-/// Restore effective root when saved UID 0 was retained by
-/// [`drop_effective_root_to_real_owner`].
+/// No-op unless a process permanently dropped via saved-UID retention.
+///
+/// Controllers prefer [`with_real_owner_euid`] around SDK connect, so this is
+/// typically unused. Teardown paths still call it for older permanent-drop
+/// sequences.
 pub(crate) fn restore_effective_root_if_saved() -> Result<()> {
     let (ruid, euid, saved_uid, saved_gid) = {
         let mut ruid = 0;
@@ -693,11 +700,9 @@ pub(crate) fn restore_effective_root_if_saved() -> Result<()> {
         (ruid, euid, saved_uid, saved_gid)
     };
     if euid == 0 || ruid == 0 || saved_uid != 0 || saved_gid != 0 {
-        // Already effective root, or this process never retained saved root via
-        // setresuid/setresgid from [`drop_effective_root_to_real_owner`].
         return Ok(());
     }
-    // SAFETY: seteuid/setegid use the retained saved IDs from setresuid/setresgid.
+    // SAFETY: seteuid/setegid use the retained saved IDs.
     if unsafe { libc::setegid(0) } != 0 {
         return Err(BoxError::BoxBootError {
             message: format!(
@@ -715,34 +720,6 @@ pub(crate) fn restore_effective_root_if_saved() -> Result<()> {
             ),
             hint: None,
         });
-    }
-    // Prepare-time state trees were handed to the real UID for peer-auth; reclaim
-    // them for effective-root mounts and Runtime state ownership checks.
-    reassign_sandbox_home_to_current_effective_owner()?;
-    Ok(())
-}
-
-fn reassign_sandbox_home_to_current_effective_owner() -> Result<()> {
-    let Some(home) = std::env::var_os("A3S_HOME").filter(|value| !value.is_empty()) else {
-        return Ok(());
-    };
-    chown_tree_to_ids(Path::new(&home), unsafe {
-        (libc::geteuid(), libc::getegid())
-    })
-}
-
-fn chown_tree_to_ids(path: &Path, ids: (u32, u32)) -> Result<()> {
-    if !path.exists() {
-        return Ok(());
-    }
-    chown_path_to_ids(path, ids)?;
-    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
-    if !metadata.is_dir() || metadata.file_type().is_symlink() {
-        return Ok(());
-    }
-    for entry in std::fs::read_dir(path).map_err(BoxError::IoError)? {
-        let entry = entry.map_err(BoxError::IoError)?;
-        chown_tree_to_ids(&entry.path(), ids)?;
     }
     Ok(())
 }

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -62,7 +62,17 @@ impl A3sOciController {
         // Effective-root CI / setuid launchers create paths as euid 0. After
         // RootlessDevicePolicyBootstrap drops to the real UID, native-linux-service
         // requires the service root parent to be owned by that UID (mode 0700).
+        // Chown the sockets root too: create_dir_all leaves it root:0700 and the
+        // post-drop controller cannot traverse or remove children otherwise.
         chown_to_real_owner(runtime_parent)?;
+        if let Some(sockets_root) = runtime_parent.parent() {
+            if sockets_root
+                .file_name()
+                .is_some_and(|name| name == "a3s-box-sockets")
+            {
+                chown_to_real_owner(sockets_root)?;
+            }
+        }
 
         let exec_listener = bind_control_listener(&launch.exec_socket_path)?;
         let pty_listener = bind_control_listener(&launch.pty_socket_path)?;

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -132,8 +132,10 @@ impl A3sOciController {
         drop((exec_listener, pty_listener, init_log));
 
         // Owner inherits effective root for device-policy bootstrap, then drops
-        // to the real UID before publishing the SDK socket. Match that durable
-        // identity here so SO_PEERCRED same-UID auth accepts the controller.
+        // to the real UID before publishing the SDK socket. Hand prepare-time
+        // home/state trees to that UID first so lifecycle locks and Runtime
+        // state remain writable after the controller matches SO_PEERCRED.
+        reassign_sandbox_home_to_real_owner()?;
         drop_effective_root_to_real_owner()?;
 
         let owner_pid = owner.id();
@@ -620,8 +622,8 @@ fn expected_owner_uid() -> u32 {
 /// Effective-root CI / setuid launchers keep euid 0 through rootfs prep and
 /// owner spawn so `native-linux-service` can install the device-policy helper.
 /// After spawn, the owner drops to the real UID and rejects other peer UIDs on
-/// the SDK socket. Keep saved UID/GID 0 so fixture cleanup can restore
-/// effective root and remove state created before the drop.
+/// the SDK socket. Keep saved UID/GID 0 so callers can restore effective root
+/// when they still need to delete prepare-time trees that escaped reassignment.
 fn drop_effective_root_to_real_owner() -> Result<()> {
     let (ruid, rgid, euid, _egid) = unsafe {
         (
@@ -657,8 +659,37 @@ fn drop_effective_root_to_real_owner() -> Result<()> {
     Ok(())
 }
 
+fn reassign_sandbox_home_to_real_owner() -> Result<()> {
+    let euid = unsafe { libc::geteuid() };
+    let ruid = unsafe { libc::getuid() };
+    if euid != 0 || ruid == 0 {
+        return Ok(());
+    }
+    let Some(home) = std::env::var_os("A3S_HOME").filter(|value| !value.is_empty()) else {
+        return Ok(());
+    };
+    chown_tree_to_real_owner(Path::new(&home))
+}
+
+fn chown_tree_to_real_owner(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    chown_to_real_owner(path)?;
+    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(path).map_err(BoxError::IoError)? {
+        let entry = entry.map_err(BoxError::IoError)?;
+        chown_tree_to_real_owner(&entry.path())?;
+    }
+    Ok(())
+}
+
 /// Restore effective root when saved UID 0 was retained by
 /// [`drop_effective_root_to_real_owner`].
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn restore_effective_root_if_saved() -> Result<()> {
     let (ruid, euid) = unsafe { (libc::getuid(), libc::geteuid()) };
     if euid == 0 || ruid == 0 {

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -148,9 +148,15 @@ impl A3sOciController {
         drop((exec_listener, pty_listener, init_log));
 
         // Keep the controller at effective root for overlay mounts, network
-        // relays, and Runtime state ownership. SO_PEERCRED is checked only at
-        // SDK connect time — [`super::a3s_oci_client`] temporarily matches the
-        // real UID for that handshake.
+        // relays, and Runtime state ownership. The durable OCI owner scans the
+        // prepared rootfs as the real UID after device-policy drop, so hand that
+        // box tree (not Runtime state) to the real owner before create.
+        if let Some(box_dir) = launch.bundle_dir.ancestors().nth(2) {
+            chown_tree_to_ids(box_dir, expected_owner_ids())?;
+        }
+        // SO_PEERCRED is checked only at SDK connect time —
+        // [`super::a3s_oci_client`] temporarily matches the real UID for that
+        // handshake.
 
         let owner_pid = owner.id();
         let owner_pid_start_time = crate::process::pid_start_time(owner_pid).ok_or_else(|| {
@@ -669,6 +675,22 @@ where
 
 fn chown_to_real_owner(path: &Path) -> Result<()> {
     chown_path_to_ids(path, expected_owner_ids())
+}
+
+fn chown_tree_to_ids(path: &Path, ids: (u32, u32)) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    chown_path_to_ids(path, ids)?;
+    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(path).map_err(BoxError::IoError)? {
+        let entry = entry.map_err(BoxError::IoError)?;
+        chown_tree_to_ids(&entry.path(), ids)?;
+    }
+    Ok(())
 }
 
 /// No-op unless a process permanently dropped via saved-UID retention.

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -3,7 +3,7 @@
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::os::unix::process::CommandExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -74,6 +74,7 @@ impl A3sOciController {
         let log_fd = inherited_log.as_raw_fd();
 
         let delegated_cgroup_root = linux_sandbox_delegated_cgroup_root();
+        let owner_cgroup = prepare_sandbox_delegation_child()?;
         let launcher = resolve_sandbox_oci_launcher(None)?;
         let mut command = Command::new(&launcher);
         command
@@ -94,8 +95,14 @@ impl A3sOciController {
 
         // Sources are duplicated above 10, so installing the fixed Box roles
         // cannot clobber another source. `dup2` clears CLOEXEC on 3/4/5.
+        // Migrate into a child below the empty delegated root so rootless open
+        // accepts host-owned membership without moving the Sandbox CI harness
+        // out of its probe cgroup.
         unsafe {
             command.pre_exec(move || {
+                if let Some(ref cgroup) = owner_cgroup {
+                    migrate_current_task_into_cgroup(cgroup)?;
+                }
                 for (source, destination) in [
                     (exec_fd, EXEC_LISTENER_FD),
                     (pty_fd, PTY_LISTENER_FD),
@@ -478,6 +485,109 @@ fn sdk_boot_error(error: a3s_oci_sdk::Error) -> BoxError {
     }
 }
 
+fn prepare_sandbox_delegation_child() -> Result<Option<PathBuf>> {
+    prepare_sandbox_delegation_child_in(PathBuf::from(linux_sandbox_delegated_cgroup_root()))
+}
+
+fn prepare_sandbox_delegation_child_in(root: PathBuf) -> Result<Option<PathBuf>> {
+    if !root.is_dir() {
+        return Ok(None);
+    }
+    let child = root.join(format!("box-sandbox-owner-{}", std::process::id()));
+    std::fs::create_dir_all(&child).map_err(|error| BoxError::BoxBootError {
+        message: format!(
+            "failed to create Sandbox OCI owner cgroup {}: {error}",
+            child.display()
+        ),
+        hint: None,
+    })?;
+    chown_to_real_owner(&child)?;
+    for name in [
+        "cgroup.procs",
+        "cgroup.subtree_control",
+        "cgroup.controllers",
+    ] {
+        let control = child.join(name);
+        if control.exists() {
+            chown_to_real_owner(&control)?;
+        }
+    }
+    Ok(Some(child))
+}
+
+fn migrate_current_task_into_cgroup(cgroup: &Path) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let procs = cgroup.join("cgroup.procs");
+    let path = std::ffi::CString::new(procs.as_os_str().as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "cgroup.procs path contains an interior NUL",
+        )
+    })?;
+    // SAFETY: open/write/close on cgroup.procs between fork and exec; path is
+    // NUL-terminated and owned for the duration of the calls.
+    let fd = unsafe { libc::open(path.as_ptr(), libc::O_WRONLY | libc::O_CLOEXEC) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let written = unsafe { libc::write(fd, b"0".as_ptr().cast(), 1) };
+    let close_rc = unsafe { libc::close(fd) };
+    if written != 1 {
+        return Err(if written < 0 {
+            std::io::Error::last_os_error()
+        } else {
+            std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "short write migrating into Sandbox owner cgroup",
+            )
+        });
+    }
+    if close_rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn chown_to_real_owner(path: &Path) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    let (uid, gid) = {
+        // SAFETY: credential queries have no pointer arguments or failure results.
+        let (ruid, rgid, euid, egid) = unsafe {
+            (
+                libc::getuid(),
+                libc::getgid(),
+                libc::geteuid(),
+                libc::getegid(),
+            )
+        };
+        if euid == 0 && ruid != 0 {
+            (ruid, rgid)
+        } else {
+            (euid, egid)
+        }
+    };
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        BoxError::ConfigError(format!(
+            "Sandbox OCI path contains an interior NUL: {}",
+            path.display()
+        ))
+    })?;
+    // SAFETY: chown takes a NUL-terminated path owned for the duration of the call.
+    let rc = unsafe { libc::chown(c_path.as_ptr(), uid, gid) };
+    if rc != 0 {
+        return Err(BoxError::BoxBootError {
+            message: format!(
+                "failed to assign Sandbox OCI path {} to UID {uid}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ),
+            hint: None,
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -532,5 +642,29 @@ mod tests {
         assert!(error
             .to_string()
             .contains("did not return a running or stopped container"));
+    }
+
+    #[test]
+    fn prepares_a_child_below_the_delegated_cgroup_root() {
+        let root = tempfile::tempdir().unwrap();
+        let child = prepare_sandbox_delegation_child_in(root.path().to_path_buf())
+            .unwrap()
+            .expect("delegated root exists");
+
+        assert!(child.starts_with(root.path()));
+        assert!(child.is_dir());
+        assert!(child
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("box-sandbox-owner-"));
+    }
+
+    #[test]
+    fn skips_delegation_child_when_the_root_is_absent() {
+        let missing = tempfile::tempdir().unwrap().path().join("missing");
+        assert!(prepare_sandbox_delegation_child_in(missing)
+            .unwrap()
+            .is_none());
     }
 }

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -635,8 +635,22 @@ where
     if euid != 0 || ruid == 0 {
         return Ok(f());
     }
+    // Without PR_SET_KEEPCAPS, seteuid(non-root) clears the permitted capability
+    // set permanently — even after seteuid(0) the process has no CAP_SYS_ADMIN
+    // for overlay mounts or network relays.
+    // SAFETY: prctl capability-keep flag has no pointer arguments.
+    if unsafe { libc::prctl(libc::PR_SET_KEEPCAPS, 1, 0, 0, 0) } != 0 {
+        return Err(BoxError::BoxBootError {
+            message: format!(
+                "failed to retain capabilities for Sandbox SDK peer auth: {}",
+                std::io::Error::last_os_error()
+            ),
+            hint: None,
+        });
+    }
     // SAFETY: seteuid/setegid use the retained saved IDs from setpriv / setuid.
     if unsafe { libc::setegid(rgid) } != 0 {
+        let _ = unsafe { libc::prctl(libc::PR_SET_KEEPCAPS, 0, 0, 0, 0) };
         return Err(BoxError::BoxBootError {
             message: format!(
                 "failed to match Sandbox controller egid {rgid} for SDK peer auth: {}",
@@ -647,6 +661,7 @@ where
     }
     if unsafe { libc::seteuid(ruid) } != 0 {
         let _ = unsafe { libc::setegid(egid) };
+        let _ = unsafe { libc::prctl(libc::PR_SET_KEEPCAPS, 0, 0, 0, 0) };
         return Err(BoxError::BoxBootError {
             message: format!(
                 "failed to match Sandbox controller euid {ruid} for SDK peer auth: {}",
@@ -656,8 +671,9 @@ where
         });
     }
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-    let restore_gid = unsafe { libc::setegid(0) };
     let restore_uid = unsafe { libc::seteuid(0) };
+    let restore_gid = unsafe { libc::setegid(0) };
+    let _ = unsafe { libc::prctl(libc::PR_SET_KEEPCAPS, 0, 0, 0, 0) };
     if restore_gid != 0 || restore_uid != 0 {
         return Err(BoxError::BoxBootError {
             message: format!(
@@ -754,8 +770,9 @@ fn chown_path_to_ids(path: &Path, (uid, gid): (u32, u32)) -> Result<()> {
             path.display()
         ))
     })?;
-    // SAFETY: chown takes a NUL-terminated path owned for the duration of the call.
-    let rc = unsafe { libc::chown(c_path.as_ptr(), uid, gid) };
+    // SAFETY: lchown takes a NUL-terminated path and does not follow symlinks,
+    // so a rootfs link cannot reassign host packaging paths such as bin/lib.
+    let rc = unsafe { libc::lchown(c_path.as_ptr(), uid, gid) };
     if rc != 0 {
         return Err(BoxError::BoxBootError {
             message: format!(

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -76,6 +76,12 @@ impl A3sOciController {
 
         let exec_listener = bind_control_listener(&launch.exec_socket_path)?;
         let pty_listener = bind_control_listener(&launch.pty_socket_path)?;
+        // Control sockets live under /tmp/a3s-box-sockets (not A3S_HOME). bind(2)
+        // creates them as euid 0 / mode 0600; after the peer-auth drop the
+        // controller must still connect for exec readiness, so assign them to
+        // the real UID before that drop.
+        chown_to_real_owner(&launch.exec_socket_path)?;
+        chown_to_real_owner(&launch.pty_socket_path)?;
         let stdout = open_log(&launch.stdout_path)?;
         let stderr = open_log(&launch.stderr_path)?;
         let init_log = open_log(&launch.init_log_path)?;

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -578,30 +578,6 @@ fn migrate_current_task_into_cgroup(cgroup: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn chown_to_real_owner(path: &Path) -> Result<()> {
-    use std::os::unix::ffi::OsStrExt;
-    let (uid, gid) = expected_owner_ids();
-    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
-        BoxError::ConfigError(format!(
-            "Sandbox OCI path contains an interior NUL: {}",
-            path.display()
-        ))
-    })?;
-    // SAFETY: chown takes a NUL-terminated path owned for the duration of the call.
-    let rc = unsafe { libc::chown(c_path.as_ptr(), uid, gid) };
-    if rc != 0 {
-        return Err(BoxError::BoxBootError {
-            message: format!(
-                "failed to assign Sandbox OCI path {} to UID {uid}: {}",
-                path.display(),
-                std::io::Error::last_os_error()
-            ),
-            hint: None,
-        });
-    }
-    Ok(())
-}
-
 /// Durable filesystem identity for Sandbox OCI owners.
 ///
 /// Under setpriv / setuid launchers (euid 0, non-root ruid), ownership follows
@@ -678,30 +654,41 @@ fn reassign_sandbox_home_to_real_owner() -> Result<()> {
     let Some(home) = std::env::var_os("A3S_HOME").filter(|value| !value.is_empty()) else {
         return Ok(());
     };
-    chown_tree_to_real_owner(Path::new(&home))
+    chown_tree_to_ids(Path::new(&home), expected_owner_ids())
 }
 
-fn chown_tree_to_real_owner(path: &Path) -> Result<()> {
-    if !path.exists() {
-        return Ok(());
-    }
-    chown_to_real_owner(path)?;
-    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
-    if !metadata.is_dir() || metadata.file_type().is_symlink() {
-        return Ok(());
-    }
-    for entry in std::fs::read_dir(path).map_err(BoxError::IoError)? {
-        let entry = entry.map_err(BoxError::IoError)?;
-        chown_tree_to_real_owner(&entry.path())?;
-    }
-    Ok(())
+fn chown_to_real_owner(path: &Path) -> Result<()> {
+    chown_path_to_ids(path, expected_owner_ids())
 }
 
 /// Restore effective root when saved UID 0 was retained by
 /// [`drop_effective_root_to_real_owner`].
 pub(crate) fn restore_effective_root_if_saved() -> Result<()> {
-    let (ruid, euid) = unsafe { (libc::getuid(), libc::geteuid()) };
-    if euid == 0 || ruid == 0 {
+    let (ruid, euid, saved_uid, saved_gid) = {
+        let mut ruid = 0;
+        let mut euid = 0;
+        let mut saved_uid = 0;
+        let mut rgid = 0;
+        let mut egid = 0;
+        let mut saved_gid = 0;
+        // SAFETY: getresuid/getresgid write three uid_t/gid_t outputs.
+        let uid_rc = unsafe { libc::getresuid(&mut ruid, &mut euid, &mut saved_uid) };
+        let gid_rc = unsafe { libc::getresgid(&mut rgid, &mut egid, &mut saved_gid) };
+        if uid_rc != 0 || gid_rc != 0 {
+            return Err(BoxError::BoxBootError {
+                message: format!(
+                    "failed to inspect Sandbox controller credentials: {}",
+                    std::io::Error::last_os_error()
+                ),
+                hint: None,
+            });
+        }
+        let _ = (rgid, egid);
+        (ruid, euid, saved_uid, saved_gid)
+    };
+    if euid == 0 || ruid == 0 || saved_uid != 0 || saved_gid != 0 {
+        // Already effective root, or this process never retained saved root via
+        // setresuid/setresgid from [`drop_effective_root_to_real_owner`].
         return Ok(());
     }
     // SAFETY: seteuid/setegid use the retained saved IDs from setresuid/setresgid.
@@ -718,6 +705,57 @@ pub(crate) fn restore_effective_root_if_saved() -> Result<()> {
         return Err(BoxError::BoxBootError {
             message: format!(
                 "failed to restore Sandbox controller euid 0: {}",
+                std::io::Error::last_os_error()
+            ),
+            hint: None,
+        });
+    }
+    // Prepare-time state trees were handed to the real UID for peer-auth; reclaim
+    // them for effective-root mounts and Runtime state ownership checks.
+    reassign_sandbox_home_to_current_effective_owner()?;
+    Ok(())
+}
+
+fn reassign_sandbox_home_to_current_effective_owner() -> Result<()> {
+    let Some(home) = std::env::var_os("A3S_HOME").filter(|value| !value.is_empty()) else {
+        return Ok(());
+    };
+    chown_tree_to_ids(Path::new(&home), unsafe {
+        (libc::geteuid(), libc::getegid())
+    })
+}
+
+fn chown_tree_to_ids(path: &Path, ids: (u32, u32)) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    chown_path_to_ids(path, ids)?;
+    let metadata = std::fs::symlink_metadata(path).map_err(BoxError::IoError)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(path).map_err(BoxError::IoError)? {
+        let entry = entry.map_err(BoxError::IoError)?;
+        chown_tree_to_ids(&entry.path(), ids)?;
+    }
+    Ok(())
+}
+
+fn chown_path_to_ids(path: &Path, (uid, gid): (u32, u32)) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        BoxError::ConfigError(format!(
+            "Sandbox OCI path contains an interior NUL: {}",
+            path.display()
+        ))
+    })?;
+    // SAFETY: chown takes a NUL-terminated path owned for the duration of the call.
+    let rc = unsafe { libc::chown(c_path.as_ptr(), uid, gid) };
+    if rc != 0 {
+        return Err(BoxError::BoxBootError {
+            message: format!(
+                "failed to assign Sandbox OCI path {} to UID {uid}: {}",
+                path.display(),
                 std::io::Error::last_os_error()
             ),
             hint: None,

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -76,7 +76,23 @@ impl A3sOciController {
         let delegated_cgroup_root = linux_sandbox_delegated_cgroup_root();
         let owner_cgroup = prepare_sandbox_delegation_child()?;
         let launcher = resolve_sandbox_oci_launcher(None)?;
-        let mut command = Command::new(&launcher);
+        // Matched-cred CI harnesses (euid==ruid) cannot bootstrap device policy.
+        // When CI supplies the setpriv wrapper, spawn the owner with euid 0 /
+        // non-root ruid so native-linux-service can install the parent-bound
+        // helper, then drop to the real identity.
+        let elevate_wrapper = std::env::var_os("A3S_BOX_CI_SETPRIV_WRAPPER")
+            .filter(|value| !value.is_empty())
+            .filter(|_| unsafe { libc::geteuid() } != 0);
+        let mut command = if let Some(wrapper) = elevate_wrapper {
+            let mut command = Command::new("bash");
+            command.arg(wrapper);
+            command.arg(&launcher);
+            command.env_remove("A3S_BOX_CI_SETPRIV_MATCHED_CREDS");
+            command.env_remove("A3S_BOX_CI_PROBE_CGROUP");
+            command
+        } else {
+            Command::new(&launcher)
+        };
         command
             .arg("native-linux-service")
             .arg("--root")

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -131,6 +131,11 @@ impl A3sOciController {
         drop((inherited_exec, inherited_pty, inherited_log));
         drop((exec_listener, pty_listener, init_log));
 
+        // Owner inherits effective root for device-policy bootstrap, then drops
+        // to the real UID before publishing the SDK socket. Match that durable
+        // identity here so SO_PEERCRED same-UID auth accepts the controller.
+        drop_effective_root_to_real_owner()?;
+
         let owner_pid = owner.id();
         let owner_pid_start_time = crate::process::pid_start_time(owner_pid).ok_or_else(|| {
             let _ = owner.kill();
@@ -608,6 +613,50 @@ fn expected_owner_ids() -> (u32, u32) {
 
 fn expected_owner_uid() -> u32 {
     expected_owner_ids().0
+}
+
+/// Permanently match the Sandbox controller to the post-bootstrap owner UID.
+///
+/// Effective-root CI / setuid launchers keep euid 0 through rootfs prep and
+/// owner spawn so `native-linux-service` can install the device-policy helper.
+/// After spawn, the owner drops to the real UID and rejects other peer UIDs on
+/// the SDK socket. Dropping here is process-wide and intentional for that
+/// connection lifetime.
+fn drop_effective_root_to_real_owner() -> Result<()> {
+    let (ruid, rgid, euid, egid) = unsafe {
+        (
+            libc::getuid(),
+            libc::getgid(),
+            libc::geteuid(),
+            libc::getegid(),
+        )
+    };
+    if euid != 0 || ruid == 0 {
+        return Ok(());
+    }
+    if egid != rgid {
+        // SAFETY: setegid takes a gid_t; failure is reported via errno.
+        if unsafe { libc::setegid(rgid) } != 0 {
+            return Err(BoxError::BoxBootError {
+                message: format!(
+                    "failed to drop Sandbox controller egid to {rgid}: {}",
+                    std::io::Error::last_os_error()
+                ),
+                hint: None,
+            });
+        }
+    }
+    // SAFETY: seteuid takes a uid_t; failure is reported via errno.
+    if unsafe { libc::seteuid(ruid) } != 0 {
+        return Err(BoxError::BoxBootError {
+            message: format!(
+                "failed to drop Sandbox controller euid to {ruid}: {}",
+                std::io::Error::last_os_error()
+            ),
+            hint: None,
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -615,15 +615,15 @@ fn expected_owner_uid() -> u32 {
     expected_owner_ids().0
 }
 
-/// Permanently match the Sandbox controller to the post-bootstrap owner UID.
+/// Match the Sandbox controller to the post-bootstrap owner UID for SDK auth.
 ///
 /// Effective-root CI / setuid launchers keep euid 0 through rootfs prep and
 /// owner spawn so `native-linux-service` can install the device-policy helper.
 /// After spawn, the owner drops to the real UID and rejects other peer UIDs on
-/// the SDK socket. Dropping here is process-wide and intentional for that
-/// connection lifetime.
+/// the SDK socket. Keep saved UID/GID 0 so fixture cleanup can restore
+/// effective root and remove state created before the drop.
 fn drop_effective_root_to_real_owner() -> Result<()> {
-    let (ruid, rgid, euid, egid) = unsafe {
+    let (ruid, rgid, euid, _egid) = unsafe {
         (
             libc::getuid(),
             libc::getgid(),
@@ -634,23 +634,50 @@ fn drop_effective_root_to_real_owner() -> Result<()> {
     if euid != 0 || ruid == 0 {
         return Ok(());
     }
-    if egid != rgid {
-        // SAFETY: setegid takes a gid_t; failure is reported via errno.
-        if unsafe { libc::setegid(rgid) } != 0 {
-            return Err(BoxError::BoxBootError {
-                message: format!(
-                    "failed to drop Sandbox controller egid to {rgid}: {}",
-                    std::io::Error::last_os_error()
-                ),
-                hint: None,
-            });
-        }
-    }
-    // SAFETY: seteuid takes a uid_t; failure is reported via errno.
-    if unsafe { libc::seteuid(ruid) } != 0 {
+    // SAFETY: setresgid/setresuid take gid_t/uid_t; keep saved IDs at 0 so the
+    // process can restore effective root for cleanup without CAP_SETUID.
+    if unsafe { libc::setresgid(rgid, rgid, 0) } != 0 {
         return Err(BoxError::BoxBootError {
             message: format!(
-                "failed to drop Sandbox controller euid to {ruid}: {}",
+                "failed to drop Sandbox controller to rgid {rgid} (saved 0): {}",
+                std::io::Error::last_os_error()
+            ),
+            hint: None,
+        });
+    }
+    if unsafe { libc::setresuid(ruid, ruid, 0) } != 0 {
+        return Err(BoxError::BoxBootError {
+            message: format!(
+                "failed to drop Sandbox controller to ruid {ruid} (saved 0): {}",
+                std::io::Error::last_os_error()
+            ),
+            hint: None,
+        });
+    }
+    Ok(())
+}
+
+/// Restore effective root when saved UID 0 was retained by
+/// [`drop_effective_root_to_real_owner`].
+pub(crate) fn restore_effective_root_if_saved() -> Result<()> {
+    let (ruid, euid) = unsafe { (libc::getuid(), libc::geteuid()) };
+    if euid == 0 || ruid == 0 {
+        return Ok(());
+    }
+    // SAFETY: seteuid/setegid use the retained saved IDs from setresuid/setresgid.
+    if unsafe { libc::setegid(0) } != 0 {
+        return Err(BoxError::BoxBootError {
+            message: format!(
+                "failed to restore Sandbox controller egid 0: {}",
+                std::io::Error::last_os_error()
+            ),
+            hint: None,
+        });
+    }
+    if unsafe { libc::seteuid(0) } != 0 {
+        return Err(BoxError::BoxBootError {
+            message: format!(
+                "failed to restore Sandbox controller euid 0: {}",
                 std::io::Error::last_os_error()
             ),
             hint: None,

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -150,9 +150,12 @@ impl A3sOciController {
         // Keep the controller at effective root for overlay mounts, network
         // relays, and Runtime state ownership. The durable OCI owner scans the
         // prepared rootfs as the real UID after device-policy drop, so hand that
-        // box tree (not Runtime state) to the real owner before create.
+        // tree (not Runtime state, and not read-only bind attachments) to the
+        // real owner before create.
         if let Some(box_dir) = launch.bundle_dir.ancestors().nth(2) {
-            chown_tree_to_ids(box_dir, expected_owner_ids())?;
+            let ids = expected_owner_ids();
+            chown_path_to_ids(box_dir, ids)?;
+            chown_tree_to_ids(&box_dir.join("rootfs"), ids)?;
         }
         // SO_PEERCRED is checked only at SDK connect time —
         // [`super::a3s_oci_client`] temporarily matches the real UID for that
@@ -774,11 +777,16 @@ fn chown_path_to_ids(path: &Path, (uid, gid): (u32, u32)) -> Result<()> {
     // so a rootfs link cannot reassign host packaging paths such as bin/lib.
     let rc = unsafe { libc::lchown(c_path.as_ptr(), uid, gid) };
     if rc != 0 {
+        let error = std::io::Error::last_os_error();
+        // Read-only bind mounts under boxes/<id> (R17 mounts profile) cannot be
+        // reassigned; skip them rather than failing the whole owner handoff.
+        if error.raw_os_error() == Some(libc::EROFS) {
+            return Ok(());
+        }
         return Err(BoxError::BoxBootError {
             message: format!(
-                "failed to assign Sandbox OCI path {} to UID {uid}: {}",
-                path.display(),
-                std::io::Error::last_os_error()
+                "failed to assign Sandbox OCI path {} to UID {uid}: {error}",
+                path.display()
             ),
             hint: None,
         });

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -149,13 +149,11 @@ impl A3sOciController {
 
         // Keep the controller at effective root for overlay mounts, network
         // relays, and Runtime state ownership. The durable OCI owner scans the
-        // prepared rootfs as the real UID after device-policy drop, so hand that
-        // tree (not Runtime state, and not read-only bind attachments) to the
-        // real owner before create.
+        // prepared rootfs/merged tree as the real UID after device-policy drop,
+        // so hand the box tree (not Runtime state) to the real owner before
+        // create. Recursion skips sandbox/attachments bind mounts (EROFS).
         if let Some(box_dir) = launch.bundle_dir.ancestors().nth(2) {
-            let ids = expected_owner_ids();
-            chown_path_to_ids(box_dir, ids)?;
-            chown_tree_to_ids(&box_dir.join("rootfs"), ids)?;
+            chown_tree_to_ids(box_dir, expected_owner_ids())?;
         }
         // SO_PEERCRED is checked only at SDK connect time —
         // [`super::a3s_oci_client`] temporarily matches the real UID for that
@@ -707,6 +705,11 @@ fn chown_tree_to_ids(path: &Path, ids: (u32, u32)) -> Result<()> {
     }
     for entry in std::fs::read_dir(path).map_err(BoxError::IoError)? {
         let entry = entry.map_err(BoxError::IoError)?;
+        // R17 mounts profile bind-mounts host paths under sandbox/attachments.
+        if entry.file_name() == "attachments" {
+            chown_path_to_ids(&entry.path(), ids)?;
+            continue;
+        }
         chown_tree_to_ids(&entry.path(), ids)?;
     }
     Ok(())

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -699,7 +699,6 @@ fn chown_tree_to_real_owner(path: &Path) -> Result<()> {
 
 /// Restore effective root when saved UID 0 was retained by
 /// [`drop_effective_root_to_real_owner`].
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn restore_effective_root_if_saved() -> Result<()> {
     let (ruid, euid) = unsafe { (libc::getuid(), libc::geteuid()) };
     if euid == 0 || ruid == 0 {

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -353,11 +353,15 @@ async fn wait_for_private_socket(owner: &mut Child, socket_path: &Path) -> Resul
 }
 
 fn private_socket_ready(socket_path: &Path) -> Result<bool> {
+    let expected_uid = expected_owner_uid();
     match std::fs::symlink_metadata(socket_path) {
         Ok(metadata) if !metadata.file_type().is_socket() => {
             Err(private_socket_contract_error(socket_path))
         }
-        Ok(metadata) if metadata.uid() != unsafe { libc::geteuid() } => {
+        // After rootless device-policy drop the socket is owned by the real UID
+        // while effective-root harnesses still have euid 0. Accept the durable
+        // owner identity, not geteuid().
+        Ok(metadata) if metadata.uid() != expected_uid => {
             Err(private_socket_contract_error(socket_path))
         }
         // bind(2) publishes the same-owner socket before the Runtime owner can
@@ -559,22 +563,7 @@ fn migrate_current_task_into_cgroup(cgroup: &Path) -> std::io::Result<()> {
 
 fn chown_to_real_owner(path: &Path) -> Result<()> {
     use std::os::unix::ffi::OsStrExt;
-    let (uid, gid) = {
-        // SAFETY: credential queries have no pointer arguments or failure results.
-        let (ruid, rgid, euid, egid) = unsafe {
-            (
-                libc::getuid(),
-                libc::getgid(),
-                libc::geteuid(),
-                libc::getegid(),
-            )
-        };
-        if euid == 0 && ruid != 0 {
-            (ruid, rgid)
-        } else {
-            (euid, egid)
-        }
-    };
+    let (uid, gid) = expected_owner_ids();
     let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
         BoxError::ConfigError(format!(
             "Sandbox OCI path contains an interior NUL: {}",
@@ -594,6 +583,31 @@ fn chown_to_real_owner(path: &Path) -> Result<()> {
         });
     }
     Ok(())
+}
+
+/// Durable filesystem identity for Sandbox OCI owners.
+///
+/// Under setpriv / setuid launchers (euid 0, non-root ruid), ownership follows
+/// the real UID so paths remain usable after rootless device-policy drop.
+fn expected_owner_ids() -> (u32, u32) {
+    // SAFETY: credential queries have no pointer arguments or failure results.
+    let (ruid, rgid, euid, egid) = unsafe {
+        (
+            libc::getuid(),
+            libc::getgid(),
+            libc::geteuid(),
+            libc::getegid(),
+        )
+    };
+    if euid == 0 && ruid != 0 {
+        (ruid, rgid)
+    } else {
+        (euid, egid)
+    }
+}
+
+fn expected_owner_uid() -> u32 {
+    expected_owner_ids().0
 }
 
 #[cfg(test)]
@@ -684,7 +698,7 @@ mod tests {
         chown_to_real_owner(&path).unwrap();
 
         let metadata = std::fs::metadata(&path).unwrap();
-        let expected = unsafe { libc::geteuid() };
+        let expected = expected_owner_uid();
         assert_eq!(metadata.uid(), expected);
         assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
     }

--- a/src/runtime/src/sandbox/a3s_oci_controller.rs
+++ b/src/runtime/src/sandbox/a3s_oci_controller.rs
@@ -59,6 +59,10 @@ impl A3sOciController {
             BoxError::ConfigError("A3S OCI runtime root has no parent".to_string())
         })?;
         create_private_dir(runtime_parent)?;
+        // Effective-root CI / setuid launchers create paths as euid 0. After
+        // RootlessDevicePolicyBootstrap drops to the real UID, native-linux-service
+        // requires the service root parent to be owned by that UID (mode 0700).
+        chown_to_real_owner(runtime_parent)?;
 
         let exec_listener = bind_control_listener(&launch.exec_socket_path)?;
         let pty_listener = bind_control_listener(&launch.pty_socket_path)?;
@@ -76,23 +80,11 @@ impl A3sOciController {
         let delegated_cgroup_root = linux_sandbox_delegated_cgroup_root();
         let owner_cgroup = prepare_sandbox_delegation_child()?;
         let launcher = resolve_sandbox_oci_launcher(None)?;
-        // Matched-cred CI harnesses (euid==ruid) cannot bootstrap device policy.
-        // When CI supplies the setpriv wrapper, spawn the owner with euid 0 /
-        // non-root ruid so native-linux-service can install the parent-bound
-        // helper, then drop to the real identity.
-        let elevate_wrapper = std::env::var_os("A3S_BOX_CI_SETPRIV_WRAPPER")
-            .filter(|value| !value.is_empty())
-            .filter(|_| unsafe { libc::geteuid() } != 0);
-        let mut command = if let Some(wrapper) = elevate_wrapper {
-            let mut command = Command::new("bash");
-            command.arg(wrapper);
-            command.arg(&launcher);
-            command.env_remove("A3S_BOX_CI_SETPRIV_MATCHED_CREDS");
-            command.env_remove("A3S_BOX_CI_PROBE_CGROUP");
-            command
-        } else {
-            Command::new(&launcher)
-        };
+        // Keep the launcher as the direct exec target. Intermediate bash/setpriv
+        // wrappers break `--a3s-box-control-fds` (ExecListener must remain a Unix
+        // stream on the fixed inherited descriptors). R17 stays on euid 0 so the
+        // owner can bootstrap device policy without elevation.
+        let mut command = Command::new(&launcher);
         command
             .arg("native-linux-service")
             .arg("--root")
@@ -682,5 +674,18 @@ mod tests {
         assert!(prepare_sandbox_delegation_child_in(missing)
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn assigns_private_dirs_to_the_real_owner_identity() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("runtime-parent");
+        create_private_dir(&path).unwrap();
+        chown_to_real_owner(&path).unwrap();
+
+        let metadata = std::fs::metadata(&path).unwrap();
+        let expected = unsafe { libc::geteuid() };
+        assert_eq!(metadata.uid(), expected);
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
     }
 }

--- a/src/runtime/src/sandbox/capability.rs
+++ b/src/runtime/src/sandbox/capability.rs
@@ -622,8 +622,24 @@ fn probe_namespaces(snapshot: &mut SandboxCapabilitySnapshot) {
         }
     }
 
-    let effective_uid = unsafe { libc::geteuid() };
-    let effective_gid = unsafe { libc::getegid() };
+    // Under setpriv / setuid launchers (euid 0, non-root ruid), the Sandbox OCI
+    // owner bootstraps device policy then permanently drops to the real UID.
+    // Plan rootless mappings for that durable identity, not for effective root.
+    let (effective_uid, effective_gid) = {
+        let (ruid, rgid, euid, egid) = unsafe {
+            (
+                libc::getuid(),
+                libc::getgid(),
+                libc::geteuid(),
+                libc::getegid(),
+            )
+        };
+        if euid == 0 && ruid != 0 {
+            (ruid, rgid)
+        } else {
+            (euid, egid)
+        }
+    };
     let username = username_for_uid(effective_uid);
     let max_user_namespaces = read_trimmed("/proc/sys/user/max_user_namespaces")
         .and_then(|value| value.parse::<u64>().ok());

--- a/src/runtime/src/sandbox/controller.rs
+++ b/src/runtime/src/sandbox/controller.rs
@@ -138,18 +138,51 @@ pub(crate) fn start_log_worker(
     })?;
     let stdout = open_log(&launch.log_worker_log_path)?;
     let stderr = stdout.try_clone().map_err(BoxError::IoError)?;
-    let mut worker = Command::new(&launch.log_worker_path)
+    let mut command = Command::new(&launch.log_worker_path);
+    command
         .arg("--sandbox-log-worker-config")
         .arg(config)
         .env("LC_ALL", "C")
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(stderr))
-        .spawn()
-        .map_err(|error| BoxError::BoxBootError {
-            message: format!("Failed to start Sandbox log worker: {error}"),
-            hint: None,
-        })?;
+        .stderr(Stdio::from(stderr));
+    // Packaged `a3s-box-shim` resolves libkrun via `$ORIGIN/../lib`. Under
+    // setpriv (`euid=0`, `ruid≠0`) the child inherits mismatched IDs, so the
+    // dynamic linker enters secure-execution mode, ignores `LD_LIBRARY_PATH`,
+    // and can fail to open the bundled libkrun (`ENOENT` / exit 127). Clear the
+    // mismatch before exec and keep the shim lib dir first on the search path.
+    if let Some(lib_dir) = launch
+        .log_worker_path
+        .parent()
+        .map(|bin| bin.join("lib"))
+        .filter(|path| path.is_dir())
+    {
+        let mut paths = vec![lib_dir];
+        if let Some(existing) = std::env::var_os("LD_LIBRARY_PATH") {
+            paths.extend(std::env::split_paths(&existing));
+        }
+        if let Ok(joined) = std::env::join_paths(paths) {
+            command.env("LD_LIBRARY_PATH", joined);
+        }
+    }
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setresgid(0, 0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::setresuid(0, 0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+    let mut worker = command.spawn().map_err(|error| BoxError::BoxBootError {
+        message: format!("Failed to start Sandbox log worker: {error}"),
+        hint: None,
+    })?;
 
     let deadline = Instant::now() + Duration::from_secs(3);
     loop {

--- a/src/runtime/src/sandbox/mod.rs
+++ b/src/runtime/src/sandbox/mod.rs
@@ -119,8 +119,6 @@ pub fn update_recorded_resources(
 #[cfg(target_os = "linux")]
 pub use a3s_oci_controller::A3sOciController;
 #[cfg(target_os = "linux")]
-pub(crate) use a3s_oci_controller::restore_effective_root_if_saved;
-#[cfg(target_os = "linux")]
 pub use a3s_oci_handler::A3sOciHandler;
 pub use capability::{
     map_container_gid, map_container_uid, plan_id_mappings, probe_sandbox_capabilities,

--- a/src/runtime/src/sandbox/mod.rs
+++ b/src/runtime/src/sandbox/mod.rs
@@ -117,7 +117,7 @@ pub fn update_recorded_resources(
 }
 
 #[cfg(target_os = "linux")]
-pub use a3s_oci_controller::A3sOciController;
+pub use a3s_oci_controller::{restore_effective_root_if_saved, A3sOciController};
 #[cfg(target_os = "linux")]
 pub use a3s_oci_handler::A3sOciHandler;
 pub use capability::{

--- a/src/runtime/src/sandbox/mod.rs
+++ b/src/runtime/src/sandbox/mod.rs
@@ -117,7 +117,9 @@ pub fn update_recorded_resources(
 }
 
 #[cfg(target_os = "linux")]
-pub use a3s_oci_controller::{restore_effective_root_if_saved, A3sOciController};
+pub use a3s_oci_controller::A3sOciController;
+#[cfg(target_os = "linux")]
+pub(crate) use a3s_oci_controller::restore_effective_root_if_saved;
 #[cfg(target_os = "linux")]
 pub use a3s_oci_handler::A3sOciHandler;
 pub use capability::{

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -507,6 +507,17 @@ impl VmManager {
 
     /// Remove host-side boot artifacts after a failed boot attempt.
     async fn cleanup_boot_failure(&mut self) {
+        // Sandbox peer-auth may have dropped this process to the real UID.
+        // Overlay unmount needs effective root / CAP_SYS_ADMIN.
+        #[cfg(target_os = "linux")]
+        if let Err(error) = crate::sandbox::a3s_oci_controller::restore_effective_root_if_saved() {
+            tracing::warn!(
+                box_id = %self.box_id,
+                %error,
+                "Failed to restore effective root before Sandbox boot-failure cleanup"
+            );
+        }
+
         let box_dir = self.home_dir.join("boxes").join(&self.box_id);
 
         #[cfg(target_os = "windows")]

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -79,6 +79,10 @@ fn reap_orphaned_box_in(home_dir: &Path, box_id: &str) {
         return;
     }
 
+    // Peer-auth drops leave the process without CAP_SYS_ADMIN; restore before
+    // overlay unmount and mount-alias cleanup.
+    let _ = crate::sandbox::a3s_oci_controller::restore_effective_root_if_saved();
+
     let runtime_owned_cgroup = match reap_recorded_sandbox(home_dir, &box_dir, box_id) {
         SandboxReap::NotPresent => false,
         SandboxReap::Cleaned => true,

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -284,11 +284,17 @@ fn verify_recorded_a3s_oci_owner(
             "Cannot resolve recorded A3S OCI runtime for {box_id}: {error}"
         ))
     })?;
-    if runtime_path != record.runtime_path
-        || std::fs::read_link(format!("/proc/{owner_pid}/exe"))
-            .ok()
-            .as_deref()
-            != Some(runtime_path.as_path())
+    let owner_exe = std::fs::read_link(format!("/proc/{owner_pid}/exe")).map_err(|error| {
+        a3s_box_core::BoxError::StateError(format!(
+            "Cannot resolve A3S OCI owner executable for {box_id}: {error}"
+        ))
+    })?;
+    // Sandbox CI/production may exec `a3s-box-sandbox-oci-launcher` (same bytes
+    // as a3s-oci) while the record stores the certified runtime path. Accept
+    // either exact path match or identical artifact digest.
+    if owner_exe != runtime_path
+        && (runtime_path != record.runtime_path
+            || sha256_file(&owner_exe).as_deref() != record.runtime_sha256.as_deref())
     {
         return Err(a3s_box_core::BoxError::StateError(format!(
             "A3S OCI owner executable identity is invalid for {box_id}"

--- a/src/runtime/src/vm/reap.rs
+++ b/src/runtime/src/vm/reap.rs
@@ -327,9 +327,21 @@ fn verify_recorded_a3s_oci_owner(
             "Cannot inspect A3S OCI endpoint for {box_id}: {error}"
         ))
     })?;
+    // After rootless device-policy drop the endpoint is owned by the real UID
+    // while effective-root controllers still have euid 0. Accept either the
+    // durable owner identity or the current effective UID.
+    let expected_uids = {
+        let ruid = unsafe { libc::getuid() };
+        let euid = unsafe { libc::geteuid() };
+        if euid == 0 && ruid != 0 {
+            [ruid, euid]
+        } else {
+            [euid, euid]
+        }
+    };
     if !metadata.file_type().is_socket()
         || metadata.permissions().mode() & 0o777 != 0o600
-        || metadata.uid() != unsafe { libc::geteuid() }
+        || !expected_uids.contains(&metadata.uid())
     {
         return Err(a3s_box_core::BoxError::StateError(format!(
             "A3S OCI endpoint identity is invalid for {box_id}"

--- a/src/runtime/src/vm/sandbox.rs
+++ b/src/runtime/src/vm/sandbox.rs
@@ -52,6 +52,11 @@ impl VmManager {
                 hint: None,
             });
         }
+        // A prior Sandbox owner may have dropped this process to the real UID
+        // for SO_PEERCRED. Restore effective root before overlay mounts and
+        // capability probes that require CAP_SYS_ADMIN.
+        #[cfg(target_os = "linux")]
+        crate::sandbox::a3s_oci_controller::restore_effective_root_if_saved()?;
         // This probe is deliberately before image pulls, rootfs mounts, volume
         // creation, or bundle writes. Every mandatory control is fail-closed.
         let capability_start = std::time::Instant::now();


### PR DESCRIPTION
## Summary
- Cloud Box provider conformance on pin `09e5874b` failed advertised R17 profiles: `rootless executor must run in a host-owned child below its empty cgroup delegation` (executor in `a3s-box-ci/probe`, delegation in `a3s-box-ci/delegated`).
- Spawn `native-linux-service` after migrating into a child of the delegated root, matching host-service composition.
- Use the module-qualified `--exact` name for `box_runtime_passes_all_advertised_profiles` so the ignored test actually runs.

## Test plan
- [x] Unit: `prepares_a_child_below_the_delegated_cgroup_root`
- [ ] Box CI Linux no-KVM / Sandbox advertised profiles
- [ ] Cloud Box provider conformance after pin bump

Closes nothing yet; required evidence for A3S-Lab/Box#172 / A3S-Lab/Cloud#85.