### PR TITLE
feat(oci): Linux KVM vertical slice Host Service restart (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ All notable changes to A3S Box will be documented in this file.
 
 - Linux qualification-only MicroVM OCI vertical-slice gate:
   `linux-kvm-oci-qualification` example plus
-  `scripts/linux-kvm-oci-qualification.sh`. It exercises create replay, Box
-  manager reopen, start, exact exit status `23`, delete replay, and residual
-  path cleanup against an operator-started `box-kvm-qualification-service`.
-  Schema `a3s.box.linux-kvm-oci-qualification.v1`. Observation-only; not a
-  fresh-host or production-routing claim.
+  `scripts/linux-kvm-oci-qualification.sh`. Schema
+  `a3s.box.linux-kvm-oci-qualification.v2` exercises create replay, Box
+  manager reopen, start, exact exit status `23`, delete replay, residual path
+  cleanup, and—when service restart inputs are supplied—Host Service
+  SIGKILL/restart while a generation is running with stopped-only reconcile
+  (no invented exit status). The local runner starts
+  `box-kvm-qualification-service` itself. Observation-only; not a fresh-host
+  or production-routing claim.
 - Linux qualification-only MicroVM OCI opt-in through
   `A3S_BOX_OCI_MIGRATION=microvm|all` plus an explicit
   `A3S_BOX_OCI_KVM_ENDPOINT` Unix socket pointing at OCI Runtime's

--- a/README.md
+++ b/README.md
@@ -288,23 +288,28 @@ sidecars, Snapshot, or persistence. Rust applications can construct
 `A3sBoxClient::with_configured_paths(...).await`.
 
 For the exact public-lifecycle vertical slice (create replay, Box-manager
-reopen, start, exact exit status, delete, residual cleanup), build and run:
+reopen, start, exact exit status, delete, residual cleanup, plus Host Service
+SIGKILL/restart while a generation is running), build and run:
 
 ```bash
 cargo build -p a3s-box-runtime --example linux-kvm-oci-qualification --release
 # place the example beside a3s-box, then:
 ./scripts/linux-kvm-oci-qualification.sh \
   --box-bin /absolute/path/to/bin \
-  --runtime-root /run/a3s/oci-kvm-box/runtime \
-  --kvm-endpoint /run/a3s/oci-kvm-box/runtime.sock \
+  --a3s-oci /absolute/path/to/a3s-oci \
+  --service-root /run/a3s/oci-kvm-box \
+  --shim /absolute/path/to/isolated-libkrun-shim \
+  --system-image-manifest /absolute/path/to/system-image.json \
   --image alpine:3.20 \
   --report /absolute/path/to/report.json \
   --home /tmp/a3s-box-kvm-oci-qualification-home
 ```
 
-The report schema is `a3s.box.linux-kvm-oci-qualification.v1`. This remains
-qualification-only evidence against an operator-started Host Service; it does
-not promote the public KVM candidate or change default MicroVM routing.
+The report schema is `a3s.box.linux-kvm-oci-qualification.v2`. The runner
+starts `box-kvm-qualification-service` and passes service restart inputs so
+phase 2 can SIGKILL/restart the Host Service. This remains qualification-only
+evidence; it does not promote the public KVM candidate or change default
+MicroVM routing.
 
 ### Exercise the qualification-only WHPX handoff on Windows
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -311,13 +311,15 @@ later gates.
 - [x] Add the Linux KVM qualification-only vertical-slice executable and local
   runner (`linux-kvm-oci-qualification`,
   `scripts/linux-kvm-oci-qualification.sh`) that prove create replay, Box
-  manager reopen, start, exact exit status, delete replay, and residual cleanup
-  against `box-kvm-qualification-service`. Existing-host WSL2 evidence on Box
-  `75879f0a` against OCI Runtime `fdc4258e` /
-  `01786abf` retained report SHA-256
-  `d10fd7bd4437cbaba223b0c7630c85a090e0999b9d69bc3704ba157804e4683c`. This does
-  not close fresh-host promotion, AArch64 promotion, runtime-service restart, or
-  default MicroVM cutover.
+  manager reopen, start, exact exit status, delete replay, residual cleanup,
+  and Host Service SIGKILL/restart (stopped-only reconcile, no invented exit
+  status) against `box-kvm-qualification-service` when service restart inputs
+  are available. Existing-host WSL2 evidence on Box `e0fd63db` (with OCI pin
+  `01786abf`) retained report SHA-256
+  `87191a0d4334866d3a06283ff615c7342479e28b23f8f95a5b91969a9a1d6d31` for
+  schema `a3s.box.linux-kvm-oci-qualification.v2` (exact exit `23` plus Host
+  Service restart → stopped-only, no invented exit). This does not close
+  fresh-host promotion, AArch64 promotion, or default MicroVM cutover.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
 through Box on Linux and Windows, including Box and runtime process restart.

