### PR TITLE
test(sdk): Unavailable request_id round-trips in Go/Python/TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to A3S Box will be documented in this file.
   a caller-provided `request_id` to avoid orphan journals. Does **not** flip
   B2 harness close, fixture continuity, or hosted-KVM claims.
 
+- Go / Python / TypeScript SDKs cover Unavailable → `request_id` /
+  `requestId` / `RequestID` round-trips (bridge decode + omit-path command
+  retry reuse). Does **not** auto-retry commands inside language SDKs or flip
+  B2 harness close.
+
 - Mutating OCI file upload and filesystem ops derive durable operation
   identity from `execution_id` + generation + request payload (same pattern as
   kill/delete), instead of minting a fresh `session-{uuid}` seed per call.

--- a/sdk/go/runtime_test.go
+++ b/sdk/go/runtime_test.go
@@ -50,20 +50,30 @@ func runBridgeHelper() {
 			fmt.Fprint(os.Stderr, "credential missing from stdin")
 			os.Exit(9)
 		}
-		writeHelperEnvelope(true, map[string]any{"accepted": true}, "", "")
+		writeHelperEnvelope(true, map[string]any{"accepted": true}, "", "", "")
 	case "error":
-		writeHelperEnvelope(false, nil, os.Getenv("A3S_BOX_GO_TEST_ERROR_CODE"), "bridge rejected request")
+		writeHelperEnvelope(
+			false,
+			nil,
+			os.Getenv("A3S_BOX_GO_TEST_ERROR_CODE"),
+			"bridge rejected request",
+			os.Getenv("A3S_BOX_GO_TEST_ERROR_REQUEST_ID"),
+		)
 	default:
-		writeHelperEnvelope(true, map[string]any{"value": "ok"}, "", "")
+		writeHelperEnvelope(true, map[string]any{"value": "ok"}, "", "", "")
 	}
 }
 
-func writeHelperEnvelope(ok bool, result any, code, message string) {
+func writeHelperEnvelope(ok bool, result any, code, message, requestID string) {
 	envelope := map[string]any{"protocol_version": bridge.ProtocolVersion, "ok": ok}
 	if ok {
 		envelope["result"] = result
 	} else {
-		envelope["error"] = map[string]string{"code": code, "message": message}
+		errorPayload := map[string]string{"code": code, "message": message}
+		if requestID != "" {
+			errorPayload["request_id"] = requestID
+		}
+		envelope["error"] = errorPayload
 	}
 	_ = json.NewEncoder(os.Stdout).Encode(envelope)
 }
@@ -105,6 +115,24 @@ func TestLocalRuntimeSendsCredentialsOnlyThroughStdin(t *testing.T) {
 	}
 	if !result.Accepted {
 		t.Fatal("helper did not accept credentials")
+	}
+}
+
+func TestLocalRuntimeMapsUnavailableRequestID(t *testing.T) {
+	t.Setenv("A3S_BOX_GO_TEST_HELPER_MODE", "error")
+	t.Setenv("A3S_BOX_GO_TEST_ERROR_CODE", "unavailable")
+	t.Setenv("A3S_BOX_GO_TEST_ERROR_REQUEST_ID", "sdk-command-abc")
+	err := helperRuntime(t, 10*time.Second).Request(
+		context.Background(),
+		map[string]any{"operation": "command_run"},
+		&struct{}{},
+	)
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("expected unavailable, got %v", err)
+	}
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) || sdkErr.RequestID != "sdk-command-abc" {
+		t.Fatalf("expected request_id on Unavailable, got %#v", err)
 	}
 }
 

--- a/sdk/go/sandbox_test.go
+++ b/sdk/go/sandbox_test.go
@@ -385,6 +385,73 @@ func TestLifecycleWaitsForInFlightCommand(t *testing.T) {
 	}
 }
 
