### PR TITLE
chore(deps): pin OCI Runtime to 931def0 for -Dwarnings agent build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   A3S_DEPS_STUB: "1"
-  A3S_OCI_RUNTIME_REV: 05a3b2bddff0668703caafc48f38514a139ee81a
+  A3S_OCI_RUNTIME_REV: 931def0b8c32313802262bbdbebfda669956ca4f
 
 jobs:
   # ── Lint & Format ──────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  A3S_OCI_RUNTIME_REV: 05a3b2bddff0668703caafc48f38514a139ee81a
+  A3S_OCI_RUNTIME_REV: 931def0b8c32313802262bbdbebfda669956ca4f
 
 jobs:
   # ── Tests must pass before release ─────────────────────────────

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-core"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=05a3b2bddff0668703caafc48f38514a139ee81a#05a3b2bddff0668703caafc48f38514a139ee81a"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=931def0b8c32313802262bbdbebfda669956ca4f#931def0b8c32313802262bbdbebfda669956ca4f"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "a3s-oci-sdk"
 version = "0.3.1"
-source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=05a3b2bddff0668703caafc48f38514a139ee81a#05a3b2bddff0668703caafc48f38514a139ee81a"
+source = "git+https://github.com/A3S-Lab/OCI-Runtime.git?rev=931def0b8c32313802262bbdbebfda669956ca4f#931def0b8c32313802262bbdbebfda669956ca4f"
 dependencies = [
  "a3s-oci-core",
  "async-trait",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3247,7 +3247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,7 +3799,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -126,7 +126,7 @@ ring = "0.17"
 a3s-acl = { version = "0.3.0", git = "https://github.com/A3S-Lab/ACL.git", rev = "5317e166222495585909d81f2caffdca90273c99" }
 a3s-transport = { version = "0.1.1", package = "a3s-common" }
 a3s-runtime = { version = "=0.5.0", git = "https://github.com/A3S-Lab/Runtime.git", rev = "4c5fbd56bedd84d1007a7d9cd046a9f7083bbdcd" }
-a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "05a3b2bddff0668703caafc48f38514a139ee81a" }
+a3s-oci-sdk = { version = "=0.3.1", git = "https://github.com/A3S-Lab/OCI-Runtime.git", rev = "931def0b8c32313802262bbdbebfda669956ca4f" }
 
 # Metrics
 prometheus = "0.13"


### PR DESCRIPTION
## Summary
- Bumps `a3s-oci-sdk` / `a3s-oci-core` from `05a3b2` to `931def0` while keeping `=0.3.1`.
- Unblocks Cloud `box-conformance` which builds `a3s-oci-agent` under `setup-rust-toolchain`'s default `RUSTFLAGS=-D warnings`.
- `931def0` already cleared the dead_code debt (`try_wait_raw`, test-only session supervisor helpers) without turning off deny-warnings.

## Test plan
- [x] Local: `RUSTFLAGS='-D warnings' cargo build --locked --release -p a3s-oci-agent -p a3s-oci-cli` at `931def0` succeeds
- [ ] Box CI green on this branch
- [ ] Cloud pin follow-up re-runs retained box-conformance after this lands (or Cloud pins this commit)