### PR TITLE
fix(runtime): spawn_main ambiguous ACK retry with guest idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,26 @@ All notable changes to A3S Box will be documented in this file.
 
 ### Fixed
 
+- `ExecClient::spawn_main` retries once on ambiguous ACK loss; guest now ACKs
+  repeat spawn-main once the container pid is published (bare and JSON frames)
+  and waits through the pending sentinel instead of NACKing. Host treats
+  `already spawned` NACK as success. Connect failures stay `Ok(false)` with no
+  retry. Does **not** flip B2 harness close, fixture continuity, or hosted-KVM
+  claims.
+
 - `ExecClient::shutdown_rootfs_maintenance` shares the control-ACK ambiguous
   transport path with `signal_main`: connect failures stay `Ok(false)` with no
   retry; write/ACK timeout/closed retries once on a fresh stream. Guest already
   ACKs repeat shutdown while `SHUTTING_DOWN`, so this avoids false-negative
-  shim force-teardown without request ids. Does **not** retry `spawn_main`,
-  flip B2 harness close, fixture continuity, or hosted-KVM claims.
+  shim force-teardown without request ids. Does **not** flip B2 harness close,
+  fixture continuity, or hosted-KVM claims.
 
 - `ExecClient::signal_main` retries once on a fresh stream when the guest may
   already have applied the signal but the ACK was lost (write/ACK timeout /
   closed / bad frame). Connect failures stay `Ok(false)` with no retry (guest
   never reached). Signal delivery is naturally idempotent, so this avoids
-  false-negative force-kills without inventing request ids. Does **not** retry
-  `spawn_main`, flip B2 harness close, fixture continuity, or hosted-KVM claims.
+  false-negative force-kills without inventing request ids. Does **not** flip
+  B2 harness close, fixture continuity, or hosted-KVM claims.
 
 - `ExecClient::exec_command` retries once on ambiguous guest transport loss when
   a non-empty `request_id` is present (fresh stream + guest replay cache). This

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -3162,7 +3162,7 @@ mod tests {
     }
 
     #[test]
