### PR TITLE
release: prepare a3s-box 3.2.6 Sandbox GA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,7 +651,7 @@ jobs:
           export A3S_BOX_CI_SETPRIV_MATCHED_CREDS=1
           export A3S_BOX_CI_SETPRIV_WRAPPER="$GITHUB_WORKSPACE/scripts/run-linux-sandbox-ci.sh"
           # Sandbox GA default: absent A3S_BOX_OCI_MIGRATION selects SandboxViaOci.
-          # Do not export the env; prove production composition without the opt-in.
+          # Do not export the env; prove production composition with the GA default.
           unset A3S_BOX_OCI_MIGRATION || true
           export A3S_DEPS_STUB=1
           export A3S_HOME

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,32 +4,24 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+## [3.2.6] — 2026-09-12
+
 ### Changed
 
-- Remove stale Sandbox “opt-in / no setting means legacy” wording from ROADMAP
-  and README (EN/zh-CN) so docs match the merged Sandbox GA default
-  (`SandboxViaOci` when `A3S_BOX_OCI_MIGRATION` is absent).
-- Productize Linux Sandbox host preparation: add operator
-  `scripts/prepare-linux-sandbox-host.sh` (setuid libexec launcher + delegated
-  cgroup), keep `prepare-linux-sandbox-ci-host.sh` as a `--ci` wrapper, document
-  the path in `docs/installation.md`, and publish `docs/sandbox-ga-evidence.md`.
-  Narrow README/website Sandbox networking claims (bridge/publish rejected;
-  loopback + R17 service relays only). Website Linux Sandbox status moves from
-  Preview to Production with the same non-claims. Does **not** flip MicroVM
-  cutover, B2 close, fixture Live, or `BX0.3`.
-- Linux Sandbox GA default activation: an absent `A3S_BOX_OCI_MIGRATION`
+- **Linux Sandbox GA production release:** an absent `A3S_BOX_OCI_MIGRATION`
   selects `SandboxViaOci` for new Sandbox records (omit-isolation remains
   MicroVM). Explicit `off` keeps the VM-only backend; explicit `sandbox`
   hard-fails when the OCI owner is not launch-ready. When the default cannot
   start the owner, MicroVM continue on legacy and Sandbox preflight fails
   closed. Hosted `sdk-local-sandbox` proves the composition with the env
-  unset. Does **not** flip omit→MicroVM cutover,
+  unset. Productized host prep (`scripts/prepare-linux-sandbox-host.sh`),
+  evidence binder (`docs/sandbox-ga-evidence.md`), and frozen networking
+  non-claims (bridge/publish rejected). Website Linux Sandbox status is
+  Production. Does **not** flip omit→MicroVM cutover,
   `b2_process_session_recovery_closed`, WHPX/KVM MicroVM production claims,
   fixture Live, or Cloud `BX0.3`.
-- Document the Linux Sandbox **production claim surface**: the OCI owner route
-  is CI-proven (SDK Local Sandbox + Native Live v4), not a “preview”.
-  Stopped-only owner crash recovery stays distinct from Live retained
-  stream/filesystem reattach.
+- Remove stale Sandbox “opt-in / no setting means legacy” wording from ROADMAP
+  and README (EN/zh-CN) so docs match the Sandbox GA default.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -76,17 +76,17 @@ is not yet a production claim.
 
 ## Current release line
 
-The `3.2.5` release line keeps the public SDK contract stable while packaging
-the latest runtime and integration fixes from `main`:
+The `3.2.6` release line keeps the public SDK contract stable while packaging
+Linux Sandbox GA activation and the latest runtime fixes from `main`:
 
 | Area | Latest behavior |
 | --- | --- |
