### PR TITLE
chore(oci): pin OCI Runtime to 01786ab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Changed
 
-- Bump the pinned OCI Runtime revision to `53e21ef204c8a45bcc2a02f28d35acf2edc9415f` so Box can target the
-  merged `box-kvm-qualification-service` Host Service.
+- Bump the pinned OCI Runtime revision to
+  `01786abf4812890ca6f274f1cadf80ebd99ad44f` so Box tracks the Guest Agent
+  portable-rootfs FD-root fix plus retained KVM lifecycle/recovery/soak/
+  create-reopen evidence on that mainline.
 
 ### Fixed
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=53e21ef204c8a45bcc2a02f28d35acf2edc9415f#53e21ef204c8a45bcc2a02f28d35acf2edc9415f"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=01786abf4812890ca6f274f1cadf80ebd99ad44f#01786abf4812890ca6f274f1cadf80ebd99ad44f"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=53e21ef204c8a45bcc2a02f28d35acf2edc9415f#53e21ef204c8a45bcc2a02f28d35acf2edc9415f"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=01786abf4812890ca6f274f1cadf80ebd99ad44f#01786abf4812890ca6f274f1cadf80ebd99ad44f"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "53e21ef204c8a45bcc2a02f28d35acf2edc9415f" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "01786abf4812890ca6f274f1cadf80ebd99ad44f" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- Bump `a3s-oci-sdk` / `a3s-oci-core` pin from `53e21ef` to `01786ab`.
- Aligns Box with the portable-rootfs FD-root Guest Agent fix and retained KVM lifecycle/recovery/soak/create-reopen evidence.

## Test plan
- [x] `cargo update -p a3s-oci-sdk -p a3s-oci-core`
- [ ] Optional: rebuild `a3s-box` against the new pin