--- a/scripts/linux-kvm-oci-qualification.sh
+++ b/scripts/linux-kvm-oci-qualification.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 # Local Linux KVM MicroVM vertical-slice gate for Box over OCI Runtime.
 #
-# Prerequisites (operator-owned):
-#   - usable /dev/kvm
-#   - running `a3s-oci box-kvm-qualification-service` with absolute --root,
-#     --shim, and --system-image-manifest on a Linux-native filesystem
-#   - release `a3s-box` / `a3s-box-shim` able to resolve libkrun
+# Starts box-kvm-qualification-service, then runs:
+#   1) create replay → Box-manager reopen → start → exact exit 23 → delete
+#   2) Host Service SIGKILL/restart while a generation is running → stopped-only
+#      reconcile without invented exit status → delete
 #
-# This script does not start the Host Service and does not claim fresh-host
-# promotion. It only proves the public Box create → manager reopen → start →
-# exact exit → delete slice against an already-running qualification service.
+# Observation-only. Does not claim fresh-host or AArch64 promotion.
 
 set -euo pipefail
 
@@ -18,8 +15,10 @@ usage() {
 Usage:
   linux-kvm-oci-qualification.sh \
     --box-bin DIR \
-    --runtime-root ABS_PATH \
-    --kvm-endpoint ABS_SOCK \
+    --a3s-oci ABS_BIN \
+    --service-root ABS_DIR \
+    --shim ABS_BIN \
+    --system-image-manifest ABS_JSON \
     --image REF \
     --report ABS_JSON \
     [--home ABS_DIR]
@@ -30,42 +29,26 @@ EOF
 }
 
 BOX_BIN=""
-RUNTIME_ROOT=""
-KVM_ENDPOINT=""
+A3S_OCI=""
+SERVICE_ROOT=""
+SHIM=""
+MANIFEST=""
 IMAGE=""
 REPORT=""
 HOME_DIR=""
+SERVICE_PID=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --box-bin)
-      BOX_BIN="${2:?}"
-      shift 2
-      ;;
-    --runtime-root)
-      RUNTIME_ROOT="${2:?}"
-      shift 2
-      ;;
-    --kvm-endpoint)
-      KVM_ENDPOINT="${2:?}"
-      shift 2
-      ;;
-    --image)
-      IMAGE="${2:?}"
-      shift 2
-      ;;
-    --report)
-      REPORT="${2:?}"
-      shift 2
-      ;;
-    --home)
-      HOME_DIR="${2:?}"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
+    --box-bin) BOX_BIN="${2:?}"; shift 2 ;;
+    --a3s-oci) A3S_OCI="${2:?}"; shift 2 ;;
+    --service-root) SERVICE_ROOT="${2:?}"; shift 2 ;;
+    --shim) SHIM="${2:?}"; shift 2 ;;
+    --system-image-manifest) MANIFEST="${2:?}"; shift 2 ;;
+    --image) IMAGE="${2:?}"; shift 2 ;;
+    --report) REPORT="${2:?}"; shift 2 ;;
+    --home) HOME_DIR="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
     *)
       echo "unknown argument: $1" >&2
       usage >&2
@@ -84,8 +67,10 @@ require_abs() {
 }
 
 require_abs "--box-bin" "${BOX_BIN}"
-require_abs "--runtime-root" "${RUNTIME_ROOT}"
-require_abs "--kvm-endpoint" "${KVM_ENDPOINT}"
+require_abs "--a3s-oci" "${A3S_OCI}"
+require_abs "--service-root" "${SERVICE_ROOT}"
+require_abs "--shim" "${SHIM}"
+require_abs "--system-image-manifest" "${MANIFEST}"
 require_abs "--report" "${REPORT}"
 
 if [[ -z "$IMAGE" ]]; then
