### PR TITLE
chore(oci): bump pin to 49d409 and requalify Linux KVM MicroVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ All notable changes to A3S Box will be documented in this file.
 ### Changed
 
 - Bump the pinned OCI Runtime revision to
+  `49d409383dc0c6214d76aa91250f6f6c0d453eba` (live Host reopen reattach
+  #257–#259: wait/kill/delete, shared supervisor cache, init process
+  inventory). Migration stays opt-in via `A3S_BOX_OCI_MIGRATION`; default
+  MicroVM/sandbox cutover is unchanged. Re-ran the existing-host WSL2 Linux
+  KVM OCI qualification v2 against that pin: exact exit `23`, Host Service
+  restart → stopped-only reconcile, report SHA-256
+  `3266909e1cb5f03a2544443bd27b19180acfa541ed9e15123b0dd10a397416eb`. Observation-only; does not close fresh-host,
+  AArch64, live-session gate, or default MicroVM cutover.
+- Bump the pinned OCI Runtime revision to
   `f14c9401f92a5fa97be62c54f58925f5fc1a2a51` (merge of supervised create PR
   #253: opt-in Native `Host → Supervisor → Launcher` create; default create
   stays Host-bound). Live reattach remains incomplete in OCI; migration stays

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -315,13 +315,14 @@ later gates.
   and Host Service SIGKILL/restart (stopped-only reconcile, no invented exit
   status) against `box-kvm-qualification-service` when service restart inputs
   are available. Existing-host WSL2 evidence with OCI pin
-  `f14c9401f92a5fa97be62c54f58925f5fc1a2a51` retained report SHA-256
-  `42a8576d93cd5e82fbe5a02ba9dec2958363a08bc8dc91cea06f552077a58edb` for
+  `49d409383dc0c6214d76aa91250f6f6c0d453eba` retained report SHA-256
+  `3266909e1cb5f03a2544443bd27b19180acfa541ed9e15123b0dd10a397416eb` for
   schema `a3s.box.linux-kvm-oci-qualification.v2` (exact exit `23` plus Host
   Service restart → stopped-only, no invented exit). Prior evidence on
-  `a318f4ec`/`60b1888`, `d57739f0`/`95d624f`, `8b2804c5`/`3cea73d7`, and
-  `e0fd63db`/`01786abf` remains historical. This does not close fresh-host
-  promotion, AArch64 promotion, or default MicroVM cutover.
+  `5431090f`/`f14c940`, `a318f4ec`/`60b1888`, `d57739f0`/`95d624f`,
+  `8b2804c5`/`3cea73d7`, and `e0fd63db`/`01786abf` remains historical. This
+  does not close fresh-host promotion, AArch64 promotion, live-session gate,
+  or default MicroVM cutover.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
 through Box on Linux and Windows, including Box and runtime process restart.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=f14c9401f92a5fa97be62c54f58925f5fc1a2a51#f14c9401f92a5fa97be62c54f58925f5fc1a2a51"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=49d409383dc0c6214d76aa91250f6f6c0d453eba#49d409383dc0c6214d76aa91250f6f6c0d453eba"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=f14c9401f92a5fa97be62c54f58925f5fc1a2a51#f14c9401f92a5fa97be62c54f58925f5fc1a2a51"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=49d409383dc0c6214d76aa91250f6f6c0d453eba#49d409383dc0c6214d76aa91250f6f6c0d453eba"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "f14c9401f92a5fa97be62c54f58925f5fc1a2a51" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "49d409383dc0c6214d76aa91250f6f6c0d453eba" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- Pin `a3s-oci-sdk` to OCI Runtime main tip `49d409383dc0c6214d76aa91250f6f6c0d453eba` (live Host reopen reattach #257–#259: wait/kill/delete, shared supervisor cache, init process inventory).
- Keep `A3S_BOX_OCI_MIGRATION` opt-in; do not flip default MicroVM/sandbox cutover.
- Record existing-host WSL2 Linux KVM OCI qualification v2 evidence (exact exit `23`, Host Service restart → stopped-only) with report SHA-256 `3266909e1cb5f03a2544443bd27b19180acfa541ed9e15123b0dd10a397416eb`.

## Test plan
- [x] `cargo update -p a3s-oci-sdk --precise 49d409…` + `cargo check --locked`
- [x] Existing-host Linux KVM OCI qualification v2 (`a3s.box.linux-kvm-oci-qualification.v2`)
- [ ] Merge without waiting on CI
