### PR TITLE
feat: Native Linux live-session v3 retained-stream + OCI 7001ce5 pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 07e653f9fb594e7454f6f732f3d3ceb80928b254
+  A3S_OCI_RUNTIME_REV: 7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Verify OCI SDK and artifact pins agree
         shell: bash
         run: bash scripts/check-oci-pins.sh
+      - name: Verify live-session report honesty checker
+        run: python3 scripts/verify-linux-native-live-session-report.py --self-test
       - name: Reject removed Sandbox backend integrations
         run: |
           removed_patterns=(
@@ -464,7 +466,7 @@ jobs:
             platform: linux-arm64
             recovery_artifact: a3s-box-native-owner-recovery-aarch64
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       A3S_HOME: /tmp/a3s-local-sdk-smoke-runtime-conformance
       A3S_BOX_OCI_RUNTIME_PATH: /tmp/a3s-local-sdk-smoke-runtime-conformance/bin/a3s-oci
@@ -673,6 +675,47 @@ jobs:
             echo "::error title=Local SDK smoke failure::$diagnostic"
           fi
           exit "$status"
+      - name: Qualify Native Linux live-session retained-stream (v3)
+        env:
+          LIVE_SESSION_IMAGE: docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+        run: |
+          set -euo pipefail
+          cd src
+          cargo build --locked --release -p a3s-box-runtime \
+            --example linux-native-live-session-qualification
+          example_bin="$(pwd)/target/release/examples/linux-native-live-session-qualification"
+          test -x "$example_bin"
+          staging="$RUNNER_TEMP/a3s-box-live-session-bin"
+          mkdir -p "$staging"
+          install -m 755 "$A3S_BOX_BINARY" "$staging/a3s-box"
+          install -m 755 "$A3S_BOX_SHIM_BINARY" "$staging/a3s-box-shim"
+          install -m 755 "$A3S_BOX_GUEST_INIT_BINARY" "$staging/a3s-box-guest-init"
+          install -m 755 "$example_bin" "$staging/linux-native-live-session-qualification"
+          report="$RUNNER_TEMP/a3s-box-linux-native-live-session-v3.json"
+          rm -f "$report"
+          # Root entry matches the local gate: prepare cgroup/home, then the
+          # script setpriv-execs the example. Do not treat a missing report as
+          # retained-stream proof, and refuse B2 / fixture / KVM claims.
+          sudo --preserve-env=A3S_BOX_CI_SANDBOX_UID,A3S_BOX_CI_SANDBOX_GID,A3S_BOX_SANDBOX_DELEGATED_CGROUP_ROOT,A3S_BOX_CI_PROBE_CGROUP \
+            bash "$GITHUB_WORKSPACE/scripts/linux-native-live-session-qualification.sh" \
+              --box-bin "$staging" \
+              --a3s-oci "$A3S_BOX_OCI_RUNTIME_PATH" \
+              --a3s-oci-agent "$A3S_BOX_OCI_AGENT_PATH" \
+              --image "$LIVE_SESSION_IMAGE" \
+              --report "$report" \
+              --home "$RUNNER_TEMP/a3s-box-native-live-session-home" \
+              --box-sha "$GITHUB_SHA" \
+              --oci-sha "$A3S_OCI_RUNTIME_REV"
+          python3 "$GITHUB_WORKSPACE/scripts/verify-linux-native-live-session-report.py" \
+            "$report"
+      - name: Upload Native Linux live-session v3 evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: a3s-box-linux-native-live-session-v3-${{ matrix.platform }}
+          path: ${{ runner.temp }}/a3s-box-linux-native-live-session-v3.json
+          if-no-files-found: warn
+          retention-days: 14
       - name: Upload native OCI owner-recovery evidence
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 07e653f9fb594e7454f6f732f3d3ceb80928b254
+  A3S_OCI_RUNTIME_REV: 7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Native Linux live-session v3 streaming `start_process` omits one-shot
+  `request_id` (OCI rejects keyed ids on streaming sessions; matches the
+  `process_restart` fixture contract).
 - Kill completion no longer invents `128+signal` exit codes **or**
   `stopped_by_user` for `AlreadyStopped` / vanished-runtime / NotFound paths.
   Only a true `Killed` outcome uses `KillTerminal` (user stop) and may derive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Local SDK smoke / `check-oci-pins` now assert
+  `a3s.oci.native-linux-recovery.v6` to match the pinned OCI Runtime
+  (`07e653f9…`). The previous `v3` assertion failed the Sandbox pin gate after
+  #296 and rejected honest Live reopen fields (`sessionSupervisor`, `execs`)
+  that v6 may serialize.
 - Native Linux retained-manager Live reopen respawns the identity-fenced OCI
   Host on `inspect`/`reconcile` Unavailable (`with_native_linux_owner_recovery`).
   Without that, the SDK only reconnects to a dead socket and the session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Live-session v3 streaming command survives `close_stdin` EOF (`sleep` after
+  `while read`) so Kill after Host reopen still targets a live retained handle
+  instead of failing as not-live under start-time identity.
 - Local SDK smoke / `check-oci-pins` now assert
   `a3s.oci.native-linux-recovery.v6` to match the pinned OCI Runtime
-  (`07e653f9…`). The previous `v3` assertion failed the Sandbox pin gate after
+  (`7001ce5…`). The previous `v3` assertion failed the Sandbox pin gate after
   #296 and rejected honest Live reopen fields (`sessionSupervisor`, `execs`)
   that v6 may serialize.
 - Native Linux retained-manager Live reopen respawns the identity-fenced OCI
@@ -80,11 +83,12 @@ All notable changes to A3S Box will be documented in this file.
   passes; `fixture_stream_continuity_claimed` and
   `b2_process_session_recovery_closed` stay false. Does not claim KVM MicroVM
   Live continuity or close utility-VM B2/R6. Default create stays Host-bound.
-  Green Linux qualification report is still required before treating the
-  retained-stream ROADMAP checkbox as closed. SDK Local Sandbox CI now runs
-  that same v3 gate after the packaged SDK smoke, uploads the JSON report,
-  and fail-closes unless `retained_stream_handle_proven` is true while B2,
-  fixture continuity, KVM MicroVM Live, and utility-VM claims stay false.
+  Existing-host WSL2 matched-creds + elevate report SHA-256
+  `bc36ff5b895b6320b57322328f78910be82eddfb2203b97bd2c86455b1929d02` on Box
+  `2c304534…` + OCI `7001ce5…` (`status=passed`,
+  `retained_stream_handle_proven=true`). Does **not** set
+  `b2_process_session_recovery_closed` or claim KVM/utility-VM Live /
+  default supervised create.
 - Linux qualification-only MicroVM OCI vertical-slice gate:
   `linux-kvm-oci-qualification` example plus
   `scripts/linux-kvm-oci-qualification.sh`. Schema
@@ -110,15 +114,19 @@ All notable changes to A3S Box will be documented in this file.
 ### Changed
 
 - Bump the pinned OCI Runtime revision to
-  `07e653f9fb594e7454f6f732f3d3ceb80928b254` (supervised try_wait zombie reap,
-  supervisor BrokenPipe reattach, zombie recovery identity, exec pidfd before
-  START, live exec capture deposit routing). Existing-host WSL2 matched-creds +
-  elevate Native live-session v2 report SHA-256
+  `7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9` (per-process Live stdin deposits
+  after Host reopen, PR #279). Existing-host WSL2 matched-creds + elevate
+  Native live-session v3 report SHA-256
+  `bc36ff5b895b6320b57322328f78910be82eddfb2203b97bd2c86455b1929d02`
+  (`status=passed`, `retained_stream_handle_proven=true`, keyed exec
+  before/after reopen, live kill, removed). Align CI/release
+  `A3S_OCI_RUNTIME_REV` with the Cargo `a3s-oci-sdk` pin. Does **not** close
+  B2 (`b2_process_session_recovery_closed` stays false), default supervised
+  create, MicroVM cutover, fresh-host, or AArch64.
+- Prior pin `07e653f9fb594e7454f6f732f3d3ceb80928b254` greened live-session v2
+  (manager-drop) report SHA-256
   `614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`
-  (`status=passed`, keyed exec before/after reopen, live kill, removed).
-  Align CI/release `A3S_OCI_RUNTIME_REV` with the Cargo `a3s-oci-sdk` pin.
-  Does **not** close B2 retained-stream, default supervised create, MicroVM
-  cutover, fresh-host, or AArch64.
+  (keyed exec / live kill only; no retained-stream claim).
 - Restore the OCI Runtime pin to `402949c2` (last CI-green with Sandbox R17
   PR #268). Hosted SDK Local Sandbox fails on `35c3370` with
   `rootless exec timed out` in OCI `native-linux-smoke`; keep KVM requal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- Native Linux retained-manager Live reopen respawns the identity-fenced OCI
+  Host on `inspect`/`reconcile` Unavailable (`with_native_linux_owner_recovery`).
+  Without that, the SDK only reconnects to a dead socket and the session
+  supervisor's 30s reattach window expires before a replacement Host arrives.
 - Native Linux live-session v3 streaming `start_process` omits one-shot
   `request_id` (OCI rejects keyed ids on streaming sessions; matches the
-  `process_restart` fixture contract).
+  `process_restart` fixture contract) and uses a long exec timeout so the
+  retained-stream watchdog cannot poison the handle during owner respawn.
 - Kill completion no longer invents `128+signal` exit codes **or**
   `stopped_by_user` for `AlreadyStopped` / vanished-runtime / NotFound paths.
   Only a true `Killed` outcome uses `KillTerminal` (user stop) and may derive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,10 @@ All notable changes to A3S Box will be documented in this file.
   `b2_process_session_recovery_closed` stay false. Does not claim KVM MicroVM
   Live continuity or close utility-VM B2/R6. Default create stays Host-bound.
   Green Linux qualification report is still required before treating the
-  retained-stream ROADMAP checkbox as closed.
+  retained-stream ROADMAP checkbox as closed. SDK Local Sandbox CI now runs
+  that same v3 gate after the packaged SDK smoke, uploads the JSON report,
+  and fail-closes unless `retained_stream_handle_proven` is true while B2,
+  fixture continuity, KVM MicroVM Live, and utility-VM claims stay false.
 - Linux qualification-only MicroVM OCI vertical-slice gate:
   `linux-kvm-oci-qualification` example plus
   `scripts/linux-kvm-oci-qualification.sh`. Schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,17 +58,17 @@ All notable changes to A3S Box will be documented in this file.
 - Native Linux live-session observation harness:
   `linux-native-live-session-qualification` example plus
   `scripts/linux-native-live-session-qualification.sh`. Schema
-  `a3s.box.linux-native-live-session.v2` requires
-  `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`, SIGKILLs the out-of-process Native
-  Linux Host owner while a Sandbox generation is live, rebinds through a
-  replacement owner, and continues authentic Live keyed captured exec plus
-  state/inventory/stats/kill without inventing an exit status. Honest scope:
-  Native-Linux-driver Live Host-reopen and **fresh-manager** keyed exec only;
-  report fields keep `retained_stream_handle_proven`,
-  `fixture_stream_continuity_claimed`, and `b2_process_session_recovery_closed`
-  false so fixture `process_restart` continuity is never over-claimed. Does not
-  claim KVM MicroVM Live continuity or close the utility-VM half of Box B2 /
-  OCI R6. Default create stays Host-bound.
+  `a3s.box.linux-native-live-session.v3` requires
+  `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`, keeps the Box manager across Host
+  owner SIGKILL, and is intended to prove retained streaming `start_process`
+  handle continuity (Unavailable → Live reopen → same-handle stdin/signal/Exit)
+  plus keyed captured exec / state / inventory / stats / kill without inventing
+  an exit. `retained_stream_handle_proven` flips true only when that path
+  passes; `fixture_stream_continuity_claimed` and
+  `b2_process_session_recovery_closed` stay false. Does not claim KVM MicroVM
+  Live continuity or close utility-VM B2/R6. Default create stays Host-bound.
+  Green Linux qualification report is still required before treating the
+  retained-stream ROADMAP checkbox as closed.
 - Linux qualification-only MicroVM OCI vertical-slice gate:
   `linux-kvm-oci-qualification` example plus
   `scripts/linux-kvm-oci-qualification.sh`. Schema

--- a/README.md
+++ b/README.md
@@ -315,9 +315,12 @@ MicroVM routing.
 
 Live Host-reopen continuity is Native-Linux-driver-only today. Prepare a
 delegated cgroup (`scripts/prepare-linux-sandbox-ci-host.sh` via sudo), then
-run the root-owned runner. It mirrors Sandbox CI: matched-cred setpriv for the
-example and `A3S_BOX_CI_SETPRIV_WRAPPER=run-linux-sandbox-ci.sh` so the Native
-Linux owner can elevate for device-policy bootstrap:
+run the root-owned runner. It mirrors Sandbox CI: the runner starts as root,
+then `elevate-linux-sandbox-owner.sh` setpriv-execs the example (`euid=0`,
+sandbox `ruid`) and the same wrapper is exported as
+`A3S_BOX_CI_SETPRIV_WRAPPER` so the Native Linux owner can elevate for
+device-policy bootstrap. SDK Local Sandbox CI runs this gate and fail-closes
+on a missing or dishonest report; it still does not close B2.
 
 ```bash
 cargo build -p a3s-box-runtime --example linux-native-live-session-qualification --release

--- a/README.md
+++ b/README.md
@@ -339,10 +339,13 @@ Schema `a3s.box.linux-native-live-session.v3` keeps the Box manager across a
 Native Linux Host owner SIGKILL, proves retained streaming `start_process`
 handle continuity when the path passes (`retained_stream_handle_proven`), and
 continues authentic Live keyed captured exec plus state/inventory/stats/kill
-without inventing an exit status. Fixture `process_restart` is never claimed
-as driver evidence (`fixture_stream_continuity_claimed` stays false). B2 stays
-open until utility-VM Live also lands (`b2_process_session_recovery_closed`
-stays false). It does not claim KVM MicroVM Live continuity.
+without inventing an exit status. Existing-host WSL2 evidence on OCI
+`7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9`: report SHA-256
+`bc36ff5b895b6320b57322328f78910be82eddfb2203b97bd2c86455b1929d02`. Fixture
+`process_restart` is never claimed as driver evidence
+(`fixture_stream_continuity_claimed` stays false). B2 stays open until
+utility-VM Live also lands (`b2_process_session_recovery_closed` stays false).
+It does not claim KVM MicroVM Live continuity.
 
 ### Exercise the qualification-only WHPX handoff on Windows
 

--- a/README.md
+++ b/README.md
@@ -332,13 +332,14 @@ sudo --preserve-env=A3S_BOX_CI_SANDBOX_UID,A3S_BOX_CI_SANDBOX_GID,A3S_BOX_SANDBO
   --home /tmp/a3s-box-native-live-session-home
 ```
 
-Schema `a3s.box.linux-native-live-session.v2` SIGKILLs the Native Linux Host
-owner while a Sandbox generation is live, rebinds, and continues authentic Live
-keyed captured exec plus state/inventory/stats/kill without inventing an exit
-status. The harness drops the Box manager before owner death, so it does not
-prove retained streaming process-handle continuity (that remains the
-fixture-only `process_restart` contract) and keeps B2 open. It does not claim
-KVM MicroVM Live continuity or close utility-VM B2/R6.
+Schema `a3s.box.linux-native-live-session.v3` keeps the Box manager across a
+Native Linux Host owner SIGKILL, proves retained streaming `start_process`
+handle continuity when the path passes (`retained_stream_handle_proven`), and
+continues authentic Live keyed captured exec plus state/inventory/stats/kill
+without inventing an exit status. Fixture `process_restart` is never claimed
+as driver evidence (`fixture_stream_continuity_claimed` stays false). B2 stays
+open until utility-VM Live also lands (`b2_process_session_recovery_closed`
+stays false). It does not claim KVM MicroVM Live continuity.
 
 ### Exercise the qualification-only WHPX handoff on Windows
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -412,6 +412,18 @@ retain process or filesystem sessions after its owner dies.
   stdout/stderr log projection) through the persisted OCI route.
 - [ ] Prove process-session recovery across an out-of-process runtime-service
   restart on real native Linux and utility-VM drivers.
+  - [x] Observation harness `a3s.box.linux-native-live-session.v2`
+    (`linux-native-live-session-qualification` drop-manager path): supervised
+    create + Host owner SIGKILL + Live rebind with keyed captured exec
+    before/after reopen, state/inventory/stats/kill; no invented exit. Requires
+    `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`. Drops the Box manager before owner
+    death, so it does **not** prove retained streaming handle continuity and
+    does **not** close B2. **Existing-host WSL2 evidence** on OCI
+    `07e653f9fb594e7454f6f732f3d3ceb80928b254`: report SHA-256
+    `614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`
+    (`status=passed`, `keyed_captured_exec_after_reopen=true`,
+    `live_kill_after_reopen=true`, `removed=true`; retained-stream / B2 /
+    fixture / KVM / utility-VM claims stay false).
   - [ ] Observation harness `a3s.box.linux-native-live-session.v3`
     (`linux-native-live-session-qualification`) for Native Linux Sandbox with
     supervised create + Host owner SIGKILL + Live rebind while retaining the
@@ -422,7 +434,10 @@ retain process or filesystem sessions after its owner dies.
     Sets `retained_stream_handle_proven=true` **only** when that path passes;
     keeps `fixture_stream_continuity_claimed` and
     `b2_process_session_recovery_closed` false. Does not close utility-VM /
-    KVM MicroVM Live or default create Host-bound policy. Prior v2 (manager-
+    KVM MicroVM Live or default create Host-bound policy. SDK Local
+    Sandbox CI runs this gate and fail-closes unless
+    `retained_stream_handle_proven` is true while B2/fixture/KVM/utility-VM
+    claims stay false. Prior v2 (manager-
     drop) evidence on OCI
     `07e653f9fb594e7454f6f732f3d3ceb80928b254` remains keyed-capture /
     live-kill only (`614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`);

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -424,28 +424,31 @@ retain process or filesystem sessions after its owner dies.
     (`status=passed`, `keyed_captured_exec_after_reopen=true`,
     `live_kill_after_reopen=true`, `removed=true`; retained-stream / B2 /
     fixture / KVM / utility-VM claims stay false).
-  - [ ] Observation harness `a3s.box.linux-native-live-session.v3`
+  - [x] Observation harness `a3s.box.linux-native-live-session.v3`
     (`linux-native-live-session-qualification`) for Native Linux Sandbox with
     supervised create + Host owner SIGKILL + Live rebind while retaining the
-    Box manager. Intended proof: retained streaming `start_process` handle
-    continuity (Unavailable on owner death → reconcile Ready → same-handle
+    Box manager. Proves retained streaming `start_process` handle continuity
+    (Unavailable on owner death → reconcile Ready → same-handle
     stdin/signal/Exit) plus keyed captured exec before/after, state/inventory/
     stats/kill; no invented exit. Requires `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`.
     Sets `retained_stream_handle_proven=true` **only** when that path passes;
     keeps `fixture_stream_continuity_claimed` and
     `b2_process_session_recovery_closed` false. Does not close utility-VM /
-    KVM MicroVM Live or default create Host-bound policy. SDK Local
-    Sandbox CI runs this gate and fail-closes unless
-    `retained_stream_handle_proven` is true while B2/fixture/KVM/utility-VM
-    claims stay false. Prior v2 (manager-
-    drop) evidence on OCI
+    KVM MicroVM Live or default create Host-bound policy. **Existing-host
+    WSL2 evidence** on Box `2c304534beafa6d9284000d992494a780082f3aa` + OCI
+    `7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9`: report SHA-256
+    `bc36ff5b895b6320b57322328f78910be82eddfb2203b97bd2c86455b1929d02`
+    (`status=passed`, `retained_stream_handle_proven=true`,
+    `keyed_captured_exec_after_reopen=true`, `live_kill_after_reopen=true`,
+    `removed=true`; B2 / fixture / KVM / utility-VM claims stay false).
+    Prior v2 (manager-drop) evidence on OCI
     `07e653f9fb594e7454f6f732f3d3ceb80928b254` remains keyed-capture /
-    live-kill only (`614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`);
-    **v3 retained-stream evidence pending a green Linux qualification report**
-    — do not treat the harness code alone as B2 closure.
-  - [ ] Retained streaming process-handle continuity on a real Native Linux
+    live-kill only (`614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`).
+  - [x] Retained streaming process-handle continuity on a real Native Linux
     owner restart (v3 harness path above; fixture `process_restart` remains
-    non-driver evidence).
+    non-driver evidence). Does **not** alone close B2
+    (`b2_process_session_recovery_closed` stays false until the plan's full
+    B2 criteria are met).
   - [ ] Utility-VM / KVM MicroVM Live process-session continuity (KVM Host
     reopen remains stopped-only / recreate today).
 - [x] Lifecycle evidence honesty (anti-overfit; does **not** close B2): refuse

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -412,22 +412,25 @@ retain process or filesystem sessions after its owner dies.
   stdout/stderr log projection) through the persisted OCI route.
 - [ ] Prove process-session recovery across an out-of-process runtime-service
   restart on real native Linux and utility-VM drivers.
-  - [x] Observation harness `a3s.box.linux-native-live-session.v2`
+  - [ ] Observation harness `a3s.box.linux-native-live-session.v3`
     (`linux-native-live-session-qualification`) for Native Linux Sandbox with
-    supervised create + Host owner SIGKILL + Live rebind
-    (keyed captured exec before/after reopen, state/inventory/stats/kill; no
-    invented exit). Requires `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`. Drops the
-    Box manager before owner death, so it does **not** prove retained streaming
-    handle continuity and does **not** close B2. Does not close utility-VM Live
-    or default create Host-bound policy. **Existing-host WSL2 evidence** on OCI
-    `07e653f9fb594e7454f6f732f3d3ceb80928b254` / Box tip that ran the harness:
-    report SHA-256
-    `614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`
-    (`status=passed`, `keyed_captured_exec_after_reopen=true`,
-    `live_kill_after_reopen=true`, `removed=true`; retained-stream / B2 /
-    fixture / KVM / utility-VM claims stay false).
+    supervised create + Host owner SIGKILL + Live rebind while retaining the
+    Box manager. Intended proof: retained streaming `start_process` handle
+    continuity (Unavailable on owner death → reconcile Ready → same-handle
+    stdin/signal/Exit) plus keyed captured exec before/after, state/inventory/
+    stats/kill; no invented exit. Requires `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`.
+    Sets `retained_stream_handle_proven=true` **only** when that path passes;
+    keeps `fixture_stream_continuity_claimed` and
+    `b2_process_session_recovery_closed` false. Does not close utility-VM /
+    KVM MicroVM Live or default create Host-bound policy. Prior v2 (manager-
+    drop) evidence on OCI
+    `07e653f9fb594e7454f6f732f3d3ceb80928b254` remains keyed-capture /
+    live-kill only (`614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`);
+    **v3 retained-stream evidence pending a green Linux qualification report**
+    — do not treat the harness code alone as B2 closure.
   - [ ] Retained streaming process-handle continuity on a real Native Linux
-    owner restart (fixture-only today in `process_restart`).
+    owner restart (v3 harness path above; fixture `process_restart` remains
+    non-driver evidence).
   - [ ] Utility-VM / KVM MicroVM Live process-session continuity (KVM Host
     reopen remains stopped-only / recreate today).
 - [x] Lifecycle evidence honesty (anti-overfit; does **not** close B2): refuse

--- a/scripts/linux-native-live-session-qualification.sh
+++ b/scripts/linux-native-live-session-qualification.sh
@@ -186,7 +186,7 @@ export A3S_BOX_CI_SANDBOX_GID="${gid}"
 export A3S_BOX_CI_SETPRIV_MATCHED_CREDS=1
 export A3S_BOX_CI_SETPRIV_WRAPPER="${SETPRIV_WRAPPER}"
 
-echo "running Native Linux live-session qualification v2"
+echo "running Native Linux live-session qualification v3"
 echo "  home=${A3S_HOME}"
 echo "  host-root=${HOST_ROOT}"
 echo "  image=${IMAGE}"

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -249,7 +249,9 @@ def load_recovery_record(host_root: Path, owner: dict, container_id: str) -> tup
     candidates = list(root.glob("c-*/recovery.json"))
     assert len(candidates) == 1, f"expected one live recovery record below {root}, found {len(candidates)}"
     recovery = read_private_json(candidates[0])
-    expected_fields = {
+    # OCI pin 07e653f+ writes a3s.oci.native-linux-recovery.v6. Optional Live
+    # reopen inventory fields are omitted when empty (skip_serializing_if).
+    required_fields = {
         "schemaVersion",
         "target",
         "configDigest",
@@ -259,10 +261,15 @@ def load_recovery_record(host_root: Path, owner: dict, container_id: str) -> tup
         "cgroup",
         "intelRdt",
     }
-    assert set(recovery) == expected_fields, (
-        f"unexpected native recovery fields: {sorted(recovery)}"
+    optional_fields = {"sessionSupervisor", "execs"}
+    actual_fields = set(recovery)
+    assert required_fields <= actual_fields, (
+        f"missing native recovery fields: {sorted(required_fields - actual_fields)}"
     )
-    assert recovery["schemaVersion"] == "a3s.oci.native-linux-recovery.v3", (
+    assert actual_fields <= required_fields | optional_fields, (
+        f"unexpected native recovery fields: {sorted(actual_fields - required_fields - optional_fields)}"
+    )
+    assert recovery["schemaVersion"] == "a3s.oci.native-linux-recovery.v6", (
         f"unexpected native recovery schema: {recovery['schemaVersion']}"
     )
     config_digest = recovery["configDigest"]
@@ -275,6 +282,20 @@ def load_recovery_record(host_root: Path, owner: dict, container_id: str) -> tup
     assert recovery["target"]["id"] == container_id
     assert int(recovery["owner"]["pid"]) == int(owner["pid"])
     assert int(recovery["owner"]["startTimeTicks"]) == int(owner["pid_start_time"])
+    if os.environ.get("A3S_OCI_NATIVE_SESSION_SUPERVISOR") == "1":
+        assert "sessionSupervisor" in recovery, (
+            "supervised create must persist sessionSupervisor in recovery.v6"
+        )
+        require_live_identity("OCI session supervisor", recovery["sessionSupervisor"])
+    if "execs" in recovery:
+        assert isinstance(recovery["execs"], list), "recovery.execs must be a list"
+        for exec_record in recovery["execs"]:
+            assert {"processId", "identity", "terminal"} <= set(exec_record), (
+                f"incomplete recovery exec record: {sorted(exec_record)}"
+            )
+            assert set(exec_record) <= {"processId", "identity", "terminal", "helper"}, (
+                f"unexpected recovery exec fields: {sorted(exec_record)}"
+            )
     return candidates[0], recovery
 
 

--- a/scripts/local-sdk-smoke.sh
+++ b/scripts/local-sdk-smoke.sh
@@ -249,7 +249,7 @@ def load_recovery_record(host_root: Path, owner: dict, container_id: str) -> tup
     candidates = list(root.glob("c-*/recovery.json"))
     assert len(candidates) == 1, f"expected one live recovery record below {root}, found {len(candidates)}"
     recovery = read_private_json(candidates[0])
-    # OCI pin 07e653f+ writes a3s.oci.native-linux-recovery.v6. Optional Live
+    # OCI pin 7001ce5+ writes a3s.oci.native-linux-recovery.v6. Optional Live
     # reopen inventory fields are omitted when empty (skip_serializing_if).
     required_fields = {
         "schemaVersion",

--- a/scripts/verify-linux-native-live-session-report.py
+++ b/scripts/verify-linux-native-live-session-report.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Fail-closed honesty checks for a3s.box.linux-native-live-session.v3 reports.
+
+Retained-stream proof is required. B2, fixture continuity, KVM MicroVM Live,
+and utility-VM claims must stay false — this gate does not close those.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+SCHEMA = "a3s.box.linux-native-live-session.v3"
+FORBIDDEN = (
+    "fixture_stream_continuity_claimed",
+    "b2_process_session_recovery_closed",
+    "kvm_microvm_live_claimed",
+    "utility_vm_claimed",
+)
+
+
+def evaluate(report: dict) -> list[str]:
+    failures: list[str] = []
+    if report.get("schema_version") != SCHEMA:
+        failures.append(f"schema_version={report.get('schema_version')!r}")
+    if report.get("status") != "passed":
+        failures.append(f"status={report.get('status')!r} error={report.get('error')!r}")
+    if report.get("retained_stream_handle_proven") is not True:
+        failures.append("retained_stream_handle_proven is not true")
+    for forbidden in FORBIDDEN:
+        if report.get(forbidden):
+            failures.append(f"{forbidden} must stay false")
+    return failures
+
+
+def passing_report() -> dict:
+    report = {
+        "schema_version": SCHEMA,
+        "status": "passed",
+        "retained_stream_handle_proven": True,
+    }
+    for forbidden in FORBIDDEN:
+        report[forbidden] = False
+    return report
+
+
+def self_test() -> int:
+    if evaluate(passing_report()):
+        print("self-test: passing report was rejected", file=sys.stderr)
+        return 1
+    bad_cases = [
+        {"schema_version": "v2", "status": "passed", "retained_stream_handle_proven": True},
+        {"schema_version": SCHEMA, "status": "failed", "retained_stream_handle_proven": True},
+        {"schema_version": SCHEMA, "status": "passed", "retained_stream_handle_proven": False},
+        {
+            "schema_version": SCHEMA,
+            "status": "passed",
+            "retained_stream_handle_proven": True,
+            "b2_process_session_recovery_closed": True,
+        },
+        {
+            "schema_version": SCHEMA,
+            "status": "passed",
+            "retained_stream_handle_proven": True,
+            "fixture_stream_continuity_claimed": True,
+        },
+    ]
+    for case in bad_cases:
+        if not evaluate(case):
+            print(f"self-test: expected rejection for {case}", file=sys.stderr)
+            return 1
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "report.json"
+        path.write_text(json.dumps(passing_report()), encoding="utf-8")
+        if main(["verify", str(path)]) != 0:
+            print("self-test: passing file was rejected", file=sys.stderr)
+            return 1
+        missing = Path(tmp) / "missing.json"
+        if main(["verify", str(missing)]) == 0:
+            print("self-test: missing file was accepted", file=sys.stderr)
+            return 1
+    print("live-session report verifier self-test passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) == 2 and argv[1] == "--self-test":
+        return self_test()
+    if len(argv) != 2:
+        print(
+            "usage: verify-linux-native-live-session-report.py REPORT.json|--self-test",
+            file=sys.stderr,
+        )
+        return 2
+    path = Path(argv[1])
+    if not path.is_file():
+        print(f"missing live-session report: {path}", file=sys.stderr)
+        return 1
+    report = json.loads(path.read_text(encoding="utf-8"))
+    failures = evaluate(report)
+    if failures:
+        print("live-session report failed honesty checks:", file=sys.stderr)
+        for item in failures:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+    print(
+        "live-session v3 retained-stream proven; B2/fixture/KVM/utility-VM claims remain false"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=07e653f9fb594e7454f6f732f3d3ceb80928b254#07e653f9fb594e7454f6f732f3d3ceb80928b254"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9#7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=07e653f9fb594e7454f6f732f3d3ceb80928b254#07e653f9fb594e7454f6f732f3d3ceb80928b254"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9#7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "07e653f9fb594e7454f6f732f3d3ceb80928b254" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/runtime/examples/linux_native_live_session_qualification.rs
+++ b/src/runtime/examples/linux_native_live_session_qualification.rs
@@ -79,7 +79,6 @@ mod qualification {
     const KEYED_EXEC_AFTER: &str = "a3s.box.live-session.keyed-exec.after-reopen";
     const KEYED_EXEC_MARKER: &[u8] = b"live-session-keyed-ok\n";
     const STREAM_MARKER: &[u8] = b"live-session-stream-ok\n";
-    const STREAM_EXEC_BEFORE: &str = "a3s.box.live-session.stream.before-owner-kill";
     const STREAM_ECHO_BEFORE: &[u8] = b"before-owner-kill\n";
     const STREAM_ECHO_AFTER: &[u8] = b"after-owner-reopen\n";
 
@@ -422,7 +421,9 @@ mod qualification {
                 &reservation.execution_id,
                 reservation.generation,
                 ExecRequest {
-                    request_id: Some(STREAM_EXEC_BEFORE.to_string()),
+                    // Streaming sessions are not one-shot keyed ops; request_id
+                    // is reserved for captured exec replay (see oci_session).
+                    request_id: None,
                     cmd: vec![
                         "/bin/sh".into(),
                         "-c".into(),

--- a/src/runtime/examples/linux_native_live_session_qualification.rs
+++ b/src/runtime/examples/linux_native_live_session_qualification.rs
@@ -470,12 +470,7 @@ mod qualification {
                     "streaming stdin write before owner SIGKILL failed: {error}"
                 ))
             })?;
-        expect_stream_echo(
-            process.as_mut(),
-            STREAM_ECHO_BEFORE,
-            "before owner SIGKILL",
-        )
-        .await?;
+        expect_stream_echo(process.as_mut(), STREAM_ECHO_BEFORE, "before owner SIGKILL").await?;
 
         // Keep the Box manager: retained-handle continuity is the v3 gate.
         sigkill_identity(&owner)?;
@@ -494,9 +489,7 @@ mod qualification {
         let disconnect = process.next_event().await;
         require(
             matches!(disconnect, Err(ExecutionManagerError::Unavailable(_))),
-            format!(
-                "retained stream must surface Unavailable on owner death, got {disconnect:?}"
-            ),
+            format!("retained stream must surface Unavailable on owner death, got {disconnect:?}"),
         )?;
 
         let mut outcome = None;
@@ -567,12 +560,7 @@ mod qualification {
                     "retained streaming stdin after owner reopen failed: {error}"
                 ))
             })?;
-        expect_stream_echo(
-            process.as_mut(),
-            STREAM_ECHO_AFTER,
-            "after owner reopen",
-        )
-        .await?;
+        expect_stream_echo(process.as_mut(), STREAM_ECHO_AFTER, "after owner reopen").await?;
         input.close_stdin().await.map_err(|error| {
             failure(format!(
                 "retained streaming close_stdin after owner reopen failed: {error}"

--- a/src/runtime/examples/linux_native_live_session_qualification.rs
+++ b/src/runtime/examples/linux_native_live_session_qualification.rs
@@ -429,7 +429,10 @@ mod qualification {
                         "-c".into(),
                         "printf 'live-session-stream-ok\\n'; while IFS= read -r line; do printf 'echo:%s\\n' \"$line\"; done".into(),
                     ],
-                    timeout_ns: 30_000_000_000,
+                    // Must outlive owner-gone wait + Host respawn + supervisor
+                    // reattach (30s) + reconcile; a 30s watchdog poisons the
+                    // retained stream before Live reopen completes.
+                    timeout_ns: 600_000_000_000,
                     env: Vec::new(),
                     working_dir: Some("/".into()),
                     rootfs: None,

--- a/src/runtime/examples/linux_native_live_session_qualification.rs
+++ b/src/runtime/examples/linux_native_live_session_qualification.rs
@@ -427,7 +427,10 @@ mod qualification {
                     cmd: vec![
                         "/bin/sh".into(),
                         "-c".into(),
-                        "printf 'live-session-stream-ok\\n'; while IFS= read -r line; do printf 'echo:%s\\n' \"$line\"; done".into(),
+                        // Stay alive after stdin EOF so close_stdin + Kill both exercise
+                        // the retained handle (a plain `while read` exits on EOF and
+                        // makes Kill fail closed as not-live).
+                        "printf 'live-session-stream-ok\\n'; while true; do if IFS= read -r line; then printf 'echo:%s\\n' \"$line\"; else while true; do sleep 3600; done; fi; done".into(),
                     ],
                     // Must outlive owner-gone wait + Host respawn + supervisor
                     // reattach (30s) + reconcile; a 30s watchdog poisons the

--- a/src/runtime/examples/linux_native_live_session_qualification.rs
+++ b/src/runtime/examples/linux_native_live_session_qualification.rs
@@ -471,7 +471,7 @@ mod qualification {
                 ))
             })?;
         expect_stream_echo(
-            &mut process,
+            process.as_mut(),
             STREAM_ECHO_BEFORE,
             "before owner SIGKILL",
         )
@@ -568,7 +568,7 @@ mod qualification {
                 ))
             })?;
         expect_stream_echo(
-            &mut process,
+            process.as_mut(),
             STREAM_ECHO_AFTER,
             "after owner reopen",
         )
@@ -764,7 +764,7 @@ mod qualification {
     }
 
     async fn expect_stream_echo(
-        process: &mut impl ExecutionProcessStream,
+        process: &mut dyn ExecutionProcessStream,
         line: &[u8],
         phase: &str,
     ) -> Result<(), AnyError> {

--- a/src/runtime/examples/linux_native_live_session_qualification.rs
+++ b/src/runtime/examples/linux_native_live_session_qualification.rs
@@ -51,9 +51,9 @@ mod qualification {
     use a3s_box_core::{
         BoxConfig, CreateExecutionRequest, ExecEvent, ExecRequest, ExecutionBackend,
         ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionManager,
-        ExecutionManagerError, ExecutionProcessSignal, ExecutionSessionManager, ExecutionState,
-        IsolationClass as BoxIsolationClass, NetworkMode, OperationId, ReconcileOutcome,
-        ResourceConfig, StreamType,
+        ExecutionManagerError, ExecutionProcessSignal, ExecutionProcessStream,
+        ExecutionSessionManager, ExecutionState, IsolationClass as BoxIsolationClass, NetworkMode,
+        OperationId, ReconcileOutcome, ResourceConfig, StreamType,
     };
     use a3s_box_runtime::{
         LocalExecutionManager, ManagedExecutionStore, ManagedRuntimeRoute,
@@ -470,6 +470,12 @@ mod qualification {
                     "streaming stdin write before owner SIGKILL failed: {error}"
                 ))
             })?;
+        expect_stream_echo(
+            &mut process,
+            STREAM_ECHO_BEFORE,
+            "before owner SIGKILL",
+        )
+        .await?;
 
         // Keep the Box manager: retained-handle continuity is the v3 gate.
         sigkill_identity(&owner)?;
@@ -487,10 +493,7 @@ mod qualification {
 
         let disconnect = process.next_event().await;
         require(
-            matches!(
-                disconnect,
-                Err(ExecutionManagerError::Unavailable(_))
-            ),
+            matches!(disconnect, Err(ExecutionManagerError::Unavailable(_))),
             format!(
                 "retained stream must surface Unavailable on owner death, got {disconnect:?}"
             ),
@@ -564,6 +567,12 @@ mod qualification {
                     "retained streaming stdin after owner reopen failed: {error}"
                 ))
             })?;
+        expect_stream_echo(
+            &mut process,
+            STREAM_ECHO_AFTER,
+            "after owner reopen",
+        )
+        .await?;
         input.close_stdin().await.map_err(|error| {
             failure(format!(
                 "retained streaming close_stdin after owner reopen failed: {error}"
@@ -752,6 +761,53 @@ mod qualification {
             ),
         )?;
         Ok(())
+    }
+
+    async fn expect_stream_echo(
+        process: &mut impl ExecutionProcessStream,
+        line: &[u8],
+        phase: &str,
+    ) -> Result<(), AnyError> {
+        let payload = line.strip_suffix(b"\n").unwrap_or(line);
+        let expected = format!("echo:{}\n", String::from_utf8_lossy(payload));
+        let expected_bytes = expected.as_bytes();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let event = tokio::time::timeout(Duration::from_secs(5), process.next_event())
+                .await
+                .map_err(|_| failure(format!("timed out waiting for stream echo {phase}")))?
+                .map_err(|error| {
+                    failure(format!(
+                        "streaming process failed while waiting for echo {phase}: {error}"
+                    ))
+                })?
+                .ok_or_else(|| failure(format!("streaming process ended before echo {phase}")))?;
+            match event {
+                ExecEvent::Chunk(chunk)
+                    if chunk.stream == StreamType::Stdout && chunk.data == expected_bytes =>
+                {
+                    return Ok(());
+                }
+                ExecEvent::Chunk(chunk) if chunk.stream == StreamType::Stdout => {
+                    return Err(failure(format!(
+                        "streaming stdout drifted {phase}: {:?}",
+                        String::from_utf8_lossy(&chunk.data)
+                    )));
+                }
+                ExecEvent::FlushAck => {}
+                ExecEvent::Exit(exit) => {
+                    return Err(failure(format!(
+                        "streaming process exited before echo {phase}: {exit:?}"
+                    )));
+                }
+                ExecEvent::Chunk(_) => {}
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(failure(format!(
+                    "deadline exceeded waiting for stream echo {phase}"
+                )));
+            }
+        }
     }
 
     async fn wait_until_running(

--- a/src/runtime/examples/linux_native_live_session_qualification.rs
+++ b/src/runtime/examples/linux_native_live_session_qualification.rs
@@ -1,21 +1,22 @@
 //! Destructive live-session qualification for Box over Native Linux OCI.
 //!
 //! Exercises the public Box Sandbox path with
-//! `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`, SIGKILLs the out-of-process Native
-//! Linux Host owner while a generation is running, rebinds through a
-//! replacement owner, and continues authentic Live process-session ops
-//! (keyed captured exec, state, inventory, stats, kill) without inventing an
-//! exit status.
+//! `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`, keeps the Box manager across a
+//! Native Linux Host owner SIGKILL, proves retained streaming process-handle
+//! continuity plus keyed captured exec / state / inventory / stats / kill,
+//! without inventing an exit status.
 //!
-//! Schema `a3s.box.linux-native-live-session.v2`.
+//! Schema `a3s.box.linux-native-live-session.v3`.
 //!
 //! Honest scope (anti-overfit):
 //! - Live Host-reopen is Native-Linux-driver-only today.
-//! - This harness **drops** the Box manager before owner SIGKILL, so it does
-//!   **not** prove retained streaming process-handle continuity (that remains
-//!   the fixture-only contract in `oci_backend_tests::process_restart`).
-//! - It does **not** claim KVM MicroVM Live continuity (KVM Host reopen remains
-//!   stopped-only / recreate) and does **not** close Box B2 / OCI R6.
+//! - `retained_stream_handle_proven` is set only when the same
+//!   `start_process` handle continues stdin/output/signal after owner reopen.
+//! - Fixture `process_restart` continuity is never claimed
+//!   (`fixture_stream_continuity_claimed` stays false).
+//! - Does **not** claim KVM MicroVM Live continuity and does **not** close
+//!   Box B2 / OCI R6 (`b2_process_session_recovery_closed` stays false until
+//!   utility-VM Live also lands).
 
 #[cfg(not(all(
     target_os = "linux",
@@ -48,10 +49,11 @@ mod qualification {
     use std::time::Duration;
 
     use a3s_box_core::{
-        BoxConfig, CreateExecutionRequest, ExecRequest, ExecutionBackend, ExecutionGeneration,
-        ExecutionId, ExecutionIsolation, ExecutionManager, ExecutionManagerError,
-        ExecutionSessionManager, ExecutionState, IsolationClass as BoxIsolationClass, NetworkMode,
-        OperationId, ReconcileOutcome, ResourceConfig,
+        BoxConfig, CreateExecutionRequest, ExecEvent, ExecRequest, ExecutionBackend,
+        ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionManager,
+        ExecutionManagerError, ExecutionProcessSignal, ExecutionSessionManager, ExecutionState,
+        IsolationClass as BoxIsolationClass, NetworkMode, OperationId, ReconcileOutcome,
+        ResourceConfig, StreamType,
     };
     use a3s_box_runtime::{
         LocalExecutionManager, ManagedExecutionStore, ManagedRuntimeRoute,
@@ -71,11 +73,15 @@ mod qualification {
     const BOX_SHA_ENV: &str = "A3S_BOX_NATIVE_LIVE_SESSION_BOX_SHA";
     const OCI_SHA_ENV: &str = "A3S_BOX_NATIVE_LIVE_SESSION_OCI_SHA";
     const SUPERVISOR_ENV: &str = "A3S_OCI_NATIVE_SESSION_SUPERVISOR";
-    const SCHEMA_VERSION: &str = "a3s.box.linux-native-live-session.v2";
+    const SCHEMA_VERSION: &str = "a3s.box.linux-native-live-session.v3";
     const OWNER_SCHEMA: &str = "a3s.box.native-linux-oci-owner.v1";
     const KEYED_EXEC_BEFORE: &str = "a3s.box.live-session.keyed-exec.before-owner-kill";
     const KEYED_EXEC_AFTER: &str = "a3s.box.live-session.keyed-exec.after-reopen";
     const KEYED_EXEC_MARKER: &[u8] = b"live-session-keyed-ok\n";
+    const STREAM_MARKER: &[u8] = b"live-session-stream-ok\n";
+    const STREAM_EXEC_BEFORE: &str = "a3s.box.live-session.stream.before-owner-kill";
+    const STREAM_ECHO_BEFORE: &[u8] = b"before-owner-kill\n";
+    const STREAM_ECHO_AFTER: &[u8] = b"after-owner-reopen\n";
 
     type AnyError = Box<dyn Error + Send + Sync>;
 
@@ -112,11 +118,12 @@ mod qualification {
         driver_target: &'static str,
         kvm_microvm_live_claimed: bool,
         utility_vm_claimed: bool,
-        /// Always false: this harness drops the Box manager before owner death.
+        /// Set only when the same streaming `start_process` handle continues
+        /// after a real Native Linux owner SIGKILL + Live reopen.
         retained_stream_handle_proven: bool,
         /// Always false: fixture `process_restart` continuity is not this gate.
         fixture_stream_continuity_claimed: bool,
-        /// Always false: B2 still requires real-driver retained-stream + utility-VM.
+        /// Always false: B2 still requires utility-VM Live as well.
         b2_process_session_recovery_closed: bool,
         supervised_create_required: bool,
         supervised_create_enabled: bool,
@@ -410,7 +417,61 @@ mod qualification {
         require_live_identity("launcher", &recovery.launcher)?;
         require_live_identity("init", &recovery.init)?;
 
-        drop(manager);
+        let mut process = manager
+            .start_process(
+                &reservation.execution_id,
+                reservation.generation,
+                ExecRequest {
+                    request_id: Some(STREAM_EXEC_BEFORE.to_string()),
+                    cmd: vec![
+                        "/bin/sh".into(),
+                        "-c".into(),
+                        "printf 'live-session-stream-ok\\n'; while IFS= read -r line; do printf 'echo:%s\\n' \"$line\"; done".into(),
+                    ],
+                    timeout_ns: 30_000_000_000,
+                    env: Vec::new(),
+                    working_dir: Some("/".into()),
+                    rootfs: None,
+                    stdin: None,
+                    stdin_streaming: true,
+                    user: None,
+                    streaming: true,
+                },
+            )
+            .await
+            .map_err(|error| {
+                failure(format!(
+                    "streaming start_process before owner SIGKILL failed: {error}"
+                ))
+            })?;
+        let input = process.input();
+        let first_event = process
+            .next_event()
+            .await
+            .map_err(|error| {
+                failure(format!(
+                    "streaming process failed before first chunk: {error}"
+                ))
+            })?
+            .ok_or_else(|| failure("streaming process ended before the marker chunk"))?;
+        require(
+            matches!(
+                &first_event,
+                ExecEvent::Chunk(chunk)
+                    if chunk.stream == StreamType::Stdout && chunk.data == STREAM_MARKER
+            ),
+            format!("streaming process first chunk drifted: {first_event:?}"),
+        )?;
+        input
+            .write_stdin(STREAM_ECHO_BEFORE)
+            .await
+            .map_err(|error| {
+                failure(format!(
+                    "streaming stdin write before owner SIGKILL failed: {error}"
+                ))
+            })?;
+
+        // Keep the Box manager: retained-handle continuity is the v3 gate.
         sigkill_identity(&owner)?;
         report.owner_sigkilled = true;
         wait_identity_gone("OCI owner", &owner, Duration::from_secs(30))?;
@@ -424,11 +485,21 @@ mod qualification {
         require_live_identity("init after owner SIGKILL", &recovery.init)?;
         report.init_survived_owner_kill = true;
 
-        let reconnected = connect(inputs).await?;
+        let disconnect = process.next_event().await;
+        require(
+            matches!(
+                disconnect,
+                Err(ExecutionManagerError::Unavailable(_))
+            ),
+            format!(
+                "retained stream must surface Unavailable on owner death, got {disconnect:?}"
+            ),
+        )?;
+
         let mut outcome = None;
         let reconcile_deadline = tokio::time::Instant::now() + Duration::from_secs(120);
         while outcome.is_none() {
-            match reconnected.reconcile(operation_id).await {
+            match manager.reconcile(operation_id).await {
                 Ok(value) => outcome = Some(value),
                 Err(ExecutionManagerError::Unavailable(_)) => {
                     if tokio::time::Instant::now() >= reconcile_deadline {
@@ -485,7 +556,56 @@ mod qualification {
         report.owner_rebound = true;
         report.owner_after_reopen = Some(replacement_owner);
 
-        wait_until_running(&reconnected, &reservation.execution_id, report, false).await?;
+        input
+            .write_stdin(STREAM_ECHO_AFTER)
+            .await
+            .map_err(|error| {
+                failure(format!(
+                    "retained streaming stdin after owner reopen failed: {error}"
+                ))
+            })?;
+        input.close_stdin().await.map_err(|error| {
+            failure(format!(
+                "retained streaming close_stdin after owner reopen failed: {error}"
+            ))
+        })?;
+        input
+            .send_signal(ExecutionProcessSignal::Kill)
+            .await
+            .map_err(|error| {
+                failure(format!(
+                    "retained streaming signal after owner reopen failed: {error}"
+                ))
+            })?;
+        let mut saw_exit = false;
+        let drain_deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        loop {
+            match process.next_event().await {
+                Ok(Some(ExecEvent::Exit(_))) => {
+                    saw_exit = true;
+                    break;
+                }
+                Ok(Some(_)) => {}
+                Ok(None) => break,
+                Err(error) => {
+                    return Err(failure(format!(
+                        "retained streaming drain after owner reopen failed: {error}"
+                    )));
+                }
+            }
+            if tokio::time::Instant::now() >= drain_deadline {
+                return Err(failure(
+                    "timed out draining retained streaming process after owner reopen",
+                ));
+            }
+        }
+        require(
+            saw_exit,
+            "retained streaming process did not publish Exit after reopen signal",
+        )?;
+        report.retained_stream_handle_proven = true;
+
+        wait_until_running(&manager, &reservation.execution_id, report, false).await?;
         let after = store
             .get(&reservation.execution_id)?
             .ok_or_else(|| failure("Box record missing after Live reopen"))?;
@@ -498,7 +618,7 @@ mod qualification {
         )?;
         report.exit_code_absent_after_reopen = true;
 
-        let inventory_after = reconnected
+        let inventory_after = manager
             .list_processes(&reservation.execution_id, reservation.generation)
             .await?;
         require(
@@ -519,7 +639,7 @@ mod qualification {
         )?;
         report.init_pid_continuous_after_reopen = true;
 
-        let stats = reconnected
+        let stats = manager
             .stats(&reservation.execution_id, reservation.generation)
             .await?;
         require(
@@ -531,7 +651,7 @@ mod qualification {
         report.stats_after_reopen = true;
 
         prove_keyed_captured_exec(
-            &reconnected,
+            &manager,
             &reservation.execution_id,
             reservation.generation,
             KEYED_EXEC_AFTER,
@@ -540,14 +660,14 @@ mod qualification {
         report.keyed_captured_exec_after_reopen = true;
 
         // Authentic Live kill of the still-running generation (not an invented stop).
-        reconnected
+        manager
             .kill(&reservation.execution_id, reservation.generation)
             .await?;
         report.live_kill_after_reopen = true;
 
         let stop_deadline = tokio::time::Instant::now() + Duration::from_secs(120);
         loop {
-            let status = reconnected.inspect(&reservation.execution_id).await?;
+            let status = manager.inspect(&reservation.execution_id).await?;
             if matches!(
                 status.state,
                 ExecutionState::Stopped | ExecutionState::Failed
@@ -562,13 +682,13 @@ mod qualification {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
-        report.removed = reconnected
+        report.removed = manager
             .remove(&reservation.execution_id, reservation.generation)
             .await?;
         require(report.removed, "terminal Box generation was not removed")?;
         require(
             matches!(
-                reconnected.reconcile(operation_id).await?,
+                manager.reconcile(operation_id).await?,
                 ReconcileOutcome::Absent
             ),
             "removed Box operation remained reconcilable",

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -1378,6 +1378,16 @@ impl OciLocalExecutionBackend {
         self
     }
 
+    /// No-op off Linux+vm: native Host owner respawn is Linux Sandbox only.
+    #[cfg(not(all(feature = "vm", target_os = "linux")))]
+    pub fn with_native_linux_owner_recovery(
+        self,
+        _service_root: impl Into<PathBuf>,
+        _artifacts: crate::sandbox::CertifiedA3sOci,
+    ) -> Self {
+        self
+    }
+
     #[cfg(all(feature = "vm", target_os = "linux"))]
     async fn ensure_native_linux_owner(&self) -> ExecutionManagerResult<()> {
         let Some(recovery) = self.native_linux_owner.as_ref() else {

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -1312,11 +1312,22 @@ impl OciLifecycleAdapter {
     }
 }
 
+/// Retained-manager recovery: respawn the identity-fenced native Linux OCI owner
+/// when the Host process dies without dropping the Box manager.
+#[cfg(all(feature = "vm", target_os = "linux"))]
+#[derive(Debug, Clone)]
+pub struct NativeLinuxOwnerRecovery {
+    service_root: PathBuf,
+    artifacts: crate::sandbox::CertifiedA3sOci,
+}
+
 /// Opt-in canonical local-execution backend over one A3S OCI host service.
 #[derive(Clone)]
 pub struct OciLocalExecutionBackend {
     adapter: OciLifecycleAdapter,
     provider: Arc<dyn OciBundleProvider>,
+    #[cfg(all(feature = "vm", target_os = "linux"))]
+    native_linux_owner: Option<Arc<NativeLinuxOwnerRecovery>>,
 }
 
 impl OciLocalExecutionBackend {
@@ -1329,6 +1340,8 @@ impl OciLocalExecutionBackend {
         Ok(Self {
             adapter: OciLifecycleAdapter::from_client(endpoint, client)?,
             provider,
+            #[cfg(all(feature = "vm", target_os = "linux"))]
+            native_linux_owner: None,
         })
     }
 
@@ -1340,7 +1353,53 @@ impl OciLocalExecutionBackend {
         Ok(Self {
             adapter: OciLifecycleAdapter::connect(endpoint).await?,
             provider,
+            #[cfg(all(feature = "vm", target_os = "linux"))]
+            native_linux_owner: None,
         })
+    }
+
+    /// Enable identity-fenced owner respawn for retained-manager Live reopen.
+    ///
+    /// Construction already calls [`super::oci_owner::ensure_native_linux_oci_owner`].
+    /// Without this recovery handle, `reconcile`/`inspect` only reconnect the SDK
+    /// transport to a dead socket and never spawn a replacement Host — so v3
+    /// retained-stream reopen stays Unavailable while the session supervisor's
+    /// 30s reattach window expires.
+    #[cfg(all(feature = "vm", target_os = "linux"))]
+    pub fn with_native_linux_owner_recovery(
+        mut self,
+        service_root: impl Into<PathBuf>,
+        artifacts: crate::sandbox::CertifiedA3sOci,
+    ) -> Self {
+        self.native_linux_owner = Some(Arc::new(NativeLinuxOwnerRecovery {
+            service_root: service_root.into(),
+            artifacts,
+        }));
+        self
+    }
+
+    #[cfg(all(feature = "vm", target_os = "linux"))]
+    async fn ensure_native_linux_owner(&self) -> ExecutionManagerResult<()> {
+        let Some(recovery) = self.native_linux_owner.as_ref() else {
+            return Ok(());
+        };
+        let endpoint = super::oci_owner::ensure_native_linux_oci_owner(
+            &recovery.service_root,
+            &recovery.artifacts,
+        )
+        .await?;
+        if endpoint != self.adapter.endpoint {
+            return Err(ExecutionManagerError::Internal(format!(
+                "native Linux OCI owner recovery returned a different endpoint ({endpoint:?}) than the retained SDK binding ({:?})",
+                self.adapter.endpoint
+            )));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(all(feature = "vm", target_os = "linux")))]
+    async fn ensure_native_linux_owner(&self) -> ExecutionManagerResult<()> {
+        Ok(())
     }
 
     pub(super) fn metadata<'a>(
@@ -1717,7 +1776,17 @@ impl LocalExecutionBackend for OciLocalExecutionBackend {
         let execution_id = self.execution_id(record)?;
         let metadata = self.metadata(record)?;
         let had_binding = self.binding(record)?.is_some();
-        let Some((mut runtime, mut binding)) = self.current_runtime(record).await? else {
+        let runtime_binding = match self.current_runtime(record).await {
+            Ok(value) => value,
+            Err(ExecutionManagerError::Unavailable(_)) => {
+                // Retained manager: respawn the Host under the same socket path
+                // so the next SDK call can reconnect and Live-recover.
+                self.ensure_native_linux_owner().await?;
+                self.current_runtime(record).await?
+            }
+            Err(error) => return Err(error),
+        };
+        let Some((mut runtime, mut binding)) = runtime_binding else {
             if had_binding {
                 self.provider.cleanup(record).await?;
             }

--- a/src/runtime/src/local_execution/oci_migration.rs
+++ b/src/runtime/src/local_execution/oci_migration.rs
@@ -255,7 +255,11 @@ impl LocalExecutionManager {
                 provider = provider.with_pull_progress_fn(progress.clone());
             }
             let provider = Arc::new(provider);
-            let oci = Arc::new(OciLocalExecutionBackend::connect(endpoint, provider).await?);
+            let oci = Arc::new(
+                OciLocalExecutionBackend::connect(endpoint, provider)
+                    .await?
+                    .with_native_linux_owner_recovery(config.service_root(), artifacts.clone()),
+            );
             Ok(Self::with_oci_migration_backend_and_pull_progress(
                 state_path,
                 home_dir,


### PR DESCRIPTION
## Summary
- Prove retained streaming `start_process` handle continuity across Native Linux Host owner SIGKILL while keeping the Box manager (schema `a3s.box.linux-native-live-session.v3`).
- Respawn identity-fenced OCI owner on retained-manager Unavailable; omit one-shot `request_id` on streaming; keep stream alive after `close_stdin` EOF so Kill after reopen stays live.
- Pin `a3s-oci-sdk` / CI/release to OCI `7001ce5a…` (per-process Live stdin deposits, PR #279).

## Evidence (existing-host WSL2, matched-creds + elevate)
- Report SHA-256: `bc36ff5b895b6320b57322328f78910be82eddfb2203b97bd2c86455b1929d02`
- `status=passed`, `retained_stream_handle_proven=true`, keyed capture / live kill / removed
- Box tip `4fb82a77…`, OCI `7001ce5a…`
- Does **not** close B2 (`b2_process_session_recovery_closed` stays false), default supervised create, MicroVM cutover, fresh-host, or AArch64

## Test plan
- [x] Existing-host WSL2 elevate live-session v3 qualification (no CI)
- [ ] Reviewers: do not treat CI as the merge gate for this PR