+| Linux Sandbox GA | Absent `A3S_BOX_OCI_MIGRATION` defaults new Sandbox records to `SandboxViaOci`; hosted x86_64/aarch64 CI proves the route with the env unset (lifecycle + Native Live v4). Operator host prep: `scripts/prepare-linux-sandbox-host.sh`. Evidence: [sandbox-ga-evidence.md](docs/sandbox-ga-evidence.md). Not a MicroVM/`BX0.3` claim. |
 | Warm pools | SIGTERM/`SIGINT`/`pool stop` drain idle VMs and leases with bounded concurrency; destroy failures best-effort reap orphans (idle, lease release/expiry, oneshot `pool run`, mid-replenish, and template teardown); snapshot template dirs (`~/.a3s/pool/tpl-*`) are removed even after a Failing/Unavailable build. |
-| Linux Sandbox | Setuid OCI launcher discovery covers env, packaged paths, and `/usr/local/libexec/...`; with a delegated user cgroup, foreground `run --rm --isolation sandbox` completes cleanly on qualified hosts. |
-| MicroVM lifecycle | Guest stop is skipped when the workload already exited; Unix cold boot fail-closes without an exec heartbeat; crash-detection grace is 80ms. |
+| MicroVM lifecycle | Guest stop is skipped when the workload already exited; Unix cold boot fail-closes without an exec heartbeat; crash-detection grace is 80ms. Transport retries cover ambiguous ACK/stream loss on keyed exec and read-only filesystem ops. |
 | CRI | PodSandbox creation defers the agent workload until `StartContainer`; cancel and destroy paths best-effort reap orphans when VM teardown fails. |
 | Runtime builds | OCI-only builds retain durable cleanup and socket handling without hypervisor dependencies. |
