### PR TITLE
fix(runtime): keyed MicroVM exec in-call replay on lost responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- MicroVM guest one-shot `exec_request` retries once on ambiguous transport
+  loss when a non-empty `request_id` is present (guest replay cache). Convenience
+  `exec_command` mints `vm-exec-*`; live MicroVM cgroup resource updates mint
+  `vm-cgroup-*` per command. Does **not** add pause/resume Runtime journals or
+  naive freezer replay (inspect/reconcile remains the recovery path), flip B2
+  harness close, fixture continuity, or hosted-KVM claims.
+
 ### Added
 
 - CRI `ExecSync` and non-interactive streaming oneshot mint a `cri-exec-*`

--- a/src/runtime/src/vm/execution.rs
+++ b/src/runtime/src/vm/execution.rs
@@ -2,6 +2,31 @@
 
 use super::*;
 
+#[cfg(unix)]
+/// True when the failure may have occurred after the guest already claimed or
+/// completed a keyed one-shot exec (lost response / broken connection).
+pub(crate) fn is_ambiguous_guest_exec_transport(error: &BoxError) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("unavailable")
+        || message.contains("closed without response")
+        || message.contains("response timed out")
+        || message.contains("response read failed")
+        || message.contains("connection failed")
+}
+
+#[cfg(unix)]
+/// Keyed one-shot exec can replay the guest journal with the same `request_id`.
+pub(crate) fn should_retry_keyed_guest_exec(
+    request: &a3s_box_core::exec::ExecRequest,
+    error: &BoxError,
+) -> bool {
+    request
+        .request_id
+        .as_ref()
+        .is_some_and(|request_id| !request_id.is_empty())
+        && is_ambiguous_guest_exec_transport(error)
+}
+
 impl VmManager {
     /// Get the exec client, if connected.
     #[cfg(unix)]
@@ -509,7 +534,13 @@ impl VmManager {
         };
 
         let exec_start = std::time::Instant::now();
-        let result = client.exec_command(request).await;
+        let mut result = client.exec_command(request).await;
+        if let Err(ref error) = result {
+            if should_retry_keyed_guest_exec(request, error) {
+                // Same request_id: guest replay cache reconciles a lost response.
+                result = client.exec_command(request).await;
+            }
+        }
 
         // Record Prometheus metrics
         if let Some(ref prom) = self.prom {
@@ -527,6 +558,9 @@ impl VmManager {
     /// Execute a command in the guest VM.
     ///
     /// Requires the VM to be in Ready, Busy, or Compacting state.
+    /// Mints a `vm-exec-*` request_id so a lost response can replay the guest
+    /// journal inside this call. Callers that need a stable outer identity
+    /// should use [`Self::exec_request`] with their own id.
     #[cfg(unix)]
     #[tracing::instrument(skip(self, cmd), fields(box_id = %self.box_id))]
     pub async fn exec_command(
@@ -535,7 +569,7 @@ impl VmManager {
         timeout_ns: u64,
     ) -> Result<a3s_box_core::exec::ExecOutput> {
         let request = a3s_box_core::exec::ExecRequest {
-            request_id: None,
+            request_id: Some(format!("vm-exec-{}", uuid::Uuid::new_v4().simple())),
             cmd,
             timeout_ns,
             env: vec![],
@@ -548,5 +582,58 @@ impl VmManager {
         };
 
         self.exec_request(&request).await
+    }
+}
+
+#[cfg(all(test, unix))]
+mod keyed_exec_tests {
+    use super::*;
+
+    #[test]
+    fn ambiguous_transport_detects_lost_response_paths() {
+        assert!(is_ambiguous_guest_exec_transport(&BoxError::ExecError(
+            "Exec server closed without response".to_string()
+        )));
+        assert!(is_ambiguous_guest_exec_transport(&BoxError::ExecError(
+            "Exec response timed out after 15s".to_string()
+        )));
+        assert!(is_ambiguous_guest_exec_transport(&BoxError::ExecError(
+            "Exec connection failed to /tmp/x".to_string()
+        )));
+        assert!(!is_ambiguous_guest_exec_transport(&BoxError::ExecError(
+            "command rejected by guest policy".to_string()
+        )));
+    }
+
+    #[test]
+    fn keyed_retry_requires_non_empty_request_id() {
+        let keyed = a3s_box_core::exec::ExecRequest {
+            request_id: Some("vm-exec-abc".to_string()),
+            cmd: vec!["true".to_string()],
+            timeout_ns: 1,
+            env: vec![],
+            working_dir: None,
+            rootfs: None,
+            stdin: None,
+            stdin_streaming: false,
+            user: None,
+            streaming: false,
+        };
+        let unkeyed = a3s_box_core::exec::ExecRequest {
+            request_id: None,
+            ..keyed.clone()
+        };
+        let empty = a3s_box_core::exec::ExecRequest {
+            request_id: Some(String::new()),
+            ..keyed.clone()
+        };
+        let lost = BoxError::ExecError("Exec server closed without response".to_string());
+        assert!(should_retry_keyed_guest_exec(&keyed, &lost));
+        assert!(!should_retry_keyed_guest_exec(&unkeyed, &lost));
+        assert!(!should_retry_keyed_guest_exec(&empty, &lost));
+        assert!(!should_retry_keyed_guest_exec(
+            &keyed,
+            &BoxError::ExecError("policy denied".to_string())
+        ));
     }
 }

--- a/src/runtime/src/vm/lifecycle.rs
+++ b/src/runtime/src/vm/lifecycle.rs
@@ -817,8 +817,22 @@ impl VmManager {
         let commands = update.build_microvm_cgroup_commands();
         for cmd_str in &commands {
             let shell_cmd = vec!["sh".to_string(), "-c".to_string(), cmd_str.clone()];
+            let request = a3s_box_core::exec::ExecRequest {
+                // Same live guest: key the journal so a lost response can replay
+                // instead of double-applying the cgroup write.
+                request_id: Some(format!("vm-cgroup-{}", uuid::Uuid::new_v4().simple())),
+                cmd: shell_cmd,
+                timeout_ns: 5_000_000_000,
+                env: vec![],
+                working_dir: None,
+                rootfs: None,
+                stdin: None,
+                stdin_streaming: false,
+                user: None,
+                streaming: false,
+            };
 
-            match self.exec_command(shell_cmd, 5_000_000_000).await {
+            match self.exec_request(&request).await {
                 Ok(output) if output.exit_code == 0 => {
                     result.applied.push(cmd_str.clone());
                 }


### PR DESCRIPTION
## Summary
- MicroVM `exec_request` retries once on ambiguous transport when a non-empty `request_id` is set (guest replay cache).
- `exec_command` mints `vm-exec-*`; live MicroVM cgroup resource updates mint `vm-cgroup-*` per command.
- Explicitly does **not** add pause/resume Runtime journals / naive freezer replay (inspect/reconcile remains the path), flip B2, fixture continuity, or hosted-KVM claims.

## Test plan
- [x] WSL: `cargo test -p a3s-box-runtime --lib keyed_exec_tests`
- [x] WSL: `test_exec_command_*` / `test_exec_request_*`
- [ ] Hosted CI Format/Clippy/Test/Sandbox green
