### PR TITLE
fix(oci): treat undrained log projection death as owner loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Terminal reconcile after utility-VM/Host owner loss no longer fails closed
+  when the managed OCI log projection exits before drain. Box treats that as
+  stopped-only owner-loss recovery and refuses to invent an exit status from
+  undrained Wait evidence.
 - Linux/macOS portable MicroVM OCI specs no longer request guest
   `a3s.oci.rootfs-metadata.v1` ownership replay. Same-uid virtio-fs retains
   Host share-root UIDs and refuses guest `chown`; Windows WHPX still opts into

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -1475,16 +1475,35 @@ impl OciLocalExecutionBackend {
         let execution_id = self.execution_id(record)?;
         let generation = self.metadata(record)?.generation;
         let status = self.adapter.wait_stopped(runtime, binding).await?;
-        if status.is_some() {
-            self.provider.ensure_log_projection(record, binding).await?;
-            self.provider
-                .wait_log_projection_drained(record, binding)
-                .await?;
-        } else {
-            self.provider
-                .wait_log_projection_stopped_after_owner_loss(record, binding)
-                .await?;
-        }
+        let exit_code = match status {
+            Some(status) => match self.provider.ensure_log_projection(record, binding).await {
+                Ok(()) => {
+                    self.provider
+                        .wait_log_projection_drained(record, binding)
+                        .await?;
+                    Some(exit_code(&status)?)
+                }
+                Err(ExecutionManagerError::Unavailable(message))
+                    if message.contains("exited before drain") =>
+                {
+                    // The projection worker died with the utility-VM/Host
+                    // owner. Do not restart it for drain theater, and do not
+                    // publish an exit code that Box cannot authenticate through
+                    // drained init output after owner loss.
+                    self.provider
+                        .wait_log_projection_stopped_after_owner_loss(record, binding)
+                        .await?;
+                    None
+                }
+                Err(error) => return Err(error),
+            },
+            None => {
+                self.provider
+                    .wait_log_projection_stopped_after_owner_loss(record, binding)
+                    .await?;
+                None
+            }
+        };
         self.adapter
             .delete(&execution_id, generation, binding, DeleteMode::StoppedOnly)
             .await?;
@@ -1492,7 +1511,7 @@ impl OciLocalExecutionBackend {
         Ok(LocalExecutionObservation {
             state: ExecutionState::Stopped,
             handle: None,
-            exit_code: status.as_ref().map(exit_code).transpose()?,
+            exit_code,
         })
     }
 }

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -1275,6 +1275,7 @@ struct FakeBundleProvider {
     projection_drains: AtomicUsize,
     projection_owner_loss_stops: AtomicUsize,
     fail_projection: AtomicBool,
+    fail_projection_exited_before_drain: AtomicBool,
     invalid_console: AtomicBool,
     expected_snapshot_lower: Mutex<Option<std::path::PathBuf>>,
     snapshot_lower_observed: AtomicBool,
@@ -1365,6 +1366,11 @@ impl OciBundleProvider for FakeBundleProvider {
         _binding: &OciRuntimeBinding,
     ) -> ExecutionManagerResult<()> {
         self.projection_ensures.fetch_add(1, Ordering::SeqCst);
+        if self.fail_projection_exited_before_drain.load(Ordering::SeqCst) {
+            return Err(ExecutionManagerError::Unavailable(
+                "managed OCI log worker for fake generation 1 exited before drain; refusing to replay its Box log projection".to_string(),
+            ));
+        }
         if self.fail_projection.load(Ordering::SeqCst) {
             return Err(ExecutionManagerError::Unavailable(
                 "fake managed OCI log projection is unavailable".to_string(),
@@ -4216,6 +4222,51 @@ async fn reopened_backend_cleans_stopped_generation_without_inventing_exit_statu
         .as_ref()
         .and_then(|metadata| metadata.oci_runtime.as_ref())
         .is_none());
+}
+
+#[tokio::test]
+async fn reopened_backend_treats_undrained_projection_death_as_owner_loss() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let provider = Arc::new(FakeBundleProvider::default());
+    let endpoint = test_endpoint();
+    let first = manager(
+        &directory,
+        endpoint.clone(),
+        service.clone(),
+        provider.clone(),
+    );
+    let lease = first
+        .create_and_start(
+            request("projection-owner-loss", ExecutionIsolation::Sandbox),
+            &box_operation("projection-owner-loss-operation"),
+        )
+        .await
+        .expect("initial launch");
+    provider
+        .fail_projection_exited_before_drain
+        .store(true, Ordering::SeqCst);
+    // Wait evidence alone must not invent a product exit when the projection
+    // died with the owner before drain.
+    service.mark_stopped(
+        &lease.execution_id,
+        ExitStatus::exited(23).expect("exit status"),
+    );
+    let reopened = manager(&directory, endpoint, service.clone(), provider.clone());
+
+    let status = reopened
+        .inspect(&lease.execution_id)
+        .await
+        .expect("projection-owner-loss terminal inspection");
+    let record = persisted(&reopened, &lease.execution_id);
+
+    assert_eq!(status.state, ExecutionState::Stopped);
+    assert_eq!(record.exit_code, None);
+    assert_eq!(provider.projection_drains.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        provider.projection_owner_loss_stops.load(Ordering::SeqCst),
+        1
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- When terminal reconcile sees Wait evidence but the managed OCI log projection exited before drain, treat it as owner-loss recovery.
- Do not invent a product exit status from undrained Wait evidence.
- First-principles unit test covers Wait(23) + undrained projection death → stopped, `exit_code=None`.

## Test plan
- [x] `cargo test -p a3s-box-runtime undrained_projection_death`