### PR TITLE
fix(oci): skip portable rootfs metadata on same-uid virtiofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Linux/macOS portable MicroVM OCI specs no longer request guest
+  `a3s.oci.rootfs-metadata.v1` ownership replay. Same-uid virtio-fs retains
+  Host share-root UIDs and refuses guest `chown`; Windows WHPX still opts into
+  the portable metadata contract. Bundle publish writes the metadata file only
+  when that annotation is present.
 - Guest rootfs archives encode FIFOs as zero-length tar special entries instead
   of opening them for read, so `a3s-box diff` succeeds when the writable layer
   contains a FIFO (#265).

--- a/README.md
+++ b/README.md
@@ -356,7 +356,12 @@ activate by accident.
 
 Current Linux opt-in covers new Sandbox reservations through the long-lived
 Native Linux owner, plus an explicit qualification-only MicroVM path through
-`box-kvm-qualification-service` when `A3S_BOX_OCI_KVM_ENDPOINT` is set. Image-declared
+`box-kvm-qualification-service` when `A3S_BOX_OCI_KVM_ENDPOINT` is set. On that
+Linux/macOS same-uid virtio-fs path, Box does not request guest portable
+rootfs-metadata ownership replay: the share retains Host UIDs and guest
+`chown` is refused by design. Windows WHPX still converts image metadata to
+`a3s.oci.rootfs-metadata.v1` so the guest can restore Linux ownership that
+NTFS cannot store. Image-declared
 anonymous volumes are planned from normalized image metadata after capability
 preflight, persisted in the initial Box reservation, and atomically claimed by
 the exact execution during bundle preparation. Recovery and removal therefore

--- a/src/runtime/src/local_execution/oci_portable_rootfs.rs
+++ b/src/runtime/src/local_execution/oci_portable_rootfs.rs
@@ -12,8 +12,9 @@ use a3s_box_core::rootfs_metadata::{
 use a3s_box_core::{BoxError, Result};
 use a3s_oci_sdk::{
     PortableRootfsEntryKind, PortableRootfsMetadataEntry, PortableRootfsMetadataManifest,
-    PORTABLE_ROOTFS_METADATA_FILE, PORTABLE_ROOTFS_METADATA_MAX_BYTES,
-    PORTABLE_ROOTFS_METADATA_MAX_ENTRIES,
+    PORTABLE_ROOTFS_METADATA_ANNOTATION, PORTABLE_ROOTFS_METADATA_FILE,
+    PORTABLE_ROOTFS_METADATA_MAX_BYTES, PORTABLE_ROOTFS_METADATA_MAX_ENTRIES,
+    PORTABLE_ROOTFS_METADATA_SCHEMA_V1,
 };
 use base64::Engine as _;
 use oci_spec::runtime::Spec;
@@ -137,7 +138,9 @@ pub(crate) fn publish_portable_bundle(
         let rootfs = pending.join("rootfs");
         crate::cache::layer_cache::copy_dir_recursive(source_rootfs, &rootfs)?;
         make_owner_writable(&rootfs)?;
-        publish_portable_rootfs_metadata(&rootfs)?;
+        if portable_rootfs_metadata_requested(spec) {
+            publish_portable_rootfs_metadata(&rootfs)?;
+        }
 
         let config = pending.join("config.json");
         let encoded = serde_json::to_vec_pretty(spec)
@@ -162,6 +165,13 @@ pub(crate) fn publish_portable_bundle(
         return Err(error);
     }
     Ok(())
+}
+
+fn portable_rootfs_metadata_requested(spec: &Spec) -> bool {
+    spec.annotations().as_ref().is_some_and(|annotations| {
+        annotations.get(PORTABLE_ROOTFS_METADATA_ANNOTATION)
+            == Some(&PORTABLE_ROOTFS_METADATA_SCHEMA_V1.to_string())
+    })
 }
 
 fn encode_portable_manifest(source: RootfsMetadataManifest) -> Result<Vec<u8>> {

--- a/src/runtime/src/sandbox/oci.rs
+++ b/src/runtime/src/sandbox/oci.rs
@@ -348,10 +348,16 @@ pub fn compile_portable_microvm_oci_spec(
         RUNTIME_BUNDLE_HANDOFF_EXTENSION.to_string(),
         RUNTIME_BUNDLE_HANDOFF_MOVE_V1.to_string(),
     );
-    annotations.insert(
-        PORTABLE_ROOTFS_METADATA_ANNOTATION.to_string(),
-        PORTABLE_ROOTFS_METADATA_SCHEMA_V1.to_string(),
-    );
+    // Windows virtio-fs cannot store Linux UID/GID; the guest must replay the
+    // portable metadata contract. Linux/macOS same-uid virtio-fs retains the
+    // Host share-root UIDs and refuses guest chown by design, so ownership
+    // replay would fail closed with EPERM.
+    if cfg!(windows) {
+        annotations.insert(
+            PORTABLE_ROOTFS_METADATA_ANNOTATION.to_string(),
+            PORTABLE_ROOTFS_METADATA_SCHEMA_V1.to_string(),
+        );
+    }
 
     SpecBuilder::default()
         .version("1.3.0".to_string())
@@ -1613,10 +1619,15 @@ mod tests {
         assert_eq!(value["ociVersion"], "1.3.0");
         assert_eq!(value["root"]["path"], "rootfs");
         assert_eq!(value["root"]["readonly"], false);
-        assert_eq!(
-            value["annotations"][PORTABLE_ROOTFS_METADATA_ANNOTATION],
-            PORTABLE_ROOTFS_METADATA_SCHEMA_V1
-        );
+        let annotations = value["annotations"].as_object().unwrap();
+        if cfg!(windows) {
+            assert_eq!(
+                annotations[PORTABLE_ROOTFS_METADATA_ANNOTATION],
+                PORTABLE_ROOTFS_METADATA_SCHEMA_V1
+            );
+        } else {
+            assert!(!annotations.contains_key(PORTABLE_ROOTFS_METADATA_ANNOTATION));
+        }
         assert_eq!(
             value["annotations"][RUNTIME_BUNDLE_HANDOFF_EXTENSION],
             RUNTIME_BUNDLE_HANDOFF_MOVE_V1


### PR DESCRIPTION
## Summary
- Linux/macOS same-uid virtio-fs retains Host share-root UIDs and refuses guest `chown` (by design for non-root Host Services).
- Portable MicroVM specs therefore omit `dev.a3s.oci.rootfs-metadata` on non-Windows hosts; Windows WHPX still opts in so the guest can restore Linux ownership NTFS cannot store.
- Bundle publish writes the metadata file only when that annotation is present.

## Test plan
- [x] `cargo test -p a3s-box-runtime portable_microvm_compiler_uses_relative_root`
- [x] `cargo test -p a3s-box-runtime publish_portable_bundle_uses_private`
- [ ] Re-run Box↔`box-kvm-qualification-service` alpine `/bin/true` smoke after merge