### PR TITLE
chore: pin OCI Runtime to 07e653f with live-session v2 evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 402949c2d73cabdf5b959113806db9108e918cf1
+  A3S_OCI_RUNTIME_REV: 07e653f9fb594e7454f6f732f3d3ceb80928b254
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 402949c2d73cabdf5b959113806db9108e918cf1
+  A3S_OCI_RUNTIME_REV: 07e653f9fb594e7454f6f732f3d3ceb80928b254
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,16 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Changed
 
+- Bump the pinned OCI Runtime revision to
+  `07e653f9fb594e7454f6f732f3d3ceb80928b254` (supervised try_wait zombie reap,
+  supervisor BrokenPipe reattach, zombie recovery identity, exec pidfd before
+  START, live exec capture deposit routing). Existing-host WSL2 matched-creds +
+  elevate Native live-session v2 report SHA-256
+  `614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`
+  (`status=passed`, keyed exec before/after reopen, live kill, removed).
+  Align CI/release `A3S_OCI_RUNTIME_REV` with the Cargo `a3s-oci-sdk` pin.
+  Does **not** close B2 retained-stream, default supervised create, MicroVM
+  cutover, fresh-host, or AArch64.
 - Restore the OCI Runtime pin to `402949c2` (last CI-green with Sandbox R17
   PR #268). Hosted SDK Local Sandbox fails on `35c3370` with
   `rootless exec timed out` in OCI `native-linux-smoke`; keep KVM requal

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -419,7 +419,13 @@ retain process or filesystem sessions after its owner dies.
     invented exit). Requires `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`. Drops the
     Box manager before owner death, so it does **not** prove retained streaming
     handle continuity and does **not** close B2. Does not close utility-VM Live
-    or default create Host-bound policy.
+    or default create Host-bound policy. **Existing-host WSL2 evidence** on OCI
+    `07e653f9fb594e7454f6f732f3d3ceb80928b254` / Box tip that ran the harness:
+    report SHA-256
+    `614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`
+    (`status=passed`, `keyed_captured_exec_after_reopen=true`,
+    `live_kill_after_reopen=true`, `removed=true`; retained-stream / B2 /
+    fixture / KVM / utility-VM claims stay false).
   - [ ] Retained streaming process-handle continuity on a real Native Linux
     owner restart (fixture-only today in `process_restart`).
   - [ ] Utility-VM / KVM MicroVM Live process-session continuity (KVM Host

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=402949c2d73cabdf5b959113806db9108e918cf1#402949c2d73cabdf5b959113806db9108e918cf1"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=07e653f9fb594e7454f6f732f3d3ceb80928b254#07e653f9fb594e7454f6f732f3d3ceb80928b254"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=402949c2d73cabdf5b959113806db9108e918cf1#402949c2d73cabdf5b959113806db9108e918cf1"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=07e653f9fb594e7454f6f732f3d3ceb80928b254#07e653f9fb594e7454f6f732f3d3ceb80928b254"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "402949c2d73cabdf5b959113806db9108e918cf1" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "07e653f9fb594e7454f6f732f3d3ceb80928b254" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- Pin `a3s-oci-sdk` / `A3S_OCI_RUNTIME_REV` to `07e653f9fb594e7454f6f732f3d3ceb80928b254`.
- Record existing-host WSL2 Native live-session v2 green evidence (report SHA-256 `614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`).
- Does not close B2 retained-stream, default supervised create, or MicroVM cutover.

## Test plan
- [x] Existing-host matched-creds + elevate live-session v2 passed on that OCI tip
- [x] Cargo.lock updated to the same rev

Merge without waiting on CI per monorepo goal.