### PR TITLE
feat(oci): add Linux KVM MicroVM qualification opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,22 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- Linux qualification-only MicroVM OCI opt-in through
+  `A3S_BOX_OCI_MIGRATION=microvm|all` plus an explicit
+  `A3S_BOX_OCI_KVM_ENDPOINT` Unix socket pointing at OCI Runtime's
+  `box-kvm-qualification-service`. The public KVM probe stays non-registerable;
+  this path reuses the portable DedicatedVm bundle provider already used by
+  WHPX and is not a production claim.
 - Windows WHPX docs now include a first-principles acceptance matrix index
   (`WIN-HOST` / `WIN-POS` / `WIN-NEG` / `WIN-SLO`) tied to issues #252, #255,
   and #257.
 - Windows CLI coverage for bridge/network-create/pool-start/container-update
   fail-closed negatives (#260).
+
+### Changed
+
+- Bump the pinned OCI Runtime revision to `53e21ef204c8a45bcc2a02f28d35acf2edc9415f` so Box can target the
+  merged `box-kvm-qualification-service` Host Service.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,13 @@ never retried on the Box backend. On Linux, the CLI, machine bridge, and the
 async Rust SDK constructor can now opt new Sandbox records into the production
 bundle provider and long-lived pinned runtime owner with
 `A3S_BOX_OCI_MIGRATION=sandbox`. With the setting absent, current behavior is
-unchanged. Windows x86_64 also has an explicit qualification-only
-`microvm`/`all` composition for the externally launched OCI Runtime WHPX
-service; it is not enabled by default and is not yet a production claim.
+unchanged. Linux also has an explicit qualification-only `microvm`/`all`
+composition for the externally launched OCI Runtime
+`box-kvm-qualification-service`; it requires `A3S_BOX_OCI_KVM_ENDPOINT`, is not
+enabled by default, and is not yet a production claim. Windows x86_64 likewise
+has an explicit qualification-only `microvm`/`all` composition for the
+externally launched OCI Runtime WHPX service; it is not enabled by default and
+is not yet a production claim.
 
 > **Looking for a lightweight Agent sandbox?** See [`a3s-sandbox`](https://github.com/A3S-Lab/Sandbox).
 > That project focuses on lightweight cross-platform command sandboxing;
@@ -256,6 +260,33 @@ Rust applications select the same path with
 `from_home`, and `with_paths` constructors retain legacy behavior for API
 compatibility.
 
+### Exercise the qualification-only KVM handoff on Linux
+
+Start the pinned OCI Runtime `box-kvm-qualification-service` with its private
+root, isolated shim, and immutable system-image manifest. Point Box at the
+driver runtime directory (`<root>/runtime`) for handoffs and at the explicit
+Unix socket (`<root>/runtime.sock`):
+
+```bash
+a3s-oci box-kvm-qualification-service \
+  --root /run/a3s/oci-kvm-box \
+  --shim /absolute/path/to/isolated-libkrun-shim \
+  --system-image-manifest /absolute/path/to/system-image.json
+
+export A3S_BOX_OCI_MIGRATION=microvm
+export A3S_BOX_OCI_HOST_ROOT=/run/a3s/oci-kvm-box/runtime
+export A3S_BOX_OCI_KVM_ENDPOINT=/run/a3s/oci-kvm-box/runtime.sock
+
+a3s-box run --rm --cpus 1 --memory 512m --network none alpine:3.20 -- /bin/true
+```
+
+The endpoint must be supplied explicitly so the experimental KVM service cannot
+activate by accident. The profile matches the WHPX qualification constraints:
+one vCPU, 512 MiB, `network=none`, and no TEE, mounts, volumes, devices,
+sidecars, Snapshot, or persistence. Rust applications can construct
+`LinuxKvmOciMigrationConfig` explicitly or use
+`A3sBoxClient::with_configured_paths(...).await`.
+
 ### Exercise the qualification-only WHPX handoff on Windows
 
 Start the pinned OCI Runtime `box-whpx-qualification-service` with its shim,
@@ -323,8 +354,9 @@ support or any unqualified option fails before image preparation. In addition,
 endpoint must be supplied explicitly so this experimental service can never
 activate by accident.
 
-Current Linux opt-in limits are intentional: only new Sandbox reservations are
-routed there, and `all`/MicroVM migration is rejected on Linux. Image-declared
+Current Linux opt-in covers new Sandbox reservations through the long-lived
+Native Linux owner, plus an explicit qualification-only MicroVM path through
+`box-kvm-qualification-service` when `A3S_BOX_OCI_KVM_ENDPOINT` is set. Image-declared
 anonymous volumes are planned from normalized image metadata after capability
 preflight, persisted in the initial Box reservation, and atomically claimed by
 the exact execution during bundle preparation. Recovery and removal therefore

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -195,8 +195,11 @@ startup across processes, records the exact PID start identity and pinned
 runtime/agent paths plus SHA-256 digests, refuses an unowned socket or live
 artifact drift, and reuses only a launch-ready SDK endpoint. The CLI, machine
 bridge and async Rust SDK constructor honor the explicit
-`A3S_BOX_OCI_MIGRATION=sandbox` opt-in; no setting means no owner probe or
-startup and preserves the legacy route. Core lifecycle, run/exec/PTY, wait,
+`A3S_BOX_OCI_MIGRATION=sandbox` Sandbox opt-in and the qualification-only
+`A3S_BOX_OCI_MIGRATION=microvm|all` MicroVM path that requires an explicit
+`A3S_BOX_OCI_KVM_ENDPOINT` for `box-kvm-qualification-service`. No setting means
+no owner probe or startup and preserves the legacy route. Core lifecycle,
+run/exec/PTY, wait,
 pause/resume and cleanup commands now detect the persisted OCI route instead
 of requiring Box guest sockets. The blocking native-Linux x86_64 and aarch64 CI
 lanes now pass the Rust, Python, TypeScript, and Go Sandbox suites through this

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=fb517c6fe7793911c860f07143f6f1b4cb37eae7#fb517c6fe7793911c860f07143f6f1b4cb37eae7"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=53e21ef204c8a45bcc2a02f28d35acf2edc9415f#53e21ef204c8a45bcc2a02f28d35acf2edc9415f"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=fb517c6fe7793911c860f07143f6f1b4cb37eae7#fb517c6fe7793911c860f07143f6f1b4cb37eae7"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=53e21ef204c8a45bcc2a02f28d35acf2edc9415f#53e21ef204c8a45bcc2a02f28d35acf2edc9415f"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "fb517c6fe7793911c860f07143f6f1b4cb37eae7" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "53e21ef204c8a45bcc2a02f28d35acf2edc9415f" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -90,8 +90,9 @@ pub use local_execution::{
 };
 #[cfg(feature = "vm")]
 pub use local_execution::{
-    NativeLinuxOciBundleProvider, NativeLinuxOciMigrationConfig, VmLocalExecutionBackend,
-    WindowsWhpxOciBundleProvider, WindowsWhpxOciMigrationConfig,
+    LinuxKvmOciBundleProvider, LinuxKvmOciMigrationConfig, NativeLinuxOciBundleProvider,
+    NativeLinuxOciMigrationConfig, VmLocalExecutionBackend, WindowsWhpxOciBundleProvider,
+    WindowsWhpxOciMigrationConfig,
 };
 pub use managed_execution_store::{
     ManagedExecutionReservation, ManagedExecutionStore, ManagedExecutionStoreError,

--- a/src/runtime/src/local_execution/mod.rs
+++ b/src/runtime/src/local_execution/mod.rs
@@ -66,9 +66,13 @@ pub use oci_backend::{
     OciRuntimeLaunch, OCI_RUNTIME_BINDING_SCHEMA_VERSION,
 };
 #[cfg(feature = "vm")]
-pub use oci_migration::{NativeLinuxOciMigrationConfig, WindowsWhpxOciMigrationConfig};
+pub use oci_migration::{
+    LinuxKvmOciMigrationConfig, NativeLinuxOciMigrationConfig, WindowsWhpxOciMigrationConfig,
+};
 #[cfg(feature = "vm")]
-pub use oci_production::{NativeLinuxOciBundleProvider, WindowsWhpxOciBundleProvider};
+pub use oci_production::{
+    LinuxKvmOciBundleProvider, NativeLinuxOciBundleProvider, WindowsWhpxOciBundleProvider,
+};
 use record::{build_managed_record, status_from_record};
 pub use router::{LocalExecutionBackendRouter, OciMigrationPolicy};
 use store::RuntimeUpdate;

--- a/src/runtime/src/local_execution/oci_migration.rs
+++ b/src/runtime/src/local_execution/oci_migration.rs
@@ -12,15 +12,21 @@ use sha2::{Digest, Sha256};
 
 use super::LocalExecutionManager;
 #[cfg(target_os = "linux")]
-use super::{NativeLinuxOciBundleProvider, OciLocalExecutionBackend, OciMigrationPolicy};
+use super::{
+    LinuxKvmOciBundleProvider, NativeLinuxOciBundleProvider, OciLocalExecutionBackend,
+    OciMigrationPolicy,
+};
 
 pub const OCI_MIGRATION_ENV: &str = "A3S_BOX_OCI_MIGRATION";
 pub const OCI_HOST_ROOT_ENV: &str = "A3S_BOX_OCI_HOST_ROOT";
 pub const OCI_RUNTIME_PATH_ENV: &str = "A3S_BOX_OCI_RUNTIME_PATH";
 pub const OCI_AGENT_PATH_ENV: &str = "A3S_BOX_OCI_AGENT_PATH";
 pub const OCI_WHPX_ENDPOINT_ENV: &str = "A3S_BOX_OCI_WHPX_ENDPOINT";
+pub const OCI_KVM_ENDPOINT_ENV: &str = "A3S_BOX_OCI_KVM_ENDPOINT";
 #[cfg(test)]
 const DEFAULT_OCI_WHPX_ENDPOINT: &str = r"\\.\pipe\a3s-oci-box-qualification";
+#[cfg(test)]
+const DEFAULT_OCI_KVM_ENDPOINT: &str = "/tmp/a3s-oci-kvm-box/runtime.sock";
 
 /// Explicit native-Linux owner and artifact selection for Sandbox migration.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,6 +41,56 @@ pub struct NativeLinuxOciMigrationConfig {
 pub struct WindowsWhpxOciMigrationConfig {
     runtime_root: PathBuf,
     endpoint: super::OciRuntimeEndpoint,
+}
+
+/// Explicit connection to an externally owned qualification-only Linux KVM service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinuxKvmOciMigrationConfig {
+    runtime_root: PathBuf,
+    endpoint: super::OciRuntimeEndpoint,
+}
+
+impl LinuxKvmOciMigrationConfig {
+    pub fn new(
+        runtime_root: impl Into<PathBuf>,
+        endpoint: impl Into<PathBuf>,
+    ) -> ExecutionManagerResult<Self> {
+        let config = Self {
+            runtime_root: runtime_root.into(),
+            endpoint: super::OciRuntimeEndpoint::unix_socket(endpoint)?,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn runtime_root(&self) -> &Path {
+        &self.runtime_root
+    }
+
+    pub fn endpoint(&self) -> &super::OciRuntimeEndpoint {
+        &self.endpoint
+    }
+
+    pub fn from_environment(home_dir: &Path) -> ExecutionManagerResult<Option<Self>> {
+        parse_linux_kvm_environment(
+            std::env::var_os(OCI_MIGRATION_ENV),
+            std::env::var_os(OCI_HOST_ROOT_ENV),
+            std::env::var_os(OCI_KVM_ENDPOINT_ENV),
+            home_dir,
+        )
+    }
+
+    fn validate(&self) -> ExecutionManagerResult<()> {
+        validate_absolute_normalized(&self.runtime_root, "KVM OCI runtime root")?;
+        match &self.endpoint {
+            super::OciRuntimeEndpoint::UnixSocket { .. } => Ok(()),
+            super::OciRuntimeEndpoint::WindowsNamedPipe { .. } => {
+                Err(ExecutionManagerError::InvalidRequest(
+                    "KVM OCI qualification requires a Unix-domain socket endpoint".to_string(),
+                ))
+            }
+        }
+    }
 }
 
 impl WindowsWhpxOciMigrationConfig {
@@ -273,8 +329,66 @@ impl LocalExecutionManager {
         }
     }
 
+    /// Compose the retained backend with the externally launched Box/KVM OCI service.
+    pub async fn with_linux_kvm_oci_qualification(
+        state_path: impl Into<PathBuf>,
+        home_dir: impl Into<PathBuf>,
+        config: LinuxKvmOciMigrationConfig,
+    ) -> ExecutionManagerResult<Self> {
+        Self::with_linux_kvm_oci_qualification_and_pull_progress(
+            state_path.into(),
+            home_dir.into(),
+            config,
+            None,
+        )
+        .await
+    }
+
+    async fn with_linux_kvm_oci_qualification_and_pull_progress(
+        state_path: PathBuf,
+        home_dir: PathBuf,
+        config: LinuxKvmOciMigrationConfig,
+        pull_progress_fn: Option<crate::PullProgressFn>,
+    ) -> ExecutionManagerResult<Self> {
+        config.validate()?;
+
+        #[cfg(all(
+            target_os = "linux",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ))]
+        {
+            let mut provider =
+                LinuxKvmOciBundleProvider::new(home_dir.clone(), config.runtime_root());
+            if let Some(progress) = pull_progress_fn.as_ref() {
+                provider = provider.with_pull_progress_fn(progress.clone());
+            }
+            let oci = Arc::new(
+                OciLocalExecutionBackend::connect(config.endpoint().clone(), Arc::new(provider))
+                    .await?,
+            );
+            Ok(Self::with_oci_migration_backend_and_pull_progress(
+                state_path,
+                home_dir,
+                oci,
+                OciMigrationPolicy::AllViaOci,
+                pull_progress_fn,
+            ))
+        }
+
+        #[cfg(not(all(
+            target_os = "linux",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        )))]
+        {
+            let _ = (state_path, home_dir, config, pull_progress_fn);
+            Err(ExecutionManagerError::Unavailable(
+                "Box/KVM OCI qualification requires Linux x86_64 or aarch64".to_string(),
+            ))
+        }
+    }
+
     /// Select the production migration composition only when explicitly opted
