### PR TITLE
chore(oci): pin OCI Runtime 95d624f and re-qualify KVM MicroVM slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ All notable changes to A3S Box will be documented in this file.
 ### Changed
 
 - Bump the pinned OCI Runtime revision to
+  `95d624f9831b79abf86bc8e369df849054c63eaf` (includes DedicatedVm containerd
+  Created/Running/Stopped daemon-restart slice,
+  `a3s.oci.linux-kvm-containerd-lifecycle.v2`). Re-ran the existing-host WSL2
+  Linux KVM OCI qualification v2 against that pin: exact exit `23`, Host
+  Service restart → stopped-only reconcile, report SHA-256
+  `1821ba153a77f17c1e4f5b5b130d6e2f7d58f3fb0abfd3f742c5531a68a50630`.
+  Observation-only; does not close fresh-host, AArch64, or default MicroVM
+  cutover.
+- Bump the pinned OCI Runtime revision to
   `3cea73d7fe6c53469ceb73ca8876e175255c3fcb` (includes containerd DedicatedVm
   bundle handoff and Linux KVM containerd vertical-slice gate). Re-ran the
   existing-host WSL2 Linux KVM OCI qualification v2 against that pin: exact

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -314,13 +314,14 @@ later gates.
   manager reopen, start, exact exit status, delete replay, residual cleanup,
   and Host Service SIGKILL/restart (stopped-only reconcile, no invented exit
   status) against `box-kvm-qualification-service` when service restart inputs
-  are available. Existing-host WSL2 evidence on Box `8b2804c5` (with OCI pin
-  `3cea73d7`) retained report SHA-256
-  `832e2d04f06197cfd7e724eee769f061af9f8f80a5ae0b60aaeabf687f5c7dfd` for
+  are available. Existing-host WSL2 evidence with OCI pin
+  `95d624f9831b79abf86bc8e369df849054c63eaf` retained report SHA-256
+  `1821ba153a77f17c1e4f5b5b130d6e2f7d58f3fb0abfd3f742c5531a68a50630` for
   schema `a3s.box.linux-kvm-oci-qualification.v2` (exact exit `23` plus Host
   Service restart → stopped-only, no invented exit). Prior evidence on
-  `e0fd63db`/`01786abf` remains historical. This does not close fresh-host
-  promotion, AArch64 promotion, or default MicroVM cutover.
+  `8b2804c5`/`3cea73d7` and `e0fd63db`/`01786abf` remains historical. This
+  does not close fresh-host promotion, AArch64 promotion, or default MicroVM
+  cutover.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
 through Box on Linux and Windows, including Box and runtime process restart.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=3cea73d7fe6c53469ceb73ca8876e175255c3fcb#3cea73d7fe6c53469ceb73ca8876e175255c3fcb"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=95d624f9831b79abf86bc8e369df849054c63eaf#95d624f9831b79abf86bc8e369df849054c63eaf"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=3cea73d7fe6c53469ceb73ca8876e175255c3fcb#3cea73d7fe6c53469ceb73ca8876e175255c3fcb"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=95d624f9831b79abf86bc8e369df849054c63eaf#95d624f9831b79abf86bc8e369df849054c63eaf"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "3cea73d7fe6c53469ceb73ca8876e175255c3fcb" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "95d624f9831b79abf86bc8e369df849054c63eaf" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- Bump `a3s-oci-sdk` pin to OCI Runtime `95d624f` (DedicatedVm containerd Created/Running/Stopped daemon-restart slice).
- Re-ran existing-host WSL2 Linux KVM OCI qualification v2: exit `23`, Host Service restart → stopped-only, report SHA-256 `1821ba153a77f17c1e4f5b5b130d6e2f7d58f3fb0abfd3f742c5531a68a50630`.
- Observation-only; does not close fresh-host, AArch64, or default MicroVM cutover.

## Test plan
- [x] `scripts/linux-kvm-oci-qualification.sh` against OCI `95d624f` binaries + pinned system image
- [x] Confirm schema `a3s.box.linux-kvm-oci-qualification.v2` `status=passed`

Made with [Cursor](https://cursor.com)