-| Evidence | Soak runs record per-capability results and versioned host-resource samples; the historical performance matrix retains numbers while documenting which Linux cleanup blockers later tips closed. |
+| Evidence | Soak runs record per-capability results and versioned host-resource samples; Sandbox GA binder freezes networking non-claims (bridge/publish rejected). |
 
 Installers, native binaries, and the Rust, Python, TypeScript, and Go SDK
 artifacts are published from the same versioned release tag. See the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,16 +51,16 @@ runtime crate 现在还暴露显式的 `OciMigrationPolicy` 与 `LocalExecutionB
 
 ## 当前发布线
 
-`3.2.5` 发布线在保持公共 SDK 契约稳定的同时，打包来自 `main` 的最新运行时与集成修复：
+`3.2.6` 发布线在保持公共 SDK 契约稳定的同时，打包 Linux Sandbox GA 默认激活与来自 `main` 的最新运行时修复：
 
 | 领域 | 最新行为 |
 | --- | --- |
+| Linux Sandbox GA | 未设置 `A3S_BOX_OCI_MIGRATION` 时，新的 Sandbox 记录默认走 `SandboxViaOci`；托管 x86_64/aarch64 CI 在未设置该变量时证明该路由（生命周期 + Native Live v4）。主机准备：`scripts/prepare-linux-sandbox-host.sh`。证据：[sandbox-ga-evidence.md](docs/sandbox-ga-evidence.md)。不是 MicroVM/`BX0.3` 宣称。 |
 | Warm pools | SIGTERM/`SIGINT`/`pool stop` 以有界并发排空空闲 VM 与租约；销毁失败尽力回收孤儿（空闲、租约释放/过期、一次性 `pool run`、补充中途与模板拆除）；即使构建为 Failing/Unavailable，也会移除快照模板目录（`~/.a3s/pool/tpl-*`）。 |
-| Linux Sandbox | Setuid OCI launcher 发现覆盖环境变量、打包路径与 `/usr/local/libexec/...`；在有委托用户 cgroup 时，前台 `run --rm --isolation sandbox` 在合格主机上干净完成。 |
-| MicroVM lifecycle | 工作负载已退出时跳过 guest stop；Unix 冷启动在无 exec 心跳时失败即关闭；崩溃检测宽限为 80ms。 |
+| MicroVM lifecycle | 工作负载已退出时跳过 guest stop；Unix 冷启动在无 exec 心跳时失败即关闭；崩溃检测宽限为 80ms。传输层对带 key 的 exec 与只读文件系统操作覆盖歧义 ACK/流丢失重试。 |
 | CRI | PodSandbox 创建将 agent 工作负载推迟到 `StartContainer`；取消与销毁路径在 VM 拆除失败时尽力回收孤儿。 |
 | Runtime builds | 仅 OCI 的构建在无 hypervisor 依赖的情况下保留持久清理与 socket 处理。 |
-| Evidence | Soak 运行记录每能力结果与版本化主机资源采样；历史性能矩阵保留数字，同时记录哪些 Linux 清理阻塞被后续 tip 关闭。 |
+| Evidence | Soak 运行记录每能力结果与版本化主机资源采样；Sandbox GA binder 冻结网络非宣称（bridge/publish 拒绝）。 |
 
 安装程序、原生二进制以及 Rust、Python、TypeScript 与 Go SDK 产物从同一版本化发布标签发布。完整补丁历史见
 [Changelog](CHANGELOG.md)。

--- a/deploy/scripts/install-runtimeclass.sh
+++ b/deploy/scripts/install-runtimeclass.sh
@@ -16,7 +16,7 @@
 # Usage:
 #   install-runtimeclass.sh [--version vX.Y.Z] [--repo OWNER/REPO] [--from-dir DIR]
 #
-#   --version   release tag to install                 (default: v3.2.5)
+#   --version   release tag to install                 (default: v3.2.6)
 #   --repo      GitHub repo to download artifacts from (default: A3S-Lab/Box)
 #   --from-dir  install from a local directory instead of downloading; the dir must
 #               contain a3s-box-<version>-linux-<arch>.tar.gz, its .sha256 file,
@@ -28,7 +28,7 @@
 # Idempotent: safe to re-run (re-installs binaries, rewrites the containerd drop-in).
 set -euo pipefail
 
-VERSION="v3.2.5"
+VERSION="v3.2.6"
 REPO="A3S-Lab/Box"
 FROM_DIR=""
 WARMUP_IMAGE="busybox:latest"   # first box on a fresh node builds a one-time cache

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ guest executable are not separated from `a3s-box`.
 
 | Behavior | Linux/macOS | Windows |
 | --- | --- | --- |
-| Pin a release | `--version v3.2.5` | `-Version v3.2.5` |
+| Pin a release | `--version v3.2.6` | `-Version v3.2.6` |
 | Choose destination | `--install-dir PATH` | `-InstallDir PATH` |
 | Do not change `PATH` | `--no-modify-path` | `-NoModifyPath` |
 | Replace an unmanaged directory | `--force` | `-Force` |
@@ -83,7 +83,7 @@ Pass Unix options after `sh -s --` when using a pipe:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.5 --no-modify-path
+  sh -s -- --version v3.2.6 --no-modify-path
 ```
 
 Invoke the downloaded PowerShell text as a script block when options are
@@ -91,7 +91,7 @@ needed:
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.5 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.6 -NoModifyPath
 ```
 
 The corresponding environment variables are `A3S_BOX_VERSION`,
@@ -137,8 +137,8 @@ Linux or macOS:
 
 ```bash
 sh ./install.sh \
-  --version v3.2.5 \
-  --archive ./a3s-box-v3.2.5-linux-x86_64.tar.gz \
+  --version v3.2.6 \
+  --archive ./a3s-box-v3.2.6-linux-x86_64.tar.gz \
   --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
@@ -146,8 +146,8 @@ Windows:
 
 ```powershell
 .\install.ps1 `
-  -Version v3.2.5 `
-  -ArchivePath .\a3s-box-v3.2.5-windows-x86_64.zip `
+  -Version v3.2.6 `
+  -ArchivePath .\a3s-box-v3.2.6-windows-x86_64.zip `
   -Sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 