-    /// in through `A3S_BOX_OCI_MIGRATION=sandbox`.
+    /// in through `A3S_BOX_OCI_MIGRATION`.
     pub async fn with_configured_backend(
         state_path: impl Into<PathBuf>,
         home_dir: impl Into<PathBuf>,
@@ -308,7 +422,35 @@ impl LocalExecutionManager {
             }
         }
 
-        #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+        #[cfg(target_os = "linux")]
+        {
+            if let Some(config) = LinuxKvmOciMigrationConfig::from_environment(&home_dir)? {
+                return Self::with_linux_kvm_oci_qualification_and_pull_progress(
+                    state_path,
+                    home_dir,
+                    config,
+                    pull_progress_fn,
+                )
+                .await;
+            }
+            match NativeLinuxOciMigrationConfig::from_environment(&home_dir)? {
+                Some(config) => {
+                    Self::with_native_linux_oci_migration_and_pull_progress(
+                        state_path,
+                        home_dir,
+                        config,
+                        pull_progress_fn,
+                    )
+                    .await
+                }
+                None => legacy_backend(state_path, home_dir, pull_progress_fn),
+            }
+        }
+
+        #[cfg(not(any(
+            target_os = "linux",
+            all(target_os = "windows", target_arch = "x86_64")
+        )))]
         {
             match NativeLinuxOciMigrationConfig::from_environment(&home_dir)? {
                 Some(config) => {
@@ -360,10 +502,10 @@ fn parse_environment(
     match mode.trim().to_ascii_lowercase().as_str() {
         "" | "0" | "false" | "off" | "disabled" | "legacy" => return Ok(None),
         "1" | "true" | "on" | "sandbox" | "sandbox-via-oci" => {}
-        "all" | "all-via-oci" => {
-            return Err(ExecutionManagerError::InvalidRequest(
-                "all-via-OCI migration is not qualified yet; use sandbox".to_string(),
-            ))
+        "all" | "all-via-oci" | "microvm" | "microvm-via-oci" | "kvm" => {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "MicroVM OCI qualification uses {OCI_KVM_ENDPOINT_ENV} with LinuxKvmOciMigrationConfig; NativeLinuxOciMigrationConfig accepts only sandbox"
+            )))
         }
         value => {
             return Err(ExecutionManagerError::InvalidRequest(format!(
@@ -442,6 +584,46 @@ fn parse_windows_environment(
             ))
         })?;
     WindowsWhpxOciMigrationConfig::new(runtime_root, endpoint).map(Some)
+}
+
+fn parse_linux_kvm_environment(
+    mode: Option<OsString>,
+    runtime_root: Option<OsString>,
+    endpoint: Option<OsString>,
+    home_dir: &Path,
+) -> ExecutionManagerResult<Option<LinuxKvmOciMigrationConfig>> {
+    let Some(mode) = mode.filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let mode = mode.to_str().ok_or_else(|| {
+        ExecutionManagerError::InvalidRequest(format!(
+            "{OCI_MIGRATION_ENV} must contain UTF-8 text"
+        ))
+    })?;
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "" | "0" | "false" | "off" | "disabled" | "legacy" | "1" | "true" | "on" | "sandbox"
+        | "sandbox-via-oci" => return Ok(None),
+        "all" | "all-via-oci" | "microvm" | "microvm-via-oci" | "kvm" => {}
+        value => {
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "unsupported {OCI_MIGRATION_ENV} value {value:?}; expected off, sandbox, microvm, or all"
+            )))
+        }
+    }
+
+    let runtime_root = runtime_root
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default_service_root(home_dir));
+    let endpoint = endpoint
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            ExecutionManagerError::InvalidRequest(format!(
+                "{OCI_KVM_ENDPOINT_ENV} must be set explicitly for the qualification-only KVM service"
+            ))
+        })
+        .map(PathBuf::from)?;
+    LinuxKvmOciMigrationConfig::new(runtime_root, endpoint).map(Some)
 }
 
 fn default_service_root(home_dir: &Path) -> PathBuf {
@@ -545,6 +727,38 @@ mod tests {
                 DEFAULT_OCI_WHPX_ENDPOINT,
             )
             .unwrap()
+        );
+    }
+
+    #[test]
+    fn linux_kvm_environment_requires_explicit_socket_and_accepts_microvm() {
+        let home = absolute("a3s-oci-config-home");
+        assert!(
+            parse_linux_kvm_environment(Some(OsString::from("microvm")), None, None, &home)
+                .is_err()
+        );
+        assert_eq!(
+            parse_linux_kvm_environment(Some(OsString::from("sandbox")), None, None, &home)
+                .unwrap(),
+            None
+        );
+
+        let config = parse_linux_kvm_environment(
+            Some(OsString::from("microvm")),
+            Some(absolute("a3s-oci-kvm-runtime").into_os_string()),
+            Some(OsString::from(DEFAULT_OCI_KVM_ENDPOINT)),
+            &home,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            config.endpoint(),
+            &crate::local_execution::OciRuntimeEndpoint::unix_socket(DEFAULT_OCI_KVM_ENDPOINT)
+                .unwrap()
+        );
+        assert_eq!(
+            config.runtime_root(),
+            absolute("a3s-oci-kvm-runtime").as_path()
         );
     }
 }

