### PR TITLE
chore(box): bump OCI Runtime pin to 05a3b2b

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 61f77712e420c176dfc1a5d7ba2457e8c8299dcf
+  A3S_OCI_RUNTIME_REV: 05a3b2bddff0668703caafc48f38514a139ee81a
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 61f77712e420c176dfc1a5d7ba2457e8c8299dcf
+  A3S_OCI_RUNTIME_REV: 05a3b2bddff0668703caafc48f38514a139ee81a
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Changed
 
+- Bump pinned OCI Runtime to `05a3b2bddff0668703caafc48f38514a139ee81a`
+  (OCI main tip). Re-greened existing-host WSL2 Native Live v4 report SHA-256
+  `9d4f9703b2735f45b34ec98561b443b8076b97d818c57a39d4b4019d7f28bbfd` and KVM
+  MicroVM Live v2 report SHA-256
+  `2fe8c2cb53ab6f8a30f8c736cfdc04f41c9fe766b9830dc94d44f09de17454d7`
+  (`retained_stream_handle_proven=true`, `retained_filesystem_proven=true`;
+  KVM also `kvm_microvm_live_claimed=true`). Harness reports keep
+  `b2_process_session_recovery_closed=false`. Does **not** flip cutover,
+  HostRuntimeService registration, fixture continuity, or default create
+  Host-bound policy. Prior pin was
+  `61f77712e420c176dfc1a5d7ba2457e8c8299dcf`.
+
 - Close ROADMAP B2 process-session recovery parent after aggregated
   existing-host WSL2 Native Live v4 + KVM MicroVM Live v2 greening (Box
   `5f74b5c2…` / OCI `61f77712…`; report SHA-256

--- a/README.md
+++ b/README.md
@@ -340,8 +340,9 @@ download after reattach on the same generation;
 v4, this closes the ROADMAP process-session recovery parent; harness reports
 still keep `b2_process_session_recovery_closed=false` (reports never
 self-certify B2 close). Pin OCI Runtime at
-`61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (KVM Live filesystem #289).
-Existing-host WSL2 `/dev/kvm` evidence report SHA-256 `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f`
+`05a3b2bddff0668703caafc48f38514a139ee81a` (OCI main tip; prior greening on
+`61f77712…` / KVM Live filesystem #289).
+Existing-host WSL2 `/dev/kvm` evidence report SHA-256 `2fe8c2cb53ab6f8a30f8c736cfdc04f41c9fe766b9830dc94d44f09de17454d7`
 (`retained_filesystem_proven=true`). Does not flip default create Host-bound
 policy or cutover.
 
@@ -381,9 +382,10 @@ plus state/inventory/stats/kill without inventing an exit status. Fixture
 Live v2, this closes the ROADMAP process-session recovery parent; harness
 reports still keep `b2_process_session_recovery_closed=false` (reports never
 self-certify B2 close). It does not alone claim KVM MicroVM Live continuity.
-Pin OCI Runtime at `61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (Native Live
-filesystem #290). Existing-host WSL2 evidence report SHA-256
-`3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818`
+Pin OCI Runtime at `05a3b2bddff0668703caafc48f38514a139ee81a` (OCI main tip;
+prior greening on `61f77712…` / Native Live filesystem #290). Existing-host
+WSL2 evidence report SHA-256
+`9d4f9703b2735f45b34ec98561b443b8076b97d818c57a39d4b4019d7f28bbfd`
 (`retained_filesystem_proven=true`). Does not flip default create Host-bound
 policy or cutover.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -486,8 +486,9 @@ retain process or filesystem sessions after its owner dies.
     before kill, download after reattach on the same generation;
     `retained_filesystem_proven` / `file_upload_before_kill` /
     `file_download_after_reattach`). Keeps retained streaming handle proof.
-    Requires OCI pin `61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (Native Live
-    filesystem, OCI-Runtime #290). Does **not** close B2
+    Requires OCI pin `05a3b2bddff0668703caafc48f38514a139ee81a` (OCI main tip;
+    Native Live filesystem landed in OCI-Runtime #290 / prior pin
+    `61f77712…`). Does **not** close B2
     (`b2_process_session_recovery_closed` stays false) and does not claim
     fixture `process_restart` continuity.
   - [x] Retained streaming process-handle continuity on a real Native Linux
@@ -497,11 +498,12 @@ retain process or filesystem sessions after its owner dies.
     `b2_process_session_recovery_closed=false`.
   - [x] Retained filesystem continuity on a real Native Linux owner restart
     (v4 harness path above). **Existing-host WSL2 evidence** on OCI
-    `61f77712e420c176dfc1a5d7ba2457e8c8299dcf`: report SHA-256
-    `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818`
+    `05a3b2bddff0668703caafc48f38514a139ee81a`: report SHA-256
+    `9d4f9703b2735f45b34ec98561b443b8076b97d818c57a39d4b4019d7f28bbfd`
     (`status=passed`, `retained_filesystem_proven=true`,
     `retained_stream_handle_proven=true`; B2 / fixture / KVM / utility-VM
-    claims stay false). Box tip SHA `7d633b15cfb4f23c092c666a0a13aadb25eccdfd`.
+    claims stay false). Prior pin `61f77712…` evidence SHA-256
+    `3d158d6755afcd187f883234768f54aaa1dbd330e56a2ef763d11164fd6b5818`.
   - [x] KVM MicroVM Live process-session continuity via observation harness
     `a3s.box.linux-kvm-live-session.v1` (`linux-kvm-live-session-qualification`)
     with `A3S_OCI_KVM_SESSION_OWNER=1`, Box manager retained across Host Service
@@ -522,12 +524,15 @@ retain process or filesystem sessions after its owner dies.
     `retained_filesystem_proven` / `file_upload_before_kill` /
     `file_download_after_reattach`). Keeps retained streaming handle proof
     and `kvm_microvm_live_claimed`. Requires OCI pin
-    `61f77712e420c176dfc1a5d7ba2457e8c8299dcf` (KVM Live filesystem,
-    OCI-Runtime #289). Does **not** close B2
-    (`b2_process_session_recovery_closed` stays false) and does not claim
-    fixture `process_restart` continuity. Does not flip cutover /
-    HostRuntimeService registration. **Existing-host WSL2 `/dev/kvm`
-    greened** report SHA-256 `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f` (`retained_filesystem_proven=true`; B2 stays false).
+    `05a3b2bddff0668703caafc48f38514a139ee81a` (OCI main tip; KVM Live
+    filesystem landed in OCI-Runtime #289 / prior pin `61f77712…`). Does
+    **not** close B2 (`b2_process_session_recovery_closed` stays false) and
+    does not claim fixture `process_restart` continuity. Does not flip
+    cutover / HostRuntimeService registration. **Existing-host WSL2 `/dev/kvm`
+    greened** report SHA-256 `2fe8c2cb53ab6f8a30f8c736cfdc04f41c9fe766b9830dc94d44f09de17454d7`
+    (`retained_filesystem_proven=true`; B2 stays false). Prior pin
+    `61f77712…` evidence SHA-256
+    `1f8cede9c5906b915a067d8347ede99ceb647b3eb93408610daca7c0ea5f758f`.
 - [x] Lifecycle evidence honesty (anti-overfit; does **not** close B2): refuse
   inventing kill exit / `stopped_by_user` on `AlreadyStopped`; refuse inventing
   `Paused` over terminal cold pause/resume evidence; warm pause/resume publish

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=61f77712e420c176dfc1a5d7ba2457e8c8299dcf#61f77712e420c176dfc1a5d7ba2457e8c8299dcf"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=05a3b2bddff0668703caafc48f38514a139ee81a#05a3b2bddff0668703caafc48f38514a139ee81a"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=61f77712e420c176dfc1a5d7ba2457e8c8299dcf#61f77712e420c176dfc1a5d7ba2457e8c8299dcf"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=05a3b2bddff0668703caafc48f38514a139ee81a#05a3b2bddff0668703caafc48f38514a139ee81a"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "61f77712e420c176dfc1a5d7ba2457e8c8299dcf" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "05a3b2bddff0668703caafc48f38514a139ee81a" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- Bump OCI Runtime pin from `61f77712…` to `05a3b2bddff0668703caafc48f38514a139ee81a`.
- Re-greened existing-host WSL2 Native Live v4 and KVM MicroVM Live v2; `b2_process_session_recovery_closed` stays false (no cutover flips).

## Report digests
- Native Live v4: `9d4f9703b2735f45b34ec98561b443b8076b97d818c57a39d4b4019d7f28bbfd`
- KVM Live v2: `2fe8c2cb53ab6f8a30f8c736cfdc04f41c9fe766b9830dc94d44f09de17454d7`

## Test plan
- [x] `scripts/check-oci-pins.sh` against OCI checkout
- [x] Native Live v4 existing-host WSL2
- [x] KVM Live v2 existing-host WSL2 `/dev/kvm`

Made with [Cursor](https://cursor.com)