--- a/docs/production-cluster-tests.md
+++ b/docs/production-cluster-tests.md
@@ -103,7 +103,7 @@ directory must contain the platform tarball, the matching standalone
 
 ```bash
 sudo deploy/scripts/install-runtimeclass.sh \
-  --version v3.2.5 \
+  --version v3.2.6 \
   --from-dir /opt/a3s-box-artifacts \
   --warmup-image docker.m.daocloud.io/library/busybox:latest
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -48,7 +48,7 @@ function Get-NormalizedTag {
         $number -notmatch '^[0-9A-Za-z.+-]+$' -or
         $number -notmatch '^[^.]+\.[^.]+\.[^.]+'
     ) {
-        throw "Invalid version '$Candidate'; expected a release such as v3.2.5."
+        throw "Invalid version '$Candidate'; expected a release such as v3.2.6."
     }
     return $tag
 }

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ Usage:
   install.sh [options]
 
 Options:
-  --version VERSION       Install a release such as v3.2.5 (default: latest).
+  --version VERSION       Install a release such as v3.2.6 (default: latest).
   --install-dir PATH      Install the self-contained distribution at PATH.
   --archive PATH          Install a local release tarball without downloading.
   --sha256 HEX            Expected SHA-256 for --archive.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "a3s-box"
-version = "3.2.5"
+version = "3.2.6"
 description = "Local-first Python SDK for the native A3S Box Sandbox API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -234,9 +234,9 @@ def response_for(request: Mapping[str, object]) -> dict[str, Any]:
         return {"names": ["old-network"]}
     if operation == "runtime_diagnostics":
         return {
-            "core_version": "3.2.5",
-            "runtime_version": "3.2.5",
-            "sdk_version": "3.2.5",
+            "core_version": "3.2.6",
+            "runtime_version": "3.2.6",
+            "sdk_version": "3.2.6",
             "home": "/tmp/a3s",
             "virtualization": {
                 "available": True,
@@ -1658,7 +1658,7 @@ class AsyncSdkTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(events.next_sequence, 11)
         self.assertEqual(sandboxes[0].id, "sandbox-local-1")
         self.assertEqual(snapshot.id, "ci-async")
-        self.assertEqual(diagnostics.sdk_version, "3.2.5")
+        self.assertEqual(diagnostics.sdk_version, "3.2.6")
         self.assertEqual(disk.snapshots_bytes, 4)
         restart = next(
             request

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/box",
-      "version": "3.2.5",
+      "version": "3.2.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "20.19.9",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/box",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "Local-first TypeScript SDK for the native A3S Box Sandbox API",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/tests/exports.mjs
+++ b/sdk/typescript/tests/exports.mjs
@@ -90,9 +90,9 @@ class FakeRuntime {
         return { names: ['old-network'] }
       case 'runtime_diagnostics':
         return {
-          core_version: '3.2.5',
-          runtime_version: '3.2.5',
-          sdk_version: '3.2.5',
+          core_version: '3.2.6',
+          runtime_version: '3.2.6',
+          sdk_version: '3.2.6',
           home: '/tmp/a3s',
           virtualization: {
             available: true,

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cli"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-core"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "a3s-acl",
  "a3s-common",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-cri"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-guest-init"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "a3s-box-core",
  "a3s-common",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-mkext4"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "crc32c",
  "proptest",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-netproxy"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "a3s-box-core",
  "libc",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-runtime"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "a3s-acl",
  "a3s-box-core",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-sdk"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "a3s-box-core",
  "a3s-box-runtime",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-box-shim"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "a3s-box-core",
  "a3s-box-netproxy",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-libkrun-sys"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "libc",
  "num_cpus",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 h2 = { path = "third_party/h2" }
 
 [workspace.package]
-version = "3.2.5"
+version = "3.2.6"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -137,7 +137,7 @@ xattr = "1.6"
 # workspace consumers on the same audited source. Keep the exact version
 # because a writer bump is a cache-schema migration rather than a routine
 # dependency update. See third_party/mkext4/A3S_PATCHES.md.
-mkext4 = { package = "a3s-box-mkext4", version = "=3.2.5", path = "../third_party/mkext4" }
+mkext4 = { package = "a3s-box-mkext4", version = "=3.2.6", path = "../third_party/mkext4" }
 
 # TEE attestation verification
 p384 = { workspace = true }

--- a/website/docs/v3/en/guide/installation.mdx
+++ b/website/docs/v3/en/guide/installation.mdx
@@ -64,7 +64,7 @@ a3s-box info
 
 | Behavior                       | Linux/macOS                   | Windows                         |
 | ------------------------------ | ----------------------------- | ------------------------------- |
-| Pin a release                  | `--version v3.2.5`            | `-Version v3.2.5`               |
+| Pin a release                  | `--version v3.2.6`            | `-Version v3.2.6`               |
 | Choose destination             | `--install-dir PATH`          | `-InstallDir PATH`              |
 | Do not change `PATH`           | `--no-modify-path`            | `-NoModifyPath`                 |
 | Replace an unmanaged directory | `--force`                     | `-Force`                        |
@@ -75,14 +75,14 @@ Pass Unix options after `sh -s --`:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.5 --no-modify-path
+  sh -s -- --version v3.2.6 --no-modify-path
 ```
 
 Invoke downloaded PowerShell text as a script block when options are needed:
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.5 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.6 -NoModifyPath
 ```
 
 The corresponding environment variables are `A3S_BOX_VERSION`,

--- a/website/docs/v3/zh/guide/installation.mdx
+++ b/website/docs/v3/zh/guide/installation.mdx
@@ -66,7 +66,7 @@ brew install a3s-lab/tap/a3s-box
 
 | 行为                 | Linux/macOS                   | Windows                         |
 | -------------------- | ----------------------------- | ------------------------------- |
-| 固定版本             | `--version v3.2.5`            | `-Version v3.2.5`               |
+| 固定版本             | `--version v3.2.6`            | `-Version v3.2.6`               |
 | 指定目录             | `--install-dir PATH`          | `-InstallDir PATH`              |
 | 不修改 `PATH`        | `--no-modify-path`            | `-NoModifyPath`                 |
 | 替换非安装器管理目录 | `--force`                     | `-Force`                        |
@@ -77,14 +77,14 @@ brew install a3s-lab/tap/a3s-box
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/A3S-Lab/Box/main/install.sh |
-  sh -s -- --version v3.2.5 --no-modify-path
+  sh -s -- --version v3.2.6 --no-modify-path
 ```
 
 Windows 带参数安装：
 
 ```powershell
 $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
-& ([scriptblock]::Create($installer)) -Version v3.2.5 -NoModifyPath
+& ([scriptblock]::Create($installer)) -Version v3.2.6 -NoModifyPath
 ```
 
 ## 离线安装
