### PR TITLE
fix(runtime): durable op identity for mutating file/FS ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Mutating OCI file upload and filesystem ops derive durable operation
+  identity from `execution_id` + generation + request payload (same pattern as
+  kill/delete), instead of minting a fresh `session-{uuid}` seed per call.
+  Outer `Unavailable` retries of the same mutation now replay one effect
+  instead of orphaning `active_operation` claims or applying twice. Does
+  **not** flip B2 harness close, fixture continuity, or hosted-KVM claims.
+
 ### Added
 
 - Command results and retryable `Unavailable` errors now surface the

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -1168,8 +1168,11 @@ impl OciLifecycleAdapter {
             BoxFileOp::Download => OciFileOp::Download,
         };
         let context = if request.op == BoxFileOp::Upload {
+            // Content-addressed by execution + generation + request payload.
+            // Do not mint a fresh session UUID: outer Unavailable retries must
+            // reuse the same durable op identity (same as kill/delete seeds).
             Some(operation_context(
-                &format!("session-{}", uuid::Uuid::new_v4().simple()),
+                execution_id.as_str(),
                 execution_generation,
                 "file",
                 (&binding.target, &request),
@@ -1223,8 +1226,11 @@ impl OciLifecycleAdapter {
             BoxFilesystemOp::Remove => OciFilesystemOp::Remove,
         };
         let context = if operation.is_mutating() {
+            // Content-addressed by execution + generation + request payload.
+            // Do not mint a fresh session UUID: outer Unavailable retries must
+            // reuse the same durable op identity (same as kill/delete seeds).
             Some(operation_context(
-                &format!("session-{}", uuid::Uuid::new_v4().simple()),
+                execution_id.as_str(),
                 execution_generation,
                 "filesystem",
                 (&binding.target, &request),

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -2614,6 +2614,81 @@ async fn file_and_filesystem_sessions_preserve_exact_targets_and_replay_mutation
 }
 
 #[tokio::test]
+async fn mutating_file_and_filesystem_ops_reuse_content_addressed_identity_across_outer_calls() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let manager = manager(
+        &directory,
+        test_endpoint(),
+        service.clone(),
+        Arc::new(FakeBundleProvider::default()),
+    );
+    let lease = manager
+        .create_and_start(
+            request("durable-mutations", ExecutionIsolation::Microvm),
+            &box_operation("durable-mutations-create"),
+        )
+        .await
+        .expect("initial launch");
+
+    let upload = BoxFileRequest {
+        op: BoxFileOp::Upload,
+        guest_path: "/work/same.txt".to_string(),
+        data: Some(STANDARD.encode(b"same bytes")),
+        user: None,
+        max_bytes: None,
+    };
+    manager
+        .transfer_file(&lease.execution_id, lease.generation, upload.clone())
+        .await
+        .expect("first upload");
+    manager
+        .transfer_file(&lease.execution_id, lease.generation, upload)
+        .await
+        .expect("outer retry upload");
+
+    let file_calls = service.file_requests();
+    assert_eq!(file_calls.len(), 2);
+    assert_eq!(
+        file_calls[0].context, file_calls[1].context,
+        "outer upload retries must reuse the durable op identity, not mint session-*"
+    );
+    assert_eq!(
+        service.file_effects().len(),
+        1,
+        "identical outer upload must replay, not apply twice"
+    );
+
+    let mkdir = BoxFilesystemRequest {
+        op: BoxFilesystemOp::MakeDir,
+        path: "/work/dir".to_string(),
+        destination: None,
+        depth: 0,
+        user: None,
+    };
+    manager
+        .filesystem(&lease.execution_id, lease.generation, mkdir.clone())
+        .await
+        .expect("first mkdir");
+    manager
+        .filesystem(&lease.execution_id, lease.generation, mkdir)
+        .await
+        .expect("outer retry mkdir");
+
+    let filesystem_calls = service.filesystem_requests();
+    assert_eq!(filesystem_calls.len(), 2);
+    assert_eq!(
+        filesystem_calls[0].context, filesystem_calls[1].context,
+        "outer mutating filesystem retries must reuse the durable op identity"
+    );
+    assert_eq!(
+        service.filesystem_effects().len(),
+        1,
+        "identical outer mkdir must replay, not apply twice"
+    );
+}
+
+#[tokio::test]
 async fn file_sessions_reject_invalid_download_limits_before_dispatch() {
     let directory = tempfile::tempdir().expect("temporary directory");
     let service = Arc::new(FakeRuntimeService::launch_ready());


### PR DESCRIPTION
## Summary
- Mutating OCI file upload and filesystem ops now derive durable operation identity from `execution_id` + generation + request payload (same pattern as kill/delete).
- Removes per-call `session-{uuid}` seeds that made outer `Unavailable` retries apply twice or orphan `active_operation` claims.
- Adds a regression test that identical outer upload/mkdir calls reuse context and apply once.

## Test plan
- [x] `cargo test -p a3s-box-runtime --lib mutating_file_and_filesystem`
- [ ] Hosted CI green
- [ ] Confirm no B2 / fixture / hosted-KVM claim flips

Made with [Cursor](https://cursor.com)