### PR TITLE
fix(live-session): same-request_id keyed-exec retry on KVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,36 @@ jobs:
         run: bash scripts/check-oci-pins.sh
       - name: Verify live-session report honesty checker
         run: python3 scripts/verify-linux-native-live-session-report.py --self-test
+      - name: Enforce live-session script +x and keyed-exec retry identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          for path in \
+            scripts/elevate-linux-sandbox-owner.sh \
+            scripts/linux-native-live-session-qualification.sh \
+            scripts/linux-kvm-live-session-qualification.sh
+          do
+            mode="$(git ls-files -s -- "$path" | awk '{print $1}')"
+            if [[ "$mode" != "100755" ]]; then
+              echo "expected 100755 for $path, got ${mode:-missing}"
+              exit 1
+            fi
+          done
+          # Same-request_id Unavailable retries (Native #300 / KVM parity): refuse
+          # resurrecting orphan `{id}.retry-N` process journals.
+          for path in \
+            src/runtime/examples/linux_native_live_session_qualification.rs \
+            src/runtime/examples/linux_kvm_live_session_qualification.rs
+          do
+            if ! grep -Fq 'Retry the same' "$path"; then
+              echo "$path must retry keyed captured exec with the same request_id"
+              exit 1
+            fi
+            if grep -Eq 'retry-\{attempt\}|format!\("\{request_id\}\.retry' "$path"; then
+              echo "$path must not mint distinct {id}.retry-N keyed exec identities"
+              exit 1
+            fi
+          done
       - name: Reject removed Sandbox backend integrations
         run: |
           removed_patterns=(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,9 @@ All notable changes to A3S Box will be documented in this file.
 - Disarm the detached OCI exec timeout watchdog as soon as `wait_process`
   observes a terminal status (not only when `Exit` is later popped), so a
   dropped stream cannot race a late timeout SIGKILL claim against a finished
-  process. Detached futures that still wait for timeout keep the watchdog.
+  process. Uses compare-exchange from `WAITING` only so a real timeout can
+  still publish the legacy `Process killed: timeout exceeded` notice.
+  Detached futures that still wait for timeout keep the watchdog.
 
 - Native live-session v4 CI on OCI `05a3b2b…` (#300): restore matched-cred
   harness, `100755` scripts, Verify cleanup, same-request_id keyed-exec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,17 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- KVM MicroVM live-session keyed captured exec retries OCI retryable
+  `Unavailable` with the **same** `request_id` (parity with Native Live #300).
+  Distinct `{id}.retry-N` keys orphan `active_operation` claims and can block
+  generation delete after Host reopen. Does **not** flip
+  `b2_process_session_recovery_closed`, fixture continuity, or hosted-KVM
+  claims without `/dev/kvm`.
+- Disarm the detached OCI exec timeout watchdog as soon as `wait_process`
+  observes a terminal status (not only when `Exit` is later popped), so a
+  dropped stream cannot race a late timeout SIGKILL claim against a finished
+  process. Detached futures that still wait for timeout keep the watchdog.
+
 - Native live-session v4 CI on OCI `05a3b2b…` (#300): restore matched-cred
   harness, `100755` scripts, Verify cleanup, same-request_id keyed-exec
   retries (orphan `{id}.retry-N` journals blocked generation delete), and

--- a/README.md
+++ b/README.md
@@ -384,9 +384,12 @@ reports still keep `b2_process_session_recovery_closed=false` (reports never
 self-certify B2 close). It does not alone claim KVM MicroVM Live continuity.
 Pin OCI Runtime at `05a3b2bddff0668703caafc48f38514a139ee81a` (OCI main tip;
 prior greening on `61f77712…` / Native Live filesystem #290). Existing-host
-WSL2 evidence report SHA-256
-`9d4f9703b2735f45b34ec98561b443b8076b97d818c57a39d4b4019d7f28bbfd`
-(`retained_filesystem_proven=true`). Does not flip default create Host-bound
+WSL2 evidence on Box `d07648d0…` / CI run `34542747784`: report SHA-256
+`36f91361c3851ea995ac7530bcfe05f0c9216d6e9a5b7e130b48f151cd4b9a75`
+(linux-x86_64) and
+`8454044deabe77a08d7f193cd970e8f3117566a8651b3f9d4023cb2223321423`
+(linux-arm64) (`retained_filesystem_proven=true`,
+`retained_stream_handle_proven=true`). Does not flip default create Host-bound
 policy or cutover.
 
 ### Exercise the qualification-only WHPX handoff on Windows

--- a/src/runtime/examples/linux_kvm_live_session_qualification.rs
+++ b/src/runtime/examples/linux_kvm_live_session_qualification.rs
@@ -805,33 +805,49 @@ mod qualification {
         generation: ExecutionGeneration,
         request_id: &str,
     ) -> Result<(), AnyError> {
-        let output = manager
-            .execute(
-                execution_id,
-                generation,
-                ExecRequest {
-                    request_id: Some(request_id.to_string()),
-                    cmd: vec![
-                        "/bin/sh".into(),
-                        "-c".into(),
-                        "printf 'live-session-keyed-ok\\n'".into(),
-                    ],
-                    timeout_ns: 30_000_000_000,
-                    env: Vec::new(),
-                    working_dir: Some("/".into()),
-                    rootfs: None,
-                    stdin: None,
-                    stdin_streaming: false,
-                    user: None,
-                    streaming: false,
-                },
-            )
-            .await
-            .map_err(|error| {
-                failure(format!(
-                    "keyed captured exec `{request_id}` failed on Live generation: {error}"
-                ))
-            })?;
+        // Short printf payloads can fully reap before OCI captures recovery
+        // identity after Host reopen (retryable Unavailable). Retry the same
+        // request_id so prepare-exec reconciles the partial journal instead of
+        // minting `{id}.retry-N` process identities that orphan active_operation
+        // claims and block generation delete (parity with Native Live #300).
+        let request = ExecRequest {
+            request_id: Some(request_id.to_string()),
+            cmd: vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "printf 'live-session-keyed-ok\\n'".into(),
+            ],
+            timeout_ns: 30_000_000_000,
+            env: Vec::new(),
+            working_dir: Some("/".into()),
+            rootfs: None,
+            stdin: None,
+            stdin_streaming: false,
+            user: None,
+            streaming: false,
+        };
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let output = loop {
+            match manager
+                .execute(execution_id, generation, request.clone())
+                .await
+            {
+                Ok(output) => break output,
+                Err(ExecutionManagerError::Unavailable(message)) => {
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(failure(format!(
+                            "keyed captured exec `{request_id}` failed on Live generation: execution backend unavailable: {message}"
+                        )));
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                Err(error) => {
+                    return Err(failure(format!(
+                        "keyed captured exec `{request_id}` failed on Live generation: {error}"
+                    )));
+                }
+            }
+        };
         require(
             output.exit_code == 0,
             format!(

--- a/src/runtime/src/local_execution/oci_session.rs
+++ b/src/runtime/src/local_execution/oci_session.rs
@@ -903,9 +903,14 @@ impl OciProcessStream {
         let event = self.pending.pop_front()?;
         if matches!(event, ExecEvent::Exit(_)) {
             self.done = true;
-            // Disarm the detached timeout watchdog once Exit is observed so it
-            // cannot later claim a signal mutation against a finished process.
-            self.watchdog.store(WATCHDOG_FINISHED, Ordering::SeqCst);
+            // Disarm only while still waiting so a timed-out kill keeps
+            // WATCHDOG_TIMED_OUT long enough for the legacy timeout notice.
+            let _ = self.watchdog.compare_exchange(
+                WATCHDOG_WAITING,
+                WATCHDOG_FINISHED,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            );
         }
         Some(event)
     }
@@ -1050,9 +1055,15 @@ impl ExecutionProcessStream for OciProcessStream {
                 {
                     Ok(status) => {
                         self.status = Some(status);
-                        // Process is terminal: disarm before Exit is popped so a
-                        // dropped stream cannot race a late timeout SIGKILL claim.
-                        self.watchdog.store(WATCHDOG_FINISHED, Ordering::SeqCst);
+                        // Disarm only while still waiting. Do not clobber
+                        // WATCHDOG_TIMED_OUT before queue_terminal_events can
+                        // publish the legacy timeout notice.
+                        let _ = self.watchdog.compare_exchange(
+                            WATCHDOG_WAITING,
+                            WATCHDOG_FINISHED,
+                            Ordering::SeqCst,
+                            Ordering::SeqCst,
+                        );
                     }
                     Err(error) if error.code == ErrorCode::DeadlineExceeded => {}
                     Err(error) => return Err(sdk_error("wait process", error)),

--- a/src/runtime/src/local_execution/oci_session.rs
+++ b/src/runtime/src/local_execution/oci_session.rs
@@ -1048,7 +1048,12 @@ impl ExecutionProcessStream for OciProcessStream {
                     })
                     .await
                 {
-                    Ok(status) => self.status = Some(status),
+                    Ok(status) => {
+                        self.status = Some(status);
+                        // Process is terminal: disarm before Exit is popped so a
+                        // dropped stream cannot race a late timeout SIGKILL claim.
+                        self.watchdog.store(WATCHDOG_FINISHED, Ordering::SeqCst);
+                    }
                     Err(error) if error.code == ErrorCode::DeadlineExceeded => {}
                     Err(error) => return Err(sdk_error("wait process", error)),
                 }


### PR DESCRIPTION
## Summary
- Port Native Live #300 same-`request_id` Unavailable retries into the KVM MicroVM live-session harness (refuse orphan `{id}.retry-N` process journals that block generation delete).
- Disarm the detached OCI exec timeout watchdog when `wait_process` observes terminal status (not only after `Exit` is popped).
- Format CI: enforce live-session script `100755` and Native/KVM keyed-exec retry-identity parity.
- README: point Native Live v4 evidence at both-arch #300 digests.

## Anti-overfit
- Does **not** flip `b2_process_session_recovery_closed`.
- Does **not** claim hosted GitHub KVM Live without `/dev/kvm`.
- Does **not** widen timeouts or weaken report schemas.

## Test plan
- [x] `cargo fmt`
- [ ] CI Format/Clippy/Test green
- [ ] Existing-host WSL2 `/dev/kvm` re-run of `linux-kvm-live-session-qualification` when available (`status=passed`, B2/fixture claims false)