### PR TITLE
fix(runtime): ExecClient keyed one-shot replay on ambiguous transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- `ExecClient::exec_command` retries once on ambiguous guest transport loss when
+  a non-empty `request_id` is present (fresh stream + guest replay cache). This
+  covers legacy MicroVM CLI/SDK socket callers that mint identity but previously
+  had no in-call replay. `VmManager::exec_request` relies on the client (no
+  double retry). Managed session `exec_command_on_stream` still rebinds itself.
+  Omit-path stays unkeyed. Does **not** flip B2 harness close, fixture
+  continuity, or hosted-KVM claims.
+
 - Managed MicroVM `ExecutionSessionManager::execute` retries once on ambiguous
   guest transport loss when a non-empty `request_id` is already present, after
   rebinding the exec stream (parity with `VmManager::exec_request`). Omit-path

--- a/src/runtime/src/grpc/exec.rs
+++ b/src/runtime/src/grpc/exec.rs
@@ -85,6 +85,29 @@ async fn connect_exec_stream(path: &Path) -> std::io::Result<ExecStream> {
     }
 }
 
+/// True when the failure may have occurred after the guest already claimed or
+/// completed a keyed one-shot exec (lost response / broken connection).
+pub(crate) fn is_ambiguous_guest_exec_transport(error: &BoxError) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("unavailable")
+        || message.contains("closed without response")
+        || message.contains("response timed out")
+        || message.contains("response read failed")
+        || message.contains("connection failed")
+}
+
+/// Keyed one-shot exec can replay the guest journal with the same `request_id`.
+pub(crate) fn should_retry_keyed_guest_exec(
+    request: &a3s_box_core::exec::ExecRequest,
+    error: &BoxError,
+) -> bool {
+    request
+        .request_id
+        .as_ref()
+        .is_some_and(|request_id| !request_id.is_empty())
+        && is_ambiguous_guest_exec_transport(error)
+}
+
 /// Client for executing commands through the platform-local guest channel.
 ///
 /// Uses the Frame wire protocol: sends a Data frame with JSON ExecRequest,
