### PR TITLE
fix(sandbox): setgroups deny + euid rootfs prepare for setpriv CI

### DIFF
--- a/src/guest/init/src/exec_server.rs
+++ b/src/guest/init/src/exec_server.rs
@@ -2754,6 +2754,10 @@ fn configure_child_process(
         let _ = no_new_privs;
         let _ = cgroup_procs;
     }
+    #[cfg(target_os = "linux")]
+    let may_setgroups = crate::namespace::setgroups_permitted();
+    #[cfg(not(target_os = "linux"))]
+    let may_setgroups = true;
 
     unsafe {
         command.pre_exec(move || {
@@ -2780,7 +2784,8 @@ fn configure_child_process(
             }
             // Apply supplemental groups while still privileged — setgroups
             // needs CAP_SETGID, which user.apply() drops via setuid below.
-            if !supplemental_groups.is_empty() {
+            // HostSandbox userns often has /proc/self/setgroups=deny; skip then.
+            if may_setgroups && !supplemental_groups.is_empty() {
                 let ret = libc::setgroups(
                     supplemental_groups.len() as _,
                     supplemental_groups.as_ptr() as *const libc::gid_t,

--- a/src/guest/init/src/namespace.rs
+++ b/src/guest/init/src/namespace.rs
@@ -313,7 +313,12 @@ fn child_process(
     // apparently successful but unbounded workload violates the resource
     // contract.
     if let Some(descriptor) = cgroup_procs {
-        crate::cgroup::join_current_process(descriptor).map_err(NamespaceError::ExecFailed)?;
+        crate::cgroup::join_current_process(descriptor).map_err(|error| {
+            NamespaceError::ExecFailed(std::io::Error::new(
+                error.kind(),
+                format!("cgroup join via inherited descriptor: {error}"),
+            ))
+        })?;
     }
 
     // Resolve bare OCI entrypoints through the container PATH. Rust's
@@ -380,8 +385,11 @@ fn child_process(
     // Replace current process with the command
     let err = cmd.exec();
 
-    // If exec returns, it failed
-    Err(NamespaceError::ExecFailed(err))
+    // If exec returns, it failed (including pre_exec failures).
+    Err(NamespaceError::ExecFailed(std::io::Error::new(
+        err.kind(),
+        format!("command exec for {command}: {err}"),
+    )))
 }
 
 fn resolve_command_path(command: &str, env: &[(&str, &str)]) -> Option<PathBuf> {
@@ -477,6 +485,23 @@ fn resolve_user_and_groups(
     Ok((Some(process_user), groups))
 }
 
+/// Whether this process may call `setgroups(2)`.
+///
+/// Unprivileged user namespaces commonly write `deny` to `/proc/self/setgroups`
+/// before installing `gid_map`. After that, `setgroups` always returns `EPERM`
+/// even for the namespace's root. HostSandbox inherits that policy from the OCI
+/// owner, so image supplemental groups must be skipped rather than treated as a
+/// hard launch failure. Primary `uid`/`gid` via `setuid`/`setgid` still apply.
+#[cfg(target_os = "linux")]
+pub(crate) fn setgroups_permitted() -> bool {
+    match std::fs::read_to_string("/proc/self/setgroups") {
+        Ok(value) => value.trim() == "allow",
+        // Outside a user namespace the file is typically absent; setgroups is
+        // then governed only by capabilities.
+        Err(_) => true,
+    }
+}
+
 /// Apply security restrictions (seccomp, no-new-privileges, capabilities) and
 /// the container user before exec using the pre_exec hook.
 ///
@@ -537,6 +562,13 @@ fn apply_security_before_exec(
     } else {
         None
     };
+    let may_setgroups = setgroups_permitted();
+    if !may_setgroups && process_user.is_some() && !supplemental_groups.is_empty() {
+        tracing::debug!(
+            groups = ?supplemental_groups,
+            "Skipping image supplemental groups because /proc/self/setgroups is deny"
+        );
+    }
 
     // Use pre_exec to apply security in the child process right before exec
     // SAFETY: pre_exec runs after fork, before exec. We only call
@@ -548,7 +580,11 @@ fn apply_security_before_exec(
             if no_new_privs {
                 let ret = libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
                 if ret != 0 {
-                    return Err(std::io::Error::last_os_error());
+                    let error = std::io::Error::last_os_error();
+                    return Err(std::io::Error::new(
+                        error.kind(),
+                        format!("pre_exec no_new_privs: {error}"),
+                    ));
                 }
             }
 
@@ -556,13 +592,17 @@ fn apply_security_before_exec(
             //    server: supplemental groups -> capabilities -> setgid+setuid.
             //    Each step needs root/CAP_SET*; setuid is LAST because it clears
             //    the privileges needed by the earlier ones.
-            if process_user.is_some() && !supplemental_groups.is_empty() {
+            if may_setgroups && process_user.is_some() && !supplemental_groups.is_empty() {
                 let ret = libc::setgroups(
                     supplemental_groups.len() as _,
                     supplemental_groups.as_ptr() as *const libc::gid_t,
                 );
                 if ret != 0 {
-                    return Err(std::io::Error::last_os_error());
+                    let error = std::io::Error::last_os_error();
+                    return Err(std::io::Error::new(
+                        error.kind(),
+                        format!("pre_exec setgroups: {error}"),
+                    ));
                 }
             }
 
@@ -572,19 +612,29 @@ fn apply_security_before_exec(
             // bits only until the identity switch, then finalize below.
             if let Some(cap_keep) = &cap_keep {
                 if let Some(user) = process_user {
-                    restrict_capabilities_to_keep_for_user(cap_keep, user)?;
+                    restrict_capabilities_to_keep_for_user(cap_keep, user).map_err(|error| {
+                        std::io::Error::new(error.kind(), format!("pre_exec restrict_caps_for_user: {error}"))
+                    })?;
                 } else {
-                    restrict_capabilities_to_keep(cap_keep)?;
+                    restrict_capabilities_to_keep(cap_keep).map_err(|error| {
+                        std::io::Error::new(error.kind(), format!("pre_exec restrict_caps: {error}"))
+                    })?;
                 }
             } else if should_drop_caps(&cap_drop) {
-                drop_capabilities(&cap_drop)?;
+                drop_capabilities(&cap_drop).map_err(|error| {
+                    std::io::Error::new(error.kind(), format!("pre_exec drop_caps: {error}"))
+                })?;
             }
 
             // 4. Drop to the target uid/gid (image USER / --user).
             if let Some(user) = process_user {
-                user.apply()?;
+                user.apply().map_err(|error| {
+                    std::io::Error::new(error.kind(), format!("pre_exec setuid/setgid: {error}"))
+                })?;
                 if let Some(cap_keep) = &cap_keep {
-                    finalize_capabilities_to_keep(cap_keep)?;
+                    finalize_capabilities_to_keep(cap_keep).map_err(|error| {
+                        std::io::Error::new(error.kind(), format!("pre_exec finalize_caps: {error}"))
+                    })?;
                 }
             }
 
@@ -592,7 +642,9 @@ fn apply_security_before_exec(
             match &seccomp_mode {
                 SeccompMode::Default => {
                     if let Some(filter) = &seccomp_filter {
-                        install_seccomp_filter(filter)?;
+                        install_seccomp_filter(filter).map_err(|error| {
+                            std::io::Error::new(error.kind(), format!("pre_exec seccomp: {error}"))
+                        })?;
                     }
                 }
                 SeccompMode::Unconfined => {
@@ -1710,6 +1762,19 @@ mod tests {
     }
 
     // --- Namespace error tests ---
+
+    #[test]
+    fn setgroups_permitted_matches_proc_file_when_present() {
+        // On hosts without userns denial the helper must not invent a deny.
+        // When the file exists, trust its trimmed value.
+        let path = std::path::Path::new("/proc/self/setgroups");
+        if !path.exists() {
+            assert!(setgroups_permitted());
+            return;
+        }
+        let value = std::fs::read_to_string(path).unwrap();
+        assert_eq!(setgroups_permitted(), value.trim() == "allow");
+    }
 
     #[test]
     fn test_namespace_error_display() {

--- a/src/guest/init/src/namespace.rs
+++ b/src/guest/init/src/namespace.rs
@@ -613,11 +613,17 @@ fn apply_security_before_exec(
             if let Some(cap_keep) = &cap_keep {
                 if let Some(user) = process_user {
                     restrict_capabilities_to_keep_for_user(cap_keep, user).map_err(|error| {
-                        std::io::Error::new(error.kind(), format!("pre_exec restrict_caps_for_user: {error}"))
+                        std::io::Error::new(
+                            error.kind(),
+                            format!("pre_exec restrict_caps_for_user: {error}"),
+                        )
                     })?;
                 } else {
                     restrict_capabilities_to_keep(cap_keep).map_err(|error| {
-                        std::io::Error::new(error.kind(), format!("pre_exec restrict_caps: {error}"))
+                        std::io::Error::new(
+                            error.kind(),
+                            format!("pre_exec restrict_caps: {error}"),
+                        )
                     })?;
                 }
             } else if should_drop_caps(&cap_drop) {
@@ -633,7 +639,10 @@ fn apply_security_before_exec(
                 })?;
                 if let Some(cap_keep) = &cap_keep {
                     finalize_capabilities_to_keep(cap_keep).map_err(|error| {
-                        std::io::Error::new(error.kind(), format!("pre_exec finalize_caps: {error}"))
+                        std::io::Error::new(
+                            error.kind(),
+                            format!("pre_exec finalize_caps: {error}"),
+                        )
                     })?;
                 }
             }

--- a/src/guest/init/src/pty_server.rs
+++ b/src/guest/init/src/pty_server.rs
@@ -228,6 +228,10 @@ fn handle_pty_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::er
         let mut seen = std::collections::HashSet::new();
         sec_supplemental_groups.retain(|gid| seen.insert(*gid));
     }
+    #[cfg(target_os = "linux")]
+    let may_setgroups = crate::namespace::setgroups_permitted();
+    #[cfg(not(target_os = "linux"))]
+    let may_setgroups = true;
     let sec_cap_drop: Vec<String> = request
         .env
         .iter()
@@ -405,7 +409,7 @@ fn handle_pty_connection(fd: std::os::fd::OwnedFd) -> Result<(), Box<dyn std::er
             // supplemental groups need CAP_SETGID and capset needs CAP_SETPCAP,
             // both cleared once user.apply() drops to a non-root uid. The default
             // keep-set retains CAP_SETUID/CAP_SETGID so user.apply still works.
-            if !sec_supplemental_groups.is_empty() {
+            if may_setgroups && !sec_supplemental_groups.is_empty() {
                 let ret = unsafe {
                     libc::setgroups(
                         sec_supplemental_groups.len() as _,

--- a/src/runtime/src/rootfs/overlay.rs
+++ b/src/runtime/src/rootfs/overlay.rs
@@ -594,7 +594,10 @@ fn mount_tmpfs(target: &Path, bytes: u64) -> Result<()> {
     let target_c = CString::new(target_string.as_ref())
         .map_err(|error| BoxError::BuildError(format!("Invalid tmpfs target path: {error}")))?;
     let fstype = CString::new("tmpfs").unwrap();
-    let data = CString::new(format!("size={bytes},mode=0700,nosuid,nodev"))
+    // nosuid/nodev belong in mount flags, not tmpfs superblock options.
+    // Kernels that reject unknown tmpfs parameters (for example some WSL builds)
+    // return EINVAL when those tokens are duplicated in the data string.
+    let data = CString::new(format!("size={bytes},mode=0700"))
         .map_err(|error| BoxError::BuildError(format!("Invalid tmpfs mount options: {error}")))?;
     let flags = libc::MS_NOSUID | libc::MS_NODEV;
     let ret = unsafe {

--- a/src/runtime/src/sandbox/rootfs.rs
+++ b/src/runtime/src/sandbox/rootfs.rs
@@ -475,19 +475,18 @@ pub(crate) fn prepare_rootfs_ownership_with_preference(
     read_only: bool,
     prefer_image_manifest: bool,
 ) -> Result<()> {
-    // Durable Sandbox identity may be non-root (setpriv ruid) while the process
-    // still has euid 0 and can translate OCI ownership to the planned host IDs.
-    // Gate preparation on CAP_CHOWN capability (euid), not on the durable uid
-    // used to select subordinate ranges / OCI mappings.
-    let host_can_chown = unsafe { libc::geteuid() } == 0;
-    if !host_can_chown {
+    // Prepare when either:
+    // - euid is 0 (setpriv CI: durable non-root ruid, but CAP_CHOWN is available), or
+    // - durable identity is root / tests pass effective_uid == 0 to request prepare.
+    // Fully non-root services (euid != 0 and durable uid != 0) still defer to PID 1.
+    let should_prepare = unsafe { libc::geteuid() } == 0 || effective_uid == 0;
+    if !should_prepare {
         if read_only {
             return Err(BoxError::ConfigError(
                 "Sandbox read-only rootfs requires a root-run service until idmapped rootfs preparation is available"
                     .to_string(),
             ));
         }
-        let _ = effective_uid;
         return Ok(());
     }
 

--- a/src/runtime/src/sandbox/rootfs.rs
+++ b/src/runtime/src/sandbox/rootfs.rs
@@ -452,10 +452,11 @@ pub(crate) fn inspect_rootfs_identity_requirements_with_preference(
 
 /// Prepare one per-box rootfs for the exact user-namespace mapping.
 ///
-/// A root-run service can translate OCI container ownership to subordinate
-/// host IDs directly. A non-root service leaves ownership replay to PID 1 from
-/// inside the user namespace. Read-only rootfs is rejected for the latter until
-/// an idmapped-mount path can guarantee replay before the read-only transition.
+/// A process with effective root (including setpriv euid 0 / non-root ruid) can
+/// translate OCI container ownership to the planned subordinate host IDs.
+/// A fully non-root service leaves ownership replay to PID 1 inside the user
+/// namespace. Read-only rootfs is rejected for the latter until an idmapped-mount
+/// path can guarantee replay before the read-only transition.
 #[cfg(target_os = "linux")]
 pub fn prepare_rootfs_ownership(
     root: &Path,
@@ -474,13 +475,19 @@ pub(crate) fn prepare_rootfs_ownership_with_preference(
     read_only: bool,
     prefer_image_manifest: bool,
 ) -> Result<()> {
-    if effective_uid != 0 {
+    // Durable Sandbox identity may be non-root (setpriv ruid) while the process
+    // still has euid 0 and can translate OCI ownership to the planned host IDs.
+    // Gate preparation on CAP_CHOWN capability (euid), not on the durable uid
+    // used to select subordinate ranges / OCI mappings.
+    let host_can_chown = unsafe { libc::geteuid() } == 0;
+    if !host_can_chown {
         if read_only {
             return Err(BoxError::ConfigError(
                 "Sandbox read-only rootfs requires a root-run service until idmapped rootfs preparation is available"
                     .to_string(),
             ));
         }
+        let _ = effective_uid;
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary
- **setgroups:** HostSandbox OCI userns sets `/proc/self/setgroups=deny`. Applying image supplemental groups via `setgroups(2)` before `setuid` returned `EPERM` and blocked non-root entrypoints (`/usr/bin/a3s` as uid 65532). Skip supplemental `setgroups` when not `allow`; primary uid/gid still apply.
- **tmpfs:** Put `nosuid`/`nodev` in mount flags only (not duplicated in tmpfs data) so kernels that reject unknown tmpfs parameters (e.g. some WSL builds) do not return `EINVAL`.
- **rootfs prepare:** setpriv CI uses non-root ruid with euid 0. Ownership prepare previously keyed off the durable identity and skipped translation, so snapshot capture saw raw host UID 0 outside OCI mappings. Gate prepare on `geteuid()==0` instead.

## Local evidence (not retained CI)
On Cloud tip `5be6a62` with a Box pin carrying these patches:
- `postgres_skill_workload_binding_rebind_unbind_and_rollback_run_through_real_box` → `A3S_CLOUD_A0_5_REAL_BOX_SKILL_LIFECYCLE_CERTIFIED` (cleanup=removed)
- `postgres_published_agent_release_runs_recovers_and_cleans_through_real_box` → `A3S_CLOUD_A0_4_REAL_BOX_RELEASE_CERTIFIED` (cleanup=removed)

## Test plan
- [ ] Unit: `setgroups_permitted_matches_proc_file_when_present`
- [ ] HostSandbox: non-root image entrypoint (`a3s --version` as 65532)
- [ ] setpriv: published Agent release / Skill workload Cloud box-conformance after pin bump