### PR TITLE
chore(oci): bump pin to 7d27d1 and requalify Linux KVM MicroVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ All notable changes to A3S Box will be documented in this file.
 ### Changed
 
 - Bump the pinned OCI Runtime revision to
+  `7d27d1deaa19566a4b51e82032658f6699230112` (PR #260: supervised stdin
+  restore on Host reopen). Migration stays opt-in via
+  `A3S_BOX_OCI_MIGRATION`; default MicroVM/sandbox cutover is unchanged.
+  Re-ran the existing-host WSL2 Linux KVM OCI qualification v2 against that
+  pin: exact exit `23`, Host Service restart → stopped-only reconcile, report
+  SHA-256
+  `a6d666ea674eb01836a6c7e57070762c45a45e633c533d9d56584fe79e11d784`.
+  Observation-only; does not close fresh-host, AArch64, live-session gate, or
+  default MicroVM cutover.
+- Bump the pinned OCI Runtime revision to
   `49d409383dc0c6214d76aa91250f6f6c0d453eba` (live Host reopen reattach
   #257–#259: wait/kill/delete, shared supervisor cache, init process
   inventory). Migration stays opt-in via `A3S_BOX_OCI_MIGRATION`; default

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -315,14 +315,14 @@ later gates.
   and Host Service SIGKILL/restart (stopped-only reconcile, no invented exit
   status) against `box-kvm-qualification-service` when service restart inputs
   are available. Existing-host WSL2 evidence with OCI pin
-  `49d409383dc0c6214d76aa91250f6f6c0d453eba` retained report SHA-256
-  `3266909e1cb5f03a2544443bd27b19180acfa541ed9e15123b0dd10a397416eb` for
+  `7d27d1deaa19566a4b51e82032658f6699230112` retained report SHA-256
+  `a6d666ea674eb01836a6c7e57070762c45a45e633c533d9d56584fe79e11d784` for
   schema `a3s.box.linux-kvm-oci-qualification.v2` (exact exit `23` plus Host
   Service restart → stopped-only, no invented exit). Prior evidence on
-  `5431090f`/`f14c940`, `a318f4ec`/`60b1888`, `d57739f0`/`95d624f`,
-  `8b2804c5`/`3cea73d7`, and `e0fd63db`/`01786abf` remains historical. This
-  does not close fresh-host promotion, AArch64 promotion, live-session gate,
-  or default MicroVM cutover.
+  `3122b6f8`/`49d409`, `5431090f`/`f14c940`, `a318f4ec`/`60b1888`,
+  `d57739f0`/`95d624f`, `8b2804c5`/`3cea73d7`, and `e0fd63db`/`01786abf`
+  remains historical. This does not close fresh-host promotion, AArch64
+  promotion, live-session gate, or default MicroVM cutover.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
 through Box on Linux and Windows, including Box and runtime process restart.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=49d409383dc0c6214d76aa91250f6f6c0d453eba#49d409383dc0c6214d76aa91250f6f6c0d453eba"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7d27d1deaa19566a4b51e82032658f6699230112#7d27d1deaa19566a4b51e82032658f6699230112"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=49d409383dc0c6214d76aa91250f6f6c0d453eba#49d409383dc0c6214d76aa91250f6f6c0d453eba"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7d27d1deaa19566a4b51e82032658f6699230112#7d27d1deaa19566a4b51e82032658f6699230112"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "49d409383dc0c6214d76aa91250f6f6c0d453eba" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "7d27d1deaa19566a4b51e82032658f6699230112" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- Pin `a3s-oci-sdk` to OCI Runtime main tip `7d27d1deaa19566a4b51e82032658f6699230112` (PR #260: supervised stdin restore on Host reopen).
- Keep `A3S_BOX_OCI_MIGRATION` opt-in; do not flip default MicroVM/sandbox cutover.
- Re-ran existing-host WSL2 Linux KVM OCI qualification v2: exact exit `23`, Host Service restart → stopped-only reconcile; report SHA-256 `a6d666ea674eb01836a6c7e57070762c45a45e633c533d9d56584fe79e11d784`.

## Test plan
- [x] `cargo update -p a3s-oci-sdk` + release rebuild of Box/OCI at tip
- [x] Linux KVM OCI qualification v2 (existing-host WSL2)
- [ ] Do not use CI

Made with [Cursor](https://cursor.com)