### PR TITLE
feat(cri): mint cri-exec-* request_id for ExecSync guest replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Added
 
+- CRI `ExecSync` and non-interactive streaming oneshot mint a `cri-exec-*`
+  guest one-shot identity and retry once on ambiguous transport loss with the
+  **same** id (guest replay cache). Streaming / SPDY / stdin sessions stay
+  unkeyed. Does **not** invent a kubelet-stable CRI wire field, flip B2 harness
+  close, fixture continuity, or hosted-KVM claims.
+
 - Warm-pool **lease** exec accepts optional `request_id` and mints a
   `cli-pool-*` guest one-shot identity when omitted, so retries on the **same
   lease VM** can reuse the guest replay cache. Ambiguous transport errors

--- a/src/cri/src/exec_request_id.rs
+++ b/src/cri/src/exec_request_id.rs
@@ -1,0 +1,152 @@
+//! Guest one-shot exec identity for CRI non-streaming paths.
+//!
+//! The guest journals keyed one-shot exec before the response write. CRI
+//! `ExecSync` and non-interactive streaming oneshot keep the sandbox VM alive,
+//! so minting a `cri-exec-*` id and retrying once on ambiguous transport loss
+//! reuses that journal instead of re-running the command. Streaming / SPDY /
+//! stdin sessions stay unkeyed (guest rejects `request_id` on streaming).
+
+use a3s_box_core::error::{BoxError, Result};
+use a3s_box_core::exec::{ExecOutput, ExecRequest};
+
+/// Mint a durable process-journal identity for one CRI one-shot exec.
+pub fn mint_cri_exec_request_id() -> String {
+    format!("cri-exec-{}", uuid::Uuid::new_v4().simple())
+}
+
+/// True when the failure may have occurred after the guest already claimed or
+/// completed the keyed exec (lost response / broken connection).
+pub fn is_ambiguous_exec_transport(error: &BoxError) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("unavailable")
+        || message.contains("closed without response")
+        || message.contains("response timed out")
+        || message.contains("response read failed")
+        || message.contains("connection failed")
+}
+
+/// Run a keyed one-shot exec once, and retry once with the **same**
+/// `request_id` after an ambiguous transport failure.
+pub async fn exec_with_guest_replay_retry<F, Fut>(
+    request: ExecRequest,
+    mut exec: F,
+) -> Result<ExecOutput>
+where
+    F: FnMut(ExecRequest) -> Fut,
+    Fut: std::future::Future<Output = Result<ExecOutput>>,
+{
+    let can_replay = request.request_id.is_some();
+    match exec(request.clone()).await {
+        Ok(output) => Ok(output),
+        Err(error) if can_replay && is_ambiguous_exec_transport(&error) => exec(request).await,
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn mint_cri_exec_request_id_uses_stable_prefix() {
+        let minted = mint_cri_exec_request_id();
+        assert!(minted.starts_with("cri-exec-"), "{minted}");
+        assert!(!minted.contains('\0'));
+        assert!(minted.len() <= 512);
+    }
+
+    #[test]
+    fn ambiguous_transport_detects_lost_response_and_connection() {
+        assert!(is_ambiguous_exec_transport(&BoxError::ExecError(
+            "Exec server closed without response".to_string()
+        )));
+        assert!(is_ambiguous_exec_transport(&BoxError::ExecError(
+            "Exec response timed out after 15s".to_string()
+        )));
+        assert!(is_ambiguous_exec_transport(&BoxError::ExecError(
+            "Exec connection failed to /tmp/x".to_string()
+        )));
+        assert!(!is_ambiguous_exec_transport(&BoxError::ExecError(
+            "command rejected by guest policy".to_string()
+        )));
+    }
+
+    #[tokio::test]
+    async fn guest_replay_retry_reuses_same_request_once() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+        let request = ExecRequest {
+            request_id: Some("cri-exec-stable-1".to_string()),
+            cmd: vec!["true".to_string()],
+            timeout_ns: 1_000_000_000,
+            env: vec![],
+            working_dir: None,
+            rootfs: None,
+            stdin: None,
+            stdin_streaming: false,
+            user: None,
+            streaming: false,
+        };
+
+        let output = exec_with_guest_replay_retry(request, move |req| {
+            let attempts = attempts_clone.clone();
+            async move {
+                assert_eq!(req.request_id.as_deref(), Some("cri-exec-stable-1"));
+                let n = attempts.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    Err(BoxError::ExecError(
+                        "Exec server closed without response".to_string(),
+                    ))
+                } else {
+                    Ok(ExecOutput {
+                        stdout: b"ok".to_vec(),
+                        stderr: Vec::new(),
+                        exit_code: 0,
+                        truncated: false,
+                    })
+                }
+            }
+        })
+        .await
+        .expect("retry recovers");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, b"ok");
+    }
+
+    #[tokio::test]
+    async fn guest_replay_retry_skips_non_ambiguous_errors() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+        let request = ExecRequest {
+            request_id: Some("cri-exec-stable-2".to_string()),
+            cmd: vec!["true".to_string()],
+            timeout_ns: 1_000_000_000,
+            env: vec![],
+            working_dir: None,
+            rootfs: None,
+            stdin: None,
+            stdin_streaming: false,
+            user: None,
+            streaming: false,
+        };
+
+        let error = exec_with_guest_replay_retry(request, move |_| {
+            let attempts = attempts_clone.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(BoxError::ExecError(
+                    "command rejected by guest policy".to_string(),
+                ))
+            }
+        })
+        .await
+        .expect_err("non-ambiguous must not retry");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert!(error.to_string().contains("guest policy"));
+    }
+}

