### PR TITLE
chore(oci): bump pin to 26ab488 and requalify Linux KVM MicroVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ All notable changes to A3S Box will be documented in this file.
 ### Changed
 
 - Bump the pinned OCI Runtime revision to
+  `26ab4889242c73216ad1b9abadd48367118df028` (PR #261: exclusive stdout/stderr
+  Host reopen via supervisor IPC relay). Migration stays opt-in via
+  `A3S_BOX_OCI_MIGRATION`; default MicroVM/sandbox cutover is unchanged.
+  Re-ran the existing-host WSL2 Linux KVM OCI qualification v2 against that
+  pin: exact exit `23`, Host Service restart → stopped-only reconcile, report
+  SHA-256
+  `576687d960023aea4e3c7599052a4138fec30f643d28a0c7c21232117d3a49f9`.
+  Observation-only; does not close fresh-host, AArch64, live-session gate, or
+  default MicroVM cutover.
+- Bump the pinned OCI Runtime revision to
   `7d27d1deaa19566a4b51e82032658f6699230112` (PR #260: supervised stdin
   restore on Host reopen). Migration stays opt-in via
   `A3S_BOX_OCI_MIGRATION`; default MicroVM/sandbox cutover is unchanged.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -315,14 +315,14 @@ later gates.
   and Host Service SIGKILL/restart (stopped-only reconcile, no invented exit
   status) against `box-kvm-qualification-service` when service restart inputs
   are available. Existing-host WSL2 evidence with OCI pin
-  `7d27d1deaa19566a4b51e82032658f6699230112` retained report SHA-256
-  `a6d666ea674eb01836a6c7e57070762c45a45e633c533d9d56584fe79e11d784` for
+  `26ab4889242c73216ad1b9abadd48367118df028` retained report SHA-256
+  `576687d960023aea4e3c7599052a4138fec30f643d28a0c7c21232117d3a49f9` for
   schema `a3s.box.linux-kvm-oci-qualification.v2` (exact exit `23` plus Host
   Service restart → stopped-only, no invented exit). Prior evidence on
-  `3122b6f8`/`49d409`, `5431090f`/`f14c940`, `a318f4ec`/`60b1888`,
-  `d57739f0`/`95d624f`, `8b2804c5`/`3cea73d7`, and `e0fd63db`/`01786abf`
-  remains historical. This does not close fresh-host promotion, AArch64
-  promotion, live-session gate, or default MicroVM cutover.
+  `3d1f073b`/`7d27d1`, `3122b6f8`/`49d409`, `5431090f`/`f14c940`,
+  `a318f4ec`/`60b1888`, `d57739f0`/`95d624f`, `8b2804c5`/`3cea73d7`, and
+  `e0fd63db`/`01786abf` remains historical. This does not close fresh-host
+  promotion, AArch64 promotion, live-session gate, or default MicroVM cutover.
 
 Exit gate: the same minimal bundle completes an exact, replay-safe lifecycle
 through Box on Linux and Windows, including Box and runtime process restart.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7d27d1deaa19566a4b51e82032658f6699230112#7d27d1deaa19566a4b51e82032658f6699230112"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=26ab4889242c73216ad1b9abadd48367118df028#26ab4889242c73216ad1b9abadd48367118df028"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7d27d1deaa19566a4b51e82032658f6699230112#7d27d1deaa19566a4b51e82032658f6699230112"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=26ab4889242c73216ad1b9abadd48367118df028#26ab4889242c73216ad1b9abadd48367118df028"
 dependencies = [
  "a3s-oci-core",
  "async-trait",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "7d27d1deaa19566a4b51e82032658f6699230112" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "26ab4889242c73216ad1b9abadd48367118df028" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- Bump `a3s-oci-sdk` to OCI-Runtime `26ab488` (PR #261: exclusive stdout/stderr Host reopen via supervisor IPC relay).
- Re-ran existing-host WSL2 Linux KVM OCI qualification v2: exit `23`, Host Service restart to stopped-only, report SHA-256 `576687d960023aea4e3c7599052a4138fec30f643d28a0c7c21232117d3a49f9`.
- Migration remains opt-in; does not claim fresh-host, AArch64, live-session gate, or default MicroVM cutover.

## Test plan
- [x] linux-kvm-oci-qualification v2 against box-kvm-qualification-service on WSL2 /dev/kvm
- [ ] Do not use CI


Made with [Cursor](https://cursor.com)