### PR TITLE
feat(sdk): optional stable command request_id for keyed-exec retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Native SDKs expose an optional stable command `request_id` /
+  `requestId` / `RunRequestID` so callers can retry retryable OCI
+  `Unavailable` with the **same** process-journal identity. Defaults still
+  mint a fresh `sdk-command-*` id. Bridge `command_run` accepts
+  `request_id`. Distinct `{id}.retry-N` keys remain forbidden (orphan
+  `active_operation` claims). Does **not** flip B2 harness close, fixture
+  continuity, or hosted-KVM claims.
+
 ### Changed
 
 - Bump pinned OCI Runtime to `05a3b2bddff0668703caafc48f38514a139ee81a`

--- a/sdk/go/commands.go
+++ b/sdk/go/commands.go
@@ -31,11 +31,12 @@ type runOptionFunc func(*runConfig)
 func (option runOptionFunc) applyRun(config *runConfig) { option(config) }
 
 type runConfig struct {
-	timeout *time.Duration
-	env     map[string]string
-	cwd     string
-	user    string
-	stdin   *[]byte
+	timeout   *time.Duration
+	env       map[string]string
+	cwd       string
+	user      string
+	stdin     *[]byte
+	requestID string
 }
 
 func RunTimeout(timeout time.Duration) RunOption {
@@ -62,6 +63,13 @@ func RunStdin(data []byte) RunOption {
 }
 
 func RunStdinString(data string) RunOption { return RunStdin([]byte(data)) }
+
+// RunRequestID sets a stable one-shot exec identity for replay-safe retries
+// after retryable Unavailable. Reuse the same id on retry; do not append
+// ".retry-N". When omitted, the Rust Sandbox facade mints a fresh id.
+func RunRequestID(requestID string) RunOption {
+	return runOptionFunc(func(config *runConfig) { config.requestID = requestID })
+}
 
 type Commands struct {
 	sandbox *Sandbox
@@ -103,6 +111,16 @@ func (commands *Commands) Run(
 	if config.timeout != nil && *config.timeout <= 0 {
 		return CommandResult{}, invalid(op, "command timeout must be greater than zero")
 	}
+	if config.requestID != "" {
+		if strings.TrimSpace(config.requestID) == "" ||
+			len(config.requestID) > 512 ||
+			strings.IndexByte(config.requestID, 0) >= 0 {
+			return CommandResult{}, invalid(
+				op,
+				"command request_id must be a non-empty string of at most 512 bytes without NUL",
+			)
+		}
+	}
 	if config.cwd != "" && strings.TrimSpace(config.cwd) == "" {
 		return CommandResult{}, invalid(op, "command working directory cannot be blank")
 	}
@@ -129,6 +147,9 @@ func (commands *Commands) Run(
 	}
 	if config.stdin != nil {
 		fields["stdin_base64"] = base64.StdEncoding.EncodeToString(*config.stdin)
+	}
+	if config.requestID != "" {
+		fields["request_id"] = config.requestID
 	}
 	var wire struct {
 		StdoutBase64 string `json:"stdout_base64"`

--- a/sdk/go/sandbox_test.go
+++ b/sdk/go/sandbox_test.go
@@ -428,12 +428,13 @@ func TestCommandsScriptsAndFilesystemAreBinarySafe(t *testing.T) {
 		RunDirectory("/workspace"),
 		RunAs("1000"),
 		RunStdin(binaryOutput),
+		RunRequestID("caller-stable-exec-1"),
 	)
 	if err != nil || !reflect.DeepEqual(result.Stdout, binaryOutput) || result.ExitCode != 7 || !result.Truncated {
 		t.Fatalf("command result=%+v err=%v", result, err)
 	}
 	command := requestByOperation(t, runtime.Requests(), "command_run")
-	if command["timeout_ms"] != float64(1500) || command["generation"] != float64(9) {
+	if command["timeout_ms"] != float64(1500) || command["generation"] != float64(9) || command["request_id"] != "caller-stable-exec-1" {
 		t.Fatalf("unexpected command request: %#v", command)
 	}
 

--- a/sdk/go/script.go
+++ b/sdk/go/script.go
@@ -16,6 +16,7 @@ type ScriptBuilder struct {
 	env         map[string]string
 	cwd         string
 	user        string
+	requestID   string
 }
 
 func (sandbox *Sandbox) Script(source string) *ScriptBuilder {
@@ -64,6 +65,11 @@ func (builder *ScriptBuilder) User(user string) *ScriptBuilder {
 	return builder
 }
 
+func (builder *ScriptBuilder) RequestID(requestID string) *ScriptBuilder {
+	builder.requestID = requestID
+	return builder
+}
+
 func (builder *ScriptBuilder) Run(ctx context.Context) (CommandResult, error) {
 	const op = "command_run"
 	if builder == nil || builder.commands == nil {
@@ -75,7 +81,7 @@ func (builder *ScriptBuilder) Run(ctx context.Context) (CommandResult, error) {
 	if len(builder.interpreter.argv) == 0 || strings.TrimSpace(builder.interpreter.argv[0]) == "" {
 		return CommandResult{}, invalid(op, "script interpreter cannot be empty")
 	}
-	options := make([]RunOption, 0, len(builder.env)+4)
+	options := make([]RunOption, 0, len(builder.env)+5)
 	if builder.timeout != nil {
 		options = append(options, RunTimeout(*builder.timeout))
 	}
@@ -87,6 +93,9 @@ func (builder *ScriptBuilder) Run(ctx context.Context) (CommandResult, error) {
 	}
 	if builder.user != "" {
 		options = append(options, RunAs(builder.user))
+	}
+	if builder.requestID != "" {
+		options = append(options, RunRequestID(builder.requestID))
 	}
 	options = append(options, RunStdin(builder.source))
 	return builder.commands.Run(ctx, builder.interpreter, options...)

--- a/sdk/python/src/a3s_box/_sandbox_requests.py
+++ b/sdk/python/src/a3s_box/_sandbox_requests.py
@@ -117,6 +117,7 @@ def command_request(
     cwd: str | None,
     user: str | None,
     stdin: str | bytes | None,
+    request_id: str | None = None,
 ) -> dict[str, object]:
     argv = ["/bin/sh", "-lc", command] if isinstance(command, str) else list(command)
     if not argv:
@@ -139,4 +140,15 @@ def command_request(
     if stdin is not None:
         raw = stdin.encode() if isinstance(stdin, str) else stdin
         request["stdin_base64"] = base64.b64encode(raw).decode()
+    if request_id is not None:
+        if (
+            not isinstance(request_id, str)
+            or not request_id
+            or len(request_id) > 512
+            or "\0" in request_id
+        ):
+            raise ValueError(
+                "request_id must be a non-empty string of at most 512 bytes without NUL"
+            )
+        request["request_id"] = request_id
     return request

--- a/sdk/python/src/a3s_box/sandbox.py
+++ b/sdk/python/src/a3s_box/sandbox.py
@@ -834,6 +834,7 @@ class Commands:
         cwd: str | None = None,
         user: str | None = None,
         stdin: str | bytes | None = None,
+        request_id: str | None = None,
     ) -> CommandResult:
         result = self._sandbox._runtime.request(
             _command_request(
@@ -844,6 +845,7 @@ class Commands:
                 cwd,
                 user,
                 stdin,
+                request_id,
             )
         )
         return _command_result(result)
@@ -859,6 +861,7 @@ class Commands:
         envs: Mapping[str, str] | None = None,
         cwd: str | None = None,
         user: str | None = None,
+        request_id: str | None = None,
     ) -> CommandResult:
         script = self.script(source)
         if timeout is not None:
@@ -869,6 +872,8 @@ class Commands:
             script.cwd(cwd)
         if user is not None:
             script.user(user)
+        if request_id is not None:
+            script.request_id(request_id)
         return script.run()
 
 
@@ -1503,6 +1508,7 @@ class AsyncCommands:
         cwd: str | None = None,
         user: str | None = None,
         stdin: str | bytes | None = None,
+        request_id: str | None = None,
     ) -> CommandResult:
         result = await self._sandbox._runtime.request(
             _command_request(
@@ -1513,6 +1519,7 @@ class AsyncCommands:
                 cwd,
                 user,
                 stdin,
+                request_id,
             )
         )
         return _command_result(result)
@@ -1528,6 +1535,7 @@ class AsyncCommands:
         envs: Mapping[str, str] | None = None,
         cwd: str | None = None,
         user: str | None = None,
+        request_id: str | None = None,
     ) -> CommandResult:
         script = self.script(source)
         if timeout is not None:
@@ -1538,6 +1546,8 @@ class AsyncCommands:
             script.cwd(cwd)
         if user is not None:
             script.user(user)
+        if request_id is not None:
+            script.request_id(request_id)
         return await script.run()
 
 

--- a/sdk/python/src/a3s_box/script.py
+++ b/sdk/python/src/a3s_box/script.py
@@ -18,6 +18,7 @@ class _SyncCommands(Protocol):
         cwd: str | None = None,
         user: str | None = None,
         stdin: str | bytes | None = None,
+        request_id: str | None = None,
     ) -> CommandResult:
         ...
 
@@ -32,6 +33,7 @@ class _AsyncCommands(Protocol):
         cwd: str | None = None,
         user: str | None = None,
         stdin: str | bytes | None = None,
+        request_id: str | None = None,
     ) -> CommandResult:
         ...
 
@@ -55,6 +57,7 @@ class ScriptBuilder:
         self._envs: dict[str, str] = {}
         self._cwd: str | None = None
         self._user: str | None = None
+        self._request_id: str | None = None
 
     def interpreter(self, executable: str, *args: str) -> ScriptBuilder:
         self._interpreter = [executable, *args]
@@ -76,6 +79,10 @@ class ScriptBuilder:
         self._user = user
         return self
 
+    def request_id(self, request_id: str) -> ScriptBuilder:
+        self._request_id = request_id
+        return self
+
     def run(self) -> CommandResult:
         _validate_script(self._source, self._interpreter)
         return self._commands.run(
@@ -85,6 +92,7 @@ class ScriptBuilder:
             cwd=self._cwd,
             user=self._user,
             stdin=self._source,
+            request_id=self._request_id,
         )
 
 
@@ -107,6 +115,7 @@ class AsyncScriptBuilder:
         self._envs: dict[str, str] = {}
         self._cwd: str | None = None
         self._user: str | None = None
+        self._request_id: str | None = None
 
     def interpreter(self, executable: str, *args: str) -> AsyncScriptBuilder:
         self._interpreter = [executable, *args]
@@ -128,6 +137,10 @@ class AsyncScriptBuilder:
         self._user = user
         return self
 
+    def request_id(self, request_id: str) -> AsyncScriptBuilder:
+        self._request_id = request_id
+        return self
+
     async def run(self) -> CommandResult:
         _validate_script(self._source, self._interpreter)
         return await self._commands.run(
@@ -137,6 +150,7 @@ class AsyncScriptBuilder:
             cwd=self._cwd,
             user=self._user,
             stdin=self._source,
+            request_id=self._request_id,
         )
 
 

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -773,6 +773,7 @@ class SdkTests(unittest.TestCase):
                 timeout=10,
                 cwd="/workspace",
                 envs={"REQUEST": "one"},
+                request_id="caller-stable-exec-1",
             )
             self.assertEqual(result.stdout, "42\n")
             self.assertEqual(result.stderr, "")
@@ -792,6 +793,7 @@ class SdkTests(unittest.TestCase):
         self.assertEqual(create["isolation"], "microvm")
         self.assertEqual(command["argv"], ["/bin/sh", "-lc", "python -c 'print(6 * 7)'"])
         self.assertEqual(command["generation"], 1)
+        self.assertEqual(command["request_id"], "caller-stable-exec-1")
         self.assertEqual(write["data_base64"], base64.b64encode(b"hello").decode())
         self.assertEqual(read["path"], "/workspace/notes.txt")
         self.assertEqual(stat["operation"], "filesystem_stat")

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -108,6 +108,12 @@ export interface CommandRunOptions {
   cwd?: string
   user?: string
   stdin?: string | Uint8Array
+  /**
+   * Stable one-shot exec identity for replay-safe retries after retryable
+   * Unavailable. When omitted, the Rust Sandbox facade mints a fresh id.
+   * Reuse the same id on retry; do not append `.retry-N`.
+   */
+  requestId?: string
 }
 
 export interface CommandResult {
@@ -930,6 +936,17 @@ export class Commands {
     if (options.timeoutMs !== undefined && options.timeoutMs <= 0) {
       throw new Error('timeoutMs must be greater than zero')
     }
+    if (options.requestId !== undefined) {
+      if (
+        options.requestId.length === 0 ||
+        options.requestId.length > 512 ||
+        options.requestId.includes('\0')
+      ) {
+        throw new Error(
+          'requestId must be a non-empty string of at most 512 bytes without NUL'
+        )
+      }
+    }
     const stdin =
       options.stdin === undefined
         ? undefined
@@ -946,6 +963,9 @@ export class Commands {
       ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
       ...(options.user === undefined ? {} : { user: options.user }),
       ...(stdin === undefined ? {} : { stdin_base64: stdin }),
+      ...(options.requestId === undefined
+        ? {}
+        : { request_id: options.requestId }),
     })
     return {
       stdout: decodeBase64(result, 'stdout_base64').toString('utf8'),
@@ -972,6 +992,9 @@ export class Commands {
     }
     if (options.cwd !== undefined) builder = builder.cwd(options.cwd)
     if (options.user !== undefined) builder = builder.user(options.user)
+    if (options.requestId !== undefined) {
+      builder = builder.requestId(options.requestId)
+    }
     return builder.run()
   }
 }
@@ -1020,6 +1043,11 @@ export class ScriptBuilder {
 
   user(user: string): ScriptBuilder {
     this.options = { ...this.options, user }
+    return this
+  }
+
+  requestId(requestId: string): ScriptBuilder {
+    this.options = { ...this.options, requestId }
     return this
   }
 

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -782,6 +782,7 @@ const result = await sandbox.commands.run("python -c 'print(6 * 7)'", {
   timeoutMs: 10_000,
   cwd: '/workspace',
   envs: { REQUEST: 'one' },
+  requestId: 'caller-stable-exec-1',
 })
 assert.equal(result.stdout, '42\n')
 assert.equal(result.stderr, '')
@@ -806,6 +807,7 @@ assert.deepEqual(command.argv, [
   "python -c 'print(6 * 7)'",
 ])
 assert.equal(command.generation, 1)
+assert.equal(command.request_id, 'caller-stable-exec-1')
 assert.equal(writeRequest.data_base64, Buffer.from('hello').toString('base64'))
 assert.equal(read.path, '/workspace/notes.txt')
 assert.equal(stat.operation, 'filesystem_stat')

--- a/src/sdk/src/bridge.rs
+++ b/src/sdk/src/bridge.rs
@@ -641,6 +641,7 @@ async fn execute_request(
             cwd,
             user,
             stdin_base64,
+            request_id,
         } => {
             let stdin = stdin_base64
                 .map(|encoded| {
@@ -660,6 +661,7 @@ async fn execute_request(
                         cwd,
                         user,
                         stdin,
+                        request_id,
                     },
                 )
                 .await?;

--- a/src/sdk/src/bridge/request.rs
+++ b/src/sdk/src/bridge/request.rs
@@ -261,6 +261,10 @@ pub enum BridgeRequest {
         user: Option<String>,
         #[serde(default)]
         stdin_base64: Option<String>,
+        /// Stable one-shot exec identity for replay-safe retries after retryable
+        /// `Unavailable`. When omitted, the Rust Sandbox facade mints a fresh id.
+        #[serde(default)]
+        request_id: Option<String>,
     },
     FileWrite {
         sandbox_id: String,

--- a/src/sdk/src/sandbox/commands.rs
+++ b/src/sdk/src/sandbox/commands.rs
@@ -70,6 +70,11 @@ pub struct CommandRunOptions {
     pub cwd: Option<String>,
     pub user: Option<String>,
     pub stdin: Option<Vec<u8>>,
+    /// Stable one-shot exec identity for replay-safe retries after retryable
+    /// `Unavailable`. When omitted, the SDK mints a fresh `sdk-command-*` id.
+    /// Callers that retry the same command after a partial prepare-exec must
+    /// reuse the same id (do not append `.retry-N`).
+    pub request_id: Option<String>,
 }
 
 impl CommandRunOptions {
@@ -95,6 +100,11 @@ impl CommandRunOptions {
 
     pub fn stdin(mut self, stdin: impl Into<Vec<u8>>) -> Self {
         self.stdin = Some(stdin.into());
+        self
+    }
+
+    pub fn request_id(mut self, request_id: impl Into<String>) -> Self {
+        self.request_id = Some(request_id.into());
         self
     }
 }
@@ -145,9 +155,16 @@ impl Commands {
             Some(timeout) => u64::try_from(timeout.as_nanos()).unwrap_or(u64::MAX),
             None => 0,
         };
+        let request_id = match options.request_id {
+            Some(request_id) => {
+                validate_command_request_id(&request_id)?;
+                request_id
+            }
+            None => format!("sdk-command-{}", uuid::Uuid::new_v4()),
+        };
         let (_, generation) = self.inner.active_execution()?;
         let request = ExecRequest {
-            request_id: Some(format!("sdk-command-{}", uuid::Uuid::new_v4())),
+            request_id: Some(request_id),
             cmd: command.into().into_argv()?,
             timeout_ns,
             env: options
@@ -178,4 +195,18 @@ impl Commands {
             stderr_bytes: output.stderr,
         })
     }
+}
+
+const MAX_COMMAND_REQUEST_ID_BYTES: usize = 512;
+
+fn validate_command_request_id(request_id: &str) -> Result<()> {
+    if request_id.is_empty()
+        || request_id.len() > MAX_COMMAND_REQUEST_ID_BYTES
+        || request_id.contains('\0')
+    {
+        return Err(ClientError::Validation(
+            "sandbox command request_id must be a non-empty UTF-8 string of at most 512 bytes without NUL".to_string(),
+        ));
+    }
+    Ok(())
 }

--- a/src/sdk/src/sandbox/script.rs
+++ b/src/sdk/src/sandbox/script.rs
@@ -51,6 +51,13 @@ impl ScriptBuilder {
         self
     }
 
+    /// Stable one-shot exec identity for replay-safe retries after retryable
+    /// `Unavailable`. Reuse the same id on retry; do not append `.retry-N`.
+    pub fn request_id(mut self, request_id: impl Into<String>) -> Self {
+        self.options.request_id = Some(request_id.into());
+        self
+    }
+
     pub async fn run(mut self) -> Result<CommandResult> {
         if self.source.is_empty() {
             return Err(ClientError::Validation(

--- a/src/sdk/src/sandbox/tests.rs
+++ b/src/sdk/src/sandbox/tests.rs
@@ -544,7 +544,69 @@ async fn local_sandbox_surface_supports_both_isolation_levels() {
 
         let exec = runtime.exec_requests.lock().unwrap();
         assert_eq!(exec[0].cmd, ["/bin/sh", "-lc", "python -c 'print(6 * 7)'"]);
+        let minted = exec[0].request_id.as_deref().unwrap();
+        assert!(
+            minted.starts_with("sdk-command-"),
+            "default request_id should be SDK-minted: {minted}"
+        );
     }
+}
+
+#[tokio::test]
+async fn command_run_reuses_stable_request_id_and_rejects_invalid_ids() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = Arc::new(RecordingRuntime::new());
+    let sandbox = Sandbox::create_with_client(
+        test_client(Arc::clone(&runtime), temp.path()),
+        SandboxCreateOptions::new("alpine:3.20"),
+    )
+    .await
+    .unwrap();
+
+    sandbox
+        .commands
+        .run_with_options(
+            "true",
+            CommandRunOptions::default().request_id("caller-stable-exec-1"),
+        )
+        .await
+        .unwrap();
+    sandbox
+        .commands
+        .run_with_options(
+            "true",
+            CommandRunOptions::default().request_id("caller-stable-exec-1"),
+        )
+        .await
+        .unwrap();
+
+    let exec = runtime.exec_requests.lock().unwrap();
+    assert_eq!(exec.len(), 2);
+    assert_eq!(exec[0].request_id.as_deref(), Some("caller-stable-exec-1"));
+    assert_eq!(exec[1].request_id.as_deref(), Some("caller-stable-exec-1"));
+    drop(exec);
+
+    let empty = sandbox
+        .commands
+        .run_with_options("true", CommandRunOptions::default().request_id(""))
+        .await
+        .unwrap_err();
+    assert!(matches!(empty, ClientError::Validation(_)));
+
+    let nul = sandbox
+        .commands
+        .run_with_options("true", CommandRunOptions::default().request_id("bad\0id"))
+        .await
+        .unwrap_err();
+    assert!(matches!(nul, ClientError::Validation(_)));
+
+    let too_long = "x".repeat(513);
+    let oversized = sandbox
+        .commands
+        .run_with_options("true", CommandRunOptions::default().request_id(too_long))
+        .await
+        .unwrap_err();
+    assert!(matches!(oversized, ClientError::Validation(_)));
 }
 
 #[tokio::test]

--- a/src/sdk/src/sandbox/tests.rs
+++ b/src/sdk/src/sandbox/tests.rs
@@ -580,11 +580,12 @@ async fn command_run_reuses_stable_request_id_and_rejects_invalid_ids() {
         .await
         .unwrap();
 
-    let exec = runtime.exec_requests.lock().unwrap();
-    assert_eq!(exec.len(), 2);
-    assert_eq!(exec[0].request_id.as_deref(), Some("caller-stable-exec-1"));
-    assert_eq!(exec[1].request_id.as_deref(), Some("caller-stable-exec-1"));
-    drop(exec);
+    {
+        let exec = runtime.exec_requests.lock().unwrap();
+        assert_eq!(exec.len(), 2);
+        assert_eq!(exec[0].request_id.as_deref(), Some("caller-stable-exec-1"));
+        assert_eq!(exec[1].request_id.as_deref(), Some("caller-stable-exec-1"));
+    }
 
     let empty = sandbox
         .commands


### PR DESCRIPTION
## Summary
- Expose optional stable `request_id` / `requestId` / `RunRequestID` on Rust, Python, TypeScript, and Go Sandbox command APIs so callers can retry retryable OCI `Unavailable` with the **same** process-journal identity.
- Bridge `command_run` accepts `request_id`; default remains a minted `sdk-command-*` id. Validation matches OCI (non-empty, ≤512 bytes, no NUL). Distinct `{id}.retry-N` suffixes remain forbidden.

## Test plan
- [x] `cargo test -p a3s-box-sdk command_run_reuses_stable_request_id`
- [x] Python `SdkTests.test_sync_sandbox_uses_local_runtime_surface`
- [ ] Hosted CI Format / Test / SDK smokes green
- [ ] Confirm no B2 / fixture / hosted-KVM claim flips

EOF

Made with [Cursor](https://cursor.com)