--- a/src/cri/src/lib.rs
+++ b/src/cri/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod config_mapper;
 pub mod container;
 pub mod error;
+pub mod exec_request_id;
 pub mod image_service;
 pub mod persistent_store;
 pub mod runtime_service;

--- a/src/cri/src/runtime_service/mod.rs
+++ b/src/cri/src/runtime_service/mod.rs
@@ -2300,7 +2300,10 @@ impl RuntimeService for BoxRuntimeService {
         };
 
         let exec_request = a3s_box_core::exec::ExecRequest {
-            request_id: None,
+            // Mint once per ExecSync RPC. Guest journals this before response
+            // write; one in-call retry reuses the journal. Do not invent a
+            // kubelet-stable CRI wire field (cross-RPC retries mint a new id).
+            request_id: Some(crate::exec_request_id::mint_cri_exec_request_id()),
             cmd: req.cmd,
             timeout_ns,
             // Inherit the container's security envelope (A3S_SEC_*, e.g.
@@ -2325,10 +2328,16 @@ impl RuntimeService for BoxRuntimeService {
             user: container.user.clone(),
             streaming: false,
         };
-        let output = vm
-            .exec_request(&exec_request)
-            .await
-            .map_err(box_error_to_status)?;
+        let output = match vm.exec_request(&exec_request).await {
+            Ok(output) => output,
+            Err(error) if crate::exec_request_id::is_ambiguous_exec_transport(&error) => {
+                // Same request_id: guest replay cache reconciles a lost response.
+                vm.exec_request(&exec_request)
+                    .await
+                    .map_err(box_error_to_status)?
+            }
+            Err(error) => return Err(box_error_to_status(error)),
+        };
 
         Ok(Response::new(ExecSyncResponse {
             stdout: output.stdout,

--- a/src/cri/src/streaming.rs
+++ b/src/cri/src/streaming.rs
@@ -363,7 +363,9 @@ async fn handle_exec_oneshot(
     }
 
     let exec_req = a3s_box_core::exec::ExecRequest {
-        request_id: None,
+        // Non-interactive oneshot keeps the sandbox VM; key the guest replay
+        // cache. Stdin/streaming paths stay unkeyed (guest rejects request_id).
+        request_id: Some(crate::exec_request_id::mint_cri_exec_request_id()),
         cmd: session.cmd.clone(),
         timeout_ns: a3s_box_core::exec::DEFAULT_EXEC_TIMEOUT_NS,
         env: vec![],
@@ -376,7 +378,13 @@ async fn handle_exec_oneshot(
     };
 
     let client = a3s_box_runtime::ExecClient::connect(Path::new(&session.exec_socket_path)).await?;
-    let output = client.exec_command(&exec_req).await?;
+    let output = match client.exec_command(&exec_req).await {
+        Ok(output) => output,
+        Err(error) if crate::exec_request_id::is_ambiguous_exec_transport(&error) => {
+            client.exec_command(&exec_req).await?
+        }
+        Err(error) => return Err(error.into()),
+    };
 
     // Send HTTP 200 with output
     let response_body = format!(


### PR DESCRIPTION
## Summary
- CRI `ExecSync` and non-interactive streaming oneshot mint `cri-exec-*` and retry once on ambiguous transport loss with the **same** id (guest replay cache).
- Streaming / SPDY / stdin sessions stay unkeyed (guest rejects `request_id` on streaming).
- Does **not** invent a kubelet-stable CRI wire field, flip B2, fixture continuity, or hosted-KVM claims.

## Test plan
- [x] WSL: `cargo test -p a3s-box-cri --lib exec_request_id` (4 tests)
- [x] WSL: `cargo test -p a3s-box-cri --lib test_exec_sync_`
- [ ] Hosted CI Format/Clippy/Test/Sandbox green
