### PR TITLE
feat(cli): mint cli-update-* request_id for container-update retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- CLI `container-update` accepts optional `--request-id` and mints a
+  `cli-update-*` identity when omitted. Managed OCI live Tier-2 updates use it
+  as the durable `operation_id` when minting a new update; legacy MicroVM live
+  updates pass it as the guest one-shot exec `request_id` so the guest replay
+  cache can reconcile lost responses. Unavailable / ambiguous transport errors
+  annotate `reuse --request-id <id>`. Pending or already-completed matching
+  managed updates keep their stored operation identity (no `{id}.retry-N`).
+  Does **not** flip B2 harness close, fixture continuity, or hosted-KVM claims.
+
 - CLI `cp` mutators that use one-shot guest `exec` (chmod restore, directory
   tar archive/extract) mint a `cli-cp-*` process-journal identity and annotate
   retryable Unavailable with that id (parity with `exec --request-id`). Does

--- a/src/cli/src/commands/container_update.rs
+++ b/src/cli/src/commands/container_update.rs
@@ -69,6 +69,13 @@ pub struct ContainerUpdateArgs {
     /// Restart policy: no, always, on-failure, unless-stopped
     #[arg(long)]
     pub restart: Option<String>,
+
+    /// Stable identity for live Tier-2 update retries after retryable
+    /// Unavailable. Omit to mint a `cli-update-*` id. Managed OCI routes use it
+    /// as the durable `operation_id` when minting a new update; legacy MicroVM
+    /// routes use it as the guest one-shot exec `request_id` (replay cache).
+    #[arg(long = "request-id")]
+    pub request_id: Option<String>,
 }
 
 pub async fn execute(args: ContainerUpdateArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -175,8 +182,11 @@ pub async fn execute(args: ContainerUpdateArgs) -> Result<(), Box<dyn std::error
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
 
     #[cfg(not(windows))]
+    let update_request_id = resolve_update_request_id(args.request_id.clone())
+        .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
+    #[cfg(not(windows))]
     let managed_live_update = if requires_live_apply && update.has_tier2_changes() {
-        managed::resolve(record, &update)
+        managed::resolve(record, &update, &update_request_id)
             .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?
     } else {
         None
@@ -222,7 +232,7 @@ pub async fn execute(args: ContainerUpdateArgs) -> Result<(), Box<dyn std::error
                     .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
                 managed_tier2_persisted = true;
             } else {
-                apply_legacy_live_tier2_update(&live_apply_record, &update)
+                apply_legacy_live_tier2_update(&live_apply_record, &update, &update_request_id)
                     .await
                     .map_err(|error| -> Box<dyn std::error::Error> { error.into() })?;
             }
@@ -290,9 +300,58 @@ pub async fn execute(args: ContainerUpdateArgs) -> Result<(), Box<dyn std::error
 }
 
 #[cfg(not(windows))]