@@ -128,12 +151,21 @@ impl ExecClient {
     /// Execute a command in the guest.
     ///
     /// Sends a Data frame with JSON ExecRequest, reads a Data frame with JSON ExecOutput.
+    /// When `request_id` is non-empty, retries once on ambiguous transport loss
+    /// with a fresh stream so the guest replay cache can reconcile a lost reply.
     pub async fn exec_command(
         &self,
         request: &a3s_box_core::exec::ExecRequest,
     ) -> Result<a3s_box_core::exec::ExecOutput> {
         let stream = self.open_stream().await?;
-        self.exec_command_on_stream(stream, request).await
+        match self.exec_command_on_stream(stream, request).await {
+            Ok(output) => Ok(output),
+            Err(error) if should_retry_keyed_guest_exec(request, &error) => {
+                let stream = self.open_stream().await?;
+                self.exec_command_on_stream(stream, request).await
+            }
+            Err(error) => Err(error),
+        }
     }
 
     pub(crate) async fn exec_command_on_stream(
@@ -1651,5 +1683,58 @@ mod windows_tests {
         assert_eq!(output.stdout, b"windows\n");
         assert_eq!(output.exit_code, 0);
         server.await.expect("server task joins");
+    }
+}
+
+#[cfg(test)]
+mod keyed_exec_tests {
+    use super::*;
+
+    #[test]
+    fn ambiguous_transport_detects_lost_response_paths() {
+        assert!(is_ambiguous_guest_exec_transport(&BoxError::ExecError(
+            "Exec server closed without response".to_string()
+        )));
+        assert!(is_ambiguous_guest_exec_transport(&BoxError::ExecError(
+            "Exec response timed out after 15s".to_string()
+        )));
+        assert!(is_ambiguous_guest_exec_transport(&BoxError::ExecError(
+            "Exec connection failed to /tmp/x".to_string()
+        )));
+        assert!(!is_ambiguous_guest_exec_transport(&BoxError::ExecError(
+            "command rejected by guest policy".to_string()
+        )));
+    }
+
+    #[test]
+    fn keyed_retry_requires_non_empty_request_id() {
+        let keyed = a3s_box_core::exec::ExecRequest {
+            request_id: Some("cli-exec-abc".to_string()),
+            cmd: vec!["true".to_string()],
+            timeout_ns: 1,
+            env: vec![],
+            working_dir: None,
+            rootfs: None,
+            stdin: None,
+            stdin_streaming: false,
+            user: None,
+            streaming: false,
+        };
+        let unkeyed = a3s_box_core::exec::ExecRequest {
+            request_id: None,
+            ..keyed.clone()
+        };
+        let empty = a3s_box_core::exec::ExecRequest {
+            request_id: Some(String::new()),
+            ..keyed.clone()
+        };
+        let lost = BoxError::ExecError("Exec server closed without response".to_string());
+        assert!(should_retry_keyed_guest_exec(&keyed, &lost));
+        assert!(!should_retry_keyed_guest_exec(&unkeyed, &lost));
+        assert!(!should_retry_keyed_guest_exec(&empty, &lost));
+        assert!(!should_retry_keyed_guest_exec(
+            &keyed,
+            &BoxError::ExecError("policy denied".to_string())
+        ));
     }
 }

--- a/src/runtime/src/grpc/mod.rs
+++ b/src/runtime/src/grpc/mod.rs
@@ -16,5 +16,6 @@ pub use attestation::{
     SecretInjectionResult, SecretInjector, UnsealResult,
 };
 pub use exec::{ExecClient, StreamingExec, StreamingExecInput};
+pub(crate) use exec::should_retry_keyed_guest_exec;
 #[cfg(unix)]
 pub use pty::{PtyClient, StreamingPty, StreamingPtyInput};

--- a/src/runtime/src/grpc/mod.rs
+++ b/src/runtime/src/grpc/mod.rs
@@ -15,7 +15,7 @@ pub use attestation::{
     AttestationClient, RaTlsAttestationClient, SealClient, SealResult, SecretEntry,
     SecretInjectionResult, SecretInjector, UnsealResult,
 };
-pub use exec::{ExecClient, StreamingExec, StreamingExecInput};
 pub(crate) use exec::should_retry_keyed_guest_exec;
+pub use exec::{ExecClient, StreamingExec, StreamingExecInput};
 #[cfg(unix)]
 pub use pty::{PtyClient, StreamingPty, StreamingPtyInput};

--- a/src/runtime/src/vm/execution.rs
+++ b/src/runtime/src/vm/execution.rs
@@ -2,31 +2,6 @@
 
 use super::*;
 
-#[cfg(unix)]
-/// True when the failure may have occurred after the guest already claimed or
-/// completed a keyed one-shot exec (lost response / broken connection).
-pub(crate) fn is_ambiguous_guest_exec_transport(error: &BoxError) -> bool {
-    let message = error.to_string().to_ascii_lowercase();
-    message.contains("unavailable")
-        || message.contains("closed without response")
-        || message.contains("response timed out")
-        || message.contains("response read failed")
-        || message.contains("connection failed")
-}
-
-#[cfg(unix)]
-/// Keyed one-shot exec can replay the guest journal with the same `request_id`.
-pub(crate) fn should_retry_keyed_guest_exec(
-    request: &a3s_box_core::exec::ExecRequest,
-    error: &BoxError,
-) -> bool {
-    request
-        .request_id
-        .as_ref()
-        .is_some_and(|request_id| !request_id.is_empty())
-        && is_ambiguous_guest_exec_transport(error)
-}
-
 impl VmManager {
     /// Get the exec client, if connected.
     #[cfg(unix)]
@@ -534,13 +509,8 @@ impl VmManager {
         };
 
         let exec_start = std::time::Instant::now();
-        let mut result = client.exec_command(request).await;
-        if let Err(ref error) = result {
-            if should_retry_keyed_guest_exec(request, error) {
-                // Same request_id: guest replay cache reconciles a lost response.
-                result = client.exec_command(request).await;
-            }
-        }
+        // ExecClient::exec_command owns keyed in-call replay on ambiguous transport.
+        let result = client.exec_command(request).await;
 
         // Record Prometheus metrics
         if let Some(ref prom) = self.prom {
@@ -582,58 +552,5 @@ impl VmManager {
         };
 
         self.exec_request(&request).await
-    }
-}
-
-#[cfg(all(test, unix))]
-mod keyed_exec_tests {
-    use super::*;
-
-    #[test]
-    fn ambiguous_transport_detects_lost_response_paths() {
-        assert!(is_ambiguous_guest_exec_transport(&BoxError::ExecError(
-            "Exec server closed without response".to_string()
-        )));
-        assert!(is_ambiguous_guest_exec_transport(&BoxError::ExecError(
-            "Exec response timed out after 15s".to_string()
-        )));
-        assert!(is_ambiguous_guest_exec_transport(&BoxError::ExecError(
-            "Exec connection failed to /tmp/x".to_string()
-        )));
-        assert!(!is_ambiguous_guest_exec_transport(&BoxError::ExecError(
-            "command rejected by guest policy".to_string()
-        )));
-    }
-
-    #[test]
-    fn keyed_retry_requires_non_empty_request_id() {
-        let keyed = a3s_box_core::exec::ExecRequest {
-            request_id: Some("vm-exec-abc".to_string()),
-            cmd: vec!["true".to_string()],
-            timeout_ns: 1,
-            env: vec![],
-            working_dir: None,
-            rootfs: None,
-            stdin: None,
-            stdin_streaming: false,
-            user: None,
-            streaming: false,
-        };
-        let unkeyed = a3s_box_core::exec::ExecRequest {
-            request_id: None,
-            ..keyed.clone()
-        };
-        let empty = a3s_box_core::exec::ExecRequest {
-            request_id: Some(String::new()),
-            ..keyed.clone()
-        };
-        let lost = BoxError::ExecError("Exec server closed without response".to_string());
-        assert!(should_retry_keyed_guest_exec(&keyed, &lost));
-        assert!(!should_retry_keyed_guest_exec(&unkeyed, &lost));
-        assert!(!should_retry_keyed_guest_exec(&empty, &lost));
-        assert!(!should_retry_keyed_guest_exec(
-            &keyed,
-            &BoxError::ExecError("policy denied".to_string())
-        ));
     }
 }

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -15,7 +15,7 @@ mod spec;
 mod windows_stop;
 
 #[cfg(unix)]
-pub(crate) use execution::should_retry_keyed_guest_exec;
+pub(crate) use crate::grpc::exec::should_retry_keyed_guest_exec;
 pub(crate) use layout::{
     legacy_sandbox_runtime_root, persistent_rootfs_generation_exists, runtime_socket_dir,
     sandbox_runtime_root,

--- a/src/runtime/src/vm/mod.rs
+++ b/src/runtime/src/vm/mod.rs
@@ -15,7 +15,7 @@ mod spec;
 mod windows_stop;
 
 #[cfg(unix)]
-pub(crate) use crate::grpc::exec::should_retry_keyed_guest_exec;
+pub(crate) use crate::grpc::should_retry_keyed_guest_exec;
 pub(crate) use layout::{
     legacy_sandbox_runtime_root, persistent_rootfs_generation_exists, runtime_socket_dir,
     sandbox_runtime_root,


### PR DESCRIPTION
## Summary
- `ExecClient::exec_command` retries once on ambiguous transport when `request_id` is set (fresh stream + guest replay cache).
- Covers legacy MicroVM CLI/SDK socket callers that already mint identity but had no in-call replay.
- `VmManager::exec_request` no longer wraps a second retry (client owns it).
- Session `on_stream` path still rebinds itself. Omit-path stays unkeyed.
- Does **not** flip B2 harness close, fixture continuity, or hosted-KVM claims.

## Test plan
- [ ] `cargo test -p a3s-box-runtime --lib keyed_exec_tests`
- [ ] Hosted CI green (esp. SDK Local Sandbox R17)
- [ ] Confirm CHANGELOG does not claim B2 close

Made with [Cursor](https://cursor.com)