### PR TITLE
fix(runtime): inner Unavailable retry for OCI resource update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to A3S Box will be documented in this file.
   still Conflicts. Does **not** flip B2 harness close, fixture continuity,
   or hosted-KVM claims.
 
+- Live OCI resource `update` retries once on retryable `Unavailable` with the
+  **same** operation identity (parity with file/FS/exec/stdin). Lost responses
+  after the Runtime journals the mutation recover inside one
+  `update_resources()`; crash recovery still replays a persisted
+  `UpdatingResources` claim across manager reopen. Does **not** flip B2
+  harness close, fixture continuity, or hosted-KVM claims.
+
 - Go / Python / TypeScript SDKs cover Unavailable → `request_id` /
   `requestId` / `RequestID` round-trips (bridge decode + omit-path command
   retry reuse). Does **not** auto-retry commands inside language SDKs or flip

--- a/src/runtime/src/local_execution/oci_backend.rs
+++ b/src/runtime/src/local_execution/oci_backend.rs
@@ -999,24 +999,28 @@ impl OciLifecycleAdapter {
         binding.validate_for(execution_id)?;
         self.require_operation(RuntimeOperation::Update, "update")
             .await?;
-        let updated = match self
-            .client
-            .update(UpdateRequest {
-                // The caller key and exact target define mutation identity.
-                // The runtime journals the full request and rejects reuse of
-                // this ID with changed resource content.
-                context: operation_context(
-                    operation_seed.as_str(),
-                    execution_generation,
-                    "update",
-                    &binding.target,
-                )?,
-                target: binding.target.clone(),
-                resources,
-            })
-            .await
-        {
+        let request = UpdateRequest {
+            // The caller key and exact target define mutation identity.
+            // The runtime journals the full request and rejects reuse of
+            // this ID with changed resource content.
+            context: operation_context(
+                operation_seed.as_str(),
+                execution_generation,
+                "update",
+                &binding.target,
+            )?,
+            target: binding.target.clone(),
+            resources,
+        };
+        let updated = match self.client.update(request.clone()).await {
             Ok(record) => record,
+            Err(error) if error.retryable => match self.client.update(request).await {
+                Ok(record) => record,
+                Err(error) if error.code == ErrorCode::NotFound => {
+                    return Err(ExecutionManagerError::NotFound(execution_id.clone()))
+                }
+                Err(error) => return Err(sdk_error("update", error)),
+            },
             Err(error) if error.code == ErrorCode::NotFound => {
                 return Err(ExecutionManagerError::NotFound(execution_id.clone()))
             }

--- a/src/runtime/src/local_execution/oci_backend_tests.rs
+++ b/src/runtime/src/local_execution/oci_backend_tests.rs
@@ -4706,22 +4706,16 @@ async fn resource_update_persists_complete_intent_and_replays_locally() {
 }
 
 #[tokio::test]
-async fn lost_resource_update_response_recovers_with_the_same_runtime_mutation() {
+async fn lost_resource_update_response_recovers_within_one_update() {
     let directory = tempfile::tempdir().expect("temporary directory");
     let service = Arc::new(FakeRuntimeService::launch_ready());
     service
         .fail_update_after_effect
         .store(true, Ordering::SeqCst);
     let provider = Arc::new(FakeBundleProvider::default());
-    let endpoint = test_endpoint();
     let create_operation = box_operation("lost-update-create");
-    let first = manager(
-        &directory,
-        endpoint.clone(),
-        service.clone(),
-        provider.clone(),
-    );
-    let lease = first
+    let manager = manager(&directory, test_endpoint(), service.clone(), provider);
+    let lease = manager
         .create_and_start(
             request("lost-update", ExecutionIsolation::Sandbox),
             &create_operation,
@@ -4732,52 +4726,95 @@ async fn lost_resource_update_response_recovers_with_the_same_runtime_mutation()
         pids_limit: Some(72),
         ..Default::default()
     };
+    let operation = box_operation("lost-update-live");
 
-    first
+    let recovered = manager
         .update_resources(
             &lease.execution_id,
             lease.generation,
-            &box_operation("lost-update-live"),
+            &operation,
             update.clone(),
         )
         .await
-        .expect_err("first response is lost");
-    let claimed = persisted(&first, &lease.execution_id);
-    assert_eq!(
-        claimed.status,
-        ManagedExecutionState::UpdatingResources.as_status()
-    );
-    assert_eq!(service.update_effects().len(), 1);
-    let conflict = first
-        .update_resources(
-            &lease.execution_id,
-            lease.generation,
-            &box_operation("lost-update-live"),
-            ExecutionResourceUpdate {
-                pids_limit: Some(73),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect_err("pending operation identity cannot change content");
-    assert!(matches!(conflict, ExecutionManagerError::Conflict { .. }));
-    assert_eq!(service.update_requests().len(), 1);
-
-    let reopened = manager(&directory, endpoint, service.clone(), provider);
-    let outcome = reopened
-        .reconcile(&create_operation)
-        .await
-        .expect("resource update recovery");
-    assert!(matches!(outcome, ReconcileOutcome::Ready(_)));
-    let recovered = persisted(&reopened, &lease.execution_id);
-    assert_eq!(recovered.status, ManagedExecutionState::Running.as_status());
-    assert_eq!(recovered.resource_limits.pids_limit, Some(72));
+        .expect("inner Unavailable retry recovers resource update");
+    assert_eq!(recovered.generation, lease.generation);
+    let persisted = persisted(&manager, &lease.execution_id);
+    assert_eq!(persisted.status, ManagedExecutionState::Running.as_status());
+    assert_eq!(persisted.resource_limits.pids_limit, Some(72));
     assert_eq!(service.update_requests().len(), 2);
     assert_eq!(service.update_effects().len(), 1);
     assert_eq!(
         service.update_requests()[0].context.operation_id,
         service.update_requests()[1].context.operation_id
     );
+
+    let conflict = manager
+        .update_resources(
+            &lease.execution_id,
+            lease.generation,
+            &operation,
+            ExecutionResourceUpdate {
+                pids_limit: Some(73),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("completed operation identity cannot change content");
+    assert!(matches!(conflict, ExecutionManagerError::Conflict { .. }));
+    assert_eq!(service.update_requests().len(), 2);
+}
+
+#[tokio::test]
+async fn interrupted_resource_update_claim_replays_after_backend_reopen() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let service = Arc::new(FakeRuntimeService::launch_ready());
+    let provider = Arc::new(FakeBundleProvider::default());
+    let endpoint = test_endpoint();
+    let create_operation = box_operation("interrupted-update-create");
+    let first = manager(
+        &directory,
+        endpoint.clone(),
+        service.clone(),
+        provider.clone(),
+    );
+    let lease = first
+        .create_and_start(
+            request("interrupted-update", ExecutionIsolation::Sandbox),
+            &create_operation,
+        )
+        .await
+        .expect("initial launch");
+    let record = persisted(&first, &lease.execution_id);
+    let update = ExecutionResourceUpdate {
+        pids_limit: Some(88),
+        ..Default::default()
+    };
+    first
+        .transition(
+            &record,
+            ManagedExecutionState::Running,
+            ManagedExecutionState::UpdatingResources,
+            RuntimeUpdate::ResourceUpdateClaim {
+                operation_id: box_operation("interrupted-update-live"),
+                update: update.clone(),
+            },
+        )
+        .await
+        .expect("persist resource update claim");
+    assert_eq!(service.update_requests().len(), 0);
+    drop(first);
+
+    let reopened = manager(&directory, endpoint, service.clone(), provider);
+    let outcome = reopened
+        .reconcile(&create_operation)
+        .await
+        .expect("resource update claim recovery");
+    assert!(matches!(outcome, ReconcileOutcome::Ready(_)));
+    let recovered = persisted(&reopened, &lease.execution_id);
+    assert_eq!(recovered.status, ManagedExecutionState::Running.as_status());
+    assert_eq!(recovered.resource_limits.pids_limit, Some(88));
+    assert_eq!(service.update_requests().len(), 1);
+    assert_eq!(service.update_effects().len(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Live OCI resource `update` retries once on retryable `Unavailable` with the **same** operation identity (parity with file/FS/exec/stdin).
- Crash recovery still replays a persisted `UpdatingResources` claim across manager reopen.
- Does **not** flip `b2_process_session_recovery_closed`, fixture continuity, or hosted-KVM claims.

## Test plan
- [x] `lost_resource_update_response_recovers_within_one_update`
- [x] `interrupted_resource_update_claim_replays_after_backend_reopen`
- [ ] Hosted CI green on this PR

Made with [Cursor](https://cursor.com)