### PR TITLE
feat(box): Native Live filesystem continuity (v4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: f532e2d818cc302849a7c92653ca8256e3ba277e
+  A3S_OCI_RUNTIME_REV: 61f77712e420c176dfc1a5d7ba2457e8c8299dcf
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────
@@ -675,7 +675,7 @@ jobs:
             echo "::error title=Local SDK smoke failure::$diagnostic"
           fi
           exit "$status"
-      - name: Qualify Native Linux live-session retained-stream (v3)
+      - name: Qualify Native Linux live-session retained-stream+fs (v4)
         env:
           LIVE_SESSION_IMAGE: docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
         run: |
@@ -691,7 +691,7 @@ jobs:
           install -m 755 "$A3S_BOX_SHIM_BINARY" "$staging/a3s-box-shim"
           install -m 755 "$A3S_BOX_GUEST_INIT_BINARY" "$staging/a3s-box-guest-init"
           install -m 755 "$example_bin" "$staging/linux-native-live-session-qualification"
-          report="$RUNNER_TEMP/a3s-box-linux-native-live-session-v3.json"
+          report="$RUNNER_TEMP/a3s-box-linux-native-live-session-v4.json"
           rm -f "$report"
           # Root entry matches the local gate: prepare cgroup/home, then the
           # script setpriv-execs the example. Do not treat a missing report as
@@ -708,12 +708,12 @@ jobs:
               --oci-sha "$A3S_OCI_RUNTIME_REV"
           python3 "$GITHUB_WORKSPACE/scripts/verify-linux-native-live-session-report.py" \
             "$report"
-      - name: Upload Native Linux live-session v3 evidence
+      - name: Upload Native Linux live-session v4 evidence
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: a3s-box-linux-native-live-session-v3-${{ matrix.platform }}
-          path: ${{ runner.temp }}/a3s-box-linux-native-live-session-v3.json
+          name: a3s-box-linux-native-live-session-v4-${{ matrix.platform }}
+          path: ${{ runner.temp }}/a3s-box-linux-native-live-session-v4.json
           if-no-files-found: warn
           retention-days: 14
       - name: Upload native OCI owner-recovery evidence

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: f532e2d818cc302849a7c92653ca8256e3ba277e
+  A3S_OCI_RUNTIME_REV: 61f77712e420c176dfc1a5d7ba2457e8c8299dcf
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- Observation harness `a3s.box.linux-native-live-session.v4` extends the
+  Native Linux live-session gate with filesystem continuity across owner
+  SIGKILL via public Box `transfer_file` (upload before kill, download after
+  reattach on the same generation; `retained_filesystem_proven`). Keeps
+  retained streaming handle proof from v3. Does **not** close B2
+  (`b2_process_session_recovery_closed` stays false) and does not claim
+  fixture `process_restart` continuity. **Existing-host WSL2 greened** on
+  OCI `61f77712e420c176dfc1a5d7ba2457e8c8299dcf`: report SHA-256
+  `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818`.
+
 - Existing-host WSL2 `/dev/kvm` greened `a3s.box.linux-kvm-live-session.v1`
   (`retained_stream_handle_proven=true`, `kvm_microvm_live_claimed=true`) on
   Box `0a6ce8d7…` + OCI `f532e2d…` (report SHA-256
@@ -24,8 +34,9 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Changed
 
-- Bump pinned OCI Runtime to `f532e2d818cc302849a7c92653ca8256e3ba277e` (KVM
-  Live retained exec I/O across Host reopen).
+- Bump pinned OCI Runtime to `61f77712e420c176dfc1a5d7ba2457e8c8299dcf`
+  (Native Live filesystem continuity, OCI-Runtime #290). Prior pin
+  `f532e2d818cc302849a7c92653ca8256e3ba277e` covered KVM Live retained exec I/O.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -335,17 +335,19 @@ sudo --preserve-env=A3S_BOX_CI_SANDBOX_UID,A3S_BOX_CI_SANDBOX_GID,A3S_BOX_SANDBO
   --home /tmp/a3s-box-native-live-session-home
 ```
 
-Schema `a3s.box.linux-native-live-session.v3` keeps the Box manager across a
+Schema `a3s.box.linux-native-live-session.v4` keeps the Box manager across a
 Native Linux Host owner SIGKILL, proves retained streaming `start_process`
 handle continuity when the path passes (`retained_stream_handle_proven`), and
-continues authentic Live keyed captured exec plus state/inventory/stats/kill
-without inventing an exit status. Existing-host WSL2 evidence on OCI
-`7001ce5a4c32cd6e2bbb9a833fc45fd05d2318c9`: report SHA-256
-`bc36ff5b895b6320b57322328f78910be82eddfb2203b97bd2c86455b1929d02`. Fixture
+proves filesystem continuity via public `transfer_file` (upload before kill,
+download after reattach on the same generation;
+`retained_filesystem_proven`). It continues authentic Live keyed captured exec
+plus state/inventory/stats/kill without inventing an exit status. Fixture
 `process_restart` is never claimed as driver evidence
 (`fixture_stream_continuity_claimed` stays false). B2 stays open until
 utility-VM Live also lands (`b2_process_session_recovery_closed` stays false).
-It does not claim KVM MicroVM Live continuity.
+It does not claim KVM MicroVM Live continuity. Pin OCI Runtime at
+`61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (Native Live filesystem #290). Existing-host WSL2 evidence report
+SHA-256 `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818` (`retained_filesystem_proven=true`; B2 stays false).
 
 ### Exercise the qualification-only WHPX handoff on Windows
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -485,7 +485,7 @@ retain process or filesystem sessions after its owner dies.
     `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818`
     (`status=passed`, `retained_filesystem_proven=true`,
     `retained_stream_handle_proven=true`; B2 / fixture / KVM / utility-VM
-    claims stay false).
+    claims stay false). Box tip SHA `7d633b15cfb4f23c092c666a0a13aadb25eccdfd`.
   - [x] KVM MicroVM Live process-session continuity via observation harness
     `a3s.box.linux-kvm-live-session.v1` (`linux-kvm-live-session-qualification`)
     with `A3S_OCI_KVM_SESSION_OWNER=1`, Box manager retained across Host Service

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -464,11 +464,28 @@ retain process or filesystem sessions after its owner dies.
     Prior v2 (manager-drop) evidence on OCI
     `07e653f9fb594e7454f6f732f3d3ceb80928b254` remains keyed-capture /
     live-kill only (`614dcb5dc08572fb9d6166c2ed00f736db4e7508b145283a047569eeb89323db`).
+  - [x] Observation harness `a3s.box.linux-native-live-session.v4`
+    (`linux-native-live-session-qualification`) extends v3 with filesystem
+    continuity across owner SIGKILL via public Box `transfer_file` (upload
+    before kill, download after reattach on the same generation;
+    `retained_filesystem_proven` / `file_upload_before_kill` /
+    `file_download_after_reattach`). Keeps retained streaming handle proof.
+    Requires OCI pin `61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (Native Live
+    filesystem, OCI-Runtime #290). Does **not** close B2
+    (`b2_process_session_recovery_closed` stays false) and does not claim
+    fixture `process_restart` continuity.
   - [x] Retained streaming process-handle continuity on a real Native Linux
-    owner restart (v3 harness path above; fixture `process_restart` remains
+    owner restart (v3/v4 harness path above; fixture `process_restart` remains
     non-driver evidence). Does **not** alone close B2
     (`b2_process_session_recovery_closed` stays false until the plan's full
     B2 criteria are met).
+  - [x] Retained filesystem continuity on a real Native Linux owner restart
+    (v4 harness path above). **Existing-host WSL2 evidence** on OCI
+    `61f77712e420c176dfc1a5d7ba2457e8c8299dcf`: report SHA-256
+    `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818`
+    (`status=passed`, `retained_filesystem_proven=true`,
+    `retained_stream_handle_proven=true`; B2 / fixture / KVM / utility-VM
+    claims stay false).
   - [x] KVM MicroVM Live process-session continuity via observation harness
     `a3s.box.linux-kvm-live-session.v1` (`linux-kvm-live-session-qualification`)
     with `A3S_OCI_KVM_SESSION_OWNER=1`, Box manager retained across Host Service

--- a/scripts/linux-native-live-session-qualification.sh
+++ b/scripts/linux-native-live-session-qualification.sh
@@ -186,7 +186,7 @@ export A3S_BOX_CI_SANDBOX_GID="${gid}"
 export A3S_BOX_CI_SETPRIV_MATCHED_CREDS=1
 export A3S_BOX_CI_SETPRIV_WRAPPER="${SETPRIV_WRAPPER}"
 
-echo "running Native Linux live-session qualification v3"
+echo "running Native Linux live-session qualification v4"
 echo "  home=${A3S_HOME}"
 echo "  host-root=${HOST_ROOT}"
 echo "  image=${IMAGE}"

--- a/scripts/verify-linux-native-live-session-report.py
+++ b/scripts/verify-linux-native-live-session-report.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Fail-closed honesty checks for a3s.box.linux-native-live-session.v3 reports.
+"""Fail-closed honesty checks for a3s.box.linux-native-live-session.v4 reports.
 
-Retained-stream proof is required. B2, fixture continuity, KVM MicroVM Live,
-and utility-VM claims must stay false — this gate does not close those.
+Retained-stream and retained-filesystem proofs are required. B2, fixture
+continuity, KVM MicroVM Live, and utility-VM claims must stay false — this gate
+does not close those.
 """
 
 from __future__ import annotations
@@ -12,7 +13,13 @@ import sys
 import tempfile
 from pathlib import Path
 
-SCHEMA = "a3s.box.linux-native-live-session.v3"
+SCHEMA = "a3s.box.linux-native-live-session.v4"
+REQUIRED_TRUE = (
+    "retained_stream_handle_proven",
+    "file_upload_before_kill",
+    "file_download_after_reattach",
+    "retained_filesystem_proven",
+)
 FORBIDDEN = (
     "fixture_stream_continuity_claimed",
     "b2_process_session_recovery_closed",
@@ -27,8 +34,9 @@ def evaluate(report: dict) -> list[str]:
         failures.append(f"schema_version={report.get('schema_version')!r}")
     if report.get("status") != "passed":
         failures.append(f"status={report.get('status')!r} error={report.get('error')!r}")
-    if report.get("retained_stream_handle_proven") is not True:
-        failures.append("retained_stream_handle_proven is not true")
+    for required in REQUIRED_TRUE:
+        if report.get(required) is not True:
+            failures.append(f"{required} is not true")
     for forbidden in FORBIDDEN:
         if report.get(forbidden):
             failures.append(f"{forbidden} must stay false")
@@ -39,8 +47,9 @@ def passing_report() -> dict:
     report = {
         "schema_version": SCHEMA,
         "status": "passed",
-        "retained_stream_handle_proven": True,
     }
+    for required in REQUIRED_TRUE:
+        report[required] = True
     for forbidden in FORBIDDEN:
         report[forbidden] = False
     return report
@@ -51,20 +60,34 @@ def self_test() -> int:
         print("self-test: passing report was rejected", file=sys.stderr)
         return 1
     bad_cases = [
-        {"schema_version": "v2", "status": "passed", "retained_stream_handle_proven": True},
+        {"schema_version": "v3", "status": "passed", "retained_stream_handle_proven": True},
         {"schema_version": SCHEMA, "status": "failed", "retained_stream_handle_proven": True},
         {"schema_version": SCHEMA, "status": "passed", "retained_stream_handle_proven": False},
         {
             "schema_version": SCHEMA,
             "status": "passed",
             "retained_stream_handle_proven": True,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": True,
+            "retained_filesystem_proven": True,
             "b2_process_session_recovery_closed": True,
         },
         {
             "schema_version": SCHEMA,
             "status": "passed",
             "retained_stream_handle_proven": True,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": True,
+            "retained_filesystem_proven": True,
             "fixture_stream_continuity_claimed": True,
+        },
+        {
+            "schema_version": SCHEMA,
+            "status": "passed",
+            "retained_stream_handle_proven": True,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": False,
+            "retained_filesystem_proven": True,
         },
     ]
     for case in bad_cases:
@@ -106,7 +129,8 @@ def main(argv: list[str]) -> int:
             print(f"  {item}", file=sys.stderr)
         return 1
     print(
-        "live-session v3 retained-stream proven; B2/fixture/KVM/utility-VM claims remain false"
+        "live-session v4 retained-stream+filesystem proven; "
+        "B2/fixture/KVM/utility-VM claims remain false"
     )
     return 0
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=f532e2d818cc302849a7c92653ca8256e3ba277e#f532e2d818cc302849a7c92653ca8256e3ba277e"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=61f77712e420c176dfc1a5d7ba2457e8c8299dcf#61f77712e420c176dfc1a5d7ba2457e8c8299dcf"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=f532e2d818cc302849a7c92653ca8256e3ba277e#f532e2d818cc302849a7c92653ca8256e3ba277e"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=61f77712e420c176dfc1a5d7ba2457e8c8299dcf#61f77712e420c176dfc1a5d7ba2457e8c8299dcf"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "f532e2d818cc302849a7c92653ca8256e3ba277e" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "61f77712e420c176dfc1a5d7ba2457e8c8299dcf" }
 
 # Metrics
 prometheus = "0.13"

--- a/src/runtime/examples/linux_native_live_session_qualification.rs
+++ b/src/runtime/examples/linux_native_live_session_qualification.rs
@@ -3,15 +3,18 @@
 //! Exercises the public Box Sandbox path with
 //! `A3S_OCI_NATIVE_SESSION_SUPERVISOR=1`, keeps the Box manager across a
 //! Native Linux Host owner SIGKILL, proves retained streaming process-handle
-//! continuity plus keyed captured exec / state / inventory / stats / kill,
-//! without inventing an exit status.
+//! continuity, filesystem continuity via public `transfer_file` (upload before
+//! kill, download after reattach on the same generation), plus keyed captured
+//! exec / state / inventory / stats / kill, without inventing an exit status.
 //!
-//! Schema `a3s.box.linux-native-live-session.v3`.
+//! Schema `a3s.box.linux-native-live-session.v4`.
 //!
 //! Honest scope (anti-overfit):
 //! - Live Host-reopen is Native-Linux-driver-only today.
 //! - `retained_stream_handle_proven` is set only when the same
 //!   `start_process` handle continues stdin/output/signal after owner reopen.
+//! - `retained_filesystem_proven` is set only when upload-before-kill bytes
+//!   match download-after-reattach on the same Box generation.
 //! - Fixture `process_restart` continuity is never claimed
 //!   (`fixture_stream_continuity_claimed` stays false).
 //! - Does **not** claim KVM MicroVM Live continuity and does **not** close
@@ -52,14 +55,17 @@ mod qualification {
         BoxConfig, CreateExecutionRequest, ExecEvent, ExecRequest, ExecutionBackend,
         ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionManager,
         ExecutionManagerError, ExecutionProcessSignal, ExecutionProcessStream,
-        ExecutionSessionManager, ExecutionState, IsolationClass as BoxIsolationClass, NetworkMode,
-        OperationId, ReconcileOutcome, ResourceConfig, StreamType,
+        ExecutionSessionManager, ExecutionState, FileOp, FileRequest,
+        IsolationClass as BoxIsolationClass, NetworkMode, OperationId, ReconcileOutcome,
+        ResourceConfig, StreamType,
     };
     use a3s_box_runtime::{
         LocalExecutionManager, ManagedExecutionStore, ManagedRuntimeRoute,
         NativeLinuxOciMigrationConfig, OciRuntimeBinding,
     };
     use a3s_oci_sdk::{DriverKind, IsolationClass as OciIsolationClass};
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
     use serde::Serialize;
     use serde_json::Value;
 
@@ -73,7 +79,7 @@ mod qualification {
     const BOX_SHA_ENV: &str = "A3S_BOX_NATIVE_LIVE_SESSION_BOX_SHA";
     const OCI_SHA_ENV: &str = "A3S_BOX_NATIVE_LIVE_SESSION_OCI_SHA";
     const SUPERVISOR_ENV: &str = "A3S_OCI_NATIVE_SESSION_SUPERVISOR";
-    const SCHEMA_VERSION: &str = "a3s.box.linux-native-live-session.v3";
+    const SCHEMA_VERSION: &str = "a3s.box.linux-native-live-session.v4";
     const OWNER_SCHEMA: &str = "a3s.box.native-linux-oci-owner.v1";
     const KEYED_EXEC_BEFORE: &str = "a3s.box.live-session.keyed-exec.before-owner-kill";
     const KEYED_EXEC_AFTER: &str = "a3s.box.live-session.keyed-exec.after-reopen";
@@ -81,6 +87,8 @@ mod qualification {
     const STREAM_MARKER: &[u8] = b"live-session-stream-ok\n";
     const STREAM_ECHO_BEFORE: &[u8] = b"before-owner-kill\n";
     const STREAM_ECHO_AFTER: &[u8] = b"after-owner-reopen\n";
+    const FS_GUEST_PATH: &str = "/tmp/.a3s-box-native-live-fs.bin";
+    const FS_PAYLOAD: &[u8] = b"a3s-box-native-live-fs\0binary\nv4\n";
 
     type AnyError = Box<dyn Error + Send + Sync>;
 
@@ -120,6 +128,13 @@ mod qualification {
         /// Set only when the same streaming `start_process` handle continues
         /// after a real Native Linux owner SIGKILL + Live reopen.
         retained_stream_handle_proven: bool,
+        /// Upload before owner SIGKILL via public Box `transfer_file`.
+        file_upload_before_kill: bool,
+        /// Download after Live reopen matches the pre-kill upload payload.
+        file_download_after_reattach: bool,
+        /// Aggregate: upload before kill + exact download match after reattach
+        /// on the same Running generation (no invented stop).
+        retained_filesystem_proven: bool,
         /// Always false: fixture `process_restart` continuity is not this gate.
         fixture_stream_continuity_claimed: bool,
         /// Always false: B2 still requires utility-VM Live as well.
@@ -176,6 +191,9 @@ mod qualification {
                 kvm_microvm_live_claimed: false,
                 utility_vm_claimed: false,
                 retained_stream_handle_proven: false,
+                file_upload_before_kill: false,
+                file_download_after_reattach: false,
+                retained_filesystem_proven: false,
                 fixture_stream_continuity_claimed: false,
                 b2_process_session_recovery_closed: false,
                 supervised_create_required: true,
@@ -401,6 +419,14 @@ mod qualification {
         .await?;
         report.keyed_captured_exec_before_owner_kill = true;
 
+        prove_file_upload_before_kill(
+            &manager,
+            &reservation.execution_id,
+            reservation.generation,
+        )
+        .await?;
+        report.file_upload_before_kill = true;
+
         let owner = load_owner_record(&inputs.host_root)?;
         report.owner_before_kill = Some(owner.clone());
         let recovery = load_live_recovery(&inputs.host_root, &owner, &binding)?;
@@ -622,6 +648,23 @@ mod qualification {
         )?;
         report.exit_code_absent_after_reopen = true;
 
+        prove_file_download_after_reattach(
+            &manager,
+            &reservation.execution_id,
+            reservation.generation,
+        )
+        .await?;
+        report.file_download_after_reattach = true;
+        report.retained_filesystem_proven = report.file_upload_before_kill
+            && report.file_download_after_reattach
+            && report.reconciled_ready_after_reopen
+            && report.observed_running_after_reopen
+            && report.exit_code_absent_after_reopen;
+        require(
+            report.retained_filesystem_proven,
+            "Live retained filesystem evidence failed its completeness audit",
+        )?;
+
         let inventory_after = manager
             .list_processes(&reservation.execution_id, reservation.generation)
             .await?;
@@ -753,6 +796,118 @@ mod qualification {
             format!(
                 "keyed captured exec `{request_id}` stdout drifted: {:?}",
                 String::from_utf8_lossy(&output.stdout)
+            ),
+        )?;
+        Ok(())
+    }
+
+
+    async fn prove_file_upload_before_kill(
+        manager: &LocalExecutionManager,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> Result<(), AnyError> {
+        let response = manager
+            .transfer_file(
+                execution_id,
+                generation,
+                FileRequest {
+                    op: FileOp::Upload,
+                    guest_path: FS_GUEST_PATH.to_string(),
+                    data: Some(STANDARD.encode(FS_PAYLOAD)),
+                    user: None,
+                    max_bytes: None,
+                },
+            )
+            .await
+            .map_err(|error| {
+                failure(format!(
+                    "Live retained file upload before owner SIGKILL failed: {error}"
+                ))
+            })?;
+        require(
+            response.success && response.error.is_none(),
+            format!(
+                "Live retained file upload before owner SIGKILL reported failure: {:?}",
+                response.error
+            ),
+        )?;
+        require(
+            response.size == FS_PAYLOAD.len() as u64,
+            format!(
+                "Live retained file upload size mismatch: got {} expected {}",
+                response.size,
+                FS_PAYLOAD.len()
+            ),
+        )?;
+        Ok(())
+    }
+
+    async fn prove_file_download_after_reattach(
+        manager: &LocalExecutionManager,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> Result<(), AnyError> {
+        // Downloads can hit retryable Unavailable briefly after Host reopen.
+        let request = FileRequest {
+            op: FileOp::Download,
+            guest_path: FS_GUEST_PATH.to_string(),
+            data: None,
+            user: None,
+            max_bytes: Some(FS_PAYLOAD.len() as u64),
+        };
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let response = loop {
+            match manager
+                .transfer_file(execution_id, generation, request.clone())
+                .await
+            {
+                Ok(response) => break response,
+                Err(ExecutionManagerError::Unavailable(message)) => {
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(failure(format!(
+                            "Live retained file download after reopen failed: execution backend unavailable: {message}"
+                        )));
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                Err(error) => {
+                    return Err(failure(format!(
+                        "Live retained file download after reopen failed: {error}"
+                    )));
+                }
+            }
+        };
+        require(
+            response.success && response.error.is_none(),
+            format!(
+                "Live retained file download after reopen reported failure: {:?}",
+                response.error
+            ),
+        )?;
+        let decoded = response
+            .data
+            .as_deref()
+            .map(|value| STANDARD.decode(value))
+            .transpose()
+            .map_err(|error| {
+                failure(format!(
+                    "Live retained file download was not base64: {error}"
+                ))
+            })?
+            .ok_or_else(|| {
+                failure("Live retained file download omitted payload data".to_string())
+            })?;
+        require(
+            decoded == FS_PAYLOAD,
+            "Live retained file download did not match the pre-SIGKILL upload payload",
+        )?;
+        require(
+            response.size == FS_PAYLOAD.len() as u64,
+            format!(
+                "Live retained file download size mismatch: got {} expected {}",
+                response.size,
+                FS_PAYLOAD.len()
             ),
         )?;
         Ok(())


### PR DESCRIPTION
## Summary
- Extend `a3s.box.linux-native-live-session` to **v4** with filesystem continuity across owner SIGKILL via public Box `transfer_file` (upload before kill, download after reattach on the same generation).
- Pin OCI Runtime to `61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (Native Live filesystem, OCI-Runtime #290).
- Keep `b2_process_session_recovery_closed=false` and do not claim fixture stream continuity or KVM/utility-VM Live.

## Test plan
- [x] Existing-host WSL2 greened: report SHA-256 `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818`
- [x] `scripts/verify-linux-native-live-session-report.py --self-test` and greened report verify
- [ ] CI Native Linux live-session v4 lane (merge without waiting)