@@ -105,16 +90,18 @@ case "$(basename "$HOME_DIR")" in
     ;;
 esac
 
-if [[ ! -x "${BOX_BIN}/a3s-box" ]]; then
-  echo "missing executable ${BOX_BIN}/a3s-box" >&2
-  exit 2
-fi
-if [[ ! -S "${KVM_ENDPOINT}" ]]; then
-  echo "missing Unix socket ${KVM_ENDPOINT}" >&2
-  exit 2
-fi
-if [[ ! -d "${RUNTIME_ROOT}" ]]; then
-  echo "missing runtime root ${RUNTIME_ROOT}" >&2
+EXAMPLE_BIN="${BOX_BIN}/linux-kvm-oci-qualification"
+for path in "${BOX_BIN}/a3s-box" "${EXAMPLE_BIN}" "${A3S_OCI}" "${SHIM}"; do
+  if [[ ! -x "$path" ]]; then
+    echo "missing executable ${path}" >&2
+    if [[ "$path" == "${EXAMPLE_BIN}" ]]; then
+      echo "  cargo build -p a3s-box-runtime --example linux-kvm-oci-qualification --release" >&2
+    fi
+    exit 2
+  fi
+done
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "missing system-image manifest ${MANIFEST}" >&2
   exit 2
 fi
 if [[ -e "${REPORT}" ]]; then
@@ -122,14 +109,56 @@ if [[ -e "${REPORT}" ]]; then
   exit 2
 fi
 
-EXAMPLE_BIN="${BOX_BIN}/linux-kvm-oci-qualification"
-if [[ ! -x "${EXAMPLE_BIN}" ]]; then
-  echo "missing executable ${EXAMPLE_BIN}; build with:" >&2
-  echo "  cargo build -p a3s-box-runtime --example linux-kvm-oci-qualification --release" >&2
+mkdir -p "${HOME_DIR}"
+mkdir -m 0700 -p "${SERVICE_ROOT}"
+chmod 0700 "${SERVICE_ROOT}"
+
+RUNTIME_ROOT="${SERVICE_ROOT}/runtime"
+KVM_ENDPOINT="${SERVICE_ROOT}/runtime.sock"
+SERVICE_LOG="${SERVICE_ROOT}/qualification-service.log"
+
+if [[ -S "${KVM_ENDPOINT}" ]]; then
+  echo "refusing to reuse an already-bound endpoint ${KVM_ENDPOINT}" >&2
   exit 2
 fi
 
