### PR TITLE
fix(runtime): inner Unavailable retry for one-shot OCI exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- One-shot OCI `exec` retries once on retryable `Unavailable` with the **same**
+  process-journal identity (parity with file upload / mutating filesystem),
+  including omit-path minted `managed-exec-*` seeds. Lost responses after the
+  Runtime journals the process no longer require a second outer `execute()` or
+  a caller-provided `request_id` to avoid orphan journals. Does **not** flip
+  B2 harness close, fixture continuity, or hosted-KVM claims.
+
 - Mutating OCI file upload and filesystem ops derive durable operation
   identity from `execution_id` + generation + request payload (same pattern as
   kill/delete), instead of minting a fresh `session-{uuid}` seed per call.

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -2225,7 +2225,7 @@ async fn launch_persists_exact_runtime_binding_for_both_product_isolations() {
 }
 
 #[tokio::test]
-async fn captured_exec_replays_after_lost_response_and_backend_reopen() {
+async fn captured_exec_replays_after_lost_response_within_one_execute() {
     let directory = tempfile::tempdir().expect("temporary directory");
     let service = Arc::new(FakeRuntimeService::launch_ready());
     let provider = Arc::new(FakeBundleProvider::default());
@@ -2235,13 +2235,13 @@ async fn captured_exec_replays_after_lost_response_and_backend_reopen() {
         ("ALPHA".to_string(), "container".to_string()),
         ("BETA".to_string(), "container".to_string()),
     ];
-    let first = manager(
+    let manager = manager(
         &directory,
         endpoint.clone(),
         service.clone(),
         provider.clone(),
     );
-    let lease = first
+    let lease = manager
         .create_and_start(create, &box_operation("captured-exec-create"))
         .await
         .expect("initial launch");
@@ -2259,23 +2259,16 @@ async fn captured_exec_replays_after_lost_response_and_backend_reopen() {
     };
     service.fail_exec_after_effect.store(true, Ordering::SeqCst);
 
-    first
-        .execute(&lease.execution_id, lease.generation, exec.clone())
-        .await
-        .expect_err("first exec response is intentionally lost");
-    drop(first);
-
-    let reopened = manager(&directory, endpoint, service.clone(), provider);
-    let output = reopened
+    let output = manager
         .execute(&lease.execution_id, lease.generation, exec)
         .await
-        .expect("replayed captured exec");
+        .expect("inner Unavailable retry recovers captured exec");
 
     assert_eq!(output.stdout, b"fake stdout\n");
     assert_eq!(output.stderr, b"fake stderr\n");
     assert_eq!(output.exit_code, 23);
     assert!(!output.truncated);
-    assert!(reopened
+    assert!(manager
         .read_logs(&lease.execution_id, lease.generation)
         .await
         .expect("structured Box logs remain readable")
@@ -2330,6 +2323,56 @@ async fn captured_exec_replays_after_lost_response_and_backend_reopen() {
     assert_eq!(stdin[0].data, b"probe input");
     assert_eq!(stdin[0].process.container, calls[0].container);
     assert_eq!(service.close_stdin_requests().len(), 1);
+}
+
+#[tokio::test]
+async fn omit_path_captured_exec_inner_retry_reuses_minted_process_identity() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let manager = manager(
+        &directory,
+        test_endpoint(),
+        service.clone(),
+        Arc::new(FakeBundleProvider::default()),
+    );
+    let lease = manager
+        .create_and_start(
+            request("omit-path-exec-retry", ExecutionIsolation::Sandbox),
+            &box_operation("omit-path-exec-retry-create"),
+        )
+        .await
+        .expect("initial launch");
+    service.fail_exec_after_effect.store(true, Ordering::SeqCst);
+
+    let output = manager
+        .execute(
+            &lease.execution_id,
+            lease.generation,
+            BoxExecRequest {
+                request_id: None,
+                cmd: vec!["/bin/true".to_string()],
+                timeout_ns: 1_000_000_000,
+                env: Vec::new(),
+                working_dir: None,
+                rootfs: None,
+                stdin: None,
+                stdin_streaming: false,
+                user: None,
+                streaming: false,
+            },
+        )
+        .await
+        .expect("omit-path inner Unavailable retry recovers without a caller request_id");
+
+    assert_eq!(output.exit_code, 23);
+    let calls = service.exec_requests();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0], calls[1]);
+    assert!(calls[0]
+        .process_id
+        .as_str()
+        .starts_with("a3s-box-exec-process-"));
+    assert_eq!(service.processes.lock().expect("process lock").len(), 1);
 }
 
 #[tokio::test]

--- a/src/runtime/src/local_execution/oci_session.rs
+++ b/src/runtime/src/local_execution/oci_session.rs
@@ -313,10 +313,13 @@ async fn launch_process(
             watchdog.clone(),
         );
     }
-    let process_record = client
-        .exec(exec_request)
-        .await
-        .map_err(|error| sdk_error("exec", error))?;
+    // Same durable process identity as file/FS: one retryable Unavailable after
+    // the Runtime has journaled the process must replay, not mint a second key.
+    let process_record = match client.exec(exec_request.clone()).await {
+        Err(error) if error.retryable => client.exec(exec_request).await,
+        result => result,
+    }
+    .map_err(|error| sdk_error("exec", error))?;
     validate_process_record(&process_record, &expected_target, terminal)?;
 
     let input = Arc::new(OciProcessInput {


### PR DESCRIPTION
## Summary
- One-shot OCI `exec` now retries once on retryable `Unavailable` with the **same** process-journal identity (parity with file upload / mutating filesystem).
- Covers keyed `request_id` and omit-path minted seeds so a lost response after the Runtime journals the process recovers inside one `execute()` without inventing `{id}.retry-N`.
- Does **not** flip `b2_process_session_recovery_closed`, fixture continuity, or hosted-KVM claims.

## Test plan
- [x] `cargo test -p a3s-box-runtime --lib captured_exec_replays_after_lost_response_within_one_execute` (WSL)
- [x] `cargo test -p a3s-box-runtime --lib omit_path_captured_exec_inner_retry_reuses_minted_process_identity` (WSL)
- [ ] Hosted CI green on this PR

Made with [Cursor](https://cursor.com)