### PR TITLE
docs(box): close B2 process-session recovery parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Close ROADMAP B2 process-session recovery parent after aggregated
+  existing-host WSL2 Native Live v4 + KVM MicroVM Live v2 greening (Box
+  `5f74b5c2…` / OCI `61f77712…`; report SHA-256
+  `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818` and
+  `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f`).
+  Harness schemas keep `b2_process_session_recovery_closed=false` by design
+  (reports never self-certify B2 close). Does **not** flip default create
+  Host-bound policy, cutover, HostRuntimeService registration, fixture
+  continuity, fresh-host promotion, or broader Utility-VM product claims.
+
 ### Added
 
 - Observation harness `a3s.box.linux-kvm-live-session.v2` extends the

--- a/README.md
+++ b/README.md
@@ -336,11 +336,14 @@ Service SIGKILL, proves retained streaming `start_process` handle continuity
 filesystem continuity via public `transfer_file` (upload before kill,
 download after reattach on the same generation;
 `retained_filesystem_proven`). Fixture continuity stays unclaimed
-(`fixture_stream_continuity_claimed` stays false). B2 stays open
-(`b2_process_session_recovery_closed` stays false). Pin OCI Runtime at
+(`fixture_stream_continuity_claimed` stays false). Together with Native Live
+v4, this closes the ROADMAP process-session recovery parent; harness reports
+still keep `b2_process_session_recovery_closed=false` (reports never
+self-certify B2 close). Pin OCI Runtime at
 `61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (KVM Live filesystem #289).
 Existing-host WSL2 `/dev/kvm` evidence report SHA-256 `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f`
-(`retained_filesystem_proven=true`; B2 stays false).
+(`retained_filesystem_proven=true`). Does not flip default create Host-bound
+policy or cutover.
 
 ### Exercise Native Linux live-session Host reopen (observation)
 
@@ -374,11 +377,15 @@ download after reattach on the same generation;
 `retained_filesystem_proven`). It continues authentic Live keyed captured exec
 plus state/inventory/stats/kill without inventing an exit status. Fixture
 `process_restart` is never claimed as driver evidence
-(`fixture_stream_continuity_claimed` stays false). B2 stays open until
-utility-VM Live also lands (`b2_process_session_recovery_closed` stays false).
-It does not claim KVM MicroVM Live continuity. Pin OCI Runtime at
-`61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (Native Live filesystem #290). Existing-host WSL2 evidence report
-SHA-256 `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818` (`retained_filesystem_proven=true`; B2 stays false).
+(`fixture_stream_continuity_claimed` stays false). Together with KVM MicroVM
+Live v2, this closes the ROADMAP process-session recovery parent; harness
+reports still keep `b2_process_session_recovery_closed=false` (reports never
+self-certify B2 close). It does not alone claim KVM MicroVM Live continuity.
+Pin OCI Runtime at `61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (Native Live
+filesystem #290). Existing-host WSL2 evidence report SHA-256
+`3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818`
+(`retained_filesystem_proven=true`). Does not flip default create Host-bound
+policy or cutover.
 
 ### Exercise the qualification-only WHPX handoff on Windows
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -430,8 +430,24 @@ retain process or filesystem sessions after its owner dies.
   exact-generation, replay-safe resource intent and no socket fallback.
 - [x] Route the remaining socket-oriented CLI projections (`attach` and init
   stdout/stderr log projection) through the persisted OCI route.
-- [ ] Prove process-session recovery across an out-of-process runtime-service
+- [x] Prove process-session recovery across an out-of-process runtime-service
   restart on real native Linux and utility-VM drivers.
+  **Closed** by aggregated existing-host WSL2 evidence on Box
+  `5f74b5c2356aca534bf35fa5b4d80043c95a691c` + OCI
+  `61f77712e420c176dfc1a5d7ba2457e8c8299dcf`: Native Live v4 stream+filesystem
+  report SHA-256
+  `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818`
+  (`retained_stream_handle_proven=true`, `retained_filesystem_proven=true`)
+  and KVM MicroVM Live v2 stream+filesystem report SHA-256
+  `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f`
+  (`retained_stream_handle_proven=true`, `retained_filesystem_proven=true`,
+  `kvm_microvm_live_claimed=true`). That satisfies W2's Native + one
+  utility-VM driver matrix for live process, I/O, and filesystem reattach.
+  Harness report schemas keep `b2_process_session_recovery_closed=false` by
+  design (individual reports never self-certify B2 close). Does **not** flip
+  default create Host-bound policy, cutover, HostRuntimeService registration,
+  fixture `process_restart` continuity, fresh-host promotion, or broader
+  Utility-VM product claims beyond the observation-scoped KVM MicroVM gate.
   - [x] Observation harness `a3s.box.linux-native-live-session.v2`
     (`linux-native-live-session-qualification` drop-manager path): supervised
     create + Host owner SIGKILL + Live rebind with keyed captured exec
@@ -476,9 +492,9 @@ retain process or filesystem sessions after its owner dies.
     fixture `process_restart` continuity.
   - [x] Retained streaming process-handle continuity on a real Native Linux
     owner restart (v3/v4 harness path above; fixture `process_restart` remains
-    non-driver evidence). Does **not** alone close B2
-    (`b2_process_session_recovery_closed` stays false until the plan's full
-    B2 criteria are met).
+    non-driver evidence). Does **not** alone close the parent (needs KVM
+    MicroVM Live siblings); harness reports keep
+    `b2_process_session_recovery_closed=false`.
   - [x] Retained filesystem continuity on a real Native Linux owner restart
     (v4 harness path above). **Existing-host WSL2 evidence** on OCI
     `61f77712e420c176dfc1a5d7ba2457e8c8299dcf`: report SHA-256
@@ -538,8 +554,12 @@ recreation, and terminal-exit races. The cross-platform deterministic owner
 contract now keeps the original Box process stream and input handle alive,
 exposes the first broken request, reconnects to a replacement process, and
 continues inventory, stdin, output, close, signal, exact wait, and cleanup with
-one exec dispatch. Native Linux and utility-VM driver reattachment on real
-hosts remains part of the unchecked exit gate. The production Linux smoke now
+one exec dispatch. Native Linux and KVM MicroVM Live reattachment on real
+hosts is checklist-closed under the process-session recovery parent above
+(existing-host WSL2 digests); harness reports still keep
+`b2_process_session_recovery_closed=false`, and default create Host-bound
+policy, cutover, fresh-host promotion, and broader Utility-VM product claims
+remain open. The production Linux smoke now
 drives the Rust, Python, TypeScript, and Go SDK lifecycle, exec, filesystem,
 route-aware stats, pause/resume, snapshot, restart and cleanup surfaces; the
 CLI `top`, `stats`, `cp`, live update, attach, and init-log projections now

--- a/src/runtime/examples/linux_kvm_live_session_qualification.rs
+++ b/src/runtime/examples/linux_kvm_live_session_qualification.rs
@@ -17,7 +17,8 @@
 //! - `retained_filesystem_proven` only when upload-before-kill bytes match
 //!   download-after-reattach on the same Box generation.
 //! - `fixture_stream_continuity_claimed` and `b2_process_session_recovery_closed`
-//!   stay false until Box deliberately closes B2.
+//!   stay false in harness reports by design (individual reports never
+//!   self-certify ROADMAP B2 close).
 
 #[cfg(not(all(
     target_os = "linux",
@@ -159,7 +160,7 @@ mod qualification {
         retained_filesystem_proven: bool,
         /// Always false: fixture `process_restart` continuity is not this gate.
         fixture_stream_continuity_claimed: bool,
-        /// Always false: B2 still requires utility-VM Live as well.
+        /// Always false: harness reports never self-certify ROADMAP B2 close.
         b2_process_session_recovery_closed: bool,
         supervised_create_required: bool,
         supervised_create_enabled: bool,

--- a/src/runtime/examples/linux_native_live_session_qualification.rs
+++ b/src/runtime/examples/linux_native_live_session_qualification.rs
@@ -17,9 +17,9 @@
 //!   match download-after-reattach on the same Box generation.
 //! - Fixture `process_restart` continuity is never claimed
 //!   (`fixture_stream_continuity_claimed` stays false).
-//! - Does **not** claim KVM MicroVM Live continuity and does **not** close
-//!   Box B2 / OCI R6 (`b2_process_session_recovery_closed` stays false until
-//!   utility-VM Live also lands).
+//! - Does **not** claim KVM MicroVM Live continuity. Harness reports keep
+//!   `b2_process_session_recovery_closed=false` by design (individual reports
+//!   never self-certify ROADMAP B2 / OCI R6 close).
 
 #[cfg(not(all(
     target_os = "linux",
@@ -137,7 +137,7 @@ mod qualification {
         retained_filesystem_proven: bool,
         /// Always false: fixture `process_restart` continuity is not this gate.
         fixture_stream_continuity_claimed: bool,
-        /// Always false: B2 still requires utility-VM Live as well.
+        /// Always false: harness reports never self-certify ROADMAP B2 close.
         b2_process_session_recovery_closed: bool,
         supervised_create_required: bool,
         supervised_create_enabled: bool,


### PR DESCRIPTION
## Summary
- Mark ROADMAP B2 process-session recovery parent `[x]` from aggregated existing-host Native Live v4 + KVM MicroVM Live v2 digests (Box `5f74b5c2` / OCI `61f77712`).
- Keep harness `b2_process_session_recovery_closed=false` by design (reports never self-certify B2 close).
- Do not flip default create Host-bound policy, cutover, HostRuntimeService registration, fixture continuity, or fresh-host promotion.

## Test plan
- [x] Confirm all B2 process-session children were already `[x]` on main
- [x] Confirm verifiers still forbid `b2_process_session_recovery_closed=true`
- [ ] Skipped CI per plan (docs/honesty close only)