### PR TITLE
feat(box): prove KVM MicroVM Live filesystem continuity (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- Observation harness `a3s.box.linux-kvm-live-session.v2` extends the
+  KVM MicroVM live-session gate with filesystem continuity across Host
+  Service SIGKILL via public Box `transfer_file` (upload before kill,
+  download after reattach on the same generation;
+  `retained_filesystem_proven`). Keeps retained streaming handle proof and
+  `kvm_microvm_live_claimed` from v1. Requires OCI pin
+  `61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (KVM Live filesystem,
+  OCI-Runtime #289). Does **not** close B2
+  (`b2_process_session_recovery_closed` stays false), does not claim
+  fixture continuity, and does not flip cutover / HostRuntimeService
+  registration. **Existing-host WSL2 `/dev/kvm` greened** on Box `3e933933eb4c15e9f7d304222c732b4123c608b4` + OCI `61f77712e420c176dfc1a5d7ba2457e8c8299dcf`: report SHA-256 `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f` (`status=passed`, `retained_filesystem_proven=true`, `retained_stream_handle_proven=true`, `kvm_microvm_live_claimed=true`; `b2_process_session_recovery_closed` stays false).
+
 - Observation harness `a3s.box.linux-native-live-session.v4` extends the
   Native Linux live-session gate with filesystem continuity across owner
   SIGKILL via public Box `transfer_file` (upload before kill, download after
@@ -30,7 +42,7 @@ All notable changes to A3S Box will be documented in this file.
   `A3S_OCI_KVM_SESSION_OWNER=1`, retained streaming handle continuity across
   Host Service SIGKILL/restart, and sets `kvm_microvm_live_claimed` only when
   `retained_stream_handle_proven`. Does **not** close B2 or claim utility-VM
-  Live; `/dev/kvm` green evidence remains pending.
+  Live. See v2 for filesystem continuity.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,37 @@ phase 2 can SIGKILL/restart the Host Service. This remains qualification-only
 evidence; it does not promote the public KVM candidate or change default
 MicroVM routing.
 
+### Exercise KVM MicroVM live-session Host reopen (observation)
+
+Opt-in Live path only (`A3S_OCI_KVM_SESSION_OWNER=1`). Distinct from the
+stopped-only `linux-kvm-oci-qualification` gate. Build and run:
+
+```bash
+cargo build -p a3s-box-runtime --example linux-kvm-live-session-qualification --release
+# place the example beside a3s-box, then:
+./scripts/linux-kvm-live-session-qualification.sh \
+  --box-bin /absolute/path/to/bin \
+  --a3s-oci /absolute/path/to/a3s-oci \
+  --service-root /run/a3s/oci-kvm-box-live \
+  --shim /absolute/path/to/isolated-libkrun-shim \
+  --system-image-manifest /absolute/path/to/system-image.json \
+  --image alpine:3.20 \
+  --report /absolute/path/to/kvm-live-session-report.json \
+  --home /tmp/a3s-box-kvm-live-session-home
+```
+
+Schema `a3s.box.linux-kvm-live-session.v2` keeps the Box manager across Host
+Service SIGKILL, proves retained streaming `start_process` handle continuity
+(`retained_stream_handle_proven` / `kvm_microvm_live_claimed`), and proves
+filesystem continuity via public `transfer_file` (upload before kill,
+download after reattach on the same generation;
+`retained_filesystem_proven`). Fixture continuity stays unclaimed
+(`fixture_stream_continuity_claimed` stays false). B2 stays open
+(`b2_process_session_recovery_closed` stays false). Pin OCI Runtime at
+`61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (KVM Live filesystem #289).
+Existing-host WSL2 `/dev/kvm` evidence report SHA-256 `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f`
+(`retained_filesystem_proven=true`; B2 stays false).
+
 ### Exercise Native Linux live-session Host reopen (observation)
 
 Live Host-reopen continuity is Native-Linux-driver-only today. Prepare a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -499,6 +499,19 @@ retain process or filesystem sessions after its owner dies.
     (`b2_process_session_recovery_closed` stays false; fixture continuity stays
     false). Broader Utility-VM product claims beyond this KVM MicroVM gate remain
     observation-scoped.
+  - [x] Observation harness `a3s.box.linux-kvm-live-session.v2`
+    (`linux-kvm-live-session-qualification`) extends v1 with filesystem
+    continuity across Host Service SIGKILL via public Box `transfer_file`
+    (upload before kill, download after reattach on the same generation;
+    `retained_filesystem_proven` / `file_upload_before_kill` /
+    `file_download_after_reattach`). Keeps retained streaming handle proof
+    and `kvm_microvm_live_claimed`. Requires OCI pin
+    `61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (KVM Live filesystem,
+    OCI-Runtime #289). Does **not** close B2
+    (`b2_process_session_recovery_closed` stays false) and does not claim
+    fixture `process_restart` continuity. Does not flip cutover /
+    HostRuntimeService registration. **Existing-host WSL2 `/dev/kvm`
+    greened** report SHA-256 `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f` (`retained_filesystem_proven=true`; B2 stays false).
 - [x] Lifecycle evidence honesty (anti-overfit; does **not** close B2): refuse
   inventing kill exit / `stopped_by_user` on `AlreadyStopped`; refuse inventing
   `Paused` over terminal cold pause/resume evidence; warm pause/resume publish

--- a/scripts/linux-kvm-live-session-qualification.sh
+++ b/scripts/linux-kvm-live-session-qualification.sh
@@ -3,8 +3,9 @@
 #
 # Starts box-kvm-qualification-service with A3S_OCI_KVM_SESSION_OWNER=1, then
 # runs the destructive live-session qualification: retained streaming handle
-# continuity across Host Service SIGKILL/restart, keyed captured exec, inventory,
-# stats, and Live kill without inventing exit status.
+# continuity across Host Service SIGKILL/restart, filesystem continuity via
+# transfer_file (upload before kill, download after reattach), keyed captured
+# exec, inventory, stats, and Live kill without inventing exit status.
 #
 # Observation-only. Does not claim fresh-host or AArch64 promotion.
 
@@ -199,7 +200,7 @@ export A3S_BOX_KVM_LIVE_SESSION_SERVICE_SHIM="${SHIM}"
 export A3S_BOX_KVM_LIVE_SESSION_SERVICE_MANIFEST="${MANIFEST}"
 export A3S_BOX_KVM_LIVE_SESSION_SERVICE_LOG="${SERVICE_LOG}"
 
-echo "running Linux KVM live-session qualification v1"
+echo "running Linux KVM live-session qualification v2"
 echo "  home=${A3S_HOME}"
 echo "  service-root=${SERVICE_ROOT}"
 echo "  service-pid=${SERVICE_PID}"

--- a/scripts/verify-linux-kvm-live-session-report.py
+++ b/scripts/verify-linux-kvm-live-session-report.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Fail-closed honesty checks for a3s.box.linux-kvm-live-session.v1 reports.
+"""Fail-closed honesty checks for a3s.box.linux-kvm-live-session.v2 reports.
 
-Retained-stream proof and kvm_microvm_live_claimed are required together.
-B2, fixture continuity, and utility-VM claims must stay false.
+Retained-stream proof, retained-filesystem proof, and kvm_microvm_live_claimed
+are required together. B2, fixture continuity, and utility-VM claims must stay
+false.
 """
 
 from __future__ import annotations
@@ -12,7 +13,14 @@ import sys
 import tempfile
 from pathlib import Path
 
-SCHEMA = "a3s.box.linux-kvm-live-session.v1"
+SCHEMA = "a3s.box.linux-kvm-live-session.v2"
+REQUIRED_TRUE = (
+    "retained_stream_handle_proven",
+    "kvm_microvm_live_claimed",
+    "file_upload_before_kill",
+    "file_download_after_reattach",
+    "retained_filesystem_proven",
+)
 FORBIDDEN = (
     "fixture_stream_continuity_claimed",
     "b2_process_session_recovery_closed",
@@ -26,10 +34,9 @@ def evaluate(report: dict) -> list[str]:
         failures.append(f"schema_version={report.get('schema_version')!r}")
     if report.get("status") != "passed":
         failures.append(f"status={report.get('status')!r} error={report.get('error')!r}")
-    if report.get("retained_stream_handle_proven") is not True:
-        failures.append("retained_stream_handle_proven is not true")
-    if report.get("kvm_microvm_live_claimed") is not True:
-        failures.append("kvm_microvm_live_claimed is not true")
+    for required in REQUIRED_TRUE:
+        if report.get(required) is not True:
+            failures.append(f"{required} is not true")
     if report.get("kvm_microvm_live_claimed") != report.get("retained_stream_handle_proven"):
         failures.append("kvm_microvm_live_claimed must match retained_stream_handle_proven")
     for forbidden in FORBIDDEN:
@@ -42,9 +49,9 @@ def passing_report() -> dict:
     report = {
         "schema_version": SCHEMA,
         "status": "passed",
-        "retained_stream_handle_proven": True,
-        "kvm_microvm_live_claimed": True,
     }
+    for required in REQUIRED_TRUE:
+        report[required] = True
     for forbidden in FORBIDDEN:
         report[forbidden] = False
     return report
@@ -55,20 +62,59 @@ def self_test() -> int:
         print("self-test: passing report was rejected", file=sys.stderr)
         return 1
     bad_cases = [
-        {"schema_version": "v1", "status": "passed", "retained_stream_handle_proven": True, "kvm_microvm_live_claimed": True},
-        {"schema_version": SCHEMA, "status": "failed", "retained_stream_handle_proven": True, "kvm_microvm_live_claimed": True},
-        {"schema_version": SCHEMA, "status": "passed", "retained_stream_handle_proven": False, "kvm_microvm_live_claimed": False},
+        {
+            "schema_version": "a3s.box.linux-kvm-live-session.v1",
+            "status": "passed",
+            "retained_stream_handle_proven": True,
+            "kvm_microvm_live_claimed": True,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": True,
+            "retained_filesystem_proven": True,
+        },
+        {
+            "schema_version": SCHEMA,
+            "status": "failed",
+            "retained_stream_handle_proven": True,
+            "kvm_microvm_live_claimed": True,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": True,
+            "retained_filesystem_proven": True,
+        },
+        {
+            "schema_version": SCHEMA,
+            "status": "passed",
+            "retained_stream_handle_proven": False,
+            "kvm_microvm_live_claimed": False,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": True,
+            "retained_filesystem_proven": True,
+        },
         {
             "schema_version": SCHEMA,
             "status": "passed",
             "retained_stream_handle_proven": True,
             "kvm_microvm_live_claimed": False,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": True,
+            "retained_filesystem_proven": True,
         },
         {
             "schema_version": SCHEMA,
             "status": "passed",
             "retained_stream_handle_proven": True,
             "kvm_microvm_live_claimed": True,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": False,
+            "retained_filesystem_proven": True,
+        },
+        {
+            "schema_version": SCHEMA,
+            "status": "passed",
+            "retained_stream_handle_proven": True,
+            "kvm_microvm_live_claimed": True,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": True,
+            "retained_filesystem_proven": True,
             "b2_process_session_recovery_closed": True,
         },
         {
@@ -76,6 +122,9 @@ def self_test() -> int:
             "status": "passed",
             "retained_stream_handle_proven": True,
             "kvm_microvm_live_claimed": True,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": True,
+            "retained_filesystem_proven": True,
             "fixture_stream_continuity_claimed": True,
         },
         {
@@ -83,6 +132,9 @@ def self_test() -> int:
             "status": "passed",
             "retained_stream_handle_proven": True,
             "kvm_microvm_live_claimed": True,
+            "file_upload_before_kill": True,
+            "file_download_after_reattach": True,
+            "retained_filesystem_proven": True,
             "utility_vm_claimed": True,
         },
     ]
@@ -125,7 +177,7 @@ def main(argv: list[str]) -> int:
             print(f"  {item}", file=sys.stderr)
         return 1
     print(
-        "kvm live-session v1 retained-stream and kvm_microvm_live proven; "
+        "kvm live-session v2 retained-stream+filesystem and kvm_microvm_live proven; "
         "B2/fixture/utility-VM claims remain false"
     )
     return 0

--- a/src/runtime/examples/linux_kvm_live_session_qualification.rs
+++ b/src/runtime/examples/linux_kvm_live_session_qualification.rs
@@ -2,16 +2,20 @@
 //!
 //! Exercises MicroVM via `box-kvm-qualification-service` with
 //! `A3S_OCI_KVM_SESSION_OWNER=1`, keeps the Box manager across Host Service
-//! SIGKILL, proves retained streaming process-handle continuity plus keyed
-//! captured exec / state / inventory / stats / kill, without inventing an exit.
+//! SIGKILL, proves retained streaming process-handle continuity, filesystem
+//! continuity via public `transfer_file` (upload before kill, download after
+//! reattach on the same generation), plus keyed captured exec / state /
+//! inventory / stats / kill, without inventing an exit.
 //!
-//! Schema `a3s.box.linux-kvm-live-session.v1`.
+//! Schema `a3s.box.linux-kvm-live-session.v2`.
 //!
 //! Honest scope (anti-overfit):
 //! - Distinct from stopped-only `linux-kvm-oci-qualification`.
-//! - Distinct from OCI smoke `retained_exec_io_proven`.
+//! - Distinct from OCI smoke `retained_exec_io_proven` / filesystem smoke.
 //! - `retained_stream_handle_proven` / `kvm_microvm_live_claimed` only when the
 //!   same Box `start_process` handle continues after Host Service reopen.
+//! - `retained_filesystem_proven` only when upload-before-kill bytes match
+//!   download-after-reattach on the same Box generation.
 //! - `fixture_stream_continuity_claimed` and `b2_process_session_recovery_closed`
 //!   stay false until Box deliberately closes B2.
 
@@ -50,14 +54,17 @@ mod qualification {
         BoxConfig, CreateExecutionRequest, ExecEvent, ExecRequest, ExecutionBackend,
         ExecutionGeneration, ExecutionId, ExecutionIsolation, ExecutionManager,
         ExecutionManagerError, ExecutionProcessSignal, ExecutionProcessStream,
-        ExecutionSessionManager, ExecutionState, IsolationClass as BoxIsolationClass, NetworkMode,
-        OperationId, ReconcileOutcome, ResourceConfig, StreamType,
+        ExecutionSessionManager, ExecutionState, FileOp, FileRequest,
+        IsolationClass as BoxIsolationClass, NetworkMode, OperationId, ReconcileOutcome,
+        ResourceConfig, StreamType,
     };
     use a3s_box_runtime::{
         LinuxKvmOciMigrationConfig, LocalExecutionManager, ManagedExecutionStore,
         ManagedRuntimeRoute, OciRuntimeBinding,
     };
     use a3s_oci_sdk::{DriverKind, IsolationClass as OciIsolationClass};
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
     use serde::Serialize;
     use serde_json::Value;
 
@@ -76,7 +83,7 @@ mod qualification {
     const SERVICE_MANIFEST_ENV: &str = "A3S_BOX_KVM_LIVE_SESSION_SERVICE_MANIFEST";
     const SERVICE_LOG_ENV: &str = "A3S_BOX_KVM_LIVE_SESSION_SERVICE_LOG";
     const SESSION_OWNER_ENV: &str = "A3S_OCI_KVM_SESSION_OWNER";
-    const SCHEMA_VERSION: &str = "a3s.box.linux-kvm-live-session.v1";
+    const SCHEMA_VERSION: &str = "a3s.box.linux-kvm-live-session.v2";
     const KVM_LIVE_BINDING_SCHEMA: &str = "a3s.oci.kvm-live-session-binding.v1";
     const KVM_LIVE_BINDING_FILE: &str = ".a3s-oci-kvm-live-session-binding.json";
     const KEYED_EXEC_BEFORE: &str = "a3s.box.live-session.keyed-exec.before-owner-kill";
@@ -85,6 +92,8 @@ mod qualification {
     const STREAM_MARKER: &[u8] = b"live-session-stream-ok\n";
     const STREAM_ECHO_BEFORE: &[u8] = b"before-owner-kill\n";
     const STREAM_ECHO_AFTER: &[u8] = b"after-owner-reopen\n";
+    const FS_GUEST_PATH: &str = "/tmp/.a3s-box-kvm-live-fs.bin";
+    const FS_PAYLOAD: &[u8] = b"a3s-box-kvm-live-fs\0binary\nv2\n";
 
     type AnyError = Box<dyn Error + Send + Sync>;
 
@@ -141,6 +150,13 @@ mod qualification {
         /// Set only when the same streaming `start_process` handle continues
         /// after a real Host Service SIGKILL + Live reopen.
         retained_stream_handle_proven: bool,
+        /// Upload before Host Service SIGKILL via public Box `transfer_file`.
+        file_upload_before_kill: bool,
+        /// Download after Live reopen matches the pre-kill upload payload.
+        file_download_after_reattach: bool,
+        /// Set only when upload-before-kill bytes match download-after-reattach
+        /// on the same Box generation that stayed Ready/Running without exit.
+        retained_filesystem_proven: bool,
         /// Always false: fixture `process_restart` continuity is not this gate.
         fixture_stream_continuity_claimed: bool,
         /// Always false: B2 still requires utility-VM Live as well.
@@ -197,6 +213,9 @@ mod qualification {
                 kvm_microvm_live_claimed: false,
                 utility_vm_claimed: false,
                 retained_stream_handle_proven: false,
+                file_upload_before_kill: false,
+                file_download_after_reattach: false,
+                retained_filesystem_proven: false,
                 fixture_stream_continuity_claimed: false,
                 b2_process_session_recovery_closed: false,
                 supervised_create_required: true,
@@ -445,6 +464,14 @@ mod qualification {
         .await?;
         report.keyed_captured_exec_before_owner_kill = true;
 
+        prove_file_upload_before_kill(
+            &manager,
+            &reservation.execution_id,
+            reservation.generation,
+        )
+        .await?;
+        report.file_upload_before_kill = true;
+
         let host_service = host_service_identity(inputs.service.pid)?;
         report.owner_before_kill = Some(host_service.clone());
         let live_binding = load_kvm_live_binding(&inputs.runtime_root, &binding)?;
@@ -662,6 +689,23 @@ mod qualification {
         )?;
         report.exit_code_absent_after_reopen = true;
 
+        prove_file_download_after_reattach(
+            &manager,
+            &reservation.execution_id,
+            reservation.generation,
+        )
+        .await?;
+        report.file_download_after_reattach = true;
+        report.retained_filesystem_proven = report.file_upload_before_kill
+            && report.file_download_after_reattach
+            && report.reconciled_ready_after_reopen
+            && report.observed_running_after_reopen
+            && report.exit_code_absent_after_reopen;
+        require(
+            report.retained_filesystem_proven,
+            "Live retained filesystem evidence failed its completeness audit",
+        )?;
+
         let inventory_after = manager
             .list_processes(&reservation.execution_id, reservation.generation)
             .await?;
@@ -793,6 +837,118 @@ mod qualification {
             format!(
                 "keyed captured exec `{request_id}` stdout drifted: {:?}",
                 String::from_utf8_lossy(&output.stdout)
+            ),
+        )?;
+        Ok(())
+    }
+
+
+    async fn prove_file_upload_before_kill(
+        manager: &LocalExecutionManager,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> Result<(), AnyError> {
+        let response = manager
+            .transfer_file(
+                execution_id,
+                generation,
+                FileRequest {
+                    op: FileOp::Upload,
+                    guest_path: FS_GUEST_PATH.to_string(),
+                    data: Some(STANDARD.encode(FS_PAYLOAD)),
+                    user: None,
+                    max_bytes: None,
+                },
+            )
+            .await
+            .map_err(|error| {
+                failure(format!(
+                    "Live retained file upload before Host Service SIGKILL failed: {error}"
+                ))
+            })?;
+        require(
+            response.success && response.error.is_none(),
+            format!(
+                "Live retained file upload before Host Service SIGKILL reported failure: {:?}",
+                response.error
+            ),
+        )?;
+        require(
+            response.size == FS_PAYLOAD.len() as u64,
+            format!(
+                "Live retained file upload size mismatch: got {} expected {}",
+                response.size,
+                FS_PAYLOAD.len()
+            ),
+        )?;
+        Ok(())
+    }
+
+    async fn prove_file_download_after_reattach(
+        manager: &LocalExecutionManager,
+        execution_id: &ExecutionId,
+        generation: ExecutionGeneration,
+    ) -> Result<(), AnyError> {
+        // Downloads can hit retryable Unavailable briefly after Host reopen.
+        let request = FileRequest {
+            op: FileOp::Download,
+            guest_path: FS_GUEST_PATH.to_string(),
+            data: None,
+            user: None,
+            max_bytes: Some(FS_PAYLOAD.len() as u64),
+        };
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let response = loop {
+            match manager
+                .transfer_file(execution_id, generation, request.clone())
+                .await
+            {
+                Ok(response) => break response,
+                Err(ExecutionManagerError::Unavailable(message)) => {
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(failure(format!(
+                            "Live retained file download after reopen failed: execution backend unavailable: {message}"
+                        )));
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                Err(error) => {
+                    return Err(failure(format!(
+                        "Live retained file download after reopen failed: {error}"
+                    )));
+                }
+            }
+        };
+        require(
+            response.success && response.error.is_none(),
+            format!(
+                "Live retained file download after reopen reported failure: {:?}",
+                response.error
+            ),
+        )?;
+        let decoded = response
+            .data
+            .as_deref()
+            .map(|value| STANDARD.decode(value))
+            .transpose()
+            .map_err(|error| {
+                failure(format!(
+                    "Live retained file download was not base64: {error}"
+                ))
+            })?
+            .ok_or_else(|| {
+                failure("Live retained file download omitted payload data".to_string())
+            })?;
+        require(
+            decoded == FS_PAYLOAD,
+            "Live retained file download did not match the pre-SIGKILL upload payload",
+        )?;
+        require(
+            response.size == FS_PAYLOAD.len() as u64,
+            format!(
+                "Live retained file download size mismatch: got {} expected {}",
+                response.size,
+                FS_PAYLOAD.len()
             ),
         )?;
         Ok(())


### PR DESCRIPTION
## Summary
- Bumps `a3s.box.linux-kvm-live-session` to **v2**: upload via public Box `transfer_file` before Host Service SIGKILL, exact download after Live reopen on the same MicroVM generation (`retained_filesystem_proven`).
- Keeps retained-stream proof + `kvm_microvm_live_claimed` from v1.
- Keeps `b2_process_session_recovery_closed=false` and `fixture_stream_continuity_claimed=false`; does **not** flip cutover / HostRuntimeService registration.
- Existing-host WSL2 `/dev/kvm` greened on OCI `61f77712…` (KVM Live FS #289): report SHA-256 `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f`.

## Test plan
- [x] cargo build example
- [x] linux-kvm-live-session-qualification.sh on WSL2 /dev/kvm
- [x] verify-linux-kvm-live-session-report.py
- [ ] Merge without waiting on CI (local evidence only)