-mkdir -p "${HOME_DIR}"
+cleanup() {
+  local status=$?
+  if [[ -f "${SERVICE_ROOT}/qualification-service.pid" ]]; then
+    SERVICE_PID="$(tr -d '[:space:]' <"${SERVICE_ROOT}/qualification-service.pid" || true)"
+  fi
+  if [[ -n "${SERVICE_PID:-}" ]] && kill -0 "${SERVICE_PID}" 2>/dev/null; then
+    kill -TERM "${SERVICE_PID}" 2>/dev/null || true
+    wait "${SERVICE_PID}" 2>/dev/null || true
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+nohup "${A3S_OCI}" box-kvm-qualification-service \
+  --root "${SERVICE_ROOT}" \
+  --shim "${SHIM}" \
+  --system-image-manifest "${MANIFEST}" \
+  >"${SERVICE_LOG}" 2>&1 &
+SERVICE_PID=$!
+echo "${SERVICE_PID}" >"${SERVICE_ROOT}/qualification-service.pid"
+
+for _ in $(seq 1 120); do
+  if [[ -S "${KVM_ENDPOINT}" ]]; then
+    break
+  fi
+  if ! kill -0 "${SERVICE_PID}" 2>/dev/null; then
+    echo "Host Service exited before readiness; log: ${SERVICE_LOG}" >&2
+    tail -40 "${SERVICE_LOG}" >&2 || true
+    exit 1
+  fi
+  sleep 0.25
+done
+if [[ ! -S "${KVM_ENDPOINT}" ]]; then
+  echo "Host Service did not publish ${KVM_ENDPOINT}" >&2
+  exit 1
+fi
+
 export PATH="${BOX_BIN}:${PATH}"
 export A3S_HOME="${HOME_DIR}"
 export A3S_BOX_OCI_HOST_ROOT="${RUNTIME_ROOT}"
@@ -137,12 +166,18 @@ export A3S_BOX_OCI_KVM_ENDPOINT="${KVM_ENDPOINT}"
 export A3S_BOX_KVM_OCI_IMAGE="${IMAGE}"
 export A3S_BOX_KVM_OCI_REPORT="${REPORT}"
 export A3S_BOX_KVM_OCI_QUALIFICATION=1
+export A3S_BOX_KVM_OCI_SERVICE_PID="${SERVICE_PID}"
+export A3S_BOX_KVM_OCI_SERVICE_BIN="${A3S_OCI}"
+export A3S_BOX_KVM_OCI_SERVICE_ROOT="${SERVICE_ROOT}"
+export A3S_BOX_KVM_OCI_SERVICE_SHIM="${SHIM}"
+export A3S_BOX_KVM_OCI_SERVICE_MANIFEST="${MANIFEST}"
+export A3S_BOX_KVM_OCI_SERVICE_LOG="${SERVICE_LOG}"
 
-echo "running Linux KVM OCI qualification"
+echo "running Linux KVM OCI qualification v2"
 echo "  home=${A3S_HOME}"
-echo "  runtime-root=${A3S_BOX_OCI_HOST_ROOT}"
-echo "  endpoint=${A3S_BOX_OCI_KVM_ENDPOINT}"
-echo "  image=${A3S_BOX_KVM_OCI_IMAGE}"
-echo "  report=${A3S_BOX_KVM_OCI_REPORT}"
+echo "  service-root=${SERVICE_ROOT}"
+echo "  service-pid=${SERVICE_PID}"
+echo "  image=${IMAGE}"
+echo "  report=${REPORT}"
 
 "${EXAMPLE_BIN}"

--- a/src/runtime/examples/linux_kvm_oci_qualification.rs
+++ b/src/runtime/examples/linux_kvm_oci_qualification.rs
@@ -1,9 +1,15 @@
 //! Destructive product-lifecycle qualification for Box over A3S OCI Runtime/KVM.
 //!
-//! A host operator owns the isolated home, `box-kvm-qualification-service`,
-//! image import, and process-leak checks. This executable exercises only the
-//! public Box lifecycle boundary and always emits a versioned JSON report when
-//! `A3S_BOX_KVM_OCI_REPORT` names an absolute output path.
+//! A host operator owns image import and process-leak checks. This executable
+//! exercises the public Box lifecycle boundary, including an optional Host
+//! Service SIGKILL/restart while a MicroVM is running. It always emits a
+//! versioned JSON report when `A3S_BOX_KVM_OCI_REPORT` names an absolute path.
+//!
+//! Schema `a3s.box.linux-kvm-oci-qualification.v2` covers:
+//! 1. create replay + Box-manager reopen + start + exact exit `23` + delete
+//! 2. when service restart inputs are present: a second generation that is
+//!    observed running, interrupted by Host Service SIGKILL/restart, and
+//!    reconciled to stopped without an invented exit status before delete
 
 #[cfg(not(all(
     target_os = "linux",
@@ -36,12 +42,14 @@ mod qualification {
     use std::fs::OpenOptions;
     use std::io::{self, Write};
     use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
     use std::time::Duration;
 
     use a3s_box_core::{
         BoxConfig, CreateExecutionRequest, ExecutionBackend, ExecutionGeneration, ExecutionId,
-        ExecutionIsolation, ExecutionManager, ExecutionState, IsolationClass as BoxIsolationClass,
-        NetworkMode, OperationId, ReconcileOutcome, ResourceConfig,
+        ExecutionIsolation, ExecutionManager, ExecutionManagerError, ExecutionState,
+        IsolationClass as BoxIsolationClass, NetworkMode, OperationId, ReconcileOutcome,
+        ResourceConfig,
     };
     use a3s_box_runtime::{
         LinuxKvmOciMigrationConfig, LocalExecutionManager, ManagedExecutionStore,
@@ -56,12 +64,28 @@ mod qualification {
     const ENDPOINT_ENV: &str = "A3S_BOX_OCI_KVM_ENDPOINT";
     const IMAGE_ENV: &str = "A3S_BOX_KVM_OCI_IMAGE";
     const REPORT_ENV: &str = "A3S_BOX_KVM_OCI_REPORT";
-    const SCHEMA_VERSION: &str = "a3s.box.linux-kvm-oci-qualification.v1";
+    const SERVICE_PID_ENV: &str = "A3S_BOX_KVM_OCI_SERVICE_PID";
+    const SERVICE_BIN_ENV: &str = "A3S_BOX_KVM_OCI_SERVICE_BIN";
+    const SERVICE_ROOT_ENV: &str = "A3S_BOX_KVM_OCI_SERVICE_ROOT";
+    const SERVICE_SHIM_ENV: &str = "A3S_BOX_KVM_OCI_SERVICE_SHIM";
+    const SERVICE_MANIFEST_ENV: &str = "A3S_BOX_KVM_OCI_SERVICE_MANIFEST";
+    const SERVICE_LOG_ENV: &str = "A3S_BOX_KVM_OCI_SERVICE_LOG";
+    const SCHEMA_VERSION: &str = "a3s.box.linux-kvm-oci-qualification.v2";
     const STDOUT_MARKER: &str = "a3s-box-kvm-oci-stdout";
     const STDERR_MARKER: &str = "a3s-box-kvm-oci-stderr";
     const EXPECTED_EXIT_CODE: i32 = 23;
 
     type AnyError = Box<dyn Error + Send + Sync>;
+
+    #[derive(Debug, Clone)]
+    struct ServiceRestartInputs {
+        pid: u32,
+        service_bin: PathBuf,
+        service_root: PathBuf,
+        service_shim: PathBuf,
+        system_image_manifest: PathBuf,
+        service_log: PathBuf,
+    }
 
     #[derive(Debug, Clone)]
     struct Inputs {
@@ -70,6 +94,7 @@ mod qualification {
         runtime_root: PathBuf,
         endpoint: PathBuf,
         image: String,
+        service_restart: Option<ServiceRestartInputs>,
     }
 
     #[derive(Debug, Serialize)]
@@ -100,6 +125,14 @@ mod qualification {
         box_directory_absent: bool,
         runtime_shares_absent: bool,
         bundle_handoffs_absent: bool,
+        runtime_service_restart_requested: bool,
+        runtime_service_restarted: bool,
+        restart_operation_id: Option<String>,
+        restart_execution_id: Option<String>,
+        restart_observed_running: bool,
+        restart_reconciled_stopped: bool,
+        restart_exit_code_absent: bool,
+        restart_removed: bool,
     }
 
     impl QualificationReport {
@@ -131,6 +164,14 @@ mod qualification {
                 box_directory_absent: false,
                 runtime_shares_absent: false,
                 bundle_handoffs_absent: false,
+                runtime_service_restart_requested: false,
+                runtime_service_restarted: false,
+                restart_operation_id: None,
+                restart_execution_id: None,
+                restart_observed_running: false,
+                restart_reconciled_stopped: false,
+                restart_exit_code_absent: false,
+                restart_removed: false,
             }
         }
     }
@@ -157,9 +198,24 @@ mod qualification {
                         report.operation_id = Some(operation_id.to_string());
                         let outcome = exercise(&inputs, &operation_id, &mut report).await;
                         if outcome.is_err() {
+                            let mut cleanup_error = None;
                             if let Err(error) = cleanup(&inputs, &operation_id).await {
-                                report.cleanup_error = Some(error.to_string());
+                                cleanup_error = Some(error.to_string());
                             }
+                            if let Some(restart_operation) = report
+                                .restart_operation_id
+                                .as_deref()
+                                .and_then(|value| OperationId::new(value.to_string()).ok())
+                            {
+                                if let Err(error) = cleanup(&inputs, &restart_operation).await {
+                                    let message = error.to_string();
+                                    cleanup_error = Some(match cleanup_error {
+                                        Some(existing) => format!("{existing}; {message}"),
+                                        None => message,
+                                    });
+                                }
+                            }
+                            report.cleanup_error = cleanup_error;
                         }
                         outcome
                     }
@@ -218,6 +274,8 @@ mod qualification {
         )?;
         let image = required_environment_string(IMAGE_ENV)?;
         let state_path = home_dir.join("managed-executions.json");
+        let service_restart = load_service_restart_inputs()?;
+        report.runtime_service_restart_requested = service_restart.is_some();
 
         report.home_dir = Some(home_dir.clone());
         report.state_path = Some(state_path.clone());
@@ -230,7 +288,27 @@ mod qualification {
             runtime_root,
             endpoint,
             image,
+            service_restart,
         })
+    }
+
+    fn load_service_restart_inputs() -> Result<Option<ServiceRestartInputs>, AnyError> {
+        let pid_raw = match std::env::var(SERVICE_PID_ENV) {
+            Ok(value) if !value.trim().is_empty() => value,
+            _ => return Ok(None),
+        };
+        let pid: u32 = pid_raw
+            .parse()
+            .map_err(|_| failure(format!("{SERVICE_PID_ENV} must be a positive pid")))?;
+        require(pid > 1, format!("{SERVICE_PID_ENV} must be a positive pid"))?;
+        Ok(Some(ServiceRestartInputs {
+            pid,
+            service_bin: absolute_environment_path(SERVICE_BIN_ENV)?,
+            service_root: absolute_environment_path(SERVICE_ROOT_ENV)?,
+            service_shim: absolute_environment_path(SERVICE_SHIM_ENV)?,
+            system_image_manifest: absolute_environment_path(SERVICE_MANIFEST_ENV)?,
+            service_log: absolute_environment_path(SERVICE_LOG_ENV)?,
+        }))
     }
 
     async fn exercise(
@@ -238,7 +316,19 @@ mod qualification {
         operation_id: &OperationId,
         report: &mut QualificationReport,
     ) -> Result<(), AnyError> {
-        let request = qualification_request(&inputs.image);
+        exercise_exact_exit(inputs, operation_id, report).await?;
+        if let Some(service) = inputs.service_restart.as_ref() {
+            exercise_runtime_service_restart(inputs, service, report).await?;
+        }
+        Ok(())
+    }
+
+    async fn exercise_exact_exit(
+        inputs: &Inputs,
+        operation_id: &OperationId,
+        report: &mut QualificationReport,
+    ) -> Result<(), AnyError> {
+        let request = qualification_request(&inputs.image, false);
         let manager = connect(inputs).await?;
         let reservation = manager.create(request.clone(), operation_id).await?;
         report.execution_id = Some(reservation.execution_id.to_string());
@@ -408,6 +498,239 @@ mod qualification {
         Ok(())
     }
 
+    async fn exercise_runtime_service_restart(
+        inputs: &Inputs,
+        service: &ServiceRestartInputs,
+        report: &mut QualificationReport,
+    ) -> Result<(), AnyError> {
+        let operation_id = OperationId::new(format!(
+            "linux-kvm-oci-runtime-restart-{}",
+            uuid::Uuid::new_v4()
+        ))?;
+        report.restart_operation_id = Some(operation_id.to_string());
+
+        let request = qualification_request(&inputs.image, true);
+        let manager = connect(inputs).await?;
+        let reservation = manager.create(request, &operation_id).await?;
+        report.restart_execution_id = Some(reservation.execution_id.to_string());
+        let lease = tokio::time::timeout(
+            Duration::from_secs(30 * 60),
+            manager.start(&reservation.execution_id, reservation.generation),
+        )
+        .await
+        .map_err(|_| failure("timed out starting the runtime-restart KVM execution"))??;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+        loop {
+            let status = manager.inspect(&lease.execution_id).await?;
+            if matches!(status.state, ExecutionState::Running) {
+                report.restart_observed_running = true;
+                break;
+            }
+            if matches!(status.state, ExecutionState::Failed | ExecutionState::Stopped) {
+                return Err(failure(
+                    "runtime-restart generation left running before Host Service SIGKILL",
+                ));
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(failure(
+                    "timed out waiting for runtime-restart generation to run",
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        drop(manager);
+        restart_host_service(service, &inputs.endpoint)?;
+        report.runtime_service_restarted = true;
+
+        let reconnected = connect(inputs).await?;
+        // Host Service reopen may briefly report Unavailable while the
+        // replacement owner recovers durable state; retry only that class.
+        let mut outcome = None;
+        let reconcile_deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+        while outcome.is_none() {
+            match reconnected.reconcile(&operation_id).await {
+                Ok(value) => outcome = Some(value),
+                Err(ExecutionManagerError::Unavailable(_)) => {
+                    if tokio::time::Instant::now() >= reconcile_deadline {
+                        return Err(failure(
+                            "Box remained Unavailable for 120s after Host Service restart",
+                        ));
+                    }
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                }
+                Err(error) => {
+                    return Err(failure(format!(
+                        "Box reconcile failed after Host Service restart: {error}"
+                    )));
+                }
+            }
+        }
+        let outcome = outcome.expect("reconcile outcome assigned before loop exit");
+        // Ready and Created carry different payload types; match them apart.
+        // Failed is the durable terminal outcome for stopped-only owner loss.
+        match outcome {
+            ReconcileOutcome::Ready(recovered) => {
+                require(
+                    recovered.execution_id == reservation.execution_id
+                        && recovered.generation == reservation.generation,
+                    "Host Service restart recovered a different Ready Box generation",
+                )?;
+            }
+            ReconcileOutcome::Created(recovered) => {
+                require(
+                    recovered.execution_id == reservation.execution_id
+                        && recovered.generation == reservation.generation,
+                    "Host Service restart recovered a different Created Box generation",
+                )?;
+            }
+            ReconcileOutcome::Failed => {}
+            ReconcileOutcome::Creating => {
+                return Err(failure(
+                    "Host Service restart left the Box generation stuck creating",
+                ));
+            }
+            ReconcileOutcome::Absent => {
+                return Err(failure(
+                    "Host Service restart lost the Box operation before stopped reconciliation",
+                ));
+            }
+        }
+
+        let status = reconnected.inspect(&reservation.execution_id).await?;
+        require(
+            matches!(status.state, ExecutionState::Stopped),
+            format!(
+                "expected stopped-only reconciliation after Host Service restart, found {:?}",
+                status.state
+            ),
+        )?;
+        report.restart_reconciled_stopped = true;
+
+        let store = ManagedExecutionStore::new(&inputs.state_path);
+        let stopped = store
+            .get(&reservation.execution_id)?
+            .ok_or_else(|| failure("restart generation record is missing after reconcile"))?;
+        require(
+            stopped.exit_code.is_none(),
+            format!(
+                "Host Service restart invented exit status {:?}",
+                stopped.exit_code
+            ),
+        )?;
+        report.restart_exit_code_absent = true;
+
+        report.restart_removed = reconnected
+            .remove(&reservation.execution_id, reservation.generation)
+            .await?;
+        require(
+            report.restart_removed,
+            "stopped restart generation was not removed",
+        )?;
+        require(
+            matches!(
+                reconnected.reconcile(&operation_id).await?,
+                ReconcileOutcome::Absent
+            ),
+            "removed restart operation remained reconcilable",
+        )?;
+        require(
+            !inputs
+                .home_dir
+                .join("boxes")
+                .join(reservation.execution_id.as_str())
+                .exists(),
+            "restart Box directory remained after deletion",
+        )?;
+        require(
+            directory_absent_or_empty(&inputs.runtime_root.join("shares"))?,
+            "runtime shares remained after restart-generation deletion",
+        )?;
+        require(
+            directory_absent_or_empty(&inputs.runtime_root.join("bundle-handoffs"))?,
+            "bundle handoffs remained after restart-generation deletion",
+        )?;
+        Ok(())
+    }
+
+    fn restart_host_service(service: &ServiceRestartInputs, endpoint: &Path) -> Result<(), AnyError> {
+        // SAFETY: qualification-only SIGKILL of the exact operator-supplied pid.
+        let kill_rc = unsafe { libc::kill(service.pid as i32, libc::SIGKILL) };
+        if kill_rc != 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() != io::ErrorKind::NotFound {
+                return Err(failure(format!(
+                    "failed to SIGKILL Host Service pid {}: {err}",
+                    service.pid
+                )));
+            }
+        }
+
+        let gone_deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while std::time::Instant::now() < gone_deadline {
+            // SAFETY: existence probe for the exact pid we killed.
+            let still_alive = unsafe { libc::kill(service.pid as i32, 0) } == 0;
+            if !still_alive && !endpoint.exists() {
+                break;
+            }
+            if endpoint.exists() {
+                let _ = std::fs::remove_file(endpoint);
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        require(
+            unsafe { libc::kill(service.pid as i32, 0) } != 0,
+            "Host Service pid remained alive after SIGKILL",
+        )?;
+
+        if let Some(parent) = service.service_log.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let log = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&service.service_log)?;
+        let log_err = log.try_clone()?;
+        let mut child = Command::new(&service.service_bin)
+            .arg("box-kvm-qualification-service")
+            .arg("--root")
+            .arg(&service.service_root)
+            .arg("--shim")
+            .arg(&service.service_shim)
+            .arg("--system-image-manifest")
+            .arg(&service.system_image_manifest)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(log))
+            .stderr(Stdio::from(log_err))
+            .spawn()?;
+        let replacement_pid = child.id();
+        std::fs::write(
+            service.service_root.join("qualification-service.pid"),
+            format!("{replacement_pid}\n"),
+        )?;
+
+        let ready_deadline = std::time::Instant::now() + Duration::from_secs(60);
+        while std::time::Instant::now() < ready_deadline {
+            if endpoint.exists() {
+                // Keep the replacement Host Service running after this process exits.
+                std::mem::forget(child);
+                return Ok(());
+            }
+            if let Some(status) = child.try_wait()? {
+                return Err(failure(format!(
+                    "replacement Host Service exited before readiness: {status}"
+                )));
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        Err(failure(
+            "replacement Host Service did not recreate the Unix endpoint",
+        ))
+    }
+
     async fn connect(inputs: &Inputs) -> Result<LocalExecutionManager, AnyError> {
         let config = LinuxKvmOciMigrationConfig::new(
             inputs.runtime_root.clone(),
@@ -421,9 +744,22 @@ mod qualification {
         .await?)
     }
 
-    fn qualification_request(image: &str) -> CreateExecutionRequest {
+    fn qualification_request(image: &str, long_running: bool) -> CreateExecutionRequest {
+        let cmd = if long_running {
+            format!(
+                "printf '{STDOUT_MARKER}\\n'; printf '{STDERR_MARKER}\\n' >&2; sleep 120; exit {EXPECTED_EXIT_CODE}"
+            )
+        } else {
+            format!(
+                "printf '{STDOUT_MARKER}\\n'; printf '{STDERR_MARKER}\\n' >&2; sleep 10; exit {EXPECTED_EXIT_CODE}"
+            )
+        };
         CreateExecutionRequest {
-            external_sandbox_id: "linux-kvm-oci-qualification".to_string(),
+            external_sandbox_id: if long_running {
+                "linux-kvm-oci-runtime-restart".to_string()
+            } else {
+                "linux-kvm-oci-qualification".to_string()
+            },
             config: BoxConfig {
                 isolation: ExecutionIsolation::Microvm,
                 image: image.to_string(),
@@ -432,20 +768,18 @@ mod qualification {
                     memory_mb: 512,
                     ..Default::default()
                 },
-                cmd: vec![
-                    "/bin/sh".to_string(),
-                    "-c".to_string(),
-                    format!(
-                        "printf '{STDOUT_MARKER}\\n'; printf '{STDERR_MARKER}\\n' >&2; sleep 10; exit {EXPECTED_EXIT_CODE}"
-                    ),
-                ],
+                cmd: vec!["/bin/sh".to_string(), "-c".to_string(), cmd],
                 network: NetworkMode::None,
                 persistent: false,
                 ..Default::default()
             },
             labels: BTreeMap::from([(
                 "purpose".to_string(),
-                "linux-kvm-oci-qualification".to_string(),
+                if long_running {
+                    "linux-kvm-oci-runtime-restart".to_string()
+                } else {
+                    "linux-kvm-oci-qualification".to_string()
+                },
             )]),
             policy: Default::default(),
             rootfs_snapshot_id: None,


### PR DESCRIPTION
## Summary
- Schema `a3s.box.linux-kvm-oci-qualification.v2`: keep create/replay/exit-23 lifecycle and add Host Service SIGKILL/restart while Running.
- Runner starts `box-kvm-qualification-service` and supplies restart inputs.
- Existing-host WSL2 evidence: report SHA-256 `87191a0d…` (passed; restart stopped-only, no invented exit).

## Test plan
- [x] `cargo build -p a3s-box-runtime --example linux-kvm-oci-qualification --release`
- [x] Local `linux-kvm-oci-qualification.sh` → `status=passed`, restart fields all true