### PR TITLE
docs: post-release Sandbox GA host prep on website for v3.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to A3S Box will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Website installation and quick-start document Linux Sandbox GA host prep for
+  the published `v3.2.6` line (leave `A3S_BOX_OCI_MIGRATION` unset; link the
+  evidence binder). README points at the GitHub Release URL.
+
 ## [3.2.6] — 2026-09-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ is not yet a production claim.
 
 ## Current release line
 
-The `3.2.6` release line keeps the public SDK contract stable while packaging
-Linux Sandbox GA activation and the latest runtime fixes from `main`:
+The `3.2.6` release line (published as
+[v3.2.6](https://github.com/A3S-Lab/Box/releases/tag/v3.2.6)) keeps the public
+SDK contract stable while packaging Linux Sandbox GA activation and the latest
+runtime fixes from `main`:
 
 | Area | Latest behavior |
 | --- | --- |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,7 +51,9 @@ runtime crate 现在还暴露显式的 `OciMigrationPolicy` 与 `LocalExecutionB
 
 ## 当前发布线
 
-`3.2.6` 发布线在保持公共 SDK 契约稳定的同时，打包 Linux Sandbox GA 默认激活与来自 `main` 的最新运行时修复：
+`3.2.6` 发布线（已发布为
+[v3.2.6](https://github.com/A3S-Lab/Box/releases/tag/v3.2.6)）在保持公共 SDK
+契约稳定的同时，打包 Linux Sandbox GA 默认激活与来自 `main` 的最新运行时修复：
 
 | 领域 | 最新行为 |
 | --- | --- |

--- a/website/docs/v3/en/guide/installation.mdx
+++ b/website/docs/v3/en/guide/installation.mdx
@@ -108,6 +108,23 @@ remove that installation directory from the per-user `PATH`.
 Uninstalling binaries intentionally does not delete runtime state stored
 elsewhere.
 
+## Linux Sandbox host preparation (3.2.6 GA)
+
+The installer does not enable Sandbox host capabilities. After installing
+`v3.2.6` or newer on a certified Linux host, prepare the delegated cgroup and
+setuid launcher, then run without setting `A3S_BOX_OCI_MIGRATION`:
+
+```bash
+sudo bash /path/to/box/scripts/prepare-linux-sandbox-host.sh \
+  --install-launcher /absolute/path/to/a3s-oci
+export A3S_BOX_SANDBOX_DELEGATED_CGROUP_ROOT=...  # printed by the script
+a3s-box run --rm --isolation sandbox alpine:3.20 -- sleep 5
+```
+
+Evidence and non-claims:
+[Sandbox GA evidence](https://github.com/A3S-Lab/Box/blob/main/docs/sandbox-ga-evidence.md)
+in the Box repository. This is not a MicroVM or `BX0.3` claim.
+
 ## Next step
 
 Continue with the [quick start](./quick-start/) or review the

--- a/website/docs/v3/en/guide/quick-start.mdx
+++ b/website/docs/v3/en/guide/quick-start.mdx
@@ -76,7 +76,9 @@ commits, exports, and filesystem snapshots.
 
 ## Select the shared-kernel Sandbox
 
-On a certified Linux host, request the Sandbox explicitly:
+On a certified Linux host prepared for Sandbox GA (`v3.2.6`+), request the
+Sandbox explicitly. Leave `A3S_BOX_OCI_MIGRATION` unset so the production
+`SandboxViaOci` owner route is selected:
 
 ```bash
 a3s-box run --rm \
@@ -87,8 +89,9 @@ a3s-box run --rm \
   sh -lc 'id; cat /proc/self/status'
 ```
 
-An explicit `--isolation microvm` value is rejected. Omission is the public way
-to select the default, which prevents scripts from treating backend names as
+Host preparation is documented in [Installation](./installation/). An explicit
+`--isolation microvm` value is rejected. Omission is the public way to select
+the default MicroVM, which prevents scripts from treating backend names as
 interchangeable compatibility modes.
 
 ## Use a native SDK

--- a/website/docs/v3/zh/guide/installation.mdx
+++ b/website/docs/v3/zh/guide/installation.mdx
@@ -116,6 +116,22 @@ sh ./install.sh \
 `# >>> a3s-box installer >>>` 与 `# <<< a3s-box installer <<<` 之间的块；
 Windows 需从用户 `PATH` 移除该目录。卸载二进制不会自动删除运行时数据。
 
+## Linux Sandbox 主机准备（3.2.6 GA）
+
+安装器不会启用 Sandbox 主机能力。在经认证的 Linux 主机上安装 `v3.2.6` 或更新版本后，
+准备委托 cgroup 与 setuid launcher，然后**不要**设置 `A3S_BOX_OCI_MIGRATION`：
+
+```bash
+sudo bash /path/to/box/scripts/prepare-linux-sandbox-host.sh \
+  --install-launcher /absolute/path/to/a3s-oci
+export A3S_BOX_SANDBOX_DELEGATED_CGROUP_ROOT=...  # 脚本会打印
+a3s-box run --rm --isolation sandbox alpine:3.20 -- sleep 5
+```
+
+证据与非宣称见 Box 仓库
+[Sandbox GA evidence](https://github.com/A3S-Lab/Box/blob/main/docs/sandbox-ga-evidence.md)。
+这不是 MicroVM 或 `BX0.3` 宣称。
+
 ## 下一步
 
 安装后继续阅读[快速开始](./quick-start/)；生产部署前请检查

--- a/website/docs/v3/zh/guide/quick-start.mdx
+++ b/website/docs/v3/zh/guide/quick-start.mdx
@@ -73,7 +73,8 @@ a3s-box volume inspect app-data
 
 ## 显式选择共享内核 Sandbox
 
-在经过认证的 Linux 主机上：
+在已完成 Sandbox GA 主机准备的认证 Linux 上（`v3.2.6`+），显式请求 Sandbox。
+保持 `A3S_BOX_OCI_MIGRATION` 未设置，以使用生产 `SandboxViaOci` 所有者路由：
 
 ```bash
 a3s-box run --rm \
@@ -84,8 +85,8 @@ a3s-box run --rm \
   sh -lc 'id; cat /proc/self/status'
 ```
 
-显式的 `--isolation microvm` 会被拒绝；省略参数才是默认 MicroVM 的公开选择方式。
-这样脚本不会误把后端名称当作可互换的兼容模式。
+主机准备见[安装](./installation/)。显式的 `--isolation microvm` 会被拒绝；
+省略参数才是默认 MicroVM 的公开选择方式，这样脚本不会误把后端名称当作可互换的兼容模式。
 
 ## 使用原生 SDK
 


### PR DESCRIPTION
## Summary
- After verifying `v3.2.6` release health (assets, crates.io, PyPI, npm, Pages install pins), update website installation/quick-start with Sandbox GA host prep.
- README links the published [v3.2.6](https://github.com/A3S-Lab/Box/releases/tag/v3.2.6) release.

## Test plan
- [ ] Docs CI / format+lint green
- [ ] Merge deploys GitHub Pages; `/Box/guide/installation.html` shows host-prep section and `v3.2.6`