### PR TITLE
fix(ci): align OCI workflow pins with Cargo 35c3370

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: f9d6eeb1c6f0c17e8abe3ed623abd586f48c9ac0
+  A3S_OCI_RUNTIME_REV: 35c3370d5aefc1d10c30b77c899044c26865c8c6
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: f9d6eeb1c6f0c17e8abe3ed623abd586f48c9ac0
+  A3S_OCI_RUNTIME_REV: 35c3370d5aefc1d10c30b77c899044c26865c8c6
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Changed
 
+- Align CI/release `A3S_OCI_RUNTIME_REV` with the Cargo `a3s-oci-sdk` pin
+  (`35c3370`). Subsequent OCI requal bumps updated Cargo only and left
+  workflow pins on `f9d6eeb`, breaking `scripts/check-oci-pins.sh` on `main`.
 - Bump the pinned OCI Runtime revision to
   `35c3370d5aefc1d10c30b77c899044c26865c8c6` (PR #266: new exec after Host
   reopen). Migration stays opt-in via `A3S_BOX_OCI_MIGRATION`; default


### PR DESCRIPTION
## Summary
- Set `A3S_OCI_RUNTIME_REV` in `ci.yml` and `release.yml` to `35c3370` to match `a3s-oci-sdk`.
- Document the drift in CHANGELOG.

Unblocks `scripts/check-oci-pins.sh` failures on `main` after PR #290.

## Test plan
- [ ] CI Format / SDK Local Sandbox pin checks pass
- [ ] `scripts/check-oci-pins.sh` agrees CI=release=SDK

Made with [Cursor](https://cursor.com)