### PR TITLE
Align CI/release OCI pins with Cargo f9d6eeb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 402949c2d73cabdf5b959113806db9108e918cf1
+  A3S_OCI_RUNTIME_REV: f9d6eeb1c6f0c17e8abe3ed623abd586f48c9ac0
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 402949c2d73cabdf5b959113806db9108e918cf1
+  A3S_OCI_RUNTIME_REV: f9d6eeb1c6f0c17e8abe3ed623abd586f48c9ac0
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,8 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Align CI/release A3S_OCI_RUNTIME_REV with the Cargo 3s-oci-sdk pin (9d6eeb).
+
 - Linux Sandbox `native-linux-service` owners now migrate into a child of the
   empty delegated cgroup root before exec, matching host-service composition.
   Advertised Runtime profiles can start when the CI harness lives in a sibling


### PR DESCRIPTION
Box main Cargo/lock pin OCI Runtime \9d6eeb\ while \A3S_OCI_RUNTIME_REV\ in CI/release still pointed at \402949c2\ from the Sandbox R17 pin. Align the workflow env pins so checkout and SDK agree.

Made with [Cursor](https://cursor.com)