### PR TITLE
fix(oci): accept native-linux-recovery.v6 for pin 35c3370

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ All notable changes to A3S Box will be documented in this file.
 - Align CI/release `A3S_OCI_RUNTIME_REV` with the Cargo `a3s-oci-sdk` pin
   (`35c3370`). Subsequent OCI requal bumps updated Cargo only and left
   workflow pins on `f9d6eeb`, breaking `scripts/check-oci-pins.sh` on `main`.
+- Accept OCI native Linux recovery schema
+  `a3s.oci.native-linux-recovery.v6` in `scripts/local-sdk-smoke.sh` so the
+  pin check and SDK Local Sandbox gate match the Cargo OCI Runtime revision.
 - Bump the pinned OCI Runtime revision to
   `35c3370d5aefc1d10c30b77c899044c26865c8c6` (PR #266: new exec after Host
   reopen). Migration stays opt-in via `A3S_BOX_OCI_MIGRATION`; default

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -259,10 +259,15 @@ def load_recovery_record(host_root: Path, owner: dict, container_id: str) -> tup
         "cgroup",
         "intelRdt",
     }
-    assert set(recovery) == expected_fields, (
-        f"unexpected native recovery fields: {sorted(recovery)}"
+    optional_fields = {"sessionSupervisor", "execs"}
+    actual_fields = set(recovery)
+    assert expected_fields <= actual_fields, (
+        f"missing native recovery fields: {sorted(expected_fields - actual_fields)}"
     )
-    assert recovery["schemaVersion"] == "a3s.oci.native-linux-recovery.v3", (
+    assert actual_fields <= expected_fields | optional_fields, (
+        f"unexpected native recovery fields: {sorted(actual_fields - expected_fields - optional_fields)}"
+    )
+    assert recovery["schemaVersion"] == "a3s.oci.native-linux-recovery.v6", (
         f"unexpected native recovery schema: {recovery['schemaVersion']}"
     )
     config_digest = recovery["configDigest"]


### PR DESCRIPTION
## Summary
- Update `local-sdk-smoke.sh` to expect `a3s.oci.native-linux-recovery.v6`.
- Allow optional v6 fields `sessionSupervisor` / `execs` when present.

Unblocks SDK Local Sandbox after PR #291 aligned workflow pins to Cargo `35c3370`.

## Test plan
- [ ] SDK Local Sandbox (x86_64/aarch64) pin + smoke pass
- [ ] Format/Test green

Made with [Cursor](https://cursor.com)