--- a/src/runtime/src/local_execution/oci_production.rs
+++ b/src/runtime/src/local_execution/oci_production.rs
@@ -29,23 +29,116 @@ pub struct NativeLinuxOciBundleProvider {
 /// Qualification-only producer for OCI Runtime's Windows dedicated-VM service.
 #[derive(Clone)]
 pub struct WindowsWhpxOciBundleProvider {
+    inner: DedicatedVmOciBundleProvider,
+}
+
+/// Qualification-only producer for OCI Runtime's Linux KVM dedicated-VM service.
+#[derive(Clone)]
+pub struct LinuxKvmOciBundleProvider {
+    inner: DedicatedVmOciBundleProvider,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DedicatedVmOciProfile {
+    WindowsWhpx,
+    LinuxKvm,
+}
+
+impl DedicatedVmOciProfile {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::WindowsWhpx => "WHPX",
+            Self::LinuxKvm => "KVM",
+        }
+    }
+
+    const fn host_supported(self) -> bool {
+        match self {
+            Self::WindowsWhpx => cfg!(all(target_os = "windows", target_arch = "x86_64")),
+            Self::LinuxKvm => {
+                cfg!(all(
+                    target_os = "linux",
+                    any(target_arch = "x86_64", target_arch = "aarch64")
+                ))
+            }
+        }
+    }
+
+    fn host_requirement(self) -> &'static str {
+        match self {
+            Self::WindowsWhpx => "Windows x86_64",
+            Self::LinuxKvm => "Linux x86_64 or aarch64",
+        }
+    }
+}
+
+#[derive(Clone)]
+struct DedicatedVmOciBundleProvider {
     preparer: VmLocalExecutionBackend,
     runtime_root: PathBuf,
+    profile: DedicatedVmOciProfile,
 }
 
 impl WindowsWhpxOciBundleProvider {
     pub fn new(home_dir: impl Into<PathBuf>, runtime_root: impl Into<PathBuf>) -> Self {
         Self {
-            preparer: VmLocalExecutionBackend::new(home_dir),
-            runtime_root: runtime_root.into(),
+            inner: DedicatedVmOciBundleProvider::new(
+                home_dir,
+                runtime_root,
+                DedicatedVmOciProfile::WindowsWhpx,
+            ),
         }
     }
 
     pub fn runtime_root(&self) -> &Path {
-        &self.runtime_root
+        self.inner.runtime_root()
     }
 
     pub fn with_pull_progress_fn(mut self, pull_progress_fn: crate::PullProgressFn) -> Self {
+        self.inner = self.inner.with_pull_progress_fn(pull_progress_fn);
+        self
+    }
+}
+
+impl LinuxKvmOciBundleProvider {
+    pub fn new(home_dir: impl Into<PathBuf>, runtime_root: impl Into<PathBuf>) -> Self {
+        Self {
+            inner: DedicatedVmOciBundleProvider::new(
+                home_dir,
+                runtime_root,
+                DedicatedVmOciProfile::LinuxKvm,
+            ),
+        }
+    }
+
+    pub fn runtime_root(&self) -> &Path {
+        self.inner.runtime_root()
+    }
+
+    pub fn with_pull_progress_fn(mut self, pull_progress_fn: crate::PullProgressFn) -> Self {
+        self.inner = self.inner.with_pull_progress_fn(pull_progress_fn);
+        self
+    }
+}
+
+impl DedicatedVmOciBundleProvider {
+    fn new(
+        home_dir: impl Into<PathBuf>,
+        runtime_root: impl Into<PathBuf>,
+        profile: DedicatedVmOciProfile,
+    ) -> Self {
+        Self {
+            preparer: VmLocalExecutionBackend::new(home_dir),
+            runtime_root: runtime_root.into(),
+            profile,
+        }
+    }
+
+    fn runtime_root(&self) -> &Path {
+        &self.runtime_root
+    }
+
+    fn with_pull_progress_fn(mut self, pull_progress_fn: crate::PullProgressFn) -> Self {
         self.preparer = self.preparer.with_pull_progress_fn(pull_progress_fn);
         self
     }
@@ -229,17 +322,122 @@ impl OciBundleProvider for WindowsWhpxOciBundleProvider {
         record: &BoxRecord,
         context: &OciBundlePreparationContext,
     ) -> ExecutionManagerResult<()> {
-        if !cfg!(all(target_os = "windows", target_arch = "x86_64")) {
-            return Err(ExecutionManagerError::Unavailable(
-                "Box/WHPX OCI qualification requires Windows x86_64".to_string(),
-            ));
+        self.inner.preflight(record, context)
+    }
+
+    async fn prepare(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<OciPreparedExecution> {
+        self.inner.prepare(record, context).await
+    }
+
+    async fn cleanup(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {
+        self.inner.cleanup(record).await
+    }
+
+    async fn ensure_log_projection(
+        &self,
+        record: &BoxRecord,
+        binding: &super::OciRuntimeBinding,
+    ) -> ExecutionManagerResult<()> {
+        self.inner.ensure_log_projection(record, binding).await
+    }
+
+    async fn wait_log_projection_drained(
+        &self,
+        record: &BoxRecord,
+        binding: &super::OciRuntimeBinding,
+    ) -> ExecutionManagerResult<()> {
+        self.inner
+            .wait_log_projection_drained(record, binding)
+            .await
+    }
+
+    async fn wait_log_projection_stopped_after_owner_loss(
+        &self,
+        record: &BoxRecord,
+        binding: &super::OciRuntimeBinding,
+    ) -> ExecutionManagerResult<()> {
+        self.inner
+            .wait_log_projection_stopped_after_owner_loss(record, binding)
+            .await
+    }
+}
+
+#[async_trait]
+impl OciBundleProvider for LinuxKvmOciBundleProvider {
+    fn preflight(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<()> {
+        self.inner.preflight(record, context)
+    }
+
+    async fn prepare(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<OciPreparedExecution> {
+        self.inner.prepare(record, context).await
+    }
+
+    async fn cleanup(&self, record: &BoxRecord) -> ExecutionManagerResult<()> {
+        self.inner.cleanup(record).await
+    }
+
+    async fn ensure_log_projection(
+        &self,
+        record: &BoxRecord,
+        binding: &super::OciRuntimeBinding,
+    ) -> ExecutionManagerResult<()> {
+        self.inner.ensure_log_projection(record, binding).await
+    }
+
+    async fn wait_log_projection_drained(
+        &self,
+        record: &BoxRecord,
+        binding: &super::OciRuntimeBinding,
+    ) -> ExecutionManagerResult<()> {
+        self.inner
+            .wait_log_projection_drained(record, binding)
+            .await
+    }
+
+    async fn wait_log_projection_stopped_after_owner_loss(
+        &self,
+        record: &BoxRecord,
+        binding: &super::OciRuntimeBinding,
+    ) -> ExecutionManagerResult<()> {
+        self.inner
+            .wait_log_projection_stopped_after_owner_loss(record, binding)
+            .await
+    }
+}
+
+#[async_trait]
+impl OciBundleProvider for DedicatedVmOciBundleProvider {
+    fn preflight(
+        &self,
+        record: &BoxRecord,
+        context: &OciBundlePreparationContext,
+    ) -> ExecutionManagerResult<()> {
+        if !self.profile.host_supported() {
+            return Err(ExecutionManagerError::Unavailable(format!(
+                "Box/{} OCI qualification requires {}",
+                self.profile.label(),
+                self.profile.host_requirement()
+            )));
         }
         if record.isolation != ExecutionIsolation::Microvm
             || !matches!(context.isolation(), IsolationRequest::DedicatedVm)
         {
-            return Err(ExecutionManagerError::InvalidRequest(
-                "Box/WHPX OCI qualification requires dedicated MicroVM isolation".to_string(),
-            ));
+            return Err(ExecutionManagerError::InvalidRequest(format!(
+                "Box/{} OCI qualification requires dedicated MicroVM isolation",
+                self.profile.label()
+            )));
         }
         let metadata = record.managed_execution.as_ref().ok_or_else(|| {
             ExecutionManagerError::Internal(format!(
@@ -256,9 +454,9 @@ impl OciBundleProvider for WindowsWhpxOciBundleProvider {
                 record.id
             )));
         }
-        validate_whpx_qualification(record)?;
+        validate_dedicated_vm_qualification(record, self.profile)?;
         context.runtime_bundle_handoff_directory(&self.runtime_root)?;
-        validate_runtime_root(&self.runtime_root)
+        validate_runtime_root(&self.runtime_root, self.profile)
     }
 
     async fn prepare(
@@ -278,11 +476,13 @@ impl OciBundleProvider for WindowsWhpxOciBundleProvider {
         let prepared = manager
             .prepare_runtime_owned_microvm_bundle(&metadata.plan, &bundle_directory)
             .await
-            .map_err(|error| whpx_preparation_error("prepare bundle", error))?;
+            .map_err(|error| {
+                dedicated_vm_preparation_error(self.profile, "prepare bundle", error)
+            })?;
         let bundle = match OciBundle::load(&prepared.bundle_dir).await {
             Ok(bundle) => bundle,
             Err(error) => {
-                return Err(cleanup_after_whpx_prepare_failure(
+                return Err(cleanup_after_dedicated_vm_prepare_failure(
                     &manager,
                     &bundle_directory,
                     format!("failed to load the generated portable OCI bundle: {error}"),
@@ -302,7 +502,7 @@ impl OciBundleProvider for WindowsWhpxOciBundleProvider {
         let attachments = match CreateAttachments::from_bundle(&bundle, io) {
             Ok(attachments) => attachments,
             Err(error) => {
-                return Err(cleanup_after_whpx_prepare_failure(
+                return Err(cleanup_after_dedicated_vm_prepare_failure(
                     &manager,
                     &bundle_directory,
                     format!("failed to derive portable OCI bundle attachments: {error}"),
@@ -316,7 +516,7 @@ impl OciBundleProvider for WindowsWhpxOciBundleProvider {
         ) {
             Ok(result) => result,
             Err(error) => {
-                return Err(cleanup_after_whpx_prepare_failure(
+                return Err(cleanup_after_dedicated_vm_prepare_failure(
                     &manager,
                     &bundle_directory,
                     format!("failed to validate portable OCI bundle attachments: {error}"),
@@ -326,7 +526,7 @@ impl OciBundleProvider for WindowsWhpxOciBundleProvider {
         result = match result.with_runtime_bundle_handoff(context, &self.runtime_root) {
             Ok(result) => result,
             Err(error) => {
-                return Err(cleanup_after_whpx_prepare_failure(
+                return Err(cleanup_after_dedicated_vm_prepare_failure(
                     &manager,
                     &bundle_directory,
                     format!("failed to bind portable OCI bundle handoff: {error}"),
@@ -341,7 +541,7 @@ impl OciBundleProvider for WindowsWhpxOciBundleProvider {
         let manager = self.preparer.new_oci_preparation_manager(record)?;
         manager
             .cleanup_runtime_owned_microvm_bundle()
-            .map_err(|error| whpx_preparation_error("cleanup bundle", error))
+            .map_err(|error| dedicated_vm_preparation_error(self.profile, "cleanup bundle", error))
     }
 
     async fn ensure_log_projection(
@@ -369,7 +569,10 @@ impl OciBundleProvider for WindowsWhpxOciBundleProvider {
     }
 }
 
-fn validate_whpx_qualification(record: &BoxRecord) -> ExecutionManagerResult<()> {
+fn validate_dedicated_vm_qualification(
+    record: &BoxRecord,
+    profile: DedicatedVmOciProfile,
+) -> ExecutionManagerResult<()> {
     let metadata = record.managed_execution.as_ref().ok_or_else(|| {
         ExecutionManagerError::Internal(format!(
             "execution {} has no managed lifecycle metadata",
@@ -380,17 +583,22 @@ fn validate_whpx_qualification(record: &BoxRecord) -> ExecutionManagerResult<()>
     let defaults = ResourceConfig::default();
     if config.resources.vcpus != 1 || config.resources.memory_mb != 512 {
         return Err(unqualified(
-            "the fixed WHPX profile requires exactly 1 vCPU and 512 MiB of memory",
+            profile,
+            "the fixed profile requires exactly 1 vCPU and 512 MiB of memory",
         ));
     }
     if config.resources.disk_mb != defaults.disk_mb || config.resources.timeout != defaults.timeout
     {
         return Err(unqualified(
-            "custom disk size or lifetime timeout is not qualified for the WHPX OCI profile",
+            profile,
+            "custom disk size or lifetime timeout is not qualified for this OCI profile",
         ));
     }
     if config.tee != TeeConfig::None {
-        return Err(unqualified("TEE is not qualified for the WHPX OCI profile"));
+        return Err(unqualified(
+            profile,
+            "TEE is not qualified for this OCI profile",
+        ));
     }
     if !config.workspace.as_os_str().is_empty()
         || !config.volumes.is_empty()
@@ -399,7 +607,8 @@ fn validate_whpx_qualification(record: &BoxRecord) -> ExecutionManagerResult<()>
         || metadata.request.policy.managed_secret_root.is_some()
     {
         return Err(unqualified(
-            "workspace, bind, named, and secret mounts are not qualified for the WHPX OCI profile",
+            profile,
+            "workspace, bind, named, and secret mounts are not qualified for this OCI profile",
         ));
     }
     if !matches!(config.network, NetworkMode::None)
@@ -409,7 +618,8 @@ fn validate_whpx_qualification(record: &BoxRecord) -> ExecutionManagerResult<()>
         || !config.add_hosts.is_empty()
     {
         return Err(unqualified(
-            "the WHPX OCI profile requires network=none and no network customization",
+            profile,
+            "this OCI profile requires network=none and no network customization",
         ));
     }
     if config.pool.enabled
@@ -422,7 +632,8 @@ fn validate_whpx_qualification(record: &BoxRecord) -> ExecutionManagerResult<()>
         || metadata.request.rootfs_snapshot_id.is_some()
     {
         return Err(unqualified(
-            "pool, deferred-main, KSM, and Snapshot modes are not qualified for the WHPX OCI profile",
+            profile,
+            "pool, deferred-main, KSM, and Snapshot modes are not qualified for this OCI profile",
         ));
     }
     if !config.tmpfs.is_empty()
@@ -437,7 +648,8 @@ fn validate_whpx_qualification(record: &BoxRecord) -> ExecutionManagerResult<()>
         || config.persistent
     {
         return Err(unqualified(
-            "custom mounts, controls, privileges, sidecars, and persistence are not qualified for the WHPX OCI profile",
+            profile,
+            "custom mounts, controls, privileges, sidecars, and persistence are not qualified for this OCI profile",
         ));
     }
     let policy = &metadata.request.policy;
@@ -449,41 +661,68 @@ fn validate_whpx_qualification(record: &BoxRecord) -> ExecutionManagerResult<()>
         || policy.oom_score_adj.is_some()
     {
         return Err(unqualified(
-            "init, device, GPU, shared-memory, and OOM overrides are not qualified for the WHPX OCI profile",
+            profile,
+            "init, device, GPU, shared-memory, and OOM overrides are not qualified for this OCI profile",
         ));
     }
     if policy.platform.as_deref().is_some_and(|platform| {
-        !matches!(
-            platform.trim().to_ascii_lowercase().as_str(),
-            "linux/amd64" | "linux/x86_64"
-        )
+        !platform_supported(profile, platform.trim().to_ascii_lowercase().as_str())
     }) {
         return Err(unqualified(
-            "the WHPX OCI profile supports only Linux amd64 images",
+            profile,
+            match profile {
+                DedicatedVmOciProfile::WindowsWhpx => {
+                    "this OCI profile supports only Linux amd64 images"
+                }
+                DedicatedVmOciProfile::LinuxKvm => {
+                    "this OCI profile supports only Linux amd64 or arm64 images"
+                }
+            },
         ));
     }
     if record.cpus != 1 || record.memory_mb != 512 {
-        return Err(ExecutionManagerError::Internal(
-            "Box record resources drifted from the fixed WHPX qualification profile".to_string(),
-        ));
+        return Err(ExecutionManagerError::Internal(format!(
+            "Box record resources drifted from the fixed {} qualification profile",
+            profile.label()
+        )));
     }
     Ok(())
 }
 
-fn unqualified(message: &str) -> ExecutionManagerError {
-    ExecutionManagerError::InvalidRequest(format!("Box/WHPX OCI qualification rejected: {message}"))
+fn unqualified(profile: DedicatedVmOciProfile, message: &str) -> ExecutionManagerError {
+    ExecutionManagerError::InvalidRequest(format!(
+        "Box/{} OCI qualification rejected: {message}",
+        profile.label()
+    ))
 }
 
-fn validate_runtime_root(path: &Path) -> ExecutionManagerResult<()> {
+fn platform_supported(profile: DedicatedVmOciProfile, platform: &str) -> bool {
+    match profile {
+        DedicatedVmOciProfile::WindowsWhpx => {
+            matches!(platform, "linux/amd64" | "linux/x86_64")
+        }
+        DedicatedVmOciProfile::LinuxKvm => matches!(
+            platform,
+            "linux/amd64" | "linux/x86_64" | "linux/arm64" | "linux/aarch64"
+        ),
+    }
+}
+
+fn validate_runtime_root(
+    path: &Path,
+    profile: DedicatedVmOciProfile,
+) -> ExecutionManagerResult<()> {
     let metadata = std::fs::symlink_metadata(path).map_err(|error| {
         ExecutionManagerError::Unavailable(format!(
-            "failed to inspect WHPX runtime root {}: {error}",
+            "failed to inspect {} runtime root {}: {error}",
+            profile.label(),
             path.display()
         ))
     })?;
     if !metadata.is_dir() || metadata_is_reparse_point(&metadata) {
         return Err(ExecutionManagerError::InvalidRequest(format!(
-            "WHPX runtime root is not a plain directory: {}",
+            "{} runtime root is not a plain directory: {}",
+            profile.label(),
             path.display()
         )));
     }
@@ -502,16 +741,21 @@ fn metadata_is_reparse_point(metadata: &std::fs::Metadata) -> bool {
     metadata.file_type().is_symlink()
 }
 
-fn whpx_preparation_error(action: &str, error: BoxError) -> ExecutionManagerError {
+fn dedicated_vm_preparation_error(
+    profile: DedicatedVmOciProfile,
+    action: &str,
+    error: BoxError,
+) -> ExecutionManagerError {
     match error {
         BoxError::ConfigError(message) => ExecutionManagerError::InvalidRequest(message),
-        error => {
-            ExecutionManagerError::Unavailable(format!("Box/WHPX OCI {action} failed: {error}"))
-        }
+        error => ExecutionManagerError::Unavailable(format!(
+            "Box/{} OCI {action} failed: {error}",
+            profile.label()
+        )),
     }
 }
 
-fn cleanup_after_whpx_prepare_failure(
+fn cleanup_after_dedicated_vm_prepare_failure(
     manager: &crate::VmManager,
     bundle_directory: &Path,
     message: String,


### PR DESCRIPTION
## Summary
- Add `LinuxKvmOciMigrationConfig` / `LinuxKvmOciBundleProvider` for explicit `A3S_BOX_OCI_KVM_ENDPOINT` opt-in (`microvm`/`all`).
- Share the portable DedicatedVm qualification profile with WHPX while keeping Sandbox OCI migration unchanged.
- Pin OCI Runtime to `53e21ef` (`box-kvm-qualification-service`) and document the Linux handoff.

## Test plan
- [x] `cargo test -p a3s-box-runtime --features vm oci_migration`
- [ ] Do not use CI
