### PR TITLE
feat(sdk): surface command request_id on success and Unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- Command results and retryable `Unavailable` errors now surface the
+  process-journal `request_id` used for that one-shot exec (SDK-minted or
+  caller-provided). Omit-path callers can retry with the same identity after
+  a partial prepare-exec without inventing `{id}.retry-N`. Bridge
+  `command_run` success includes `request_id`; Unavailable bridge errors may
+  include `request_id`. Does **not** flip B2 harness close or auto-retry
+  commands inside the SDK.
+
 - Native SDKs expose an optional stable command `request_id` /
   `requestId` / `RunRequestID` so callers can retry retryable OCI
   `Unavailable` with the **same** process-journal identity. Defaults still

--- a/sdk/go/commands.go
+++ b/sdk/go/commands.go
@@ -156,9 +156,13 @@ func (commands *Commands) Run(
 		StderrBase64 string `json:"stderr_base64"`
 		ExitCode     int    `json:"exit_code"`
 		Truncated    bool   `json:"truncated"`
+		RequestID    string `json:"request_id"`
 	}
 	if err := commands.sandbox.readRequest(ctx, op, fields, &wire, true); err != nil {
 		return CommandResult{}, err
+	}
+	if strings.TrimSpace(wire.RequestID) == "" {
+		return CommandResult{}, sdkError(op, CodeProtocol, "command result is missing request_id", nil)
 	}
 	stdout, err := base64.StdEncoding.DecodeString(wire.StdoutBase64)
 	if err != nil {
@@ -173,6 +177,7 @@ func (commands *Commands) Run(
 		Stderr:    stderr,
 		ExitCode:  wire.ExitCode,
 		Truncated: wire.Truncated,
+		RequestID: wire.RequestID,
 	}, nil
 }
 

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -45,10 +45,11 @@ var (
 // Cause is retained so errors.Is continues to recognize context cancellation
 // and process errors.
 type Error struct {
-	Op      string
-	Code    ErrorCode
-	Message string
-	Cause   error
+	Op        string
+	Code      ErrorCode
+	Message   string
+	RequestID string
+	Cause     error
 }
 
 func (e *Error) Error() string {
@@ -82,6 +83,10 @@ func (e *Error) Is(target error) bool {
 
 func sdkError(op string, code ErrorCode, message string, cause error) error {
 	return &Error{Op: op, Code: code, Message: message, Cause: cause}
+}
+
+func sdkErrorWithRequestID(op string, code ErrorCode, message, requestID string, cause error) error {
+	return &Error{Op: op, Code: code, Message: message, RequestID: requestID, Cause: cause}
 }
 
 func invalid(op, message string) error {

--- a/sdk/go/internal/bridge/protocol.go
+++ b/sdk/go/internal/bridge/protocol.go
@@ -71,6 +71,7 @@ type Envelope struct {
 }
 
 type RemoteError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	RequestID string `json:"request_id,omitempty"`
 }

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -312,6 +312,7 @@ type CommandResult struct {
 	Stderr    []byte
 	ExitCode  int
 	Truncated bool
+	RequestID string
 }
 
 func (result CommandResult) StdoutString() string { return string(result.Stdout) }

--- a/sdk/go/operation_coverage_test.go
+++ b/sdk/go/operation_coverage_test.go
@@ -214,7 +214,7 @@ func operationFixture(_ context.Context, request map[string]any) (any, error) {
 	case "sandbox_remove":
 		return SandboxInfo{SandboxID: "box-remove", Generation: 1, State: StateRemoved, Isolation: IsolationMicroVM}, nil
 	case "command_run":
-		return map[string]any{"stdout_base64": "", "stderr_base64": "", "exit_code": 0, "truncated": false}, nil
+		return map[string]any{"stdout_base64": "", "stderr_base64": "", "exit_code": 0, "truncated": false, "request_id": "sdk-command-test"}, nil
 	case "file_write":
 		return WriteInfo{Path: "/tmp/value", Size: 5}, nil
 	case "file_read":

--- a/sdk/go/runtime.go
+++ b/sdk/go/runtime.go
@@ -192,6 +192,9 @@ func decodeBridgeResponse(operation string, output []byte, result any) error {
 		if message == "" {
 			message = "local bridge request failed"
 		}
+		if envelope.Error.RequestID != "" {
+			return sdkErrorWithRequestID(operation, code, message, envelope.Error.RequestID, nil)
+		}
 		return sdkError(operation, code, message, nil)
 	}
 	trimmed := bytes.TrimSpace(envelope.Result)

--- a/sdk/go/sandbox_test.go
+++ b/sdk/go/sandbox_test.go
@@ -354,7 +354,7 @@ func TestLifecycleWaitsForInFlightCommand(t *testing.T) {
 		case "command_run":
 			close(commandStarted)
 			<-releaseCommand
-			return map[string]any{"stdout_base64": "", "stderr_base64": "", "exit_code": 0, "truncated": false}, nil
+			return map[string]any{"stdout_base64": "", "stderr_base64": "", "exit_code": 0, "truncated": false, "request_id": "sdk-command-test"}, nil
 		case "sandbox_kill":
 			close(killReachedRuntime)
 			return SandboxInfo{SandboxID: "box-1", Generation: 1, State: StateFailed, Isolation: IsolationMicroVM}, nil
@@ -395,6 +395,7 @@ func TestCommandsScriptsAndFilesystemAreBinarySafe(t *testing.T) {
 				"stderr_base64": base64.StdEncoding.EncodeToString([]byte("warning")),
 				"exit_code":     7,
 				"truncated":     true,
+				"request_id":    "caller-stable-exec-1",
 			}, nil
 		case "file_write":
 			data, err := base64.StdEncoding.DecodeString(stringValue(request["data_base64"]))
@@ -430,7 +431,7 @@ func TestCommandsScriptsAndFilesystemAreBinarySafe(t *testing.T) {
 		RunStdin(binaryOutput),
 		RunRequestID("caller-stable-exec-1"),
 	)
-	if err != nil || !reflect.DeepEqual(result.Stdout, binaryOutput) || result.ExitCode != 7 || !result.Truncated {
+	if err != nil || !reflect.DeepEqual(result.Stdout, binaryOutput) || result.ExitCode != 7 || !result.Truncated || result.RequestID != "caller-stable-exec-1" {
 		t.Fatalf("command result=%+v err=%v", result, err)
 	}
 	command := requestByOperation(t, runtime.Requests(), "command_run")

--- a/sdk/python/src/a3s_box/_bridge_values.py
+++ b/sdk/python/src/a3s_box/_bridge_values.py
@@ -363,11 +363,15 @@ def filesystem_snapshot_info(
 def command_result(result: Mapping[str, object]) -> CommandResult:
     stdout = decoded_base64(result.get("stdout_base64", ""), "stdout_base64")
     stderr = decoded_base64(result.get("stderr_base64", ""), "stderr_base64")
+    request_id = result.get("request_id")
+    if not isinstance(request_id, str) or not request_id:
+        protocol_error("command_run result missing request_id")
     return CommandResult(
         stdout=stdout.decode(errors="replace"),
         stderr=stderr.decode(errors="replace"),
         exit_code=integer(result["exit_code"]),
         truncated=boolean(result.get("truncated", False)),
+        request_id=request_id,
     )
 
 

--- a/sdk/python/src/a3s_box/exceptions.py
+++ b/sdk/python/src/a3s_box/exceptions.py
@@ -6,9 +6,16 @@ from __future__ import annotations
 class A3SBoxError(RuntimeError):
     """Base error returned by the local A3S Box runtime."""
 
-    def __init__(self, message: str, *, code: str = "runtime_error") -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "runtime_error",
+        request_id: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.code = code
+        self.request_id = request_id
 
 
 class A3SBoxNotInstalledError(A3SBoxError):

--- a/sdk/python/src/a3s_box/models.py
+++ b/sdk/python/src/a3s_box/models.py
@@ -12,6 +12,7 @@ class CommandResult:
     stderr: str
     exit_code: int
     truncated: bool = False
+    request_id: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/sdk/python/src/a3s_box/runtime.py
+++ b/sdk/python/src/a3s_box/runtime.py
@@ -307,10 +307,16 @@ def _decode_response(stdout: str, stderr: str, returncode: int) -> dict[str, Any
         if isinstance(raw_error, dict):
             code = str(raw_error.get("code", "runtime_error"))
             message = str(raw_error.get("message", "Local A3S Box request failed"))
+            request_id = raw_error.get("request_id")
+            if request_id is not None and not isinstance(request_id, str):
+                request_id = None
+            elif isinstance(request_id, str) and not request_id:
+                request_id = None
         else:
             code = "runtime_error"
             message = "Local A3S Box request failed"
-        raise A3SBoxError(message, code=code)
+            request_id = None
+        raise A3SBoxError(message, code=code, request_id=request_id)
     result = envelope.get("result")
     if not isinstance(result, dict):
         raise A3SBoxError(

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -387,6 +387,7 @@ def response_for(request: Mapping[str, object]) -> dict[str, Any]:
             "stderr_base64": "",
             "exit_code": 0,
             "truncated": False,
+            "request_id": request.get("request_id") or "sdk-command-test",
         }
     if operation == "file_write":
         return {"path": request["path"], "size": 5}
@@ -794,6 +795,7 @@ class SdkTests(unittest.TestCase):
         self.assertEqual(command["argv"], ["/bin/sh", "-lc", "python -c 'print(6 * 7)'"])
         self.assertEqual(command["generation"], 1)
         self.assertEqual(command["request_id"], "caller-stable-exec-1")
+        self.assertEqual(result.request_id, "caller-stable-exec-1")
         self.assertEqual(write["data_base64"], base64.b64encode(b"hello").decode())
         self.assertEqual(read["path"], "/workspace/notes.txt")
         self.assertEqual(stat["operation"], "filesystem_stat")

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,10 +1,18 @@
 export class A3SBoxError extends Error {
   readonly code: string
+  readonly requestId?: string
 
-  constructor(message: string, code = 'runtime_error') {
+  constructor(
+    message: string,
+    code = 'runtime_error',
+    options?: { requestId?: string }
+  ) {
     super(message)
     this.name = 'A3SBoxError'
     this.code = code
+    if (options?.requestId !== undefined) {
+      this.requestId = options.requestId
+    }
   }
 }
 

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -297,7 +297,13 @@ function decodeResponse(
       isRecord(error) && typeof error.message === 'string'
         ? error.message
         : 'Local A3S Box request failed'
-    throw new A3SBoxError(message, code)
+    const requestId =
+      isRecord(error) &&
+      typeof error.request_id === 'string' &&
+      error.request_id.length > 0
+        ? error.request_id
+        : undefined
+    throw new A3SBoxError(message, code, { requestId })
   }
   if (!isRecord(envelope.result)) {
     throw new A3SBoxError(

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -121,6 +121,8 @@ export interface CommandResult {
   stderr: string
   exitCode: number
   truncated: boolean
+  /** Process-journal identity used for this one-shot exec. */
+  requestId: string
 }
 
 export interface WriteInfo {
@@ -972,6 +974,7 @@ export class Commands {
       stderr: decodeBase64(result, 'stderr_base64').toString('utf8'),
       exitCode: requiredNumber(result, 'exit_code'),
       truncated: requiredBoolean(result, 'truncated'),
+      requestId: requiredString(result, 'request_id'),
     }
   }
 

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -274,6 +274,7 @@ class FakeRuntime {
           stderr_base64: '',
           exit_code: 0,
           truncated: false,
+          request_id: request.request_id ?? 'sdk-command-test',
         }
       case 'file_write':
         return { path: request.path, size: 5 }
@@ -787,6 +788,7 @@ const result = await sandbox.commands.run("python -c 'print(6 * 7)'", {
 assert.equal(result.stdout, '42\n')
 assert.equal(result.stderr, '')
 assert.equal(result.exitCode, 0)
+assert.equal(result.requestId, 'caller-stable-exec-1')
 
 const write = await sandbox.files.write('/workspace/notes.txt', 'hello')
 assert.equal(write.size, 5)

--- a/src/sdk/src/bridge.rs
+++ b/src/sdk/src/bridge.rs
@@ -171,12 +171,17 @@ pub struct BridgeResponse {
 pub struct BridgeError {
     pub code: &'static str,
     pub message: String,
+    /// Present for retryable command_run Unavailable so callers can reuse the
+    /// same process-journal identity on retry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
 }
 
 #[derive(Debug)]
 struct BridgeFailure {
     code: &'static str,
     message: String,
+    request_id: Option<String>,
 }
 
 impl BridgeResponse {
@@ -197,6 +202,7 @@ impl BridgeResponse {
             error: Some(BridgeError {
                 code: error.code,
                 message: error.message,
+                request_id: error.request_id,
             }),
         }
     }
@@ -210,6 +216,7 @@ pub async fn dispatch_json(input: &str) -> BridgeResponse {
             return BridgeResponse::failure(BridgeFailure {
                 code: "invalid_request",
                 message: format!("invalid SDK bridge request: {error}"),
+                request_id: None,
             })
         }
     };
@@ -219,6 +226,7 @@ pub async fn dispatch_json(input: &str) -> BridgeResponse {
             return BridgeResponse::failure(BridgeFailure {
                 code: "runtime_error",
                 message: format!("failed to configure local execution: {error}"),
+                request_id: None,
             })
         }
     };
@@ -670,6 +678,7 @@ async fn execute_request(
                 "stderr_base64": STANDARD.encode(output.stderr_bytes),
                 "exit_code": output.exit_code,
                 "truncated": output.truncated,
+                "request_id": output.request_id,
             }))
         }
         BridgeRequest::FileWrite {
@@ -863,6 +872,7 @@ fn serialize_value(value: impl Serialize) -> Result<Value, BridgeFailure> {
     serde_json::to_value(value).map_err(|error| BridgeFailure {
         code: "runtime_error",
         message: format!("failed to encode SDK bridge result: {error}"),
+        request_id: None,
     })
 }
 
@@ -916,6 +926,7 @@ fn bridge_encoding_failure(message: impl Into<String>) -> BridgeFailure {
     BridgeFailure {
         code: "runtime_error",
         message: format!("failed to encode SDK bridge result: {}", message.into()),
+        request_id: None,
     }
 }
 
@@ -968,6 +979,7 @@ fn invalid(message: impl Into<String>) -> BridgeFailure {
     BridgeFailure {
         code: "invalid_request",
         message: message.into(),
+        request_id: None,
     }
 }
 
@@ -975,44 +987,63 @@ fn conflict(message: impl Into<String>) -> BridgeFailure {
     BridgeFailure {
         code: "conflict",
         message: message.into(),
+        request_id: None,
     }
 }
 
 impl From<ClientError> for BridgeFailure {
     fn from(error: ClientError) -> Self {
-        let code = match &error {
-            ClientError::BoxNotFound(_) => "not_found",
-            ClientError::AmbiguousBoxQuery { .. } | ClientError::Validation(_) => "invalid_request",
-            ClientError::Execution(a3s_box_core::ExecutionManagerError::NotFound(_)) => "not_found",
-            ClientError::Execution(a3s_box_core::ExecutionManagerError::InvalidRequest(_)) => {
-                "invalid_request"
-            }
-            ClientError::Execution(a3s_box_core::ExecutionManagerError::Conflict { .. }) => {
-                "conflict"
-            }
-            ClientError::Execution(a3s_box_core::ExecutionManagerError::Unavailable(_)) => {
-                "unavailable"
-            }
-            ClientError::Runtime(BoxError::ConfigError(_) | BoxError::TeeConfig(_)) => {
-                "invalid_request"
-            }
-            ClientError::Runtime(BoxError::TeeNotSupported(_)) => "unavailable",
-            ClientError::Guest(message) => {
-                if message.to_ascii_lowercase().contains("not found") {
-                    "not_found"
-                } else {
-                    "runtime_error"
+        match error {
+            ClientError::CommandUnavailable {
+                request_id,
+                message,
+            } => Self {
+                code: "unavailable",
+                message,
+                request_id: Some(request_id),
+            },
+            error => {
+                let code = match &error {
+                    ClientError::BoxNotFound(_) => "not_found",
+                    ClientError::AmbiguousBoxQuery { .. } | ClientError::Validation(_) => {
+                        "invalid_request"
+                    }
+                    ClientError::Execution(a3s_box_core::ExecutionManagerError::NotFound(_)) => {
+                        "not_found"
+                    }
+                    ClientError::Execution(
+                        a3s_box_core::ExecutionManagerError::InvalidRequest(_),
+                    ) => "invalid_request",
+                    ClientError::Execution(a3s_box_core::ExecutionManagerError::Conflict {
+                        ..
+                    }) => "conflict",
+                    ClientError::Execution(a3s_box_core::ExecutionManagerError::Unavailable(_)) => {
+                        "unavailable"
+                    }
+                    ClientError::Runtime(BoxError::ConfigError(_) | BoxError::TeeConfig(_)) => {
+                        "invalid_request"
+                    }
+                    ClientError::Runtime(BoxError::TeeNotSupported(_)) => "unavailable",
+                    ClientError::Guest(message) => {
+                        if message.to_ascii_lowercase().contains("not found") {
+                            "not_found"
+                        } else {
+                            "runtime_error"
+                        }
+                    }
+                    ClientError::State(_)
+                    | ClientError::Runtime(_)
+                    | ClientError::Execution(a3s_box_core::ExecutionManagerError::Internal(_)) => {
+                        "runtime_error"
+                    }
+                    ClientError::CommandUnavailable { .. } => unreachable!(),
+                };
+                Self {
+                    code,
+                    message: error.to_string(),
+                    request_id: None,
                 }
             }
-            ClientError::State(_)
-            | ClientError::Runtime(_)
-            | ClientError::Execution(a3s_box_core::ExecutionManagerError::Internal(_)) => {
-                "runtime_error"
-            }
-        };
-        Self {
-            code,
-            message: error.to_string(),
         }
     }
 }

--- a/src/sdk/src/bridge/tests.rs
+++ b/src/sdk/src/bridge/tests.rs
@@ -202,6 +202,50 @@ fn unsupported_runtime_capabilities_are_unavailable() {
 
     assert_eq!(failure.code, "unavailable");
     assert!(failure.message.contains("no TEE device"));
+    assert_eq!(failure.request_id, None);
+}
+
+#[test]
+fn command_unavailable_surfaces_request_id_on_bridge_error() {
+    let failure = BridgeFailure::from(ClientError::CommandUnavailable {
+        request_id: "sdk-command-abc".to_string(),
+        message: "prepare-exec interrupted".to_string(),
+    });
+    assert_eq!(failure.code, "unavailable");
+    assert_eq!(failure.request_id.as_deref(), Some("sdk-command-abc"));
+    assert!(failure.message.contains("prepare-exec"));
+}
+
+#[test]
+fn command_run_request_accepts_optional_request_id() {
+    let with_id: BridgeRequest = serde_json::from_str(
+        r#"{
+            "operation":"command_run",
+            "sandbox_id":"box-1",
+            "generation":1,
+            "argv":["true"],
+            "request_id":"caller-stable-exec-1"
+        }"#,
+    )
+    .unwrap();
+    let BridgeRequest::CommandRun { request_id, .. } = with_id else {
+        panic!("expected command_run");
+    };
+    assert_eq!(request_id.as_deref(), Some("caller-stable-exec-1"));
+
+    let omitted: BridgeRequest = serde_json::from_str(
+        r#"{
+            "operation":"command_run",
+            "sandbox_id":"box-1",
+            "generation":1,
+            "argv":["true"]
+        }"#,
+    )
+    .unwrap();
+    let BridgeRequest::CommandRun { request_id, .. } = omitted else {
+        panic!("expected command_run");
+    };
+    assert_eq!(request_id, None);
 }
 
 #[tokio::test]

--- a/src/sdk/src/client/types.rs
+++ b/src/sdk/src/client/types.rs
@@ -10,6 +10,10 @@ pub enum ClientError {
     Runtime(#[from] a3s_box_core::error::BoxError),
     #[error("execution lifecycle error: {0}")]
     Execution(#[from] a3s_box_core::ExecutionManagerError),
+    /// Retryable command failure that already claimed process-journal
+    /// `request_id`. Callers must reuse that id on retry.
+    #[error("{message}")]
+    CommandUnavailable { request_id: String, message: String },
     #[error("validation error: {0}")]
     Validation(String),
     #[error("guest operation failed: {0}")]

--- a/src/sdk/src/sandbox/commands.rs
+++ b/src/sdk/src/sandbox/commands.rs
@@ -116,6 +116,9 @@ pub struct CommandResult {
     pub stderr: String,
     pub exit_code: i32,
     pub truncated: bool,
+    /// Process-journal identity used for this one-shot exec (caller-provided or
+    /// SDK-minted). Reuse on retryable `Unavailable` retries.
+    pub request_id: String,
     pub(crate) stdout_bytes: Vec<u8>,
     pub(crate) stderr_bytes: Vec<u8>,
 }
@@ -164,7 +167,7 @@ impl Commands {
         };
         let (_, generation) = self.inner.active_execution()?;
         let request = ExecRequest {
-            request_id: Some(request_id),
+            request_id: Some(request_id.clone()),
             cmd: command.into().into_argv()?,
             timeout_ns,
             env: options
@@ -180,17 +183,30 @@ impl Commands {
             streaming: false,
         };
 
-        let output = self
+        let output = match self
             .inner
             .client
             .execute_execution(&self.inner.execution_id, generation, request)
-            .await?;
+            .await
+        {
+            Ok(output) => output,
+            Err(ClientError::Execution(a3s_box_core::ExecutionManagerError::Unavailable(
+                message,
+            ))) => {
+                return Err(ClientError::CommandUnavailable {
+                    request_id,
+                    message,
+                });
+            }
+            Err(error) => return Err(error),
+        };
 
         Ok(CommandResult {
             stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
             stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
             exit_code: output.exit_code,
             truncated: output.truncated,
+            request_id,
             stdout_bytes: output.stdout,
             stderr_bytes: output.stderr,
         })

--- a/src/sdk/src/sandbox/tests.rs
+++ b/src/sdk/src/sandbox/tests.rs
@@ -46,6 +46,7 @@ struct RecordingRuntime {
     logs: Mutex<Vec<LogEntry>>,
     event_requests: Mutex<VecDeque<(ExecutionGeneration, ExecutionEventsRequest)>>,
     runtime_events: Mutex<Vec<ExecutionRuntimeEvent>>,
+    fail_next_execute: Mutex<bool>,
 }
 
 impl RecordingRuntime {
@@ -120,7 +121,12 @@ impl RecordingRuntime {
                     attributes: BTreeMap::new(),
                 },
             ]),
+            fail_next_execute: Mutex::new(false),
         }
+    }
+
+    fn fail_next_execute(&self) {
+        *self.fail_next_execute.lock().unwrap() = true;
     }
 
     fn execution_id() -> ExecutionId {
@@ -394,6 +400,11 @@ impl ExecutionSessionManager for RecordingRuntime {
         request: ExecRequest,
     ) -> ExecutionManagerResult<ExecOutput> {
         self.exec_requests.lock().unwrap().push(request);
+        if std::mem::replace(&mut *self.fail_next_execute.lock().unwrap(), false) {
+            return Err(ExecutionManagerError::Unavailable(
+                "prepare-exec interrupted".to_string(),
+            ));
+        }
         Ok(ExecOutput {
             stdout: b"42\n".to_vec(),
             stderr: Vec::new(),
@@ -608,6 +619,55 @@ async fn command_run_reuses_stable_request_id_and_rejects_invalid_ids() {
         .await
         .unwrap_err();
     assert!(matches!(oversized, ClientError::Validation(_)));
+}
+
+#[tokio::test]
+async fn command_run_unavailable_preserves_request_id_for_retry() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = Arc::new(RecordingRuntime::new());
+    let sandbox = Sandbox::create_with_client(
+        test_client(Arc::clone(&runtime), temp.path()),
+        SandboxCreateOptions::new("alpine:3.20"),
+    )
+    .await
+    .unwrap();
+
+    runtime.fail_next_execute();
+    let first = sandbox
+        .commands
+        .run_with_options("true", CommandRunOptions::default())
+        .await
+        .unwrap_err();
+    let ClientError::CommandUnavailable {
+        request_id,
+        message,
+    } = first
+    else {
+        panic!("expected CommandUnavailable, got {first:?}");
+    };
+    assert!(
+        request_id.starts_with("sdk-command-"),
+        "minted request_id missing: {request_id}"
+    );
+    assert!(message.contains("prepare-exec"));
+
+    let recovered = sandbox
+        .commands
+        .run_with_options(
+            "true",
+            CommandRunOptions::default().request_id(request_id.clone()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(recovered.request_id, request_id);
+    assert_eq!(recovered.exit_code, 0);
+
+    {
+        let exec = runtime.exec_requests.lock().unwrap();
+        assert_eq!(exec.len(), 2);
+        assert_eq!(exec[0].request_id.as_deref(), Some(request_id.as_str()));
+        assert_eq!(exec[1].request_id.as_deref(), Some(request_id.as_str()));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `CommandResult` now includes the process-journal `request_id` used for each one-shot exec (caller-provided or SDK-minted).
- Retryable `Unavailable` maps to `ClientError::CommandUnavailable` and bridge errors may carry `request_id`, so omit-path retries can reuse the same identity (no `{id}.retry-N`).
- Bridge serde/contract tests cover optional `command_run.request_id` and Unavailable surfacing. Language SDKs (Python/TS/Go) parse success + error `request_id`.

## Test plan
- [x] `cargo test -p a3s-box-sdk command_run_`
- [x] Python sync sandbox surface test
- [ ] Hosted CI green (Format/Clippy/Test/SDK Packages/SDK Local)
- [ ] Confirm no B2 / fixture / hosted-KVM claim flips

Made with [Cursor](https://cursor.com)