### PR TITLE
fix(oci): restore pin 402949c2 after hosted rootless smoke timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 35c3370d5aefc1d10c30b77c899044c26865c8c6
+  A3S_OCI_RUNTIME_REV: 402949c2d73cabdf5b959113806db9108e918cf1
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 35c3370d5aefc1d10c30b77c899044c26865c8c6
+  A3S_OCI_RUNTIME_REV: 402949c2d73cabdf5b959113806db9108e918cf1
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,12 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Changed
 
+- Restore the OCI Runtime pin to `402949c2` (last CI-green with Sandbox R17
+  PR #268). Hosted SDK Local Sandbox fails on `35c3370` with
+  `rootless exec timed out` in OCI `native-linux-smoke`; keep KVM requal
+  bumps observation-only until that smoke is green on GitHub-hosted runners.
 - Align CI/release `A3S_OCI_RUNTIME_REV` with the Cargo `a3s-oci-sdk` pin
-  (`35c3370`). Subsequent OCI requal bumps updated Cargo only and left
-  workflow pins on `f9d6eeb`, breaking `scripts/check-oci-pins.sh` on `main`.
-- Accept OCI native Linux recovery schema
-  `a3s.oci.native-linux-recovery.v6` in `scripts/local-sdk-smoke.sh` so the
-  pin check and SDK Local Sandbox gate match the Cargo OCI Runtime revision.
+  (`402949c2`) and keep recovery smoke on `a3s.oci.native-linux-recovery.v3`.
 - Bump the pinned OCI Runtime revision to
   `35c3370d5aefc1d10c30b77c899044c26865c8c6` (PR #266: new exec after Host
   reopen). Migration stays opt-in via `A3S_BOX_OCI_MIGRATION`; default

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -259,15 +259,10 @@ def load_recovery_record(host_root: Path, owner: dict, container_id: str) -> tup
         "cgroup",
         "intelRdt",
     }
-    optional_fields = {"sessionSupervisor", "execs"}
-    actual_fields = set(recovery)
-    assert expected_fields <= actual_fields, (
-        f"missing native recovery fields: {sorted(expected_fields - actual_fields)}"
+    assert set(recovery) == expected_fields, (
+        f"unexpected native recovery fields: {sorted(recovery)}"
     )
-    assert actual_fields <= expected_fields | optional_fields, (
-        f"unexpected native recovery fields: {sorted(actual_fields - expected_fields - optional_fields)}"
-    )
-    assert recovery["schemaVersion"] == "a3s.oci.native-linux-recovery.v6", (
+    assert recovery["schemaVersion"] == "a3s.oci.native-linux-recovery.v3", (
         f"unexpected native recovery schema: {recovery['schemaVersion']}"
     )
     config_digest = recovery["configDigest"]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=35c3370d5aefc1d10c30b77c899044c26865c8c6#35c3370d5aefc1d10c30b77c899044c26865c8c6"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=402949c2d73cabdf5b959113806db9108e918cf1#402949c2d73cabdf5b959113806db9108e918cf1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=35c3370d5aefc1d10c30b77c899044c26865c8c6#35c3370d5aefc1d10c30b77c899044c26865c8c6"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=402949c2d73cabdf5b959113806db9108e918cf1#402949c2d73cabdf5b959113806db9108e918cf1"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "35c3370d5aefc1d10c30b77c899044c26865c8c6" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "402949c2d73cabdf5b959113806db9108e918cf1" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- Revert OCI Runtime pin to `402949c2` (Cargo + CI/release + lock).
- Restore recovery smoke to `native-linux-recovery.v3`.

`35c3370` hosted SDK Local Sandbox fails with `rootless exec timed out` in OCI `native-linux-smoke`. Last green Box `main` CI was `8b2804c5` on this pin; Cloud conformance still pins the same pair.

## Test plan
- [ ] Format pin check
- [ ] SDK Local Sandbox x86_64/aarch64
- [ ] Test/Clippy

Made with [Cursor](https://cursor.com)