+func TestCommandUnavailablePreservesRequestIDForRetry(t *testing.T) {
+	failOnce := true
+	runtime := &fakeRuntime{handler: func(_ context.Context, request map[string]any) (any, error) {
+		if request["operation"] != "command_run" {
+			return map[string]any{}, nil
+		}
+		if failOnce {
+			failOnce = false
+			return nil, sdkErrorWithRequestID(
+				"command_run",
+				CodeUnavailable,
+				"prepare-exec response was lost",
+				"sdk-command-minted-1",
+				nil,
+			)
+		}
+		requestID := stringValue(request["request_id"])
+		return map[string]any{
+			"stdout_base64": "",
+			"stderr_base64": "",
+			"exit_code":     0,
+			"truncated":     false,
+			"request_id":    requestID,
+		}, nil
+	}}
+	sandbox := newSandbox(runtime, SandboxInfo{
+		SandboxID:  "box-1",
+		Generation: 1,
+		State:      StateRunning,
+		Isolation:  IsolationMicroVM,
+	})
+	_, err := sandbox.Run(context.Background(), Argv("true"))
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("expected unavailable, got %v", err)
+	}
+	var first *Error
+	if !errors.As(err, &first) || first.RequestID != "sdk-command-minted-1" {
+		t.Fatalf("expected minted request_id on Unavailable, got %#v", err)
+	}
+	result, err := sandbox.Run(
+		context.Background(),
+		Argv("true"),
+		RunRequestID(first.RequestID),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequestID != first.RequestID {
+		t.Fatalf("retry result request_id=%q, want %q", result.RequestID, first.RequestID)
+	}
+	commands := make([]map[string]any, 0, 2)
+	for _, request := range runtime.Requests() {
+		if request["operation"] == "command_run" {
+			commands = append(commands, request)
+		}
+	}
+	if len(commands) != 2 {
+		t.Fatalf("expected two command_run calls, got %d", len(commands))
+	}
+	if commands[0]["request_id"] != nil {
+		t.Fatalf("omit-path first call should omit request_id, got %#v", commands[0]["request_id"])
+	}
+	if commands[1]["request_id"] != "sdk-command-minted-1" {
+		t.Fatalf("retry must reuse minted request_id, got %#v", commands[1]["request_id"])
+	}
+}
+
 func TestCommandsScriptsAndFilesystemAreBinarySafe(t *testing.T) {
 	binaryOutput := []byte{0xff, 0x00, 'A'}
 	runtime := &fakeRuntime{handler: func(_ context.Context, request map[string]any) (any, error) {

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -726,6 +726,69 @@ class SdkTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, "bridge_protocol_error")
 
+    def test_unavailable_error_preserves_request_id_from_bridge(self) -> None:
+        envelope = json.dumps(
+            {
+                "protocol_version": BRIDGE_PROTOCOL_VERSION,
+                "ok": False,
+                "error": {
+                    "code": "unavailable",
+                    "message": "prepare-exec response was lost",
+                    "request_id": "sdk-command-abc",
+                },
+            }
+        )
+
+        with self.assertRaises(A3SBoxError) as raised:
+            _decode_response(envelope, "", 0)
+
+        self.assertEqual(raised.exception.code, "unavailable")
+        self.assertEqual(raised.exception.request_id, "sdk-command-abc")
+        self.assertIn("prepare-exec", str(raised.exception))
+
+    def test_command_unavailable_preserves_request_id_for_retry(self) -> None:
+        class UnavailableOnceRuntime(FakeRuntime):
+            def __init__(self) -> None:
+                super().__init__()
+                self._fail_next_command = True
+
+            def request(self, request: Mapping[str, object]) -> dict[str, Any]:
+                payload = dict(request)
+                if payload["operation"] != "sdk_capabilities":
+                    self.requests.append(payload)
+                if (
+                    payload["operation"] == "command_run"
+                    and self._fail_next_command
+                ):
+                    self._fail_next_command = False
+                    raise A3SBoxError(
+                        "prepare-exec response was lost",
+                        code="unavailable",
+                        request_id="sdk-command-minted-1",
+                    )
+                return response_for(payload)
+
+        runtime = UnavailableOnceRuntime()
+        sandbox = Sandbox.create(runtime=runtime)
+        with self.assertRaises(A3SBoxError) as raised:
+            sandbox.commands.run("true")
+        self.assertEqual(raised.exception.code, "unavailable")
+        self.assertEqual(raised.exception.request_id, "sdk-command-minted-1")
+
+        result = sandbox.commands.run(
+            "true",
+            request_id=raised.exception.request_id,
+        )
+        self.assertEqual(result.request_id, "sdk-command-minted-1")
+        commands = [
+            request
+            for request in runtime.requests
+            if request["operation"] == "command_run"
+        ]
+        self.assertEqual(len(commands), 2)
+        self.assertNotIn("request_id", commands[0])
+        self.assertEqual(commands[1]["request_id"], "sdk-command-minted-1")
+
     def test_exports_native_local_clients(self) -> None:
         self.assertIs(a3s_box.Sandbox, Sandbox)
         self.assertIs(a3s_box.AsyncSandbox, AsyncSandbox)

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -790,6 +790,43 @@ assert.equal(result.stderr, '')
 assert.equal(result.exitCode, 0)
 assert.equal(result.requestId, 'caller-stable-exec-1')
 
+class UnavailableOnceRuntime extends FakeRuntime {
+  #failNextCommand = true
+
+  async request(request) {
+    if (request.operation === 'command_run' && this.#failNextCommand) {
+      this.requests.push(request)
+      this.#failNextCommand = false
+      throw new A3SBoxError('prepare-exec response was lost', 'unavailable', {
+        requestId: 'sdk-command-minted-1',
+      })
+    }
+    return super.request(request)
+  }
+}
+
+const unavailableRuntime = new UnavailableOnceRuntime()
+const unavailableSandbox = await Sandbox.create(undefined, {
+  runtime: unavailableRuntime,
+})
+await assert.rejects(
+  unavailableSandbox.commands.run('true'),
+  (error) =>
+    error instanceof A3SBoxError &&
+    error.code === 'unavailable' &&
+    error.requestId === 'sdk-command-minted-1'
+)
+const recovered = await unavailableSandbox.commands.run('true', {
+  requestId: 'sdk-command-minted-1',
+})
+assert.equal(recovered.requestId, 'sdk-command-minted-1')
+const unavailableCommands = unavailableRuntime.requests.filter(
+  (request) => request.operation === 'command_run'
+)
+assert.equal(unavailableCommands.length, 2)
+assert.equal(unavailableCommands[0].request_id, undefined)
+assert.equal(unavailableCommands[1].request_id, 'sdk-command-minted-1')
+
 const write = await sandbox.files.write('/workspace/notes.txt', 'hello')
 assert.equal(write.size, 5)
 assert.equal(await sandbox.files.read('/workspace/notes.txt'), 'hello')


### PR DESCRIPTION
## Summary
- Add Go/Python/TypeScript coverage that Unavailable surfaces `request_id` / `requestId` / `RequestID` and omit-path callers can retry with that identity.
- Includes bridge-envelope decode (Go helper + Python `_decode_response`) and command-level FakeRuntime retry reuse.
- Does **not** auto-retry inside language SDKs, flip B2 harness close, or claim hosted KVM Live.

## Test plan
- [x] Python: `test_unavailable_error_preserves_request_id_from_bridge`, `test_command_unavailable_preserves_request_id_for_retry`
- [x] TypeScript: `npm test` in `sdk/typescript`
- [ ] CI SDK Packages (includes `go test ./...`)

Made with [Cursor](https://cursor.com)