+const MAX_UPDATE_REQUEST_ID_BYTES: usize = 512;
+
+#[cfg(not(windows))]
+fn mint_cli_update_request_id() -> String {
+    format!("cli-update-{}", uuid::Uuid::new_v4().simple())
+}
+
+#[cfg(not(windows))]
+fn validate_update_request_id(request_id: &str) -> Result<(), String> {
+    if request_id.is_empty()
+        || request_id.len() > MAX_UPDATE_REQUEST_ID_BYTES
+        || request_id.contains('\0')
+    {
+        return Err(
+            "update request_id must be a non-empty UTF-8 string of at most 512 bytes without NUL"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn resolve_update_request_id(request_id: Option<String>) -> Result<String, String> {
+    match request_id {
+        Some(request_id) => {
+            validate_update_request_id(&request_id)?;
+            Ok(request_id)
+        }
+        None => Ok(mint_cli_update_request_id()),
+    }
+}
+
+#[cfg(not(windows))]
+fn annotate_legacy_update_unavailable(message: String, request_id: &str) -> String {
+    let lower = message.to_ascii_lowercase();
+    let retryable = lower.contains("unavailable")
+        || lower.contains("closed without response")
+        || lower.contains("response timed out")
+        || lower.contains("response read failed")
+        || lower.contains("connection failed");
+    if retryable {
+        format!("{message} (reuse --request-id {request_id})")
+    } else {
+        message
+    }
+}
+
+#[cfg(not(windows))]
 async fn apply_legacy_live_tier2_update(
     record: &crate::state::BoxRecord,
     update: &ResourceUpdate,
+    request_id: &str,
 ) -> Result<(), String> {
     if record.isolation.is_sandbox() {
         let config = crate::boot::config_from_record(record)?;
@@ -329,9 +388,12 @@ async fn apply_legacy_live_tier2_update(
     let client = ExecClient::connect(&exec_socket_path)
         .await
         .map_err(|error| {
-            format!(
-                "failed to connect to {} for live update: {error}; no state changes were persisted",
-                record.name
+            annotate_legacy_update_unavailable(
+                format!(
+                    "failed to connect to {} for live update: {error}; no state changes were persisted",
+                    record.name
+                ),
+                request_id,
             )
         })?;
     let commands = update.build_microvm_cgroup_commands();
@@ -342,7 +404,7 @@ async fn apply_legacy_live_tier2_update(
         );
     }
     let request = ExecRequest {
-        request_id: None,
+        request_id: Some(request_id.to_string()),
         cmd: vec![
             "sh".to_string(),
             "-c".to_string(),
@@ -369,9 +431,12 @@ async fn apply_legacy_live_tier2_update(
                 stderr.trim()
             ))
         }
-        Err(error) => Err(format!(
-            "failed to apply live update to {}: {error}; no state changes were persisted",
-            record.name
+        Err(error) => Err(annotate_legacy_update_unavailable(
+            format!(
+                "failed to apply live update to {}: {error}; no state changes were persisted",
+                record.name
+            ),
+            request_id,
         )),
     }
 }
@@ -739,24 +804,75 @@ mod tests {
         assert!(error.contains("stop the box"));
     }
 
-    #[cfg(windows)]
+    #[cfg(not(windows))]
     #[test]
-    fn windows_update_rejects_persisted_effective_health_check() {
-        let mut record = crate::test_helpers::fixtures::make_record(
-            "health-update-id",
-            "health-update",
-            "stopped",
-            None,
+    fn resolve_update_request_id_mints_cli_prefix_when_omitted() {
+        let minted = resolve_update_request_id(None).expect("mint");
+        assert!(
+            minted.starts_with("cli-update-"),
+            "unexpected request_id: {minted}"
         );
-        record.health_check = Some(crate::state::HealthCheck {
-            cmd: vec!["true".to_string()],
-            interval_secs: 30,
-            timeout_secs: 5,
-            retries: 3,
-            start_period_secs: 0,
-        });
+        assert!(validate_update_request_id(&minted).is_ok());
+    }
 
-        let error = sync_managed_creation_intent(&mut record, false).unwrap_err();
-        assert!(error.contains("health checks are not supported on Windows"));
+    #[cfg(not(windows))]
+    #[test]
+    fn resolve_update_request_id_rejects_invalid_ids() {
+        assert!(resolve_update_request_id(Some(String::new())).is_err());
+        assert!(resolve_update_request_id(Some("bad\0id".to_string())).is_err());
+        assert!(resolve_update_request_id(Some("x".repeat(513))).is_err());
+        assert_eq!(
+            resolve_update_request_id(Some("caller-stable-update-1".to_string())).as_deref(),
+            Ok("caller-stable-update-1")
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn annotate_legacy_update_unavailable_surfaces_request_id() {
+        let annotated = annotate_legacy_update_unavailable(
+            "failed to apply live update: Exec server closed without response".to_string(),
+            "cli-update-abc",
+        );
+        assert!(
+            annotated.contains("reuse --request-id cli-update-abc"),
+            "{annotated}"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn annotate_legacy_update_non_retryable_keeps_message() {
+        let annotated = annotate_legacy_update_unavailable(
+            "live cgroup update failed for demo (exit 1): boom".to_string(),
+            "cli-update-abc",
+        );
+        assert!(!annotated.contains("reuse --request-id"), "{annotated}");
+    }
+
+    #[test]
+    fn clap_parses_request_id_for_container_update() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        #[command(name = "container-update")]
+        struct UpdateCli {
+            #[command(flatten)]
+            update: ContainerUpdateArgs,
+        }
+
+        let cli = UpdateCli::try_parse_from([
+            "container-update",
+            "demo",
+            "--cpu-shares",
+            "512",
+            "--request-id",
+            "caller-stable-update-1",
+        ])
+        .expect("parse");
+        assert_eq!(
+            cli.update.request_id.as_deref(),
+            Some("caller-stable-update-1")
+        );
     }
 }

--- a/src/cli/src/commands/container_update/managed.rs
+++ b/src/cli/src/commands/container_update/managed.rs
@@ -17,9 +17,14 @@ pub(super) struct ManagedLiveUpdate {
 
 /// Select the canonical managed path without allowing an OCI record to fall
 /// back to a compatibility socket after an unavailable or interrupted call.
+///
+/// `operation_seed` is the caller-stable identity used only when minting a
+/// **new** update operation. Pending and completed matching updates keep their
+/// durable `operation_id` (do not invent `{id}.retry-N`).
 pub(super) fn resolve(
     record: &crate::state::BoxRecord,
     update: &ResourceUpdate,
+    operation_seed: &str,
 ) -> Result<Option<ManagedLiveUpdate>, String> {
     let Some(metadata) = record
         .managed_execution
@@ -40,8 +45,7 @@ pub(super) fn resolve(
             }) {
                 completed.operation_id.clone()
             } else {
-                OperationId::new(format!("cli-update-{}", uuid::Uuid::new_v4()))
-                    .map_err(|error| error.to_string())?
+                OperationId::new(operation_seed.to_string()).map_err(|error| error.to_string())?
             }
         }
         ManagedExecutionState::UpdatingResources => match metadata.pending_operation.as_ref() {
@@ -107,11 +111,21 @@ pub(super) async fn apply(
         .await
         .map(|_| ())
         .map_err(|error| {
-            format!(
+            let message = format!(
                 "failed to apply managed live resource update to {}: {error}; no CLI policy changes were persisted and the exact-generation operation can be retried safely",
                 target.box_name
-            )
+            );
+            annotate_update_unavailable(message, target.operation_id.as_str())
         })
+}
+
+fn annotate_update_unavailable(message: String, request_id: &str) -> String {
+    let unavailable = message.to_ascii_lowercase().contains("unavailable");
+    if unavailable {
+        format!("{message} (reuse --request-id {request_id})")
+    } else {
+        message
+    }
 }
 
 #[cfg(test)]
@@ -242,18 +256,22 @@ mod tests {
     #[test]
     fn persisted_oci_route_selects_exact_generation_managed_update() {
         let record = managed_oci_record(ManagedExecutionState::Running);
-        let target = resolve(&record, &cpu_share_update(512)).unwrap().unwrap();
+        let target = resolve(&record, &cpu_share_update(512), "cli-update-seed-1")
+            .unwrap()
+            .unwrap();
 
         assert_eq!(target.execution_id.as_str(), record.id);
         assert_eq!(target.generation, ExecutionGeneration::new(7).unwrap());
         assert_eq!(target.update.cpu_shares, Some(512));
-        assert!(target.operation_id.as_str().starts_with("cli-update-"));
+        assert_eq!(target.operation_id.as_str(), "cli-update-seed-1");
     }
 
     #[tokio::test]
     async fn managed_update_dispatches_exact_identity_and_partial_intent() {
         let record = managed_oci_record(ManagedExecutionState::Running);
-        let target = resolve(&record, &cpu_share_update(512)).unwrap().unwrap();
+        let target = resolve(&record, &cpu_share_update(512), "cli-update-seed-2")
+            .unwrap()
+            .unwrap();
         let metadata = record.managed_execution.as_ref().unwrap();
         let manager = RecordingExecutionManager {
             call: std::sync::Mutex::new(None),
@@ -284,7 +302,11 @@ mod tests {
             None,
         );
 
-        assert!(resolve(&record, &cpu_share_update(512)).unwrap().is_none());
+        assert!(
+            resolve(&record, &cpu_share_update(512), "cli-update-unused")
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -298,7 +320,9 @@ mod tests {
                 update: pending_update.clone(),
             });
 
-        let target = resolve(&record, &cpu_share_update(1024)).unwrap().unwrap();
+        let target = resolve(&record, &cpu_share_update(1024), "cli-update-ignored-seed")
+            .unwrap()
+            .unwrap();
 
         assert_eq!(target.operation_id, pending_id);
         assert_eq!(target.update, pending_update);
@@ -313,7 +337,7 @@ mod tests {
                 update: to_execution_resource_update(&cpu_share_update(512)),
             });
 
-        let error = resolve(&record, &cpu_share_update(1024)).unwrap_err();
+        let error = resolve(&record, &cpu_share_update(1024), "cli-update-unused").unwrap_err();
 
         assert!(error.contains("different live resource update in progress"));
         assert!(error.contains("retry that update"));
@@ -334,7 +358,9 @@ mod tests {
             update: completed_update,
         });
 
-        let target = resolve(&record, &cpu_share_update(2048)).unwrap().unwrap();
+        let target = resolve(&record, &cpu_share_update(2048), "cli-update-ignored-seed")
+            .unwrap()
+            .unwrap();
 
         assert_eq!(target.operation_id, completed_id);
     }
@@ -353,10 +379,12 @@ mod tests {
             update: to_execution_resource_update(&cpu_share_update(2048)),
         });
 
-        let target = resolve(&record, &cpu_share_update(2048)).unwrap().unwrap();
+        let target = resolve(&record, &cpu_share_update(2048), "cli-update-fresh-seed")
+            .unwrap()
+            .unwrap();
 
         assert_ne!(target.operation_id, completed_id);
-        assert!(target.operation_id.as_str().starts_with("cli-update-"));
+        assert_eq!(target.operation_id.as_str(), "cli-update-fresh-seed");
     }
 
     #[test]
@@ -393,9 +421,28 @@ mod tests {
     fn paused_managed_update_does_not_fall_back_to_legacy_transport() {
         let record = managed_oci_record(ManagedExecutionState::Paused);
 
-        let error = resolve(&record, &cpu_share_update(512)).unwrap_err();
+        let error = resolve(&record, &cpu_share_update(512), "cli-update-unused").unwrap_err();
 
         assert!(error.contains("while it is paused"));
         assert!(error.contains("retry"));
+    }
+
+    #[test]
+    fn annotate_update_unavailable_surfaces_request_id() {
+        let annotated = annotate_update_unavailable(
+            "failed: Unavailable(response lost)".to_string(),
+            "cli-update-abc",
+        );
+        assert!(
+            annotated.contains("reuse --request-id cli-update-abc"),
+            "{annotated}"
+        );
+    }
+
+    #[test]
+    fn annotate_update_non_unavailable_keeps_message() {
+        let annotated =
+            annotate_update_unavailable("failed: invalid limits".to_string(), "cli-update-abc");
+        assert!(!annotated.contains("reuse --request-id"), "{annotated}");
     }
 }


### PR DESCRIPTION
## Summary
- `container-update` accepts optional `--request-id` and mints `cli-update-*` when omitted.
- Managed OCI live Tier-2 updates use that seed as the durable `operation_id` when minting a **new** update; pending/completed matching updates keep their stored identity (no `{id}.retry-N`).
- Legacy MicroVM live updates pass it as the guest one-shot exec `request_id` so the guest replay cache can reconcile lost responses; Unavailable / ambiguous transport errors annotate `reuse --request-id <id>`.
- Does **not** flip `b2_process_session_recovery_closed`, fixture continuity, or hosted-KVM claims.

## Test plan
- [x] `cargo test -p a3s-box-cli --lib commands::container_update` on Windows (clap + shared tests)
- [x] Same filter under WSL (27 tests including managed resolve/annotate + mint helpers)
- [ ] Hosted CI Format/Clippy/Test/Sandbox green