@@ -93,15 +93,15 @@ $installer = irm https://raw.githubusercontent.com/A3S-Lab/Box/main/install.ps1
 
 ```bash
 sh ./install.sh \
-  --version v3.2.5 \
-  --archive ./a3s-box-v3.2.5-linux-x86_64.tar.gz \
+  --version v3.2.6 \
+  --archive ./a3s-box-v3.2.6-linux-x86_64.tar.gz \
   --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 ```powershell
 .\install.ps1 `
-  -Version v3.2.5 `
-  -ArchivePath .\a3s-box-v3.2.5-windows-x86_64.zip `
+  -Version v3.2.6 `
+  -ArchivePath .\a3s-box-v3.2.6-windows-x86_64.zip `
   -Sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 


### PR DESCRIPTION
## Summary
- Bump a3s-box to **3.2.6** (Rust workspace, Python/TS SDKs, installers, docs).
- Current release line documents Linux Sandbox GA: default `SandboxViaOci` without `A3S_BOX_OCI_MIGRATION`, host prep, evidence binder, frozen networking non-claims.
- CHANGELOG folds Unreleased Sandbox GA + transport retries into `[3.2.6]`.
- Does **not** claim MicroVM cutover, B2 close, fixture Live, or `BX0.3`.

## Test plan
- [ ] CI green (incl. SDK Local Sandbox x86_64/aarch64)
- [ ] `cargo metadata` reports `a3s-box-cli` 3.2.6
- [ ] After merge: tag `v3.2.6` to trigger Release workflow