-    fn only_a_repeated_stashed_main_trigger_is_idempotent() {
+    fn published_main_pid_acks_any_repeated_spawn_main() {
         assert_eq!(published_main_pid(42), Some(42));
         assert_eq!(published_main_pid(-1), None);
         assert_eq!(published_main_pid(-2), None);

--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -226,11 +226,14 @@ pub fn set_deferred_main_spec(
 /// code could deadlock from this multi-threaded PID 1. The pid is published WHILE
 /// still registered MANAGED (the reaper can't reap it as an orphan before the
 /// hand-off), then released to the supervision loop, which reaps it for the real
-/// exit code. A CAS makes only the first spawn-main win.
+/// exit code. The first spawn claims the sentinel; concurrent/retried
+/// spawn-main frames wait for the published pid and ACK (no duplicate main).
 #[cfg(target_os = "linux")]
 fn spawn_deferred_main(frame: Option<DeferredMainSpec>) -> Result<i32, String> {
-    let uses_stashed_spec = frame.is_none();
-    if let Some(pid) = idempotent_stashed_main_pid(uses_stashed_spec, container_pid()) {
+    // One main per VM: if the pid is already published, ACK without re-spawning.
+    // Covers bare (stashed) and JSON (pool) frames alike — a lost ACK must not
+    // force a duplicate main or a false NACK.
+    if let Some(pid) = published_main_pid(container_pid()) {
         return Ok(pid);
     }
 
@@ -296,14 +299,19 @@ fn spawn_deferred_main(frame: Option<DeferredMainSpec>) -> Result<i32, String> {
         command.stdin(std::process::Stdio::null());
     }
 
-    // Idempotency: claim the sentinel (-1 → -2 pending); a second spawn-main loses.
-    // Concurrent triggers still race on the sentinel CAS. Once the real PID is
-    // published, a repeated bare trigger returns it above and is acknowledged
-    // without spawning a duplicate main.
+    // Idempotency: claim the sentinel (-1 → -2 pending). Concurrent / retried
+    // triggers wait for the published pid and ACK instead of NACKing — a lost ACK
+    // after the first spawn must not look like failure to the host.
     if CONTAINER_PID
         .compare_exchange(-1, -2, Ordering::SeqCst, Ordering::SeqCst)
         .is_err()
     {
+        if let Some(pid) = published_main_pid(container_pid()) {
+            return Ok(pid);
+        }
+        if let Some(pid) = wait_for_published_container_pid(Duration::from_secs(2)) {
+            return Ok(pid);
+        }
         return Err("container main already spawned".to_string());
     }
 
@@ -324,8 +332,27 @@ fn spawn_deferred_main(frame: Option<DeferredMainSpec>) -> Result<i32, String> {
     }
 }
 
-fn idempotent_stashed_main_pid(uses_stashed_spec: bool, current_pid: i32) -> Option<i32> {
-    (uses_stashed_spec && current_pid > 0).then_some(current_pid)
+#[cfg(target_os = "linux")]
+fn published_main_pid(current_pid: i32) -> Option<i32> {
+    (current_pid > 0).then_some(current_pid)
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_published_container_pid(timeout: Duration) -> Option<i32> {
+    let start = std::time::Instant::now();
+    loop {
+        if let Some(pid) = published_main_pid(container_pid()) {
+            return Some(pid);
+        }
+        // Spawn failed and reset the sentinel — caller may reclaim.
+        if container_pid() == -1 {
+            return None;
+        }
+        if start.elapsed() >= timeout {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
 }
 
 /// Maximum payload bytes per streamed exec chunk.
@@ -3136,10 +3163,9 @@ mod tests {
 
     #[test]
     fn only_a_repeated_stashed_main_trigger_is_idempotent() {
-        assert_eq!(idempotent_stashed_main_pid(true, 42), Some(42));
-        assert_eq!(idempotent_stashed_main_pid(false, 42), None);
-        assert_eq!(idempotent_stashed_main_pid(true, -1), None);
-        assert_eq!(idempotent_stashed_main_pid(true, -2), None);
+        assert_eq!(published_main_pid(42), Some(42));
+        assert_eq!(published_main_pid(-1), None);
+        assert_eq!(published_main_pid(-2), None);
     }
 
     #[cfg(target_os = "linux")]

--- a/src/runtime/src/grpc/exec.rs
+++ b/src/runtime/src/grpc/exec.rs
@@ -51,7 +51,7 @@ const EXEC_HOST_SLACK_SECS: u64 = 10;
 /// force-kill fallback.
 const SIGNAL_MAIN_ACK_TIMEOUT_SECS: u64 = 10;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ControlAckAttempt {
     /// Guest sent the expected control ACK.
     Acked,
@@ -59,6 +59,20 @@ enum ControlAckAttempt {
     NotReached,
     /// Write may have reached the guest, or the ACK was lost/timed out.
     Ambiguous,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SpawnMainAttempt {
+    /// Guest sent `spawn-main-ack`.
+    Acked,
+    /// Connect failed; the control frame never left the host.
+    NotReached,
+    /// Write may have reached the guest, or the ACK was lost/timed out.
+    Ambiguous,
+    /// Guest reported the main is already present (idempotent success).
+    AlreadySpawned,
+    /// Guest rejected the spawn with a non-idempotent reason.
+    Rejected(String),
 }
 
 type ExecFrameReader = a3s_transport::FrameReader<tokio::io::ReadHalf<ExecStream>>;
@@ -603,10 +617,34 @@ impl ExecClient {
     /// command — already known to the guest via BOX_EXEC_* — as the MAIN process.
     /// The spawned main inherits the console (so its output reaches the json-file
     /// logs) and drives the VM lifecycle. Returns `Ok(true)` if acknowledged.
+    ///
+    /// Connect failures stay `Ok(false)` with no retry. After a write may have
+    /// reached the guest, a lost ACK is ambiguous: the guest publishes at most
+    /// one main and ACKs repeat spawn-main once the pid is published, so one
+    /// fresh-stream retry is safe. An `already spawned` NACK is treated as
+    /// success (observe-after-ambiguity).
     pub async fn spawn_main(&self, spec_json: Option<&[u8]>) -> Result<bool> {
+        match self.spawn_main_once(spec_json).await? {
+            SpawnMainAttempt::Acked => Ok(true),
+            SpawnMainAttempt::NotReached => Ok(false),
+            SpawnMainAttempt::AlreadySpawned => Ok(true),
+            SpawnMainAttempt::Rejected(reason) => Err(BoxError::ExecError(format!(
+                "spawn-main rejected by guest: {reason}"
+            ))),
+            SpawnMainAttempt::Ambiguous => match self.spawn_main_once(spec_json).await? {
+                SpawnMainAttempt::Acked | SpawnMainAttempt::AlreadySpawned => Ok(true),
+                SpawnMainAttempt::NotReached | SpawnMainAttempt::Ambiguous => Ok(false),
+                SpawnMainAttempt::Rejected(reason) => Err(BoxError::ExecError(format!(
+                    "spawn-main rejected by guest: {reason}"
+                ))),
+            },
+        }
+    }
+
+    async fn spawn_main_once(&self, spec_json: Option<&[u8]>) -> Result<SpawnMainAttempt> {
         let mut stream = match connect_exec_stream(&self.socket_path).await {
             Ok(s) => s,
-            Err(_) => return Ok(false),
+            Err(_) => return Ok(SpawnMainAttempt::NotReached),
         };
 
         let mut payload = b"spawn-main:".to_vec();
@@ -619,28 +657,35 @@ impl ExecClient {
             .map_err(|e| BoxError::ExecError(format!("spawn-main frame encode failed: {}", e)))?;
 
         if stream.write_all(&encoded).await.is_err() {
-            return Ok(false);
+            return Ok(SpawnMainAttempt::Ambiguous);
         }
 
         let (r, _w) = tokio::io::split(stream);
         let mut reader = a3s_transport::FrameReader::new(r);
-        match reader.read_frame().await {
-            Ok(Some(f))
+        let read = tokio::time::timeout(
+            std::time::Duration::from_secs(SIGNAL_MAIN_ACK_TIMEOUT_SECS),
+            reader.read_frame(),
+        )
+        .await;
+        match read {
+            Ok(Ok(Some(f)))
                 if f.frame_type == a3s_transport::FrameType::Control
                     && f.payload == EXEC_SPAWN_MAIN_ACK =>
             {
-                Ok(true)
+                Ok(SpawnMainAttempt::Acked)
             }
-            Ok(Some(f))
+            Ok(Ok(Some(f)))
                 if f.frame_type == a3s_transport::FrameType::Control
                     && f.payload.starts_with(EXEC_SPAWN_MAIN_NACK) =>
             {
                 let reason = String::from_utf8_lossy(&f.payload[EXEC_SPAWN_MAIN_NACK.len()..]);
-                Err(BoxError::ExecError(format!(
-                    "spawn-main rejected by guest: {reason}"
-                )))
+                if reason.contains("already spawned") {
+                    Ok(SpawnMainAttempt::AlreadySpawned)
+                } else {
+                    Ok(SpawnMainAttempt::Rejected(reason.into_owned()))
+                }
             }
-            _ => Ok(false),
+            _ => Ok(SpawnMainAttempt::Ambiguous),
         }
     }
 }
@@ -1330,6 +1375,80 @@ mod tests {
             frames.load(std::sync::atomic::Ordering::SeqCst),
             2,
             "guest must see shutdown twice (natural idempotency)"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_main_retries_once_after_lost_ack() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock_path = tmp.path().join("spawn_main_retry.sock");
+        let Some(listener) = bind_test_listener(&sock_path) else {
+            return;
+        };
+        let frames = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let frames_server = frames.clone();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            drop(stream);
+
+            // First spawn-main: guest applies then drops both halves (lost ACK).
+            let (stream, _) = listener.accept().await.unwrap();
+            let (r, w) = tokio::io::split(stream);
+            let mut reader = a3s_transport::FrameReader::new(r);
+            let frame = reader.read_frame().await.unwrap().unwrap();
+            assert_eq!(frame.frame_type, a3s_transport::FrameType::Control);
+            assert!(frame.payload.starts_with(b"spawn-main:"));
+            frames_server.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            drop(reader);
+            drop(w);
+
+            // Second spawn-main: ACK (guest published-pid idempotency).
+            let (stream, _) = listener.accept().await.unwrap();
+            let (r, w) = tokio::io::split(stream);
+            let mut reader = a3s_transport::FrameReader::new(r);
+            let mut writer = a3s_transport::FrameWriter::new(w);
+            let frame = reader.read_frame().await.unwrap().unwrap();
+            assert!(frame.payload.starts_with(b"spawn-main:"));
+            frames_server.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            writer.write_control(EXEC_SPAWN_MAIN_ACK).await.unwrap();
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        let client = ExecClient::connect(&sock_path).await.unwrap();
+        assert!(
+            client.spawn_main(None).await.unwrap(),
+            "lost ACK must recover via one fresh-stream retry"
+        );
+        assert_eq!(frames.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn spawn_main_treats_already_spawned_nack_as_success() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock_path = tmp.path().join("spawn_main_already.sock");
+        let Some(listener) = bind_test_listener(&sock_path) else {
+            return;
+        };
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            drop(stream);
+            let (stream, _) = listener.accept().await.unwrap();
+            let (r, w) = tokio::io::split(stream);
+            let mut reader = a3s_transport::FrameReader::new(r);
+            let mut writer = a3s_transport::FrameWriter::new(w);
+            let _ = reader.read_frame().await.unwrap().unwrap();
+            let mut nack = EXEC_SPAWN_MAIN_NACK.to_vec();
+            nack.extend_from_slice(b"container main already spawned");
+            writer.write_control(&nack).await.unwrap();
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        let client = ExecClient::connect(&sock_path).await.unwrap();
+        assert!(
+            client.spawn_main(None).await.unwrap(),
+            "already-spawned NACK is observe-after-ambiguity success"
         );
     }
 


### PR DESCRIPTION
## Summary
- Guest: any published container pid ACKs repeat `spawn-main` (bare and JSON); CAS races wait for publish instead of NACK.
- Host: `ExecClient::spawn_main` retries once on ambiguous ACK loss; `already spawned` NACK is observe-after-ambiguity success.
- Connect failures stay `Ok(false)` with no retry.

## Honesty
- Does **not** flip `b2_process_session_recovery_closed`.
- Does **not** claim fixture continuity or hosted-KVM Live.
- Does **not** invent FakeRuntime journals or widen timeouts.

## Test plan
- [x] WSL `cargo test -p a3s-box-runtime --features vm --lib spawn_main` (2 passed)
- [x] WSL `cargo test -p a3s-box-guest-init --lib published_main_pid_acks_any_repeated_spawn_main`
- [ ] Hosted CI green (prefer rerun on R17 flake; do not weaken schemas)